### PR TITLE
feat: add portless dev server proxy for apps/web

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "portless web next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
     "lint": "biome check .",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "version-sync": "bun run beep version-sync",
     "purge": "bun run beep purge",
     "clean": "node scripts/clean.mjs",
+    "dev": "bunx turbo run dev",
     "build": "bunx turbo run build",
     "changeset": "changeset",
     "changeset:status": "changeset status",

--- a/turbo.json
+++ b/turbo.json
@@ -50,6 +50,11 @@
       "inputs": ["$TURBO_DEFAULT$"],
       "outputs": ["docs/**", "dtslint/**"]
     },
+    "dev": {
+      "persistent": true,
+      "cache": false,
+      "dependsOn": ["^build"]
+    },
     "storybook": {
       "persistent": true,
       "cache": false


### PR DESCRIPTION
Route apps/web through portless so it's accessible at http://web.localhost:1355 instead of a random port. Adds a Turbo `dev` task and root `dev` script to run it from the monorepo root.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration and build pipeline settings to optimize workflow execution and consistency across the project.
  * Modified development scripts and task dependencies to streamline the build process and improve development infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->