### PR TITLE
[codex] refine repo-memory packet kernel

### DIFF
--- a/.changeset/soft-bees-heal.md
+++ b/.changeset/soft-bees-heal.md
@@ -1,0 +1,4 @@
+---
+---
+
+Record the repo-memory packet-kernel refinement, retrieval-packet schema work, and repo-wide quality gate fixes without forcing a package release decision on this branch.

--- a/apps/desktop/scripts/dev-with-portless.ts
+++ b/apps/desktop/scripts/dev-with-portless.ts
@@ -9,20 +9,11 @@ import * as O from "effect/Option";
 import type * as PlatformError from "effect/PlatformError";
 import * as S from "effect/Schema";
 import * as Str from "effect/String";
-import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http";
+import { HttpClient, HttpClientRequest } from "effect/unstable/http";
 import { ChildProcess } from "effect/unstable/process";
 import type { ChildProcessHandle } from "effect/unstable/process/ChildProcessSpawner";
 
 const $DesktopDevId = $I.create("apps/desktop/scripts/dev-with-portless");
-
-interface BunTlsRequestInit extends RequestInit {
-  readonly tls?:
-    | {
-        readonly rejectUnauthorized?: boolean | undefined;
-        readonly serverName?: string | undefined;
-      }
-    | undefined;
-}
 
 class DevWithPortlessError extends TaggedErrorClass<DevWithPortlessError>($DesktopDevId`DevWithPortlessError`)(
   "DevWithPortlessError",
@@ -67,26 +58,6 @@ const makeManagedChildExitError = (child: string, message: string, exitCode: num
     exitCode
   );
 
-const makeProbeFetch = (host: string): typeof globalThis.fetch =>
-  Object.assign(
-    (input: RequestInfo | URL, init?: RequestInit) => {
-      const currentInit = init as BunTlsRequestInit | undefined;
-      const requestInit: BunTlsRequestInit = {
-        ...currentInit,
-        tls: {
-          ...currentInit?.tls,
-          rejectUnauthorized: false,
-          serverName: host,
-        },
-      };
-
-      return globalThis.fetch(input, requestInit as RequestInit);
-    },
-    {
-      preconnect: globalThis.fetch.preconnect.bind(globalThis.fetch),
-    }
-  ) as typeof globalThis.fetch;
-
 const mapManagedChildPlatformError = (child: string, error: PlatformError.PlatformError) =>
   makeManagedChildExitError(
     child,
@@ -120,15 +91,8 @@ const routeStatus = Effect.fn("DesktopDev.routeStatus")(function* (
   targetPath: string,
   method: "GET" | "HEAD"
 ) {
-  const request = HttpClientRequest.make(method)(`https://127.0.0.1:${portlessProxyPort}${targetPath}`, {
-    headers: {
-      host,
-    },
-  });
-  const responseOption = yield* HttpClient.execute(request).pipe(
-    Effect.provideService(FetchHttpClient.Fetch, makeProbeFetch(host)),
-    Effect.option
-  );
+  const request = HttpClientRequest.make(method)(`https://${host}:${portlessProxyPort}${targetPath}`);
+  const responseOption = yield* HttpClient.execute(request).pipe(Effect.option);
 
   if (O.isNone(responseOption)) {
     return O.none<number>();

--- a/apps/desktop/scripts/dev-with-portless.ts
+++ b/apps/desktop/scripts/dev-with-portless.ts
@@ -209,7 +209,7 @@ const awaitSidecarHealth = Effect.fn("DesktopDev.awaitSidecarHealth")(function* 
     return yield* new DevWithPortlessError({ message: timeoutMessage });
   }).pipe(
     Effect.retry(
-      Schedule.spaced(sidecarStartupPollInterval).pipe(Schedule.compose(Schedule.recurs(sidecarStartupRetries)))
+      Schedule.spaced(sidecarStartupPollInterval).pipe(Schedule.both(Schedule.recurs(sidecarStartupRetries)))
     )
   );
 });

--- a/apps/desktop/src/RepoMemoryDesktop.tsx
+++ b/apps/desktop/src/RepoMemoryDesktop.tsx
@@ -20,6 +20,7 @@ import {
   RunCursor,
   RunId,
   type RunStreamEvent,
+  renderRetrievalPacketAnswer,
   type SidecarBootstrap,
   StreamRunEventsRequest,
 } from "@beep/runtime-protocol";
@@ -273,9 +274,125 @@ const findLatestPacketEvent = (
     A.last
   );
 
+const formatPacketEntity = (
+  value:
+    | { readonly kind: "file"; readonly filePath: string }
+    | { readonly kind: "module"; readonly moduleSpecifier: string }
+    | { readonly kind: "symbol"; readonly symbolName: string; readonly symbolKind: string; readonly filePath: string }
+    | {
+        readonly kind: "parameter";
+        readonly name: string;
+        readonly type: O.Option<string>;
+        readonly description: O.Option<string>;
+      }
+    | { readonly kind: "return" | "throw"; readonly type: O.Option<string>; readonly description: O.Option<string> }
+): string => {
+  if (value.kind === "file") {
+    return value.filePath;
+  }
+
+  if (value.kind === "module") {
+    return value.moduleSpecifier;
+  }
+
+  if (value.kind === "symbol") {
+    return `${value.symbolName} (${value.symbolKind}) in ${value.filePath}`;
+  }
+
+  const header =
+    value.kind === "parameter"
+      ? pipe(
+          value.type,
+          O.match({
+            onNone: () => value.name,
+            onSome: (type) => `${value.name}: ${type}`,
+          })
+        )
+      : pipe(
+          value.type,
+          O.getOrElse(() => "unspecified")
+        );
+
+  return pipe(
+    value.description,
+    O.match({
+      onNone: () => header,
+      onSome: (description) => `${header} - ${description}`,
+    })
+  );
+};
+
+const packetPayloadLines = (packet: RetrievalPacket): ReadonlyArray<string> =>
+  pipe(
+    packet.payload,
+    O.match({
+      onNone: () => [],
+      onSome: (payload) => {
+        if (payload.family === "count") {
+          return [`target: ${payload.target}`, `count: ${payload.count}`];
+        }
+
+        if (payload.family === "subject-detail") {
+          return [
+            `subject: ${formatPacketEntity(payload.subject)}`,
+            `aspect: ${payload.aspect}`,
+            `facets: ${
+              pipe(
+                payload.facets,
+                A.map((facet) => facet.kind),
+                A.join(", ")
+              ) || "none"
+            }`,
+          ];
+        }
+
+        if (payload.family === "relation-list") {
+          return [
+            `relation: ${payload.relation}`,
+            `subject: ${formatPacketEntity(payload.subject)}`,
+            `items: ${pipe(payload.items, A.map(formatPacketEntity), A.join("; ")) || "none"}`,
+          ];
+        }
+
+        return [
+          `query: ${payload.query}`,
+          `items: ${pipe(payload.items, A.map(formatPacketEntity), A.join("; ")) || "none"}`,
+        ];
+      },
+    })
+  );
+
+const packetIssueLines = (packet: RetrievalPacket): ReadonlyArray<string> =>
+  pipe(
+    packet.issue,
+    O.match({
+      onNone: () => [],
+      onSome: (issue) => {
+        if (issue.kind === "no-match") {
+          return [`requested: ${issue.requested.value}`, `note: ${issue.note}`];
+        }
+
+        if (issue.kind === "ambiguous") {
+          return [
+            `requested: ${issue.requested.value}`,
+            `candidates: ${pipe(
+              issue.candidates,
+              A.map((candidate) => formatPacketEntity(candidate.subject)),
+              A.join("; ")
+            )}`,
+          ];
+        }
+
+        return [`requested: ${issue.requested.value}`, `reason: ${issue.reason}`];
+      },
+    })
+  );
+
 const answerFromRun = (run: QueryRun, events: ReadonlyArray<RunStreamEvent>): string =>
   pipe(
-    run.answer,
+    retrievalPacketFromRun(run, events),
+    O.map(renderRetrievalPacketAnswer),
+    O.orElse(() => run.answer),
     O.orElse(() =>
       pipe(
         findLatestAnswerEvent(events),
@@ -1505,6 +1622,18 @@ export function RepoMemoryDesktop() {
                                 <dd>{packet.query}</dd>
                               </div>
                               <div>
+                                <dt>Normalized</dt>
+                                <dd>{packet.normalizedQuery}</dd>
+                              </div>
+                              <div>
+                                <dt>Query kind</dt>
+                                <dd>{packet.queryKind}</dd>
+                              </div>
+                              <div>
+                                <dt>Outcome</dt>
+                                <dd>{packet.outcome}</dd>
+                              </div>
+                              <div>
                                 <dt>Retrieved</dt>
                                 <dd>{formatDateTime(packet.retrievedAt)}</dd>
                               </div>
@@ -1522,6 +1651,26 @@ export function RepoMemoryDesktop() {
                                 <dd>{packet.citations.length}</dd>
                               </div>
                             </dl>
+                            {packetPayloadLines(packet).length === 0 ? null : (
+                              <>
+                                <h4>Payload</h4>
+                                <ul className="note-list">
+                                  {packetPayloadLines(packet).map((line) => (
+                                    <li key={line}>{line}</li>
+                                  ))}
+                                </ul>
+                              </>
+                            )}
+                            {packetIssueLines(packet).length === 0 ? null : (
+                              <>
+                                <h4>Issue</h4>
+                                <ul className="note-list">
+                                  {packetIssueLines(packet).map((line) => (
+                                    <li key={line}>{line}</li>
+                                  ))}
+                                </ul>
+                              </>
+                            )}
                             {packet.notes.length === 0 ? null : (
                               <ul className="note-list">
                                 {packet.notes.map((note) => (

--- a/packages/repo-memory/model/src/internal/domain.ts
+++ b/packages/repo-memory/model/src/internal/domain.ts
@@ -460,6 +460,730 @@ export class RepoSymbolDocumentation extends S.Class<RepoSymbolDocumentation>($I
 ) {}
 
 /**
+ * Canonical deterministic query kinds supported by repo-memory grounded retrieval.
+ *
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export const RetrievalQueryKind = LiteralKit([
+  "countFiles",
+  "countSymbols",
+  "locateSymbol",
+  "describeSymbol",
+  "symbolParams",
+  "symbolReturns",
+  "symbolThrows",
+  "symbolDeprecation",
+  "listFileExports",
+  "listFileImports",
+  "listFileImporters",
+  "listSymbolImporters",
+  "listFileDependencies",
+  "listFileDependents",
+  "keywordSearch",
+  "unsupported",
+]).annotate(
+  $I.annote("RetrievalQueryKind", {
+    description: "Canonical deterministic query kinds supported by repo-memory grounded retrieval.",
+  })
+);
+
+/**
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export type RetrievalQueryKind = typeof RetrievalQueryKind.Type;
+
+/**
+ * Packet-level retrieval outcome for one grounded query run.
+ *
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export const RetrievalOutcome = LiteralKit(["resolved", "none", "ambiguous", "unsupported"]).annotate(
+  $I.annote("RetrievalOutcome", {
+    description: "Packet-level retrieval outcome for one grounded query run.",
+  })
+);
+
+/**
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export type RetrievalOutcome = typeof RetrievalOutcome.Type;
+
+/**
+ * Match posture recorded for ambiguous or relaxed packet candidates.
+ *
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export const RetrievalMatchKind = LiteralKit(["exact", "normalized", "fuzzy"]).annotate(
+  $I.annote("RetrievalMatchKind", {
+    description: "Match posture recorded for ambiguous or relaxed packet candidates.",
+  })
+);
+
+/**
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export type RetrievalMatchKind = typeof RetrievalMatchKind.Type;
+
+/**
+ * Query target requested before grounding resolves it to a concrete subject.
+ *
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export class RetrievalFileRequestedTarget extends S.Class<RetrievalFileRequestedTarget>(
+  $I`RetrievalFileRequestedTarget`
+)(
+  {
+    kind: S.tag("file-query"),
+    value: S.String,
+  },
+  $I.annote("RetrievalFileRequestedTarget", {
+    description: "Requested file-oriented query target before grounding resolves it to one concrete file.",
+  })
+) {}
+
+/**
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export class RetrievalSymbolRequestedTarget extends S.Class<RetrievalSymbolRequestedTarget>(
+  $I`RetrievalSymbolRequestedTarget`
+)(
+  {
+    kind: S.tag("symbol-query"),
+    value: S.String,
+  },
+  $I.annote("RetrievalSymbolRequestedTarget", {
+    description: "Requested symbol-oriented query target before grounding resolves it to one concrete symbol.",
+  })
+) {}
+
+/**
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export class RetrievalModuleRequestedTarget extends S.Class<RetrievalModuleRequestedTarget>(
+  $I`RetrievalModuleRequestedTarget`
+)(
+  {
+    kind: S.tag("module-query"),
+    value: S.String,
+  },
+  $I.annote("RetrievalModuleRequestedTarget", {
+    description:
+      "Requested module-oriented query target before grounding resolves it to one module or file-like specifier.",
+  })
+) {}
+
+/**
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export class RetrievalKeywordRequestedTarget extends S.Class<RetrievalKeywordRequestedTarget>(
+  $I`RetrievalKeywordRequestedTarget`
+)(
+  {
+    kind: S.tag("keyword-query"),
+    value: S.String,
+  },
+  $I.annote("RetrievalKeywordRequestedTarget", {
+    description: "Requested keyword-search target before retrieval resolves it to matching grounded items.",
+  })
+) {}
+
+/**
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export class RetrievalQuestionRequestedTarget extends S.Class<RetrievalQuestionRequestedTarget>(
+  $I`RetrievalQuestionRequestedTarget`
+)(
+  {
+    kind: S.tag("question"),
+    value: S.String,
+  },
+  $I.annote("RetrievalQuestionRequestedTarget", {
+    description: "Original question string preserved for unsupported deterministic query shapes.",
+  })
+) {}
+
+/**
+ * Requested retrieval target preserved before grounding resolves it to a concrete subject.
+ *
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export const RetrievalRequestedTarget = S.Union([
+  RetrievalFileRequestedTarget,
+  RetrievalSymbolRequestedTarget,
+  RetrievalModuleRequestedTarget,
+  RetrievalKeywordRequestedTarget,
+  RetrievalQuestionRequestedTarget,
+]).pipe(
+  S.toTaggedUnion("kind"),
+  S.annotate(
+    $I.annote("RetrievalRequestedTarget", {
+      description: "Requested retrieval target preserved before grounding resolves it to a concrete subject.",
+    })
+  )
+);
+
+/**
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export type RetrievalRequestedTarget = typeof RetrievalRequestedTarget.Type;
+
+/**
+ * Grounded file subject carried by a retrieval packet.
+ *
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export class RetrievalFileSubject extends S.Class<RetrievalFileSubject>($I`RetrievalFileSubject`)(
+  {
+    kind: S.tag("file"),
+    label: S.String,
+    filePath: FilePath,
+    citationIds: ArrayOfStrings,
+  },
+  $I.annote("RetrievalFileSubject", {
+    description: "Grounded file subject carried by a retrieval packet.",
+  })
+) {}
+
+/**
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export class RetrievalSymbolSubject extends S.Class<RetrievalSymbolSubject>($I`RetrievalSymbolSubject`)(
+  {
+    kind: S.tag("symbol"),
+    label: S.String,
+    symbolId: S.String,
+    symbolName: S.String,
+    qualifiedName: S.String,
+    symbolKind: S.suspend(() => RepoSymbolKind),
+    filePath: FilePath,
+    citationIds: ArrayOfStrings,
+  },
+  $I.annote("RetrievalSymbolSubject", {
+    description: "Grounded symbol subject carried by a retrieval packet.",
+  })
+) {}
+
+/**
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export class RetrievalModuleSubject extends S.Class<RetrievalModuleSubject>($I`RetrievalModuleSubject`)(
+  {
+    kind: S.tag("module"),
+    label: S.String,
+    moduleSpecifier: S.String,
+    citationIds: ArrayOfStrings,
+  },
+  $I.annote("RetrievalModuleSubject", {
+    description: "Grounded module subject carried by a retrieval packet.",
+  })
+) {}
+
+/**
+ * Grounded subject carried by a retrieval packet.
+ *
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export const RetrievalSubject = S.Union([RetrievalFileSubject, RetrievalSymbolSubject, RetrievalModuleSubject]).pipe(
+  S.toTaggedUnion("kind"),
+  S.annotate(
+    $I.annote("RetrievalSubject", {
+      description: "Grounded subject carried by a retrieval packet.",
+    })
+  )
+);
+
+/**
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export type RetrievalSubject = typeof RetrievalSubject.Type;
+
+/**
+ * Candidate subject surfaced when retrieval cannot safely resolve to one grounded subject.
+ *
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export class RetrievalCandidate extends S.Class<RetrievalCandidate>($I`RetrievalCandidate`)(
+  {
+    subject: RetrievalSubject,
+    matchKind: RetrievalMatchKind,
+    note: S.OptionFromOptionalKey(S.String),
+  },
+  $I.annote("RetrievalCandidate", {
+    description: "Candidate subject surfaced when retrieval cannot safely resolve to one grounded subject.",
+  })
+) {}
+
+/**
+ * Parameter item carried inside retrieval facets and payloads.
+ *
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export class RetrievalParameterItem extends S.Class<RetrievalParameterItem>($I`RetrievalParameterItem`)(
+  {
+    kind: S.tag("parameter"),
+    name: S.String,
+    type: S.OptionFromOptionalKey(S.String),
+    description: S.OptionFromOptionalKey(S.String),
+    citationIds: ArrayOfStrings,
+  },
+  $I.annote("RetrievalParameterItem", {
+    description: "Parameter item carried inside retrieval facets and payloads.",
+  })
+) {}
+
+/**
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export class RetrievalReturnItem extends S.Class<RetrievalReturnItem>($I`RetrievalReturnItem`)(
+  {
+    kind: S.tag("return"),
+    type: S.OptionFromOptionalKey(S.String),
+    description: S.OptionFromOptionalKey(S.String),
+    citationIds: ArrayOfStrings,
+  },
+  $I.annote("RetrievalReturnItem", {
+    description: "Return item carried inside retrieval facets and payloads.",
+  })
+) {}
+
+/**
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export class RetrievalThrowItem extends S.Class<RetrievalThrowItem>($I`RetrievalThrowItem`)(
+  {
+    kind: S.tag("throw"),
+    type: S.OptionFromOptionalKey(S.String),
+    description: S.OptionFromOptionalKey(S.String),
+    citationIds: ArrayOfStrings,
+  },
+  $I.annote("RetrievalThrowItem", {
+    description: "Throw item carried inside retrieval facets and payloads.",
+  })
+) {}
+
+/**
+ * Display-ready retrieval item shown inside packet payloads.
+ *
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export const RetrievalItem = S.Union([
+  RetrievalFileSubject,
+  RetrievalSymbolSubject,
+  RetrievalModuleSubject,
+  RetrievalParameterItem,
+  RetrievalReturnItem,
+  RetrievalThrowItem,
+]).pipe(
+  S.toTaggedUnion("kind"),
+  S.annotate(
+    $I.annote("RetrievalItem", {
+      description: "Display-ready retrieval item shown inside packet payloads.",
+    })
+  )
+);
+
+/**
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export type RetrievalItem = typeof RetrievalItem.Type;
+
+/**
+ * Subject detail aspect requested by a deterministic subject-detail query.
+ *
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export const RetrievalSubjectDetailAspect = LiteralKit([
+  "location",
+  "description",
+  "params",
+  "returns",
+  "throws",
+  "deprecation",
+]).annotate(
+  $I.annote("RetrievalSubjectDetailAspect", {
+    description: "Subject detail aspect requested by a deterministic subject-detail query.",
+  })
+);
+
+/**
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export type RetrievalSubjectDetailAspect = typeof RetrievalSubjectDetailAspect.Type;
+
+/**
+ * Location facet attached to one grounded subject.
+ *
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export class RetrievalLocationFacet extends S.Class<RetrievalLocationFacet>($I`RetrievalLocationFacet`)(
+  {
+    kind: S.tag("location"),
+    filePath: FilePath,
+    startLine: PosInt,
+    endLine: PosInt,
+    citationIds: ArrayOfStrings,
+  },
+  $I.annote("RetrievalLocationFacet", {
+    description: "Location facet attached to one grounded subject.",
+  })
+) {}
+
+/**
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export class RetrievalDeclarationFacet extends S.Class<RetrievalDeclarationFacet>($I`RetrievalDeclarationFacet`)(
+  {
+    kind: S.tag("declaration"),
+    signature: S.String,
+    exported: S.OptionFromOptionalKey(S.Boolean),
+    citationIds: ArrayOfStrings,
+  },
+  $I.annote("RetrievalDeclarationFacet", {
+    description: "Declaration facet attached to one grounded subject.",
+  })
+) {}
+
+/**
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export class RetrievalDocumentationFacet extends S.Class<RetrievalDocumentationFacet>($I`RetrievalDocumentationFacet`)(
+  {
+    kind: S.tag("documentation"),
+    summary: S.OptionFromOptionalKey(S.String),
+    description: S.OptionFromOptionalKey(S.String),
+    remarks: S.OptionFromOptionalKey(S.String),
+    citationIds: ArrayOfStrings,
+  },
+  $I.annote("RetrievalDocumentationFacet", {
+    description: "Documentation facet attached to one grounded subject.",
+  })
+) {}
+
+/**
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export class RetrievalParametersFacet extends S.Class<RetrievalParametersFacet>($I`RetrievalParametersFacet`)(
+  {
+    kind: S.tag("parameters"),
+    items: S.Array(RetrievalParameterItem),
+  },
+  $I.annote("RetrievalParametersFacet", {
+    description: "Parameter facet attached to one grounded subject.",
+  })
+) {}
+
+/**
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export class RetrievalReturnsFacet extends S.Class<RetrievalReturnsFacet>($I`RetrievalReturnsFacet`)(
+  {
+    kind: S.tag("returns"),
+    item: S.OptionFromOptionalKey(RetrievalReturnItem),
+  },
+  $I.annote("RetrievalReturnsFacet", {
+    description: "Return facet attached to one grounded subject.",
+  })
+) {}
+
+/**
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export class RetrievalThrowsFacet extends S.Class<RetrievalThrowsFacet>($I`RetrievalThrowsFacet`)(
+  {
+    kind: S.tag("throws"),
+    items: S.Array(RetrievalThrowItem),
+  },
+  $I.annote("RetrievalThrowsFacet", {
+    description: "Throws facet attached to one grounded subject.",
+  })
+) {}
+
+/**
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export class RetrievalDeprecationFacet extends S.Class<RetrievalDeprecationFacet>($I`RetrievalDeprecationFacet`)(
+  {
+    kind: S.tag("deprecation"),
+    isDeprecated: S.Boolean,
+    note: S.OptionFromOptionalKey(S.String),
+    citationIds: ArrayOfStrings,
+  },
+  $I.annote("RetrievalDeprecationFacet", {
+    description: "Deprecation facet attached to one grounded subject.",
+  })
+) {}
+
+/**
+ * Grounded subject facet carried by a retrieval packet.
+ *
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export const RetrievalFacet = S.Union([
+  RetrievalLocationFacet,
+  RetrievalDeclarationFacet,
+  RetrievalDocumentationFacet,
+  RetrievalParametersFacet,
+  RetrievalReturnsFacet,
+  RetrievalThrowsFacet,
+  RetrievalDeprecationFacet,
+]).pipe(
+  S.toTaggedUnion("kind"),
+  S.annotate(
+    $I.annote("RetrievalFacet", {
+      description: "Grounded subject facet carried by a retrieval packet.",
+    })
+  )
+);
+
+/**
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export type RetrievalFacet = typeof RetrievalFacet.Type;
+
+/**
+ * Relation family carried by relation-list retrieval payloads.
+ *
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export const RetrievalRelation = LiteralKit([
+  "exports",
+  "imports",
+  "imported-by",
+  "depends-on",
+  "depended-on-by",
+]).annotate(
+  $I.annote("RetrievalRelation", {
+    description: "Relation family carried by relation-list retrieval payloads.",
+  })
+);
+
+/**
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export type RetrievalRelation = typeof RetrievalRelation.Type;
+
+/**
+ * Count target family carried by count retrieval payloads.
+ *
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export const RetrievalCountTarget = LiteralKit(["files", "symbols"]).annotate(
+  $I.annote("RetrievalCountTarget", {
+    description: "Count target family carried by count retrieval payloads.",
+  })
+);
+
+/**
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export type RetrievalCountTarget = typeof RetrievalCountTarget.Type;
+
+/**
+ * Resolved count payload carried by a retrieval packet.
+ *
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export class RetrievalCountPayload extends S.Class<RetrievalCountPayload>($I`RetrievalCountPayload`)(
+  {
+    family: S.tag("count"),
+    target: RetrievalCountTarget,
+    count: NonNegativeInt,
+  },
+  $I.annote("RetrievalCountPayload", {
+    description: "Resolved count payload carried by a retrieval packet.",
+  })
+) {}
+
+/**
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export class RetrievalSubjectDetailPayload extends S.Class<RetrievalSubjectDetailPayload>(
+  $I`RetrievalSubjectDetailPayload`
+)(
+  {
+    family: S.tag("subject-detail"),
+    aspect: RetrievalSubjectDetailAspect,
+    subject: RetrievalSubject,
+    facets: S.Array(RetrievalFacet),
+  },
+  $I.annote("RetrievalSubjectDetailPayload", {
+    description: "Resolved subject-detail payload carried by a retrieval packet.",
+  })
+) {}
+
+/**
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export class RetrievalRelationListPayload extends S.Class<RetrievalRelationListPayload>(
+  $I`RetrievalRelationListPayload`
+)(
+  {
+    family: S.tag("relation-list"),
+    relation: RetrievalRelation,
+    subject: RetrievalSubject,
+    items: S.Array(RetrievalItem),
+  },
+  $I.annote("RetrievalRelationListPayload", {
+    description: "Resolved relation-list payload carried by a retrieval packet.",
+  })
+) {}
+
+/**
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export class RetrievalSearchResultsPayload extends S.Class<RetrievalSearchResultsPayload>(
+  $I`RetrievalSearchResultsPayload`
+)(
+  {
+    family: S.tag("search-results"),
+    query: S.String,
+    items: S.Array(RetrievalItem),
+  },
+  $I.annote("RetrievalSearchResultsPayload", {
+    description: "Resolved search-results payload carried by a retrieval packet.",
+  })
+) {}
+
+/**
+ * Resolved payload carried by a retrieval packet.
+ *
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export const RetrievalPayload = S.Union([
+  RetrievalCountPayload,
+  RetrievalSubjectDetailPayload,
+  RetrievalRelationListPayload,
+  RetrievalSearchResultsPayload,
+]).pipe(
+  S.toTaggedUnion("family"),
+  S.annotate(
+    $I.annote("RetrievalPayload", {
+      description: "Resolved payload carried by a retrieval packet.",
+    })
+  )
+);
+
+/**
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export type RetrievalPayload = typeof RetrievalPayload.Type;
+
+/**
+ * No-match issue carried by a retrieval packet when no grounded subject or item can be resolved.
+ *
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export class RetrievalNoMatchIssue extends S.Class<RetrievalNoMatchIssue>($I`RetrievalNoMatchIssue`)(
+  {
+    kind: S.tag("no-match"),
+    requested: RetrievalRequestedTarget,
+    note: S.String,
+  },
+  $I.annote("RetrievalNoMatchIssue", {
+    description: "No-match issue carried by a retrieval packet when no grounded subject or item can be resolved.",
+  })
+) {}
+
+/**
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export class RetrievalAmbiguousIssue extends S.Class<RetrievalAmbiguousIssue>($I`RetrievalAmbiguousIssue`)(
+  {
+    kind: S.tag("ambiguous"),
+    requested: RetrievalRequestedTarget,
+    candidates: S.Array(RetrievalCandidate),
+  },
+  $I.annote("RetrievalAmbiguousIssue", {
+    description:
+      "Ambiguous issue carried by a retrieval packet when retrieval finds multiple viable grounded candidates.",
+  })
+) {}
+
+/**
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export class RetrievalUnsupportedIssue extends S.Class<RetrievalUnsupportedIssue>($I`RetrievalUnsupportedIssue`)(
+  {
+    kind: S.tag("unsupported"),
+    requested: RetrievalRequestedTarget,
+    reason: S.String,
+  },
+  $I.annote("RetrievalUnsupportedIssue", {
+    description:
+      "Unsupported issue carried by a retrieval packet when the question does not match a supported deterministic query shape.",
+  })
+) {}
+
+/**
+ * Non-resolved issue carried by a retrieval packet.
+ *
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export const RetrievalIssue = S.Union([RetrievalNoMatchIssue, RetrievalAmbiguousIssue, RetrievalUnsupportedIssue]).pipe(
+  S.toTaggedUnion("kind"),
+  S.annotate(
+    $I.annote("RetrievalIssue", {
+      description: "Non-resolved issue carried by a retrieval packet.",
+    })
+  )
+);
+
+/**
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export type RetrievalIssue = typeof RetrievalIssue.Type;
+
+/**
  * Bounded evidence packet returned alongside a grounded answer.
  *
  * @since 0.0.0
@@ -470,13 +1194,19 @@ export class RetrievalPacket extends S.Class<RetrievalPacket>($I`RetrievalPacket
     repoId: RepoId,
     sourceSnapshotId: S.OptionFromOptionalKey(SourceSnapshotId),
     query: S.String,
+    normalizedQuery: S.String,
+    queryKind: RetrievalQueryKind,
     retrievedAt: S.DateTimeUtcFromMillis,
+    outcome: RetrievalOutcome,
     summary: S.String,
     citations: S.Array(Citation),
     notes: ArrayOfStrings,
+    issue: S.OptionFromOptionalKey(RetrievalIssue),
+    payload: S.OptionFromOptionalKey(RetrievalPayload),
   },
   $I.annote("RetrievalPacket", {
-    description: "Bounded answer context returned by the sidecar so grounded answers stay inspectable.",
+    description:
+      "Bounded answer context returned by the sidecar so grounded answers stay inspectable and derivable from packet state alone.",
   })
 ) {}
 

--- a/packages/repo-memory/model/src/retrieval/RetrievalPacket.ts
+++ b/packages/repo-memory/model/src/retrieval/RetrievalPacket.ts
@@ -1,9 +1,717 @@
+import { pipe } from "effect";
+import * as A from "effect/Array";
+import * as O from "effect/Option";
+import type {
+  RetrievalAmbiguousIssue,
+  RetrievalCandidate,
+  RetrievalCountPayload,
+  RetrievalDeprecationFacet,
+  RetrievalDocumentationFacet,
+  RetrievalFacet,
+  RetrievalIssue,
+  RetrievalItem,
+  RetrievalLocationFacet,
+  RetrievalNoMatchIssue,
+  RetrievalPacket,
+  RetrievalPayload,
+  RetrievalRelationListPayload,
+  RetrievalReturnsFacet,
+  RetrievalSearchResultsPayload,
+  RetrievalSubject,
+  RetrievalSubjectDetailPayload,
+  RetrievalThrowsFacet,
+  RetrievalUnsupportedIssue,
+} from "../internal/domain.js";
+
+const formatSnapshotSuffix = (packet: RetrievalPacket): string =>
+  pipe(
+    packet.sourceSnapshotId,
+    O.match({
+      onNone: () => "",
+      onSome: (sourceSnapshotId) => ` in snapshot ${sourceSnapshotId}`,
+    })
+  );
+
+const renderSubjectLabel = (subject: RetrievalSubject): string => {
+  if (subject.kind === "file") {
+    return subject.filePath;
+  }
+
+  if (subject.kind === "module") {
+    return subject.moduleSpecifier;
+  }
+
+  return subject.symbolName;
+};
+
+const renderItem = (item: RetrievalItem): string => {
+  if (item.kind === "file") {
+    return item.filePath;
+  }
+
+  if (item.kind === "module") {
+    return item.moduleSpecifier;
+  }
+
+  if (item.kind === "symbol") {
+    return `${item.symbolName} (${item.symbolKind}) in ${item.filePath}`;
+  }
+
+  const header =
+    item.kind === "parameter"
+      ? pipe(
+          item.type,
+          O.match({
+            onNone: () => item.name,
+            onSome: (type) => `${item.name}: ${type}`,
+          })
+        )
+      : pipe(
+          item.type,
+          O.getOrElse(() => "unspecified")
+        );
+
+  return pipe(
+    item.description,
+    O.match({
+      onNone: () => header,
+      onSome: (description) => `${header} - ${description}`,
+    })
+  );
+};
+
+const renderCandidates = (candidates: ReadonlyArray<RetrievalCandidate>): string =>
+  pipe(
+    candidates,
+    A.map((candidate) => renderSubjectLabel(candidate.subject)),
+    A.join(", ")
+  );
+
+const findLocationFacet = (facets: ReadonlyArray<RetrievalFacet>) =>
+  pipe(
+    facets,
+    A.findFirst((facet): facet is RetrievalLocationFacet => facet.kind === "location")
+  );
+
+const findDeclarationFacet = (facets: ReadonlyArray<RetrievalFacet>) =>
+  pipe(
+    facets,
+    A.findFirst((facet) => facet.kind === "declaration")
+  );
+
+const findDocumentationFacet = (facets: ReadonlyArray<RetrievalFacet>) =>
+  pipe(
+    facets,
+    A.findFirst((facet): facet is RetrievalDocumentationFacet => facet.kind === "documentation")
+  );
+
+const findReturnsFacet = (facets: ReadonlyArray<RetrievalFacet>) =>
+  pipe(
+    facets,
+    A.findFirst((facet): facet is RetrievalReturnsFacet => facet.kind === "returns")
+  );
+
+const findThrowsFacet = (facets: ReadonlyArray<RetrievalFacet>) =>
+  pipe(
+    facets,
+    A.findFirst((facet): facet is RetrievalThrowsFacet => facet.kind === "throws")
+  );
+
+const findDeprecationFacet = (facets: ReadonlyArray<RetrievalFacet>) =>
+  pipe(
+    facets,
+    A.findFirst((facet): facet is RetrievalDeprecationFacet => facet.kind === "deprecation")
+  );
+
+const renderCountPayload = (packet: RetrievalPacket, payload: RetrievalCountPayload): string =>
+  payload.target === "files"
+    ? `Indexed${formatSnapshotSuffix(packet)} currently contains ${payload.count} TypeScript source files.`
+    : `Indexed${formatSnapshotSuffix(packet)} currently contains ${payload.count} captured TypeScript symbols.`;
+
+const renderSubjectDetailPayload = (packet: RetrievalPacket, payload: RetrievalSubjectDetailPayload): string => {
+  if (payload.aspect === "location") {
+    return pipe(
+      findLocationFacet(payload.facets),
+      O.match({
+        onNone: () =>
+          `${renderSubjectLabel(payload.subject)} is grounded but no location facet was captured${formatSnapshotSuffix(packet)}.`,
+        onSome: (facet) =>
+          `${renderSubjectLabel(payload.subject)} is located in ${facet.filePath}:${facet.startLine}-${facet.endLine}${formatSnapshotSuffix(packet)}.`,
+      })
+    );
+  }
+
+  if (payload.aspect === "description") {
+    const declaration = findDeclarationFacet(payload.facets);
+    const documentation = findDocumentationFacet(payload.facets);
+
+    return pipe(
+      A.make(
+        `Symbol "${renderSubjectLabel(payload.subject)}"${formatSnapshotSuffix(packet)}.`,
+        pipe(
+          declaration,
+          O.match({
+            onNone: () => "",
+            onSome: (facet) => `Signature: ${facet.signature}.`,
+          })
+        ),
+        pipe(
+          documentation,
+          O.match({
+            onNone: () => "",
+            onSome: (facet) =>
+              pipe(
+                A.make(
+                  pipe(
+                    facet.summary,
+                    O.match({
+                      onNone: () => "",
+                      onSome: (summary) => `Summary: ${summary}.`,
+                    })
+                  ),
+                  pipe(
+                    facet.description,
+                    O.match({
+                      onNone: () => "",
+                      onSome: (description) => `Description: ${description}.`,
+                    })
+                  ),
+                  pipe(
+                    facet.remarks,
+                    O.match({
+                      onNone: () => "",
+                      onSome: (remarks) => `Remarks: ${remarks}.`,
+                    })
+                  )
+                ),
+                A.filter((part) => part.length > 0),
+                A.join(" ")
+              ),
+          })
+        )
+      ),
+      A.filter((part) => part.length > 0),
+      A.join(" ")
+    );
+  }
+
+  if (payload.aspect === "params") {
+    return pipe(
+      payload.facets,
+      A.findFirst((facet) => facet.kind === "parameters"),
+      O.match({
+        onNone: () =>
+          `Symbol "${renderSubjectLabel(payload.subject)}" has no documented parameters${formatSnapshotSuffix(packet)}.`,
+        onSome: (facet) =>
+          pipe(
+            facet.items,
+            A.match({
+              onEmpty: () =>
+                `Symbol "${renderSubjectLabel(payload.subject)}" has no documented parameters${formatSnapshotSuffix(packet)}.`,
+              onNonEmpty: (items) =>
+                `Documented parameters for "${renderSubjectLabel(payload.subject)}"${formatSnapshotSuffix(packet)}: ${pipe(items, A.map(renderItem), A.join("; "))}.`,
+            })
+          ),
+      })
+    );
+  }
+
+  if (payload.aspect === "returns") {
+    return pipe(
+      findReturnsFacet(payload.facets),
+      O.match({
+        onNone: () =>
+          `Symbol "${renderSubjectLabel(payload.subject)}" has no documented return contract${formatSnapshotSuffix(packet)}.`,
+        onSome: (facet) =>
+          pipe(
+            facet.item,
+            O.match({
+              onNone: () =>
+                `Symbol "${renderSubjectLabel(payload.subject)}" has no documented return contract${formatSnapshotSuffix(packet)}.`,
+              onSome: (item) =>
+                `Returns for "${renderSubjectLabel(payload.subject)}"${formatSnapshotSuffix(packet)}: ${renderItem(item)}.`,
+            })
+          ),
+      })
+    );
+  }
+
+  if (payload.aspect === "throws") {
+    return pipe(
+      findThrowsFacet(payload.facets),
+      O.match({
+        onNone: () =>
+          `Symbol "${renderSubjectLabel(payload.subject)}" has no documented throws contract${formatSnapshotSuffix(packet)}.`,
+        onSome: (facet) =>
+          pipe(
+            facet.items,
+            A.match({
+              onEmpty: () =>
+                `Symbol "${renderSubjectLabel(payload.subject)}" has no documented throws contract${formatSnapshotSuffix(packet)}.`,
+              onNonEmpty: (items) =>
+                `Throws for "${renderSubjectLabel(payload.subject)}"${formatSnapshotSuffix(packet)}: ${pipe(items, A.map(renderItem), A.join("; "))}.`,
+            })
+          ),
+      })
+    );
+  }
+
+  return pipe(
+    findDeprecationFacet(payload.facets),
+    O.match({
+      onNone: () =>
+        `No deprecation metadata was captured for "${renderSubjectLabel(payload.subject)}"${formatSnapshotSuffix(packet)}.`,
+      onSome: (facet) =>
+        facet.isDeprecated
+          ? pipe(
+              facet.note,
+              O.match({
+                onNone: () =>
+                  `Symbol "${renderSubjectLabel(payload.subject)}" is deprecated${formatSnapshotSuffix(packet)}.`,
+                onSome: (note) =>
+                  `Symbol "${renderSubjectLabel(payload.subject)}" is deprecated${formatSnapshotSuffix(packet)}. ${note}`,
+              })
+            )
+          : `Symbol "${renderSubjectLabel(payload.subject)}" is not marked deprecated${formatSnapshotSuffix(packet)}.`,
+    })
+  );
+};
+
+const renderRelationListPayload = (packet: RetrievalPacket, payload: RetrievalRelationListPayload): string => {
+  const subjectLabel = renderSubjectLabel(payload.subject);
+
+  if (payload.relation === "exports") {
+    return pipe(
+      payload.items,
+      A.match({
+        onEmpty: () => `No indexed exports were recorded for ${subjectLabel}${formatSnapshotSuffix(packet)}.`,
+        onNonEmpty: (items) =>
+          `Exports for ${subjectLabel}${formatSnapshotSuffix(packet)}: ${pipe(items, A.map(renderItem), A.join("; "))}.`,
+      })
+    );
+  }
+
+  if (payload.relation === "imports") {
+    return pipe(
+      payload.items,
+      A.match({
+        onEmpty: () => `No indexed imports were recorded for ${subjectLabel}${formatSnapshotSuffix(packet)}.`,
+        onNonEmpty: (items) =>
+          `Imports for ${subjectLabel}${formatSnapshotSuffix(packet)}: ${pipe(items, A.map(renderItem), A.join("; "))}.`,
+      })
+    );
+  }
+
+  if (payload.relation === "imported-by") {
+    if (payload.subject.kind === "symbol") {
+      const subject = payload.subject;
+
+      return pipe(
+        payload.items,
+        A.match({
+          onEmpty: () =>
+            `No indexed files import symbol "${subject.symbolName}" from ${subject.filePath}${formatSnapshotSuffix(packet)}.`,
+          onNonEmpty: (items) =>
+            `Files importing symbol "${subject.symbolName}" from ${subject.filePath}${formatSnapshotSuffix(packet)}: ${pipe(items, A.map(renderItem), A.join("; "))}.`,
+        })
+      );
+    }
+
+    return pipe(
+      payload.items,
+      A.match({
+        onEmpty: () => `No indexed files import ${subjectLabel}${formatSnapshotSuffix(packet)}.`,
+        onNonEmpty: (items) =>
+          `Files importing ${subjectLabel}${formatSnapshotSuffix(packet)}: ${pipe(items, A.map(renderItem), A.join("; "))}.`,
+      })
+    );
+  }
+
+  if (payload.relation === "depends-on") {
+    return pipe(
+      payload.items,
+      A.match({
+        onEmpty: () => `No repo-local dependencies were resolved for ${subjectLabel}${formatSnapshotSuffix(packet)}.`,
+        onNonEmpty: (items) =>
+          `Resolved repo-local dependencies for ${subjectLabel}${formatSnapshotSuffix(packet)}: ${pipe(items, A.map(renderItem), A.join("; "))}.`,
+      })
+    );
+  }
+
+  return pipe(
+    payload.items,
+    A.match({
+      onEmpty: () => `No repo-local files depend on ${subjectLabel}${formatSnapshotSuffix(packet)}.`,
+      onNonEmpty: (items) =>
+        `Files depending on ${subjectLabel}${formatSnapshotSuffix(packet)}: ${pipe(items, A.map(renderItem), A.join("; "))}.`,
+    })
+  );
+};
+
+const renderSearchResultsPayload = (packet: RetrievalPacket, payload: RetrievalSearchResultsPayload): string =>
+  pipe(
+    payload.items,
+    A.match({
+      onEmpty: () => `No indexed symbols matched keyword query "${payload.query}"${formatSnapshotSuffix(packet)}.`,
+      onNonEmpty: (items) =>
+        `Keyword search matched${formatSnapshotSuffix(packet)}: ${pipe(items, A.map(renderItem), A.join("; "))}.`,
+    })
+  );
+
+const renderNoMatchIssue = (packet: RetrievalPacket, issue: RetrievalNoMatchIssue): string => {
+  if (issue.requested.kind === "file-query") {
+    return `No indexed TypeScript file matching "${issue.requested.value}" was found${formatSnapshotSuffix(packet)}.`;
+  }
+
+  if (issue.requested.kind === "symbol-query") {
+    return `No indexed symbol named "${issue.requested.value}" was found${formatSnapshotSuffix(packet)}.`;
+  }
+
+  if (issue.requested.kind === "module-query") {
+    return `No indexed importers matched "${issue.requested.value}"${formatSnapshotSuffix(packet)}.`;
+  }
+
+  if (issue.requested.kind === "keyword-query") {
+    return `No indexed symbols matched keyword query "${issue.requested.value}"${formatSnapshotSuffix(packet)}.`;
+  }
+
+  return `No grounded result was found for "${issue.requested.value}"${formatSnapshotSuffix(packet)}.`;
+};
+
+const renderAmbiguousIssue = (packet: RetrievalPacket, issue: RetrievalAmbiguousIssue): string => {
+  if (issue.requested.kind === "file-query") {
+    return `Ambiguous file query "${issue.requested.value}"${formatSnapshotSuffix(packet)}. Matching files: ${renderCandidates(issue.candidates)}.`;
+  }
+
+  if (issue.requested.kind === "symbol-query") {
+    return `Ambiguous symbol query "${issue.requested.value}"${formatSnapshotSuffix(packet)}. Matching symbols: ${renderCandidates(issue.candidates)}.`;
+  }
+
+  return `Ambiguous query "${issue.requested.value}"${formatSnapshotSuffix(packet)}. Matching candidates: ${renderCandidates(issue.candidates)}.`;
+};
+
+const renderUnsupportedIssue = (_packet: RetrievalPacket, issue: RetrievalUnsupportedIssue): string =>
+  `Unsupported query shape. ${issue.reason}`;
+
+const renderPayload = (packet: RetrievalPacket, payload: RetrievalPayload): string => {
+  if (payload.family === "count") {
+    return renderCountPayload(packet, payload);
+  }
+
+  if (payload.family === "subject-detail") {
+    return renderSubjectDetailPayload(packet, payload);
+  }
+
+  if (payload.family === "relation-list") {
+    return renderRelationListPayload(packet, payload);
+  }
+
+  return renderSearchResultsPayload(packet, payload);
+};
+
+const renderIssue = (packet: RetrievalPacket, issue: RetrievalIssue): string => {
+  if (issue.kind === "no-match") {
+    return renderNoMatchIssue(packet, issue);
+  }
+
+  if (issue.kind === "ambiguous") {
+    return renderAmbiguousIssue(packet, issue);
+  }
+
+  return renderUnsupportedIssue(packet, issue);
+};
+
+/**
+ * Render a deterministic grounded answer from a frozen retrieval packet.
+ *
+ * @since 0.0.0
+ * @category DomainModel
+ */
+export const renderRetrievalPacketAnswer = (packet: RetrievalPacket): string => {
+  if (packet.outcome === "resolved") {
+    return pipe(
+      packet.payload,
+      O.match({
+        onNone: () => packet.summary,
+        onSome: (payload) => renderPayload(packet, payload),
+      })
+    );
+  }
+
+  return pipe(
+    packet.issue,
+    O.match({
+      onNone: () => packet.summary,
+      onSome: (issue) => renderIssue(packet, issue),
+    })
+  );
+};
+
 export {
   /**
-   * Grounded retrieval packet model.
+   * Ambiguous retrieval issue model.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalAmbiguousIssue,
+  /**
+   * Retrieval candidate model.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalCandidate,
+  /**
+   * Resolved count payload model.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalCountPayload,
+  /**
+   * Count target literal domain.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalCountTarget,
+  /**
+   * Declaration facet model.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalDeclarationFacet,
+  /**
+   * Deprecation facet model.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalDeprecationFacet,
+  /**
+   * Documentation facet model.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalDocumentationFacet,
+  /**
+   * Retrieval facet union model.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalFacet,
+  /**
+   * File requested-target model.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalFileRequestedTarget,
+  /**
+   * File subject model.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalFileSubject,
+  /**
+   * Retrieval issue union model.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalIssue,
+  /**
+   * Retrieval item union model.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalItem,
+  /**
+   * Location facet model.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalLocationFacet,
+  /**
+   * Retrieval match-kind literal domain.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalMatchKind,
+  /**
+   * Module requested-target model.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalModuleRequestedTarget,
+  /**
+   * Module subject model.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalModuleSubject,
+  /**
+   * No-match retrieval issue model.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalNoMatchIssue,
+  /**
+   * Retrieval outcome literal domain.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalOutcome,
+  /**
+   * Retrieval packet model.
    *
    * @since 0.0.0
    * @category DomainModel
    */
   RetrievalPacket,
+  /**
+   * Parameter item model.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalParameterItem,
+  /**
+   * Parameters facet model.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalParametersFacet,
+  /**
+   * Retrieval payload union model.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalPayload,
+  /**
+   * Retrieval query-kind literal domain.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalQueryKind,
+  /**
+   * Question requested-target model.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalQuestionRequestedTarget,
+  /**
+   * Retrieval relation literal domain.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalRelation,
+  /**
+   * Relation-list payload model.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalRelationListPayload,
+  /**
+   * Requested-target union model.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalRequestedTarget,
+  /**
+   * Return item model.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalReturnItem,
+  /**
+   * Returns facet model.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalReturnsFacet,
+  /**
+   * Search-results payload model.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalSearchResultsPayload,
+  /**
+   * Retrieval subject union model.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalSubject,
+  /**
+   * Subject-detail aspect literal domain.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalSubjectDetailAspect,
+  /**
+   * Subject-detail payload model.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalSubjectDetailPayload,
+  /**
+   * Symbol requested-target model.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalSymbolRequestedTarget,
+  /**
+   * Symbol subject model.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalSymbolSubject,
+  /**
+   * Throw item model.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalThrowItem,
+  /**
+   * Throws facet model.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalThrowsFacet,
+  /**
+   * Unsupported retrieval issue model.
+   *
+   * @since 0.0.0
+   * @category DomainModel
+   */
+  RetrievalUnsupportedIssue,
 } from "../internal/domain.js";

--- a/packages/repo-memory/model/test/RepoMemoryModel.test.ts
+++ b/packages/repo-memory/model/test/RepoMemoryModel.test.ts
@@ -3,11 +3,15 @@ import {
   RepoId,
   RepoRun,
   ResumeRepoRunRequest,
+  RetrievalCountPayload,
+  RetrievalPacket,
   RunCommandAck,
   RunCursor,
   RunId,
+  renderRetrievalPacketAnswer,
   StreamRunEventsRequest,
 } from "@beep/repo-memory-model";
+import { NonNegativeInt } from "@beep/schema";
 import { describe, expect, it } from "@effect/vitest";
 import { PrimaryKey } from "effect";
 import * as O from "effect/Option";
@@ -16,6 +20,8 @@ import * as S from "effect/Schema";
 const decodeRepoId = S.decodeUnknownSync(RepoId);
 const decodeRunCursor = S.decodeUnknownSync(RunCursor);
 const decodeRunId = S.decodeUnknownSync(RunId);
+const decodeRetrievalPacket = S.decodeUnknownSync(RetrievalPacket);
+const decodeNonNegativeInt = S.decodeUnknownSync(NonNegativeInt);
 
 describe("repo-memory model", () => {
   it("builds stable primary keys for replayable run-event subscriptions", () => {
@@ -78,5 +84,27 @@ describe("repo-memory model", () => {
     expect(interruptRequest.runId).toBe("run:interrupt:model");
     expect(resumeRequest.runId).toBe("run:resume:model");
     expect(ack.command).toBe("interrupt");
+  });
+
+  it("decodes structured retrieval packets and renders an answer from packet state alone", () => {
+    const packet = decodeRetrievalPacket({
+      repoId: decodeRepoId("repo:model:packet"),
+      sourceSnapshotId: "snapshot:model:packet",
+      query: "How many files?",
+      normalizedQuery: "how many files?",
+      queryKind: "countFiles",
+      retrievedAt: Date.parse("2026-03-10T10:00:00.000Z"),
+      outcome: "resolved",
+      summary: "Counted indexed TypeScript source files.",
+      citations: [],
+      notes: ["countFiles=7"],
+      payload: new RetrievalCountPayload({
+        target: "files",
+        count: decodeNonNegativeInt(7),
+      }),
+    });
+
+    expect(packet.queryKind).toBe("countFiles");
+    expect(renderRetrievalPacketAnswer(packet)).toContain("7 TypeScript source files");
   });
 });

--- a/packages/repo-memory/runtime/src/internal/RepoMemoryRuntime.ts
+++ b/packages/repo-memory/runtime/src/internal/RepoMemoryRuntime.ts
@@ -925,11 +925,18 @@ const makeRepoRunService = Effect.fn("RepoRunService.make")(function* () {
               runId,
               sequence: nextSequenceForRun(runningRun),
               emittedAt: yield* DateTime.now,
-              phase: "interpret",
+              phase: "grounding",
               message: "Normalizing the question into one supported deterministic query shape.",
               percent: O.some(decodeNonNegativeInt(25)),
             })
           )
+        );
+        const grounding = yield* profileRunPhase(
+          "query",
+          "grounding",
+          groundedRetrieval
+            .ground(payload)
+            .pipe(Effect.mapError((error) => toRunServiceError(error.message, error.status, error.cause)))
         );
 
         runningRun = yield* ensureProjectedQueryRun(
@@ -939,7 +946,7 @@ const makeRepoRunService = Effect.fn("RepoRunService.make")(function* () {
               runId,
               sequence: nextSequenceForRun(runningRun),
               emittedAt: yield* DateTime.now,
-              phase: "retrieve",
+              phase: "retrieval",
               message: "Retrieving bounded source-grounded artifacts from the latest persisted snapshot.",
               percent: O.some(decodeNonNegativeInt(60)),
             })
@@ -947,11 +954,57 @@ const makeRepoRunService = Effect.fn("RepoRunService.make")(function* () {
         );
         yield* suspendIfRunInterrupted(runId);
 
-        const groundedQuery = yield* profileRunPhase(
+        const retrievedEvidence = yield* profileRunPhase(
           "query",
-          "retrieve",
+          "retrieval",
           groundedRetrieval
-            .resolve(payload)
+            .retrieve(grounding)
+            .pipe(Effect.mapError((error) => toRunServiceError(error.message, error.status, error.cause)))
+        );
+
+        runningRun = yield* ensureProjectedQueryRun(
+          yield* appendProjectedEvent(
+            runningRun,
+            new RunProgressUpdatedEvent({
+              runId,
+              sequence: nextSequenceForRun(runningRun),
+              emittedAt: yield* DateTime.now,
+              phase: "packet",
+              message: "Freezing the bounded retrieval packet for durable inspection and replay.",
+              percent: O.some(decodeNonNegativeInt(80)),
+            })
+          )
+        );
+        yield* suspendIfRunInterrupted(runId);
+
+        const retrievalPacket = yield* profileRunPhase(
+          "query",
+          "packet",
+          groundedRetrieval
+            .materializePacket(retrievedEvidence)
+            .pipe(Effect.mapError((error) => toRunServiceError(error.message, error.status, error.cause)))
+        );
+
+        runningRun = yield* ensureProjectedQueryRun(
+          yield* appendProjectedEvent(
+            runningRun,
+            new RunProgressUpdatedEvent({
+              runId,
+              sequence: nextSequenceForRun(runningRun),
+              emittedAt: yield* DateTime.now,
+              phase: "answer",
+              message: "Rendering the final answer from the frozen retrieval packet only.",
+              percent: O.some(decodeNonNegativeInt(95)),
+            })
+          )
+        );
+        yield* suspendIfRunInterrupted(runId);
+
+        const groundedAnswer = yield* profileRunPhase(
+          "query",
+          "answer",
+          groundedRetrieval
+            .draftAnswer(retrievalPacket)
             .pipe(Effect.mapError((error) => toRunServiceError(error.message, error.status, error.cause)))
         );
 
@@ -962,7 +1015,7 @@ const makeRepoRunService = Effect.fn("RepoRunService.make")(function* () {
               runId,
               sequence: nextSequenceForRun(runningRun),
               emittedAt: yield* DateTime.now,
-              packet: groundedQuery.packet,
+              packet: retrievalPacket,
             })
           )
         );
@@ -974,15 +1027,15 @@ const makeRepoRunService = Effect.fn("RepoRunService.make")(function* () {
               runId,
               sequence: nextSequenceForRun(runningRun),
               emittedAt: yield* DateTime.now,
-              answer: groundedQuery.answer,
-              citations: groundedQuery.citations,
+              answer: groundedAnswer,
+              citations: retrievalPacket.citations,
             })
           )
         );
 
         const completedAt = yield* DateTime.now;
         const completedRun = yield* mapStateMachineError(
-          completeQueryRun(runningRun, completedAt, groundedQuery.answer, groundedQuery.citations, groundedQuery.packet)
+          completeQueryRun(runningRun, completedAt, groundedAnswer, retrievalPacket.citations, retrievalPacket)
         );
 
         yield* appendRunEvent(

--- a/packages/repo-memory/runtime/src/retrieval/GroundedRetrieval.ts
+++ b/packages/repo-memory/runtime/src/retrieval/GroundedRetrieval.ts
@@ -12,7 +12,37 @@ import {
   type RepoSourceFile,
   type RepoSymbolDocumentation,
   type RepoSymbolRecord,
+  RetrievalAmbiguousIssue,
+  RetrievalCandidate,
+  RetrievalCountPayload,
+  RetrievalDeclarationFacet,
+  RetrievalDeprecationFacet,
+  RetrievalDocumentationFacet,
+  RetrievalFileRequestedTarget,
+  RetrievalFileSubject,
+  type RetrievalIssue,
+  RetrievalLocationFacet,
+  RetrievalModuleSubject,
+  RetrievalNoMatchIssue,
+  type RetrievalOutcome,
   RetrievalPacket,
+  RetrievalParameterItem,
+  RetrievalParametersFacet,
+  type RetrievalPayload,
+  type RetrievalQueryKind,
+  RetrievalQuestionRequestedTarget,
+  RetrievalRelationListPayload,
+  RetrievalReturnItem,
+  RetrievalReturnsFacet,
+  RetrievalSearchResultsPayload,
+  type RetrievalSubjectDetailAspect,
+  RetrievalSubjectDetailPayload,
+  RetrievalSymbolRequestedTarget,
+  RetrievalSymbolSubject,
+  RetrievalThrowItem,
+  RetrievalThrowsFacet,
+  RetrievalUnsupportedIssue,
+  renderRetrievalPacketAnswer,
   type SourceSnapshotId,
 } from "@beep/repo-memory-model";
 import {
@@ -24,20 +54,23 @@ import {
   RepoSymbolStore,
   type RepoSymbolStoreShape,
 } from "@beep/repo-memory-store";
-import { makeStatusCauseError, PosInt, StatusCauseFields, TaggedErrorClass } from "@beep/schema";
-import { thunkEmptyStr } from "@beep/utils";
+import {
+  type FilePath,
+  makeStatusCauseError,
+  NonNegativeInt,
+  PosInt,
+  StatusCauseFields,
+  TaggedErrorClass,
+} from "@beep/schema";
 import * as Str from "@beep/utils/Str";
 import { DateTime, Effect, HashSet, Layer, Order, pipe, ServiceMap } from "effect";
 import * as A from "effect/Array";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
-import {
-  type QueryKindMetric,
-  recordQueryInterpretation,
-  recordQueryResult,
-} from "../telemetry/RepoMemoryTelemetry.js";
+import { recordQueryInterpretation, recordQueryResult } from "../telemetry/RepoMemoryTelemetry.js";
 
 const $I = $RepoMemoryRuntimeId.create("retrieval/GroundedRetrieval");
+const decodeNonNegativeInt = S.decodeUnknownSync(NonNegativeInt);
 const decodePosInt = S.decodeUnknownSync(PosInt);
 const citationOrder = Order.mapInput(
   Order.String,
@@ -265,6 +298,29 @@ export class GroundedQueryResult extends S.Class<GroundedQueryResult>($I`Grounde
   })
 ) {}
 
+type GroundingArtifact = {
+  readonly repoId: RepoId;
+  readonly question: string;
+  readonly normalizedQuery: string;
+  readonly interpretation: QueryInterpretation;
+  readonly queryKind: RetrievalQueryKind;
+  readonly questionNotes: ReadonlyArray<string>;
+};
+
+type RetrievedEvidence = {
+  readonly repoId: RepoId;
+  readonly sourceSnapshotId: SourceSnapshotId;
+  readonly query: string;
+  readonly normalizedQuery: string;
+  readonly queryKind: RetrievalQueryKind;
+  readonly outcome: RetrievalOutcome;
+  readonly summary: string;
+  readonly citations: ReadonlyArray<Citation>;
+  readonly notes: ReadonlyArray<string>;
+  readonly payload: O.Option<RetrievalPayload>;
+  readonly issue: O.Option<RetrievalIssue>;
+};
+
 /**
  * Typed retrieval failure raised while resolving deterministic grounded queries.
  *
@@ -286,7 +342,11 @@ export class GroundedRetrievalError extends TaggedErrorClass<GroundedRetrievalEr
  * @category PortContract
  */
 export interface GroundedRetrievalServiceShape {
+  readonly draftAnswer: (packet: RetrievalPacket) => Effect.Effect<string, GroundedRetrievalError>;
+  readonly ground: (payload: QueryRepoRunInput) => Effect.Effect<GroundingArtifact, GroundedRetrievalError>;
+  readonly materializePacket: (evidence: RetrievedEvidence) => Effect.Effect<RetrievalPacket, GroundedRetrievalError>;
   readonly resolve: (payload: QueryRepoRunInput) => Effect.Effect<GroundedQueryResult, GroundedRetrievalError>;
+  readonly retrieve: (grounding: GroundingArtifact) => Effect.Effect<RetrievedEvidence, GroundedRetrievalError>;
 }
 
 /**
@@ -724,103 +784,239 @@ const normalizeCitations = (citations: ReadonlyArray<Citation>): ReadonlyArray<C
     A.dedupeWith((left, right) => left.id === right.id)
   );
 
-const prefixedText = (label: string, value: O.Option<string>): O.Option<string> =>
+const citationIds = (citations: ReadonlyArray<Citation>): ReadonlyArray<string> =>
   pipe(
-    value,
-    O.map((text) => `${label}: ${text}.`)
+    citations,
+    A.map((citation) => citation.id)
   );
 
-const formatDocumentedParameter = (parameter: RepoDocumentedParameter): string => {
-  const header = pipe(
-    parameter.type,
-    O.match({
-      onNone: () => parameter.name,
-      onSome: (type) => `${parameter.name}: ${type}`,
-    })
-  );
+const issueMatchKind = (nlpNotes: ReadonlyArray<string>): "exact" | "normalized" | "fuzzy" =>
+  A.isReadonlyArrayNonEmpty(nlpNotes) ? "normalized" : "exact";
 
-  return pipe(
-    parameter.description,
-    O.match({
-      onNone: () => header,
-      onSome: (description) => `${header} — ${description}`,
-    })
-  );
+const fileRequestedTarget = (value: string) => new RetrievalFileRequestedTarget({ value });
+const symbolRequestedTarget = (value: string) => new RetrievalSymbolRequestedTarget({ value });
+const questionRequestedTarget = (value: string) => new RetrievalQuestionRequestedTarget({ value });
+
+const fileSubject = (filePath: FilePath, ids: ReadonlyArray<string> = A.empty()) =>
+  new RetrievalFileSubject({
+    label: filePath,
+    filePath,
+    citationIds: ids,
+  });
+
+const fileSubjectFromRecord = (file: Pick<RepoSourceFile, "filePath">, ids: ReadonlyArray<string> = A.empty()) =>
+  fileSubject(file.filePath, ids);
+
+const moduleSubject = (moduleSpecifier: string, ids: ReadonlyArray<string> = A.empty()) =>
+  new RetrievalModuleSubject({
+    label: moduleSpecifier,
+    moduleSpecifier,
+    citationIds: ids,
+  });
+
+const symbolSubject = (
+  symbol: Pick<RepoSymbolRecord, "symbolId" | "symbolName" | "qualifiedName" | "symbolKind" | "filePath">,
+  ids: ReadonlyArray<string> = A.empty()
+) =>
+  new RetrievalSymbolSubject({
+    label: symbol.symbolName,
+    symbolId: symbol.symbolId,
+    symbolName: symbol.symbolName,
+    qualifiedName: symbol.qualifiedName,
+    symbolKind: symbol.symbolKind,
+    filePath: symbol.filePath,
+    citationIds: ids,
+  });
+
+const parameterItem = (parameter: RepoDocumentedParameter, ids: ReadonlyArray<string>) =>
+  new RetrievalParameterItem({
+    name: parameter.name,
+    type: parameter.type,
+    description: parameter.description,
+    citationIds: ids,
+  });
+
+const returnItem = (documentation: RepoDocumentedReturn, ids: ReadonlyArray<string>) =>
+  new RetrievalReturnItem({
+    type: documentation.type,
+    description: documentation.description,
+    citationIds: ids,
+  });
+
+const throwItem = (documentation: RepoDocumentedThrow, ids: ReadonlyArray<string>) =>
+  new RetrievalThrowItem({
+    type: documentation.type,
+    description: documentation.description,
+    citationIds: ids,
+  });
+
+const locationFacet = (
+  symbol: Pick<RepoSymbolRecord, "filePath" | "startLine" | "endLine">,
+  ids: ReadonlyArray<string>
+) =>
+  new RetrievalLocationFacet({
+    filePath: symbol.filePath,
+    startLine: decodePosInt(symbol.startLine),
+    endLine: decodePosInt(symbol.endLine),
+    citationIds: ids,
+  });
+
+const documentationFacet = (documentation: RepoSymbolDocumentation, ids: ReadonlyArray<string>) =>
+  new RetrievalDocumentationFacet({
+    summary: documentation.summary,
+    description: documentation.description,
+    remarks: documentation.remarks,
+    citationIds: ids,
+  });
+
+const deprecationFacet = (documentation: RepoSymbolDocumentation, ids: ReadonlyArray<string>) =>
+  new RetrievalDeprecationFacet({
+    isDeprecated: documentation.isDeprecated,
+    note: documentation.deprecationNote,
+    citationIds: ids,
+  });
+
+const returnsFacet = (documentation: RepoSymbolDocumentation, ids: ReadonlyArray<string>) =>
+  new RetrievalReturnsFacet({
+    item: pipe(
+      documentation.returns,
+      O.map((value) => returnItem(value, ids))
+    ),
+  });
+
+const throwsFacet = (documentation: RepoSymbolDocumentation, ids: ReadonlyArray<string>) =>
+  new RetrievalThrowsFacet({
+    items: pipe(
+      documentation.throws,
+      A.map((value) => throwItem(value, ids))
+    ),
+  });
+
+const symbolDetailPayload = (
+  symbol: RepoSymbolRecord,
+  aspect: RetrievalSubjectDetailAspect
+): RetrievalSubjectDetailPayload => {
+  const declarationCitation = symbolCitation(symbol);
+  const docCitations = documentationCitations(symbol);
+  const declarationIds = A.make(declarationCitation.id);
+  const documentationIds = citationIds(docCitations);
+  const subject = symbolSubject(symbol, declarationIds);
+  const facets =
+    aspect === "location"
+      ? A.make(locationFacet(symbol, declarationIds))
+      : aspect === "description"
+        ? pipe(
+            symbol.documentation,
+            O.match({
+              onNone: () =>
+                A.make(
+                  locationFacet(symbol, declarationIds),
+                  new RetrievalDeclarationFacet({
+                    signature: symbol.signature,
+                    exported: O.some(symbol.exported),
+                    citationIds: declarationIds,
+                  })
+                ),
+              onSome: (documentation) =>
+                A.make(
+                  locationFacet(symbol, declarationIds),
+                  new RetrievalDeclarationFacet({
+                    signature: symbol.signature,
+                    exported: O.some(symbol.exported),
+                    citationIds: declarationIds,
+                  }),
+                  documentationFacet(documentation, documentationIds)
+                ),
+            })
+          )
+        : aspect === "params"
+          ? pipe(
+              symbol.documentation,
+              O.match({
+                onNone: A.empty,
+                onSome: (documentation) =>
+                  A.make(
+                    new RetrievalParametersFacet({
+                      items: pipe(
+                        documentation.params,
+                        A.map((parameter) => parameterItem(parameter, documentationIds))
+                      ),
+                    })
+                  ),
+              })
+            )
+          : aspect === "returns"
+            ? pipe(
+                symbol.documentation,
+                O.match({
+                  onNone: A.empty,
+                  onSome: (documentation) => A.make(returnsFacet(documentation, documentationIds)),
+                })
+              )
+            : aspect === "throws"
+              ? pipe(
+                  symbol.documentation,
+                  O.match({
+                    onNone: A.empty,
+                    onSome: (documentation) => A.make(throwsFacet(documentation, documentationIds)),
+                  })
+                )
+              : pipe(
+                  symbol.documentation,
+                  O.match({
+                    onNone: A.empty,
+                    onSome: (documentation) => A.make(deprecationFacet(documentation, documentationIds)),
+                  })
+                );
+
+  return new RetrievalSubjectDetailPayload({
+    aspect,
+    subject,
+    facets,
+  });
 };
 
-const formatDocumentedReturn = (documentation: RepoDocumentedReturn): string =>
-  pipe(
-    A.make(
-      pipe(documentation.type, O.getOrElse(thunkEmptyStr)),
-      pipe(documentation.description, O.getOrElse(thunkEmptyStr))
-    ),
-    A.filter(Str.isNonEmpty),
-    A.join(" — ")
-  );
+const retrievalIssue = (issue: RetrievalIssue): O.Option<RetrievalIssue> => O.some(issue);
+const retrievalPayload = (payload: RetrievalPayload): O.Option<RetrievalPayload> => O.some(payload);
 
-const formatDocumentedThrow = (documentation: RepoDocumentedThrow): string =>
-  pipe(
-    A.make(
-      pipe(documentation.type, O.getOrElse(thunkEmptyStr)),
-      pipe(documentation.description, O.getOrElse(thunkEmptyStr))
-    ),
-    A.filter(Str.isNonEmpty),
-    A.join(" — ")
-  );
-
-const describeDocumentation = (documentation: RepoSymbolDocumentation): string =>
-  pipe(
-    A.make(
-      pipe(prefixedText("Summary", documentation.summary), O.getOrElse(thunkEmptyStr)),
-      pipe(prefixedText("Description", documentation.description), O.getOrElse(thunkEmptyStr)),
-      pipe(prefixedText("Remarks", documentation.remarks), O.getOrElse(thunkEmptyStr)),
-      documentation.isDeprecated
-        ? pipe(
-            prefixedText("Deprecated", documentation.deprecationNote),
-            O.getOrElse(() => "Deprecated.")
-          )
-        : "",
-      pipe(
-        documentation.params,
-        A.match({
-          onEmpty: thunkEmptyStr,
-          onNonEmpty: (params) =>
-            `Documented parameters: ${pipe(params, A.map(formatDocumentedParameter), A.join("; "))}.`,
-        })
-      ),
-      pipe(
-        documentation.returns,
-        O.match({
-          onNone: thunkEmptyStr,
-          onSome: (result) => `Returns: ${formatDocumentedReturn(result)}.`,
-        })
-      ),
-      pipe(
-        documentation.throws,
-        A.match({
-          onEmpty: thunkEmptyStr,
-          onNonEmpty: (errors) => `Throws: ${pipe(errors, A.map(formatDocumentedThrow), A.join("; "))}.`,
-        })
-      ),
-      pipe(
-        documentation.see,
-        A.match({
-          onEmpty: thunkEmptyStr,
-          onNonEmpty: (references) => `See also: ${A.join(references, ", ")}.`,
-        })
-      )
-    ),
-    A.filter(Str.isNonEmpty),
-    A.join(" ")
-  );
+const packetEvidence = (options: {
+  readonly repoId: RepoId;
+  readonly sourceSnapshotId: SourceSnapshotId;
+  readonly query: string;
+  readonly normalizedQuery: string;
+  readonly queryKind: RetrievalQueryKind;
+  readonly outcome: RetrievalOutcome;
+  readonly summary: string;
+  readonly citations: ReadonlyArray<Citation>;
+  readonly notes: ReadonlyArray<string>;
+  readonly payload: O.Option<RetrievalPayload>;
+  readonly issue: O.Option<RetrievalIssue>;
+}): RetrievedEvidence => ({
+  repoId: options.repoId,
+  sourceSnapshotId: options.sourceSnapshotId,
+  query: options.query,
+  normalizedQuery: options.normalizedQuery,
+  queryKind: options.queryKind,
+  outcome: options.outcome,
+  summary: options.summary,
+  citations: options.citations,
+  notes: options.notes,
+  payload: options.payload,
+  issue: options.issue,
+});
 
 const makePacket = (options: {
   readonly repoId: RepoId;
   readonly sourceSnapshotId: SourceSnapshotId;
   readonly query: string;
+  readonly normalizedQuery: string;
+  readonly queryKind: RetrievalQueryKind;
+  readonly outcome: RetrievalOutcome;
   readonly summary: string;
   readonly citations: ReadonlyArray<Citation>;
   readonly notes: ReadonlyArray<string>;
+  readonly payload: O.Option<RetrievalPayload>;
+  readonly issue: O.Option<RetrievalIssue>;
 }): Effect.Effect<RetrievalPacket> =>
   Effect.map(
     DateTime.now,
@@ -829,12 +1025,68 @@ const makePacket = (options: {
         repoId: options.repoId,
         sourceSnapshotId: O.some(options.sourceSnapshotId),
         query: options.query,
+        normalizedQuery: options.normalizedQuery,
+        queryKind: options.queryKind,
         retrievedAt,
+        outcome: options.outcome,
         summary: options.summary,
         citations: options.citations,
         notes: VariantText.orderedDedupe(A.append(options.notes, `sourceSnapshotId=${options.sourceSnapshotId}`)),
+        payload: options.payload,
+        issue: options.issue,
       })
   );
+
+const resolvedEvidence = (options: {
+  readonly repoId: RepoId;
+  readonly sourceSnapshotId: SourceSnapshotId;
+  readonly query: string;
+  readonly normalizedQuery: string;
+  readonly queryKind: RetrievalQueryKind;
+  readonly summary: string;
+  readonly citations: ReadonlyArray<Citation>;
+  readonly notes: ReadonlyArray<string>;
+  readonly payload: RetrievalPayload;
+}): RetrievedEvidence =>
+  packetEvidence({
+    repoId: options.repoId,
+    sourceSnapshotId: options.sourceSnapshotId,
+    query: options.query,
+    normalizedQuery: options.normalizedQuery,
+    queryKind: options.queryKind,
+    outcome: "resolved",
+    summary: options.summary,
+    citations: options.citations,
+    notes: options.notes,
+    payload: retrievalPayload(options.payload),
+    issue: O.none(),
+  });
+
+const unresolvedEvidence = (options: {
+  readonly repoId: RepoId;
+  readonly sourceSnapshotId: SourceSnapshotId;
+  readonly query: string;
+  readonly normalizedQuery: string;
+  readonly queryKind: RetrievalQueryKind;
+  readonly outcome: "none" | "ambiguous" | "unsupported";
+  readonly summary: string;
+  readonly citations: ReadonlyArray<Citation>;
+  readonly notes: ReadonlyArray<string>;
+  readonly issue: RetrievalIssue;
+}): RetrievedEvidence =>
+  packetEvidence({
+    repoId: options.repoId,
+    sourceSnapshotId: options.sourceSnapshotId,
+    query: options.query,
+    normalizedQuery: options.normalizedQuery,
+    queryKind: options.queryKind,
+    outcome: options.outcome,
+    summary: options.summary,
+    citations: options.citations,
+    notes: options.notes,
+    payload: O.none(),
+    issue: retrievalIssue(options.issue),
+  });
 
 type MatchSelection<A> = {
   readonly matches: ReadonlyArray<A>;
@@ -969,20 +1221,6 @@ const selectSingleMatch = <A>(selection: MatchSelection<A>): SingleMatchSelectio
     nlpNotes: selection.nlpNotes,
   };
 };
-
-const formatFileCandidates = (files: ReadonlyArray<RepoSourceFile>): string =>
-  pipe(
-    files,
-    A.map((file) => file.filePath),
-    A.join(", ")
-  );
-
-const formatSymbolCandidates = (symbols: ReadonlyArray<RepoSymbolRecord>): string =>
-  pipe(
-    symbols,
-    A.map((symbol) => `${symbol.symbolName} in ${symbol.filePath}:${symbol.startLine}`),
-    A.join(", ")
-  );
 
 const rankFileMatch = (
   filePath: string,
@@ -1305,17 +1543,8 @@ const searchKeywordMatches = (store: GroundedRetrievalStoreShape, repoId: RepoId
     };
   });
 
-const toQueryKindMetric = (interpretation: QueryInterpretation): QueryKindMetric => interpretation.kind;
-
-const queryResultOutcome = (
-  interpretation: QueryInterpretation,
-  result: GroundedQueryResult
-): "cited" | "notCited" | "unsupported" =>
-  interpretation.kind === "unsupported"
-    ? "unsupported"
-    : A.isReadonlyArrayNonEmpty(result.citations)
-      ? "cited"
-      : "notCited";
+const queryResultOutcome = (packet: RetrievalPacket): "cited" | "notCited" | "unsupported" =>
+  packet.outcome === "unsupported" ? "unsupported" : A.isReadonlyArrayNonEmpty(packet.citations) ? "cited" : "notCited";
 
 const loadSemanticArtifacts = (store: GroundedRetrievalStoreShape) =>
   Effect.fn("GroundedRetrieval.loadSemanticArtifacts")(function* (
@@ -1359,29 +1588,24 @@ const matchedSemanticAnchorCount = (
 };
 
 const withSemanticOverlay = (
-  result: GroundedQueryResult,
+  packet: RetrievalPacket,
   semanticArtifacts: O.Option<RepoSemanticArtifacts>
-): GroundedQueryResult => {
+): RetrievalPacket => {
   if (O.isNone(semanticArtifacts)) {
-    return result;
+    return packet;
   }
 
-  const matchedAnchorCount = matchedSemanticAnchorCount(result.citations, semanticArtifacts);
+  const matchedAnchorCount = matchedSemanticAnchorCount(packet.citations, semanticArtifacts);
 
-  return new GroundedQueryResult({
-    answer: result.answer,
-    citations: result.citations,
-    packet: new RetrievalPacket({
-      ...result.packet,
-      summary: `${result.packet.summary} Semantic overlay available for dependency, provenance, and evidence context.`,
-      notes: pipe(
-        result.packet.notes,
-        A.append(`semanticDatasetQuads=${semanticArtifacts.value.dataset.quads.length}`),
-        A.append(`semanticProvenanceRecords=${semanticArtifacts.value.provenance.records.length}`),
-        A.append(`semanticEvidenceAnchors=${semanticArtifacts.value.evidenceAnchors.length}`),
-        A.append(`semanticCitationAnchors=${matchedAnchorCount}/${A.length(result.packet.citations)}`)
-      ),
-    }),
+  return new RetrievalPacket({
+    ...packet,
+    notes: pipe(
+      packet.notes,
+      A.append(`semanticDatasetQuads=${semanticArtifacts.value.dataset.quads.length}`),
+      A.append(`semanticProvenanceRecords=${semanticArtifacts.value.provenance.records.length}`),
+      A.append(`semanticEvidenceAnchors=${semanticArtifacts.value.evidenceAnchors.length}`),
+      A.append(`semanticCitationAnchors=${matchedAnchorCount}/${A.length(packet.citations)}`)
+    ),
   });
 };
 
@@ -1393,739 +1617,1028 @@ const makeGroundedRetrievalService = Effect.fn("GroundedRetrieval.make")(functio
   const latestSnapshot = latestSnapshotForRepo(store);
   const latestSemanticArtifacts = loadSemanticArtifacts(store);
 
-  const resolve: GroundedRetrievalServiceShape["resolve"] = Effect.fn("GroundedRetrieval.resolve")(function* (payload) {
-    const sourceSnapshotId = yield* latestSnapshot(payload.repoId);
-    const semanticArtifacts = yield* latestSemanticArtifacts(payload.repoId, sourceSnapshotId);
+  const ground: GroundedRetrievalServiceShape["ground"] = Effect.fn("GroundedRetrieval.ground")(function* (payload) {
+    const normalizedQuery = normalizeQuestion(payload.question);
     const interpretation = interpretQuery(payload.question);
-    const queryKind = toQueryKindMetric(interpretation);
-    const questionNotes = nlpQuestionNotes(payload.question);
-    const findMatches = findSymbolMatches(store, payload.repoId, sourceSnapshotId);
-    const findFiles = resolveFileCandidates(store);
-    const findKeywordMatches = searchKeywordMatches(store, payload.repoId, sourceSnapshotId);
-
-    const makeQueryPacket = (options: {
-      readonly summary: string;
-      readonly citations: ReadonlyArray<Citation>;
-      readonly notes: ReadonlyArray<string>;
-    }) =>
-      makePacket({
-        repoId: payload.repoId,
-        sourceSnapshotId,
-        query: payload.question,
-        summary: options.summary,
-        citations: options.citations,
-        notes: VariantText.orderedDedupe(A.appendAll(questionNotes, options.notes)),
-      });
-
-    const noSymbolMatchResult = Effect.fn("GroundedRetrieval.noSymbolMatchResult")(function* (
-      symbolName: string,
-      note: string,
-      nlpNotes: ReadonlyArray<string>
-    ) {
-      const packet = yield* makeQueryPacket({
-        summary: `No indexed symbol matched "${symbolName}" in snapshot ${sourceSnapshotId}.`,
-        citations: A.empty(),
-        notes: A.appendAll(A.make(note), nlpNotes),
-      });
-
-      return new GroundedQueryResult({
-        answer: `No indexed symbol named "${symbolName}" was found in snapshot ${sourceSnapshotId}.`,
-        citations: A.empty(),
-        packet,
-      });
-    });
-
-    const ambiguousSymbolMatchResult = Effect.fn("GroundedRetrieval.ambiguousSymbolMatchResult")(function* (
-      symbolName: string,
-      matches: ReadonlyArray<RepoSymbolRecord>,
-      nlpNotes: ReadonlyArray<string>
-    ) {
-      const citations = normalizeCitations(pipe(matches, A.take(10), A.map(symbolCitation)));
-      const packet = yield* makeQueryPacket({
-        summary: `Symbol query "${symbolName}" matched multiple indexed symbols.`,
-        citations,
-        notes: A.appendAll(A.make(`candidateCount=${A.length(matches)}`), nlpNotes),
-      });
-
-      return new GroundedQueryResult({
-        answer: `Ambiguous symbol query "${symbolName}". Matching symbols: ${formatSymbolCandidates(matches)}.`,
-        citations,
-        packet,
-      });
-    });
-
-    const noFileMatchResult = Effect.fn("GroundedRetrieval.noFileMatchResult")(function* (
-      fileQuery: string,
-      note: string,
-      nlpNotes: ReadonlyArray<string>
-    ) {
-      const packet = yield* makeQueryPacket({
-        summary: `No indexed file matched "${fileQuery}" in snapshot ${sourceSnapshotId}.`,
-        citations: A.empty(),
-        notes: A.appendAll(A.make(note), nlpNotes),
-      });
-
-      return new GroundedQueryResult({
-        answer: `No indexed TypeScript file matching "${fileQuery}" was found in snapshot ${sourceSnapshotId}.`,
-        citations: A.empty(),
-        packet,
-      });
-    });
-
-    const ambiguousFileMatchResult = Effect.fn("GroundedRetrieval.ambiguousFileMatchResult")(function* (
-      fileQuery: string,
-      matches: ReadonlyArray<RepoSourceFile>,
-      nlpNotes: ReadonlyArray<string>
-    ) {
-      const citations = normalizeCitations(pipe(matches, A.take(10), A.map(fileCitation)));
-      const packet = yield* makeQueryPacket({
-        summary: `File query "${fileQuery}" matched multiple indexed files.`,
-        citations,
-        notes: A.appendAll(A.make(`candidateCount=${A.length(matches)}`), nlpNotes),
-      });
-
-      return new GroundedQueryResult({
-        answer: `Ambiguous file query "${fileQuery}". Matching files: ${formatFileCandidates(matches)}.`,
-        citations,
-        packet,
-      });
-    });
-
+    const queryKind = interpretation.kind;
     yield* Effect.annotateCurrentSpan({
       repo_id: payload.repoId,
-      source_snapshot_id: sourceSnapshotId,
       query_kind: queryKind,
     });
     yield* recordQueryInterpretation(queryKind);
 
-    const result = yield* QueryInterpretation.match(interpretation, {
-      countFiles: () =>
-        Effect.gen(function* () {
-          const fileCount = yield* mapStoreError(store.countSourceFiles(payload.repoId, sourceSnapshotId));
-          const packet = yield* makeQueryPacket({
-            summary: `Counted indexed TypeScript source files for snapshot ${sourceSnapshotId}.`,
-            citations: A.empty(),
-            notes: A.make(`countFiles=${fileCount}`),
-          });
-
-          return new GroundedQueryResult({
-            answer: `Indexed snapshot ${sourceSnapshotId} currently contains ${fileCount} TypeScript source files.`,
-            citations: A.empty(),
-            packet,
-          });
-        }),
-      countSymbols: () =>
-        Effect.gen(function* () {
-          const symbolCount = yield* mapStoreError(store.listSymbolRecords(payload.repoId, sourceSnapshotId)).pipe(
-            Effect.map(A.length)
-          );
-          const packet = yield* makeQueryPacket({
-            summary: `Counted indexed TypeScript symbols for snapshot ${sourceSnapshotId}.`,
-            citations: A.empty(),
-            notes: A.make(`countSymbols=${symbolCount}`),
-          });
-
-          return new GroundedQueryResult({
-            answer: `Indexed snapshot ${sourceSnapshotId} currently contains ${symbolCount} captured TypeScript symbols.`,
-            citations: A.empty(),
-            packet,
-          });
-        }),
-      locateSymbol: (value) =>
-        Effect.gen(function* () {
-          const selection = selectSingleMatch(yield* findMatches(value.symbolName));
-
-          if (selection.kind === "none") {
-            return yield* noSymbolMatchResult(value.symbolName, "locateSymbol=no-match", selection.nlpNotes);
-          }
-
-          if (selection.kind === "ambiguous") {
-            return yield* ambiguousSymbolMatchResult(value.symbolName, selection.matches, selection.nlpNotes);
-          }
-
-          const symbol = selection.match;
-
-          const citations = normalizeCitations(A.make(symbolCitation(symbol)));
-          const packet = yield* makeQueryPacket({
-            summary: `Located symbol "${symbol.symbolName}" from indexed symbol records.`,
-            citations,
-            notes: A.appendAll(A.make(`symbolId=${symbol.symbolId}`), selection.nlpNotes),
-          });
-
-          return new GroundedQueryResult({
-            answer: `Symbol "${symbol.symbolName}" is declared in ${symbol.filePath} on lines ${symbol.startLine}-${symbol.endLine}.`,
-            citations,
-            packet,
-          });
-        }),
-      describeSymbol: (value) =>
-        Effect.gen(function* () {
-          const selection = selectSingleMatch(yield* findMatches(value.symbolName));
-
-          if (selection.kind === "none") {
-            return yield* noSymbolMatchResult(value.symbolName, "describeSymbol=no-match", selection.nlpNotes);
-          }
-
-          if (selection.kind === "ambiguous") {
-            return yield* ambiguousSymbolMatchResult(value.symbolName, selection.matches, selection.nlpNotes);
-          }
-
-          const symbol = selection.match;
-
-          const documentationText = pipe(
-            symbol.documentation,
-            O.map(describeDocumentation),
-            O.filter(Str.isNonEmpty),
-            O.getOrElse(() =>
-              pipe(
-                symbol.documentation,
-                O.match({
-                  onNone: () => "No indexed JSDoc-backed documentation was found.",
-                  onSome: () => "Indexed JSDoc is present but none of the core semantic fields were captured.",
-                })
-              )
-            )
-          );
-          const citations = O.isSome(symbol.documentation)
-            ? documentationCitations(symbol, { includeDeclaration: true })
-            : normalizeCitations(A.make(symbolCitation(symbol)));
-          const packet = yield* makeQueryPacket({
-            summary: O.isSome(symbol.documentation)
-              ? `Described symbol "${symbol.symbolName}" from its indexed declaration and JSDoc semantics.`
-              : `Described symbol "${symbol.symbolName}" from its indexed declaration because no JSDoc semantics were captured.`,
-            citations,
-            notes: A.appendAll(
-              A.make(`signature=${symbol.signature}`, `documentation=${O.isSome(symbol.documentation)}`),
-              selection.nlpNotes
-            ),
-          });
-
-          return new GroundedQueryResult({
-            answer: `Symbol "${symbol.symbolName}" is a ${symbol.symbolKind}. Signature: ${symbol.signature}. ${documentationText}`,
-            citations,
-            packet,
-          });
-        }),
-      symbolParams: (value) =>
-        Effect.gen(function* () {
-          const selection = selectSingleMatch(yield* findMatches(value.symbolName));
-
-          if (selection.kind === "none") {
-            return yield* noSymbolMatchResult(value.symbolName, "symbolParams=no-match", selection.nlpNotes);
-          }
-
-          if (selection.kind === "ambiguous") {
-            return yield* ambiguousSymbolMatchResult(value.symbolName, selection.matches, selection.nlpNotes);
-          }
-
-          const symbol = selection.match;
-
-          if (O.isNone(symbol.documentation)) {
-            const packet = yield* makeQueryPacket({
-              summary: `No JSDoc-backed documentation was indexed for symbol "${symbol.symbolName}".`,
-              citations: A.empty(),
-              notes: A.appendAll(A.make("symbolParams=no-documentation"), selection.nlpNotes),
-            });
-
-            return new GroundedQueryResult({
-              answer: `No indexed JSDoc-backed documentation was found for "${symbol.symbolName}".`,
-              citations: A.empty(),
-              packet,
-            });
-          }
-
-          const documentation = symbol.documentation.value;
-          const citations = documentationCitations(symbol);
-          const packet = yield* makeQueryPacket({
-            summary: `Returned documented parameters for symbol "${symbol.symbolName}".`,
-            citations,
-            notes: A.appendAll(A.make(`paramCount=${A.length(documentation.params)}`), selection.nlpNotes),
-          });
-
-          return new GroundedQueryResult({
-            answer: pipe(
-              documentation.params,
-              A.match({
-                onEmpty: () =>
-                  `Symbol "${symbol.symbolName}" has indexed JSDoc, but no documented parameters were captured.`,
-                onNonEmpty: (params) =>
-                  `Documented parameters for "${symbol.symbolName}": ${pipe(params, A.map(formatDocumentedParameter), A.join("; "))}.`,
-              })
-            ),
-            citations,
-            packet,
-          });
-        }),
-      symbolReturns: (value) =>
-        Effect.gen(function* () {
-          const selection = selectSingleMatch(yield* findMatches(value.symbolName));
-
-          if (selection.kind === "none") {
-            return yield* noSymbolMatchResult(value.symbolName, "symbolReturns=no-match", selection.nlpNotes);
-          }
-
-          if (selection.kind === "ambiguous") {
-            return yield* ambiguousSymbolMatchResult(value.symbolName, selection.matches, selection.nlpNotes);
-          }
-
-          const symbol = selection.match;
-
-          if (O.isNone(symbol.documentation)) {
-            const packet = yield* makeQueryPacket({
-              summary: `No JSDoc-backed documentation was indexed for symbol "${symbol.symbolName}".`,
-              citations: A.empty(),
-              notes: A.appendAll(A.make("symbolReturns=no-documentation"), selection.nlpNotes),
-            });
-
-            return new GroundedQueryResult({
-              answer: `No indexed JSDoc-backed documentation was found for "${symbol.symbolName}".`,
-              citations: A.empty(),
-              packet,
-            });
-          }
-
-          const documentation = symbol.documentation.value;
-          const citations = documentationCitations(symbol);
-          const packet = yield* makeQueryPacket({
-            summary: `Returned documented return semantics for symbol "${symbol.symbolName}".`,
-            citations,
-            notes: A.appendAll(A.make(`hasReturns=${O.isSome(documentation.returns)}`), selection.nlpNotes),
-          });
-
-          return new GroundedQueryResult({
-            answer: pipe(
-              documentation.returns,
-              O.match({
-                onNone: () =>
-                  `Symbol "${symbol.symbolName}" has indexed JSDoc, but no documented return contract was captured.`,
-                onSome: (result) => `Documented return for "${symbol.symbolName}": ${formatDocumentedReturn(result)}.`,
-              })
-            ),
-            citations,
-            packet,
-          });
-        }),
-      symbolThrows: (value) =>
-        Effect.gen(function* () {
-          const selection = selectSingleMatch(yield* findMatches(value.symbolName));
-
-          if (selection.kind === "none") {
-            return yield* noSymbolMatchResult(value.symbolName, "symbolThrows=no-match", selection.nlpNotes);
-          }
-
-          if (selection.kind === "ambiguous") {
-            return yield* ambiguousSymbolMatchResult(value.symbolName, selection.matches, selection.nlpNotes);
-          }
-
-          const symbol = selection.match;
-
-          if (O.isNone(symbol.documentation)) {
-            const packet = yield* makeQueryPacket({
-              summary: `No JSDoc-backed documentation was indexed for symbol "${symbol.symbolName}".`,
-              citations: A.empty(),
-              notes: A.appendAll(A.make("symbolThrows=no-documentation"), selection.nlpNotes),
-            });
-
-            return new GroundedQueryResult({
-              answer: `No indexed JSDoc-backed documentation was found for "${symbol.symbolName}".`,
-              citations: A.empty(),
-              packet,
-            });
-          }
-
-          const documentation = symbol.documentation.value;
-          const citations = documentationCitations(symbol);
-          const packet = yield* makeQueryPacket({
-            summary: `Returned documented throw semantics for symbol "${symbol.symbolName}".`,
-            citations,
-            notes: A.appendAll(A.make(`throwCount=${A.length(documentation.throws)}`), selection.nlpNotes),
-          });
-
-          return new GroundedQueryResult({
-            answer: pipe(
-              documentation.throws,
-              A.match({
-                onEmpty: () =>
-                  `Symbol "${symbol.symbolName}" has indexed JSDoc, but no documented throws were captured.`,
-                onNonEmpty: (errors) =>
-                  `Documented throws for "${symbol.symbolName}": ${pipe(errors, A.map(formatDocumentedThrow), A.join("; "))}.`,
-              })
-            ),
-            citations,
-            packet,
-          });
-        }),
-      symbolDeprecation: (value) =>
-        Effect.gen(function* () {
-          const selection = selectSingleMatch(yield* findMatches(value.symbolName));
-
-          if (selection.kind === "none") {
-            return yield* noSymbolMatchResult(value.symbolName, "symbolDeprecation=no-match", selection.nlpNotes);
-          }
-
-          if (selection.kind === "ambiguous") {
-            return yield* ambiguousSymbolMatchResult(value.symbolName, selection.matches, selection.nlpNotes);
-          }
-
-          const symbol = selection.match;
-
-          if (O.isNone(symbol.documentation)) {
-            const packet = yield* makeQueryPacket({
-              summary: `No JSDoc-backed documentation was indexed for symbol "${symbol.symbolName}".`,
-              citations: A.empty(),
-              notes: A.appendAll(A.make("symbolDeprecation=no-documentation"), selection.nlpNotes),
-            });
-
-            return new GroundedQueryResult({
-              answer: `No indexed JSDoc-backed documentation was found for "${symbol.symbolName}".`,
-              citations: A.empty(),
-              packet,
-            });
-          }
-
-          const documentation = symbol.documentation.value;
-          const citations = documentationCitations(symbol);
-          const packet = yield* makeQueryPacket({
-            summary: `Returned deprecation documentation for symbol "${symbol.symbolName}".`,
-            citations,
-            notes: A.appendAll(A.make(`deprecated=${documentation.isDeprecated}`), selection.nlpNotes),
-          });
-
-          return new GroundedQueryResult({
-            answer: documentation.isDeprecated
-              ? pipe(
-                  documentation.deprecationNote,
-                  O.match({
-                    onNone: () => `Symbol "${symbol.symbolName}" is documented as deprecated.`,
-                    onSome: (note) => `Symbol "${symbol.symbolName}" is documented as deprecated. ${note}`,
-                  })
-                )
-              : `Symbol "${symbol.symbolName}" has indexed JSDoc, but it is not documented as deprecated.`,
-            citations,
-            packet,
-          });
-        }),
-      listFileExports: (value) =>
-        Effect.gen(function* () {
-          const selection = selectSingleMatch(yield* findFiles(payload.repoId, sourceSnapshotId, value.fileQuery));
-
-          if (selection.kind === "none") {
-            return yield* noFileMatchResult(value.fileQuery, "listFileExports=no-file-match", selection.nlpNotes);
-          }
-
-          if (selection.kind === "ambiguous") {
-            return yield* ambiguousFileMatchResult(value.fileQuery, selection.matches, selection.nlpNotes);
-          }
-
-          const file = selection.match;
-
-          const symbols = yield* mapStoreError(
-            store.listExportedSymbolsForFile(payload.repoId, sourceSnapshotId, file.filePath)
-          );
-          const citations = normalizeCitations(pipe(symbols, A.map(symbolCitation)));
-          const packet = yield* makeQueryPacket({
-            summary: `Listed exported symbols for ${file.filePath}.`,
-            citations,
-            notes: A.appendAll(
-              A.make(`filePath=${file.filePath}`, `exportCount=${A.length(symbols)}`),
-              selection.nlpNotes
-            ),
-          });
-
-          const answer = !A.isReadonlyArrayNonEmpty(symbols)
-            ? `File ${file.filePath} has no indexed exported top-level symbols in snapshot ${sourceSnapshotId}.`
-            : `File ${file.filePath} exports: ${pipe(
-                symbols,
-                A.map((symbol) => `${symbol.symbolName} (${symbol.symbolKind})`),
-                A.join(", ")
-              )}.`;
-
-          return new GroundedQueryResult({
-            answer,
-            citations,
-            packet,
-          });
-        }),
-      listFileImports: (value) =>
-        Effect.gen(function* () {
-          const selection = selectSingleMatch(yield* findFiles(payload.repoId, sourceSnapshotId, value.fileQuery));
-
-          if (selection.kind === "none") {
-            return yield* noFileMatchResult(value.fileQuery, "listFileImports=no-file-match", selection.nlpNotes);
-          }
-
-          if (selection.kind === "ambiguous") {
-            return yield* ambiguousFileMatchResult(value.fileQuery, selection.matches, selection.nlpNotes);
-          }
-
-          const file = selection.match;
-
-          const matchingEdges = yield* mapStoreError(
-            store.listImportEdgesForImporterFile(payload.repoId, sourceSnapshotId, file.filePath)
-          );
-          const citations = normalizeCitations(pipe(matchingEdges, A.map(importEdgeCitation)));
-          const importedModules = pipe(
-            matchingEdges,
-            A.map((edge) => edge.moduleSpecifier),
-            A.dedupe
-          );
-          const packet = yield* makeQueryPacket({
-            summary: `Listed import declarations captured for ${file.filePath}.`,
-            citations,
-            notes: A.appendAll(
-              A.make(`filePath=${file.filePath}`, `importCount=${A.length(matchingEdges)}`),
-              selection.nlpNotes
-            ),
-          });
-
-          const answer = !A.isReadonlyArrayNonEmpty(importedModules)
-            ? `File ${file.filePath} has no indexed import declarations in snapshot ${sourceSnapshotId}.`
-            : `File ${file.filePath} imports: ${A.join(importedModules, ", ")}.`;
-
-          return new GroundedQueryResult({
-            answer,
-            citations,
-            packet,
-          });
-        }),
-      listFileDependencies: (value) =>
-        Effect.gen(function* () {
-          const selection = selectSingleMatch(yield* findFiles(payload.repoId, sourceSnapshotId, value.fileQuery));
-
-          if (selection.kind === "none") {
-            return yield* noFileMatchResult(value.fileQuery, "listFileDependencies=no-file-match", selection.nlpNotes);
-          }
-
-          if (selection.kind === "ambiguous") {
-            return yield* ambiguousFileMatchResult(value.fileQuery, selection.matches, selection.nlpNotes);
-          }
-
-          const file = selection.match;
-          const fileEdges = yield* mapStoreError(
-            store.listImportEdgesForImporterFile(payload.repoId, sourceSnapshotId, file.filePath)
-          );
-          const resolvedEdges = pipe(
-            fileEdges,
-            A.filter((edge) => O.isSome(edge.resolvedTargetFilePath))
-          );
-          const citations = normalizeCitations(pipe(resolvedEdges, A.map(importEdgeCitation)));
-          const dependencyFiles = pipe(
-            resolvedEdges,
-            A.map((edge) => edge.resolvedTargetFilePath),
-            A.getSomes,
-            A.sort(Order.String),
-            A.dedupe
-          );
-          const packet = yield* makeQueryPacket({
-            summary: `Listed repo-local resolved file dependencies for ${file.filePath}.`,
-            citations,
-            notes: A.appendAll(
-              A.make(
-                `filePath=${file.filePath}`,
-                `dependencyCount=${A.length(dependencyFiles)}`,
-                `unresolvedImportCount=${A.length(fileEdges) - A.length(resolvedEdges)}`
-              ),
-              selection.nlpNotes
-            ),
-          });
-
-          const answer = !A.isReadonlyArrayNonEmpty(dependencyFiles)
-            ? `File ${file.filePath} has no repo-local resolved file dependencies in snapshot ${sourceSnapshotId}.`
-            : `File ${file.filePath} depends on: ${A.join(dependencyFiles, ", ")}.`;
-
-          return new GroundedQueryResult({
-            answer,
-            citations,
-            packet,
-          });
-        }),
-      listFileDependents: (value) =>
-        Effect.gen(function* () {
-          const selection = selectSingleMatch(yield* findFiles(payload.repoId, sourceSnapshotId, value.fileQuery));
-
-          if (selection.kind === "none") {
-            return yield* noFileMatchResult(value.fileQuery, "listFileDependents=no-file-match", selection.nlpNotes);
-          }
-
-          if (selection.kind === "ambiguous") {
-            return yield* ambiguousFileMatchResult(value.fileQuery, selection.matches, selection.nlpNotes);
-          }
-
-          const file = selection.match;
-          const matchingEdges = yield* mapStoreError(
-            store.listImportEdgesForResolvedTargetFile(payload.repoId, sourceSnapshotId, file.filePath)
-          );
-          const citations = normalizeCitations(pipe(matchingEdges, A.map(importEdgeCitation)));
-          const importerFiles = pipe(
-            matchingEdges,
-            A.map((edge) => edge.importerFilePath),
-            A.sort(Order.String),
-            A.dedupe
-          );
-          const packet = yield* makeQueryPacket({
-            summary: `Listed repo-local files depending on ${file.filePath}.`,
-            citations,
-            notes: A.appendAll(
-              A.make(`filePath=${file.filePath}`, `dependentCount=${A.length(importerFiles)}`),
-              selection.nlpNotes
-            ),
-          });
-
-          const answer = !A.isReadonlyArrayNonEmpty(importerFiles)
-            ? `No indexed repo-local files depend on ${file.filePath} in snapshot ${sourceSnapshotId}.`
-            : `Files depending on ${file.filePath}: ${A.join(importerFiles, ", ")}.`;
-
-          return new GroundedQueryResult({
-            answer,
-            citations,
-            packet,
-          });
-        }),
-      listFileImporters: (value) =>
-        Effect.gen(function* () {
-          const importEdges = yield* mapStoreError(store.listImportEdges(payload.repoId, sourceSnapshotId));
-          const selection = selectImporterEdges(value.moduleQuery, importEdges);
-          const matchingEdges = selection.matches;
-          const citations = normalizeCitations(pipe(matchingEdges, A.map(importEdgeCitation)));
-          const importerFiles = pipe(
-            matchingEdges,
-            A.map((edge) => edge.importerFilePath),
-            A.sort(Order.String),
-            A.dedupe
-          );
-          const packet = yield* makeQueryPacket({
-            summary: `Listed files importing "${value.moduleQuery}" from captured import edges.`,
-            citations,
-            notes: A.appendAll(
-              A.make(`moduleQuery=${value.moduleQuery}`, `importerCount=${A.length(importerFiles)}`),
-              selection.nlpNotes
-            ),
-          });
-
-          const answer = !A.isReadonlyArrayNonEmpty(importerFiles)
-            ? `No indexed files import "${value.moduleQuery}" in snapshot ${sourceSnapshotId}.`
-            : `Files importing "${value.moduleQuery}": ${A.join(importerFiles, ", ")}.`;
-
-          return new GroundedQueryResult({
-            answer,
-            citations,
-            packet,
-          });
-        }),
-      listSymbolImporters: (value) =>
-        Effect.gen(function* () {
-          const selection = selectSingleMatch(yield* findMatches(value.symbolName));
-
-          if (selection.kind === "none") {
-            return yield* noSymbolMatchResult(value.symbolName, "listSymbolImporters=no-match", selection.nlpNotes);
-          }
-
-          if (selection.kind === "ambiguous") {
-            return yield* ambiguousSymbolMatchResult(value.symbolName, selection.matches, selection.nlpNotes);
-          }
-
-          const symbol = selection.match;
-          const importEdges = yield* mapStoreError(
-            store.listImportEdgesForResolvedTargetFile(payload.repoId, sourceSnapshotId, symbol.filePath)
-          );
-          const matchingEdges = pipe(
-            importEdges,
-            A.filter((edge) => O.isSome(edge.importedName) && edge.importedName.value === symbol.symbolName)
-          );
-          const importerFiles = pipe(
-            matchingEdges,
-            A.map((edge) => edge.importerFilePath),
-            A.sort(Order.String),
-            A.dedupe
-          );
-          const typeOnlyImporterCount = pipe(
-            matchingEdges,
-            A.filter((edge) => edge.typeOnly),
-            A.map((edge) => edge.importerFilePath),
-            A.dedupe,
-            A.length
-          );
-          const citations = normalizeCitations(
-            A.appendAll(A.make(symbolCitation(symbol)), pipe(matchingEdges, A.map(importEdgeCitation)))
-          );
-          const packet = yield* makeQueryPacket({
-            summary: `Listed files importing symbol "${symbol.symbolName}" from ${symbol.filePath}.`,
-            citations,
-            notes: A.appendAll(
-              A.make(
-                `symbolName=${symbol.symbolName}`,
-                `symbolFilePath=${symbol.filePath}`,
-                `importerCount=${A.length(importerFiles)}`,
-                `typeOnlyImporterCount=${typeOnlyImporterCount}`
-              ),
-              selection.nlpNotes
-            ),
-          });
-
-          const answer = !A.isReadonlyArrayNonEmpty(importerFiles)
-            ? `No indexed files import symbol "${symbol.symbolName}" from ${symbol.filePath} in snapshot ${sourceSnapshotId}.`
-            : `Files importing symbol "${symbol.symbolName}" from ${symbol.filePath}: ${A.join(importerFiles, ", ")}.`;
-
-          return new GroundedQueryResult({
-            answer,
-            citations,
-            packet,
-          });
-        }),
-      keywordSearch: (value) =>
-        Effect.gen(function* () {
-          const selection = yield* findKeywordMatches(value.query);
-          const matches = selection.matches;
-          const citations = normalizeCitations(pipe(matches, A.map(symbolCitation)));
-          const packet = yield* makeQueryPacket({
-            summary: `Keyword search over indexed symbols using "${value.query}".`,
-            citations,
-            notes: A.appendAll(A.make(`matchCount=${A.length(matches)}`), selection.nlpNotes),
-          });
-
-          const answer = !A.isReadonlyArrayNonEmpty(matches)
-            ? `No indexed symbols matched keyword query "${value.query}" in snapshot ${sourceSnapshotId}.`
-            : `Keyword search matched: ${pipe(
-                matches,
-                A.map((symbol) => `${symbol.symbolName} in ${symbol.filePath}`),
-                A.join("; ")
-              )}.`;
-
-          return new GroundedQueryResult({
-            answer,
-            citations,
-            packet,
-          });
-        }),
-      unsupported: (value) =>
-        Effect.gen(function* () {
-          const packet = yield* makeQueryPacket({
-            summary: "The question did not match one of the supported deterministic query shapes.",
-            citations: A.empty(),
-            notes: A.make(value.reason),
-          });
-
-          return new GroundedQueryResult({
-            answer: `Unsupported query shape. ${value.reason}`,
-            citations: A.empty(),
-            packet,
-          });
-        }),
-    });
-    const enrichedResult = withSemanticOverlay(result, semanticArtifacts);
-
-    const outcome = queryResultOutcome(interpretation, enrichedResult);
-    yield* Effect.annotateCurrentSpan({
-      query_kind: queryKind,
-      query_outcome: outcome,
-      citation_count: A.length(enrichedResult.citations),
-      retrieval_packet_citation_count: A.length(enrichedResult.packet.citations),
-      retrieval_note_count: A.length(enrichedResult.packet.notes),
-    });
-    yield* recordQueryResult(queryKind, outcome, A.length(enrichedResult.citations));
-
-    return enrichedResult;
+    return {
+      repoId: payload.repoId,
+      question: payload.question,
+      normalizedQuery,
+      interpretation,
+      queryKind,
+      questionNotes: nlpQuestionNotes(payload.question),
+    };
   });
 
-  return GroundedRetrievalService.of({ resolve });
+  const retrieve: GroundedRetrievalServiceShape["retrieve"] = Effect.fn("GroundedRetrieval.retrieve")(
+    function* (grounding) {
+      const sourceSnapshotId = yield* latestSnapshot(grounding.repoId);
+      const findMatches = findSymbolMatches(store, grounding.repoId, sourceSnapshotId);
+      const findFiles = resolveFileCandidates(store);
+      const findKeywordMatches = searchKeywordMatches(store, grounding.repoId, sourceSnapshotId);
+      const withGroundingNotes = (notes: ReadonlyArray<string>) =>
+        VariantText.orderedDedupe(A.appendAll(grounding.questionNotes, notes));
+      const symbolCandidates = (matches: ReadonlyArray<RepoSymbolRecord>, nlpNotes: ReadonlyArray<string>) =>
+        pipe(
+          matches,
+          A.take(10),
+          A.map(
+            (symbol) =>
+              new RetrievalCandidate({
+                subject: symbolSubject(symbol, A.make(symbol.symbolId)),
+                matchKind: issueMatchKind(nlpNotes),
+                note: O.none(),
+              })
+          )
+        );
+      const fileCandidates = (matches: ReadonlyArray<RepoSourceFile>, nlpNotes: ReadonlyArray<string>) =>
+        pipe(
+          matches,
+          A.take(10),
+          A.map(
+            (file) =>
+              new RetrievalCandidate({
+                subject: fileSubjectFromRecord(file, A.make(file.filePath)),
+                matchKind: issueMatchKind(nlpNotes),
+                note: O.none(),
+              })
+          )
+        );
+
+      yield* Effect.annotateCurrentSpan({
+        repo_id: grounding.repoId,
+        source_snapshot_id: sourceSnapshotId,
+        query_kind: grounding.queryKind,
+      });
+
+      return yield* QueryInterpretation.match(grounding.interpretation, {
+        countFiles: () =>
+          Effect.gen(function* () {
+            const fileCount = yield* mapStoreError(store.countSourceFiles(grounding.repoId, sourceSnapshotId));
+            return resolvedEvidence({
+              repoId: grounding.repoId,
+              sourceSnapshotId,
+              query: grounding.question,
+              normalizedQuery: grounding.normalizedQuery,
+              queryKind: grounding.queryKind,
+              summary: `Counted indexed TypeScript source files for snapshot ${sourceSnapshotId}.`,
+              citations: A.empty(),
+              notes: withGroundingNotes(A.make(`countFiles=${fileCount}`)),
+              payload: new RetrievalCountPayload({
+                target: "files",
+                count: decodeNonNegativeInt(fileCount),
+              }),
+            });
+          }),
+        countSymbols: () =>
+          Effect.gen(function* () {
+            const symbolCount = yield* mapStoreError(store.listSymbolRecords(grounding.repoId, sourceSnapshotId)).pipe(
+              Effect.map(A.length)
+            );
+            return resolvedEvidence({
+              repoId: grounding.repoId,
+              sourceSnapshotId,
+              query: grounding.question,
+              normalizedQuery: grounding.normalizedQuery,
+              queryKind: grounding.queryKind,
+              summary: `Counted indexed TypeScript symbols for snapshot ${sourceSnapshotId}.`,
+              citations: A.empty(),
+              notes: withGroundingNotes(A.make(`countSymbols=${symbolCount}`)),
+              payload: new RetrievalCountPayload({
+                target: "symbols",
+                count: decodeNonNegativeInt(symbolCount),
+              }),
+            });
+          }),
+        locateSymbol: (value) =>
+          Effect.gen(function* () {
+            const selection = selectSingleMatch(yield* findMatches(value.symbolName));
+
+            if (selection.kind === "none") {
+              return unresolvedEvidence({
+                repoId: grounding.repoId,
+                sourceSnapshotId,
+                query: grounding.question,
+                normalizedQuery: grounding.normalizedQuery,
+                queryKind: grounding.queryKind,
+                outcome: "none",
+                summary: `No indexed symbol matched "${value.symbolName}" in snapshot ${sourceSnapshotId}.`,
+                citations: A.empty(),
+                notes: withGroundingNotes(A.appendAll(A.make("locateSymbol=no-match"), selection.nlpNotes)),
+                issue: new RetrievalNoMatchIssue({
+                  requested: symbolRequestedTarget(value.symbolName),
+                  note: "locateSymbol=no-match",
+                }),
+              });
+            }
+
+            if (selection.kind === "ambiguous") {
+              const citations = normalizeCitations(pipe(selection.matches, A.take(10), A.map(symbolCitation)));
+
+              return unresolvedEvidence({
+                repoId: grounding.repoId,
+                sourceSnapshotId,
+                query: grounding.question,
+                normalizedQuery: grounding.normalizedQuery,
+                queryKind: grounding.queryKind,
+                outcome: "ambiguous",
+                summary: `Symbol query "${value.symbolName}" matched multiple indexed symbols.`,
+                citations,
+                notes: withGroundingNotes(
+                  A.appendAll(A.make(`candidateCount=${A.length(selection.matches)}`), selection.nlpNotes)
+                ),
+                issue: new RetrievalAmbiguousIssue({
+                  requested: symbolRequestedTarget(value.symbolName),
+                  candidates: symbolCandidates(selection.matches, selection.nlpNotes),
+                }),
+              });
+            }
+
+            const symbol = selection.match;
+            const citations = normalizeCitations(A.make(symbolCitation(symbol)));
+
+            return resolvedEvidence({
+              repoId: grounding.repoId,
+              sourceSnapshotId,
+              query: grounding.question,
+              normalizedQuery: grounding.normalizedQuery,
+              queryKind: grounding.queryKind,
+              summary: `Located symbol "${symbol.symbolName}" from indexed symbol records.`,
+              citations,
+              notes: withGroundingNotes(A.appendAll(A.make(`symbolId=${symbol.symbolId}`), selection.nlpNotes)),
+              payload: symbolDetailPayload(symbol, "location"),
+            });
+          }),
+        describeSymbol: (value) =>
+          Effect.gen(function* () {
+            const selection = selectSingleMatch(yield* findMatches(value.symbolName));
+
+            if (selection.kind === "none") {
+              return unresolvedEvidence({
+                repoId: grounding.repoId,
+                sourceSnapshotId,
+                query: grounding.question,
+                normalizedQuery: grounding.normalizedQuery,
+                queryKind: grounding.queryKind,
+                outcome: "none",
+                summary: `No indexed symbol matched "${value.symbolName}" in snapshot ${sourceSnapshotId}.`,
+                citations: A.empty(),
+                notes: withGroundingNotes(A.appendAll(A.make("describeSymbol=no-match"), selection.nlpNotes)),
+                issue: new RetrievalNoMatchIssue({
+                  requested: symbolRequestedTarget(value.symbolName),
+                  note: "describeSymbol=no-match",
+                }),
+              });
+            }
+
+            if (selection.kind === "ambiguous") {
+              const citations = normalizeCitations(pipe(selection.matches, A.take(10), A.map(symbolCitation)));
+
+              return unresolvedEvidence({
+                repoId: grounding.repoId,
+                sourceSnapshotId,
+                query: grounding.question,
+                normalizedQuery: grounding.normalizedQuery,
+                queryKind: grounding.queryKind,
+                outcome: "ambiguous",
+                summary: `Symbol query "${value.symbolName}" matched multiple indexed symbols.`,
+                citations,
+                notes: withGroundingNotes(
+                  A.appendAll(A.make(`candidateCount=${A.length(selection.matches)}`), selection.nlpNotes)
+                ),
+                issue: new RetrievalAmbiguousIssue({
+                  requested: symbolRequestedTarget(value.symbolName),
+                  candidates: symbolCandidates(selection.matches, selection.nlpNotes),
+                }),
+              });
+            }
+
+            const symbol = selection.match;
+            const citations = O.isSome(symbol.documentation)
+              ? documentationCitations(symbol, { includeDeclaration: true })
+              : normalizeCitations(A.make(symbolCitation(symbol)));
+
+            return resolvedEvidence({
+              repoId: grounding.repoId,
+              sourceSnapshotId,
+              query: grounding.question,
+              normalizedQuery: grounding.normalizedQuery,
+              queryKind: grounding.queryKind,
+              summary: O.isSome(symbol.documentation)
+                ? `Described symbol "${symbol.symbolName}" from its indexed declaration and JSDoc semantics.`
+                : `Described symbol "${symbol.symbolName}" from its indexed declaration because no JSDoc semantics were captured.`,
+              citations,
+              notes: withGroundingNotes(
+                A.appendAll(
+                  A.make(`signature=${symbol.signature}`, `documentation=${O.isSome(symbol.documentation)}`),
+                  selection.nlpNotes
+                )
+              ),
+              payload: symbolDetailPayload(symbol, "description"),
+            });
+          }),
+        symbolParams: (value) =>
+          Effect.gen(function* () {
+            const selection = selectSingleMatch(yield* findMatches(value.symbolName));
+
+            if (selection.kind === "none") {
+              return unresolvedEvidence({
+                repoId: grounding.repoId,
+                sourceSnapshotId,
+                query: grounding.question,
+                normalizedQuery: grounding.normalizedQuery,
+                queryKind: grounding.queryKind,
+                outcome: "none",
+                summary: `No indexed symbol matched "${value.symbolName}" in snapshot ${sourceSnapshotId}.`,
+                citations: A.empty(),
+                notes: withGroundingNotes(A.appendAll(A.make("symbolParams=no-match"), selection.nlpNotes)),
+                issue: new RetrievalNoMatchIssue({
+                  requested: symbolRequestedTarget(value.symbolName),
+                  note: "symbolParams=no-match",
+                }),
+              });
+            }
+
+            if (selection.kind === "ambiguous") {
+              const citations = normalizeCitations(pipe(selection.matches, A.take(10), A.map(symbolCitation)));
+
+              return unresolvedEvidence({
+                repoId: grounding.repoId,
+                sourceSnapshotId,
+                query: grounding.question,
+                normalizedQuery: grounding.normalizedQuery,
+                queryKind: grounding.queryKind,
+                outcome: "ambiguous",
+                summary: `Symbol query "${value.symbolName}" matched multiple indexed symbols.`,
+                citations,
+                notes: withGroundingNotes(
+                  A.appendAll(A.make(`candidateCount=${A.length(selection.matches)}`), selection.nlpNotes)
+                ),
+                issue: new RetrievalAmbiguousIssue({
+                  requested: symbolRequestedTarget(value.symbolName),
+                  candidates: symbolCandidates(selection.matches, selection.nlpNotes),
+                }),
+              });
+            }
+
+            const symbol = selection.match;
+            const citations = O.isSome(symbol.documentation)
+              ? documentationCitations(symbol)
+              : normalizeCitations(A.make(symbolCitation(symbol)));
+            const notes = O.isSome(symbol.documentation)
+              ? A.appendAll(A.make(`paramCount=${A.length(symbol.documentation.value.params)}`), selection.nlpNotes)
+              : A.appendAll(A.make("symbolParams=no-documentation"), selection.nlpNotes);
+
+            return resolvedEvidence({
+              repoId: grounding.repoId,
+              sourceSnapshotId,
+              query: grounding.question,
+              normalizedQuery: grounding.normalizedQuery,
+              queryKind: grounding.queryKind,
+              summary: O.isSome(symbol.documentation)
+                ? `Returned documented parameters for symbol "${symbol.symbolName}".`
+                : `No JSDoc-backed documentation was indexed for symbol "${symbol.symbolName}".`,
+              citations,
+              notes: withGroundingNotes(notes),
+              payload: symbolDetailPayload(symbol, "params"),
+            });
+          }),
+        symbolReturns: (value) =>
+          Effect.gen(function* () {
+            const selection = selectSingleMatch(yield* findMatches(value.symbolName));
+
+            if (selection.kind === "none") {
+              return unresolvedEvidence({
+                repoId: grounding.repoId,
+                sourceSnapshotId,
+                query: grounding.question,
+                normalizedQuery: grounding.normalizedQuery,
+                queryKind: grounding.queryKind,
+                outcome: "none",
+                summary: `No indexed symbol matched "${value.symbolName}" in snapshot ${sourceSnapshotId}.`,
+                citations: A.empty(),
+                notes: withGroundingNotes(A.appendAll(A.make("symbolReturns=no-match"), selection.nlpNotes)),
+                issue: new RetrievalNoMatchIssue({
+                  requested: symbolRequestedTarget(value.symbolName),
+                  note: "symbolReturns=no-match",
+                }),
+              });
+            }
+
+            if (selection.kind === "ambiguous") {
+              const citations = normalizeCitations(pipe(selection.matches, A.take(10), A.map(symbolCitation)));
+
+              return unresolvedEvidence({
+                repoId: grounding.repoId,
+                sourceSnapshotId,
+                query: grounding.question,
+                normalizedQuery: grounding.normalizedQuery,
+                queryKind: grounding.queryKind,
+                outcome: "ambiguous",
+                summary: `Symbol query "${value.symbolName}" matched multiple indexed symbols.`,
+                citations,
+                notes: withGroundingNotes(
+                  A.appendAll(A.make(`candidateCount=${A.length(selection.matches)}`), selection.nlpNotes)
+                ),
+                issue: new RetrievalAmbiguousIssue({
+                  requested: symbolRequestedTarget(value.symbolName),
+                  candidates: symbolCandidates(selection.matches, selection.nlpNotes),
+                }),
+              });
+            }
+
+            const symbol = selection.match;
+            const citations = O.isSome(symbol.documentation)
+              ? documentationCitations(symbol)
+              : normalizeCitations(A.make(symbolCitation(symbol)));
+            const notes = O.isSome(symbol.documentation)
+              ? A.appendAll(A.make(`hasReturns=${O.isSome(symbol.documentation.value.returns)}`), selection.nlpNotes)
+              : A.appendAll(A.make("symbolReturns=no-documentation"), selection.nlpNotes);
+
+            return resolvedEvidence({
+              repoId: grounding.repoId,
+              sourceSnapshotId,
+              query: grounding.question,
+              normalizedQuery: grounding.normalizedQuery,
+              queryKind: grounding.queryKind,
+              summary: O.isSome(symbol.documentation)
+                ? `Returned documented return semantics for symbol "${symbol.symbolName}".`
+                : `No JSDoc-backed documentation was indexed for symbol "${symbol.symbolName}".`,
+              citations,
+              notes: withGroundingNotes(notes),
+              payload: symbolDetailPayload(symbol, "returns"),
+            });
+          }),
+        symbolThrows: (value) =>
+          Effect.gen(function* () {
+            const selection = selectSingleMatch(yield* findMatches(value.symbolName));
+
+            if (selection.kind === "none") {
+              return unresolvedEvidence({
+                repoId: grounding.repoId,
+                sourceSnapshotId,
+                query: grounding.question,
+                normalizedQuery: grounding.normalizedQuery,
+                queryKind: grounding.queryKind,
+                outcome: "none",
+                summary: `No indexed symbol matched "${value.symbolName}" in snapshot ${sourceSnapshotId}.`,
+                citations: A.empty(),
+                notes: withGroundingNotes(A.appendAll(A.make("symbolThrows=no-match"), selection.nlpNotes)),
+                issue: new RetrievalNoMatchIssue({
+                  requested: symbolRequestedTarget(value.symbolName),
+                  note: "symbolThrows=no-match",
+                }),
+              });
+            }
+
+            if (selection.kind === "ambiguous") {
+              const citations = normalizeCitations(pipe(selection.matches, A.take(10), A.map(symbolCitation)));
+
+              return unresolvedEvidence({
+                repoId: grounding.repoId,
+                sourceSnapshotId,
+                query: grounding.question,
+                normalizedQuery: grounding.normalizedQuery,
+                queryKind: grounding.queryKind,
+                outcome: "ambiguous",
+                summary: `Symbol query "${value.symbolName}" matched multiple indexed symbols.`,
+                citations,
+                notes: withGroundingNotes(
+                  A.appendAll(A.make(`candidateCount=${A.length(selection.matches)}`), selection.nlpNotes)
+                ),
+                issue: new RetrievalAmbiguousIssue({
+                  requested: symbolRequestedTarget(value.symbolName),
+                  candidates: symbolCandidates(selection.matches, selection.nlpNotes),
+                }),
+              });
+            }
+
+            const symbol = selection.match;
+            const citations = O.isSome(symbol.documentation)
+              ? documentationCitations(symbol)
+              : normalizeCitations(A.make(symbolCitation(symbol)));
+            const notes = O.isSome(symbol.documentation)
+              ? A.appendAll(A.make(`throwCount=${A.length(symbol.documentation.value.throws)}`), selection.nlpNotes)
+              : A.appendAll(A.make("symbolThrows=no-documentation"), selection.nlpNotes);
+
+            return resolvedEvidence({
+              repoId: grounding.repoId,
+              sourceSnapshotId,
+              query: grounding.question,
+              normalizedQuery: grounding.normalizedQuery,
+              queryKind: grounding.queryKind,
+              summary: O.isSome(symbol.documentation)
+                ? `Returned documented throw semantics for symbol "${symbol.symbolName}".`
+                : `No JSDoc-backed documentation was indexed for symbol "${symbol.symbolName}".`,
+              citations,
+              notes: withGroundingNotes(notes),
+              payload: symbolDetailPayload(symbol, "throws"),
+            });
+          }),
+        symbolDeprecation: (value) =>
+          Effect.gen(function* () {
+            const selection = selectSingleMatch(yield* findMatches(value.symbolName));
+
+            if (selection.kind === "none") {
+              return unresolvedEvidence({
+                repoId: grounding.repoId,
+                sourceSnapshotId,
+                query: grounding.question,
+                normalizedQuery: grounding.normalizedQuery,
+                queryKind: grounding.queryKind,
+                outcome: "none",
+                summary: `No indexed symbol matched "${value.symbolName}" in snapshot ${sourceSnapshotId}.`,
+                citations: A.empty(),
+                notes: withGroundingNotes(A.appendAll(A.make("symbolDeprecation=no-match"), selection.nlpNotes)),
+                issue: new RetrievalNoMatchIssue({
+                  requested: symbolRequestedTarget(value.symbolName),
+                  note: "symbolDeprecation=no-match",
+                }),
+              });
+            }
+
+            if (selection.kind === "ambiguous") {
+              const citations = normalizeCitations(pipe(selection.matches, A.take(10), A.map(symbolCitation)));
+
+              return unresolvedEvidence({
+                repoId: grounding.repoId,
+                sourceSnapshotId,
+                query: grounding.question,
+                normalizedQuery: grounding.normalizedQuery,
+                queryKind: grounding.queryKind,
+                outcome: "ambiguous",
+                summary: `Symbol query "${value.symbolName}" matched multiple indexed symbols.`,
+                citations,
+                notes: withGroundingNotes(
+                  A.appendAll(A.make(`candidateCount=${A.length(selection.matches)}`), selection.nlpNotes)
+                ),
+                issue: new RetrievalAmbiguousIssue({
+                  requested: symbolRequestedTarget(value.symbolName),
+                  candidates: symbolCandidates(selection.matches, selection.nlpNotes),
+                }),
+              });
+            }
+
+            const symbol = selection.match;
+            const citations = O.isSome(symbol.documentation)
+              ? documentationCitations(symbol)
+              : normalizeCitations(A.make(symbolCitation(symbol)));
+            const notes = O.isSome(symbol.documentation)
+              ? A.appendAll(A.make(`deprecated=${symbol.documentation.value.isDeprecated}`), selection.nlpNotes)
+              : A.appendAll(A.make("symbolDeprecation=no-documentation"), selection.nlpNotes);
+
+            return resolvedEvidence({
+              repoId: grounding.repoId,
+              sourceSnapshotId,
+              query: grounding.question,
+              normalizedQuery: grounding.normalizedQuery,
+              queryKind: grounding.queryKind,
+              summary: O.isSome(symbol.documentation)
+                ? `Returned deprecation documentation for symbol "${symbol.symbolName}".`
+                : `No JSDoc-backed documentation was indexed for symbol "${symbol.symbolName}".`,
+              citations,
+              notes: withGroundingNotes(notes),
+              payload: symbolDetailPayload(symbol, "deprecation"),
+            });
+          }),
+        listFileExports: (value) =>
+          Effect.gen(function* () {
+            const selection = selectSingleMatch(yield* findFiles(grounding.repoId, sourceSnapshotId, value.fileQuery));
+
+            if (selection.kind === "none") {
+              return unresolvedEvidence({
+                repoId: grounding.repoId,
+                sourceSnapshotId,
+                query: grounding.question,
+                normalizedQuery: grounding.normalizedQuery,
+                queryKind: grounding.queryKind,
+                outcome: "none",
+                summary: `No indexed file matched "${value.fileQuery}" in snapshot ${sourceSnapshotId}.`,
+                citations: A.empty(),
+                notes: withGroundingNotes(A.appendAll(A.make("listFileExports=no-file-match"), selection.nlpNotes)),
+                issue: new RetrievalNoMatchIssue({
+                  requested: fileRequestedTarget(value.fileQuery),
+                  note: "listFileExports=no-file-match",
+                }),
+              });
+            }
+
+            if (selection.kind === "ambiguous") {
+              const citations = normalizeCitations(pipe(selection.matches, A.take(10), A.map(fileCitation)));
+
+              return unresolvedEvidence({
+                repoId: grounding.repoId,
+                sourceSnapshotId,
+                query: grounding.question,
+                normalizedQuery: grounding.normalizedQuery,
+                queryKind: grounding.queryKind,
+                outcome: "ambiguous",
+                summary: `File query "${value.fileQuery}" matched multiple indexed files.`,
+                citations,
+                notes: withGroundingNotes(
+                  A.appendAll(A.make(`candidateCount=${A.length(selection.matches)}`), selection.nlpNotes)
+                ),
+                issue: new RetrievalAmbiguousIssue({
+                  requested: fileRequestedTarget(value.fileQuery),
+                  candidates: fileCandidates(selection.matches, selection.nlpNotes),
+                }),
+              });
+            }
+
+            const file = selection.match;
+            const symbols = yield* mapStoreError(
+              store.listExportedSymbolsForFile(grounding.repoId, sourceSnapshotId, file.filePath)
+            );
+            const citations = normalizeCitations(pipe(symbols, A.map(symbolCitation)));
+
+            return resolvedEvidence({
+              repoId: grounding.repoId,
+              sourceSnapshotId,
+              query: grounding.question,
+              normalizedQuery: grounding.normalizedQuery,
+              queryKind: grounding.queryKind,
+              summary: `Listed exported symbols for ${file.filePath}.`,
+              citations,
+              notes: withGroundingNotes(
+                A.appendAll(A.make(`filePath=${file.filePath}`, `exportCount=${A.length(symbols)}`), selection.nlpNotes)
+              ),
+              payload: new RetrievalRelationListPayload({
+                relation: "exports",
+                subject: fileSubjectFromRecord(file),
+                items: pipe(
+                  symbols,
+                  A.map((symbol) => symbolSubject(symbol, A.make(symbol.symbolId)))
+                ),
+              }),
+            });
+          }),
+        listFileImports: (value) =>
+          Effect.gen(function* () {
+            const selection = selectSingleMatch(yield* findFiles(grounding.repoId, sourceSnapshotId, value.fileQuery));
+
+            if (selection.kind === "none") {
+              return unresolvedEvidence({
+                repoId: grounding.repoId,
+                sourceSnapshotId,
+                query: grounding.question,
+                normalizedQuery: grounding.normalizedQuery,
+                queryKind: grounding.queryKind,
+                outcome: "none",
+                summary: `No indexed file matched "${value.fileQuery}" in snapshot ${sourceSnapshotId}.`,
+                citations: A.empty(),
+                notes: withGroundingNotes(A.appendAll(A.make("listFileImports=no-file-match"), selection.nlpNotes)),
+                issue: new RetrievalNoMatchIssue({
+                  requested: fileRequestedTarget(value.fileQuery),
+                  note: "listFileImports=no-file-match",
+                }),
+              });
+            }
+
+            if (selection.kind === "ambiguous") {
+              const citations = normalizeCitations(pipe(selection.matches, A.take(10), A.map(fileCitation)));
+
+              return unresolvedEvidence({
+                repoId: grounding.repoId,
+                sourceSnapshotId,
+                query: grounding.question,
+                normalizedQuery: grounding.normalizedQuery,
+                queryKind: grounding.queryKind,
+                outcome: "ambiguous",
+                summary: `File query "${value.fileQuery}" matched multiple indexed files.`,
+                citations,
+                notes: withGroundingNotes(
+                  A.appendAll(A.make(`candidateCount=${A.length(selection.matches)}`), selection.nlpNotes)
+                ),
+                issue: new RetrievalAmbiguousIssue({
+                  requested: fileRequestedTarget(value.fileQuery),
+                  candidates: fileCandidates(selection.matches, selection.nlpNotes),
+                }),
+              });
+            }
+
+            const file = selection.match;
+            const matchingEdges = yield* mapStoreError(
+              store.listImportEdgesForImporterFile(grounding.repoId, sourceSnapshotId, file.filePath)
+            );
+            const citations = normalizeCitations(pipe(matchingEdges, A.map(importEdgeCitation)));
+            const items = pipe(
+              matchingEdges,
+              A.map((edge) => moduleSubject(edge.moduleSpecifier, A.make(importEdgeCitation(edge).id))),
+              A.dedupeWith((left, right) => left.moduleSpecifier === right.moduleSpecifier)
+            );
+
+            return resolvedEvidence({
+              repoId: grounding.repoId,
+              sourceSnapshotId,
+              query: grounding.question,
+              normalizedQuery: grounding.normalizedQuery,
+              queryKind: grounding.queryKind,
+              summary: `Listed import declarations captured for ${file.filePath}.`,
+              citations,
+              notes: withGroundingNotes(
+                A.appendAll(
+                  A.make(`filePath=${file.filePath}`, `importCount=${A.length(matchingEdges)}`),
+                  selection.nlpNotes
+                )
+              ),
+              payload: new RetrievalRelationListPayload({
+                relation: "imports",
+                subject: fileSubjectFromRecord(file),
+                items,
+              }),
+            });
+          }),
+        listFileDependencies: (value) =>
+          Effect.gen(function* () {
+            const selection = selectSingleMatch(yield* findFiles(grounding.repoId, sourceSnapshotId, value.fileQuery));
+
+            if (selection.kind === "none") {
+              return unresolvedEvidence({
+                repoId: grounding.repoId,
+                sourceSnapshotId,
+                query: grounding.question,
+                normalizedQuery: grounding.normalizedQuery,
+                queryKind: grounding.queryKind,
+                outcome: "none",
+                summary: `No indexed file matched "${value.fileQuery}" in snapshot ${sourceSnapshotId}.`,
+                citations: A.empty(),
+                notes: withGroundingNotes(
+                  A.appendAll(A.make("listFileDependencies=no-file-match"), selection.nlpNotes)
+                ),
+                issue: new RetrievalNoMatchIssue({
+                  requested: fileRequestedTarget(value.fileQuery),
+                  note: "listFileDependencies=no-file-match",
+                }),
+              });
+            }
+
+            if (selection.kind === "ambiguous") {
+              const citations = normalizeCitations(pipe(selection.matches, A.take(10), A.map(fileCitation)));
+
+              return unresolvedEvidence({
+                repoId: grounding.repoId,
+                sourceSnapshotId,
+                query: grounding.question,
+                normalizedQuery: grounding.normalizedQuery,
+                queryKind: grounding.queryKind,
+                outcome: "ambiguous",
+                summary: `File query "${value.fileQuery}" matched multiple indexed files.`,
+                citations,
+                notes: withGroundingNotes(
+                  A.appendAll(A.make(`candidateCount=${A.length(selection.matches)}`), selection.nlpNotes)
+                ),
+                issue: new RetrievalAmbiguousIssue({
+                  requested: fileRequestedTarget(value.fileQuery),
+                  candidates: fileCandidates(selection.matches, selection.nlpNotes),
+                }),
+              });
+            }
+
+            const file = selection.match;
+            const fileEdges = yield* mapStoreError(
+              store.listImportEdgesForImporterFile(grounding.repoId, sourceSnapshotId, file.filePath)
+            );
+            const resolvedEdges = pipe(
+              fileEdges,
+              A.filter((edge) => O.isSome(edge.resolvedTargetFilePath))
+            );
+            const citations = normalizeCitations(pipe(resolvedEdges, A.map(importEdgeCitation)));
+            const items = pipe(
+              resolvedEdges,
+              A.map((edge) =>
+                fileSubject(O.getOrThrow(edge.resolvedTargetFilePath), A.make(importEdgeCitation(edge).id))
+              ),
+              A.dedupeWith((left, right) => left.filePath === right.filePath)
+            );
+
+            return resolvedEvidence({
+              repoId: grounding.repoId,
+              sourceSnapshotId,
+              query: grounding.question,
+              normalizedQuery: grounding.normalizedQuery,
+              queryKind: grounding.queryKind,
+              summary: `Listed repo-local resolved file dependencies for ${file.filePath}.`,
+              citations,
+              notes: withGroundingNotes(
+                A.appendAll(
+                  A.make(
+                    `filePath=${file.filePath}`,
+                    `dependencyCount=${A.length(items)}`,
+                    `unresolvedImportCount=${A.length(fileEdges) - A.length(resolvedEdges)}`
+                  ),
+                  selection.nlpNotes
+                )
+              ),
+              payload: new RetrievalRelationListPayload({
+                relation: "depends-on",
+                subject: fileSubjectFromRecord(file),
+                items,
+              }),
+            });
+          }),
+        listFileDependents: (value) =>
+          Effect.gen(function* () {
+            const selection = selectSingleMatch(yield* findFiles(grounding.repoId, sourceSnapshotId, value.fileQuery));
+
+            if (selection.kind === "none") {
+              return unresolvedEvidence({
+                repoId: grounding.repoId,
+                sourceSnapshotId,
+                query: grounding.question,
+                normalizedQuery: grounding.normalizedQuery,
+                queryKind: grounding.queryKind,
+                outcome: "none",
+                summary: `No indexed file matched "${value.fileQuery}" in snapshot ${sourceSnapshotId}.`,
+                citations: A.empty(),
+                notes: withGroundingNotes(A.appendAll(A.make("listFileDependents=no-file-match"), selection.nlpNotes)),
+                issue: new RetrievalNoMatchIssue({
+                  requested: fileRequestedTarget(value.fileQuery),
+                  note: "listFileDependents=no-file-match",
+                }),
+              });
+            }
+
+            if (selection.kind === "ambiguous") {
+              const citations = normalizeCitations(pipe(selection.matches, A.take(10), A.map(fileCitation)));
+
+              return unresolvedEvidence({
+                repoId: grounding.repoId,
+                sourceSnapshotId,
+                query: grounding.question,
+                normalizedQuery: grounding.normalizedQuery,
+                queryKind: grounding.queryKind,
+                outcome: "ambiguous",
+                summary: `File query "${value.fileQuery}" matched multiple indexed files.`,
+                citations,
+                notes: withGroundingNotes(
+                  A.appendAll(A.make(`candidateCount=${A.length(selection.matches)}`), selection.nlpNotes)
+                ),
+                issue: new RetrievalAmbiguousIssue({
+                  requested: fileRequestedTarget(value.fileQuery),
+                  candidates: fileCandidates(selection.matches, selection.nlpNotes),
+                }),
+              });
+            }
+
+            const file = selection.match;
+            const matchingEdges = yield* mapStoreError(
+              store.listImportEdgesForResolvedTargetFile(grounding.repoId, sourceSnapshotId, file.filePath)
+            );
+            const citations = normalizeCitations(pipe(matchingEdges, A.map(importEdgeCitation)));
+            const items = pipe(
+              matchingEdges,
+              A.map((edge) => fileSubject(edge.importerFilePath, A.make(importEdgeCitation(edge).id))),
+              A.dedupeWith((left, right) => left.filePath === right.filePath)
+            );
+
+            return resolvedEvidence({
+              repoId: grounding.repoId,
+              sourceSnapshotId,
+              query: grounding.question,
+              normalizedQuery: grounding.normalizedQuery,
+              queryKind: grounding.queryKind,
+              summary: `Listed repo-local files depending on ${file.filePath}.`,
+              citations,
+              notes: withGroundingNotes(
+                A.appendAll(
+                  A.make(`filePath=${file.filePath}`, `dependentCount=${A.length(items)}`),
+                  selection.nlpNotes
+                )
+              ),
+              payload: new RetrievalRelationListPayload({
+                relation: "depended-on-by",
+                subject: fileSubjectFromRecord(file),
+                items,
+              }),
+            });
+          }),
+        listFileImporters: (value) =>
+          Effect.gen(function* () {
+            const importEdges = yield* mapStoreError(store.listImportEdges(grounding.repoId, sourceSnapshotId));
+            const selection = selectImporterEdges(value.moduleQuery, importEdges);
+            const matchingEdges = selection.matches;
+            const citations = normalizeCitations(pipe(matchingEdges, A.map(importEdgeCitation)));
+            const items = pipe(
+              matchingEdges,
+              A.map((edge) => fileSubject(edge.importerFilePath, A.make(importEdgeCitation(edge).id))),
+              A.dedupeWith((left, right) => left.filePath === right.filePath)
+            );
+
+            return resolvedEvidence({
+              repoId: grounding.repoId,
+              sourceSnapshotId,
+              query: grounding.question,
+              normalizedQuery: grounding.normalizedQuery,
+              queryKind: grounding.queryKind,
+              summary: `Listed files importing "${value.moduleQuery}" from captured import edges.`,
+              citations,
+              notes: withGroundingNotes(
+                A.appendAll(
+                  A.make(`moduleQuery=${value.moduleQuery}`, `importerCount=${A.length(items)}`),
+                  selection.nlpNotes
+                )
+              ),
+              payload: new RetrievalRelationListPayload({
+                relation: "imported-by",
+                subject: moduleSubject(value.moduleQuery),
+                items,
+              }),
+            });
+          }),
+        listSymbolImporters: (value) =>
+          Effect.gen(function* () {
+            const selection = selectSingleMatch(yield* findMatches(value.symbolName));
+
+            if (selection.kind === "none") {
+              return unresolvedEvidence({
+                repoId: grounding.repoId,
+                sourceSnapshotId,
+                query: grounding.question,
+                normalizedQuery: grounding.normalizedQuery,
+                queryKind: grounding.queryKind,
+                outcome: "none",
+                summary: `No indexed symbol matched "${value.symbolName}" in snapshot ${sourceSnapshotId}.`,
+                citations: A.empty(),
+                notes: withGroundingNotes(A.appendAll(A.make("listSymbolImporters=no-match"), selection.nlpNotes)),
+                issue: new RetrievalNoMatchIssue({
+                  requested: symbolRequestedTarget(value.symbolName),
+                  note: "listSymbolImporters=no-match",
+                }),
+              });
+            }
+
+            if (selection.kind === "ambiguous") {
+              const citations = normalizeCitations(pipe(selection.matches, A.take(10), A.map(symbolCitation)));
+
+              return unresolvedEvidence({
+                repoId: grounding.repoId,
+                sourceSnapshotId,
+                query: grounding.question,
+                normalizedQuery: grounding.normalizedQuery,
+                queryKind: grounding.queryKind,
+                outcome: "ambiguous",
+                summary: `Symbol query "${value.symbolName}" matched multiple indexed symbols.`,
+                citations,
+                notes: withGroundingNotes(
+                  A.appendAll(A.make(`candidateCount=${A.length(selection.matches)}`), selection.nlpNotes)
+                ),
+                issue: new RetrievalAmbiguousIssue({
+                  requested: symbolRequestedTarget(value.symbolName),
+                  candidates: symbolCandidates(selection.matches, selection.nlpNotes),
+                }),
+              });
+            }
+
+            const symbol = selection.match;
+            const importEdges = yield* mapStoreError(
+              store.listImportEdgesForResolvedTargetFile(grounding.repoId, sourceSnapshotId, symbol.filePath)
+            );
+            const matchingEdges = pipe(
+              importEdges,
+              A.filter((edge) => O.isSome(edge.importedName) && edge.importedName.value === symbol.symbolName)
+            );
+            const typeOnlyImporterCount = pipe(
+              matchingEdges,
+              A.filter((edge) => edge.typeOnly),
+              A.map((edge) => edge.importerFilePath),
+              A.dedupe,
+              A.length
+            );
+            const citations = normalizeCitations(
+              A.appendAll(A.make(symbolCitation(symbol)), pipe(matchingEdges, A.map(importEdgeCitation)))
+            );
+            const items = pipe(
+              matchingEdges,
+              A.map((edge) => fileSubject(edge.importerFilePath, A.make(importEdgeCitation(edge).id))),
+              A.dedupeWith((left, right) => left.filePath === right.filePath)
+            );
+
+            return resolvedEvidence({
+              repoId: grounding.repoId,
+              sourceSnapshotId,
+              query: grounding.question,
+              normalizedQuery: grounding.normalizedQuery,
+              queryKind: grounding.queryKind,
+              summary: `Listed files importing symbol "${symbol.symbolName}" from ${symbol.filePath}.`,
+              citations,
+              notes: withGroundingNotes(
+                A.appendAll(
+                  A.make(
+                    `symbolName=${symbol.symbolName}`,
+                    `symbolFilePath=${symbol.filePath}`,
+                    `importerCount=${A.length(items)}`,
+                    `typeOnlyImporterCount=${typeOnlyImporterCount}`
+                  ),
+                  selection.nlpNotes
+                )
+              ),
+              payload: new RetrievalRelationListPayload({
+                relation: "imported-by",
+                subject: symbolSubject(symbol, A.make(symbol.symbolId)),
+                items,
+              }),
+            });
+          }),
+        keywordSearch: (value) =>
+          Effect.gen(function* () {
+            const selection = yield* findKeywordMatches(value.query);
+            const matches = selection.matches;
+            const citations = normalizeCitations(pipe(matches, A.map(symbolCitation)));
+
+            return resolvedEvidence({
+              repoId: grounding.repoId,
+              sourceSnapshotId,
+              query: grounding.question,
+              normalizedQuery: grounding.normalizedQuery,
+              queryKind: grounding.queryKind,
+              summary: `Keyword search over indexed symbols using "${value.query}".`,
+              citations,
+              notes: withGroundingNotes(A.appendAll(A.make(`matchCount=${A.length(matches)}`), selection.nlpNotes)),
+              payload: new RetrievalSearchResultsPayload({
+                query: value.query,
+                items: pipe(
+                  matches,
+                  A.map((symbol) => symbolSubject(symbol, A.make(symbol.symbolId)))
+                ),
+              }),
+            });
+          }),
+        unsupported: (value) =>
+          Effect.succeed(
+            unresolvedEvidence({
+              repoId: grounding.repoId,
+              sourceSnapshotId,
+              query: grounding.question,
+              normalizedQuery: grounding.normalizedQuery,
+              queryKind: grounding.queryKind,
+              outcome: "unsupported",
+              summary: "The question did not match one of the supported deterministic query shapes.",
+              citations: A.empty(),
+              notes: withGroundingNotes(A.make(value.reason)),
+              issue: new RetrievalUnsupportedIssue({
+                requested: questionRequestedTarget(grounding.question),
+                reason: value.reason,
+              }),
+            })
+          ),
+      });
+    }
+  );
+
+  const materializePacket: GroundedRetrievalServiceShape["materializePacket"] = Effect.fn(
+    "GroundedRetrieval.materializePacket"
+  )(function* (evidence) {
+    const semanticArtifacts = yield* latestSemanticArtifacts(evidence.repoId, evidence.sourceSnapshotId);
+    const packet = yield* makePacket({
+      repoId: evidence.repoId,
+      sourceSnapshotId: evidence.sourceSnapshotId,
+      query: evidence.query,
+      normalizedQuery: evidence.normalizedQuery,
+      queryKind: evidence.queryKind,
+      outcome: evidence.outcome,
+      summary: evidence.summary,
+      citations: evidence.citations,
+      notes: evidence.notes,
+      payload: evidence.payload,
+      issue: evidence.issue,
+    });
+
+    return withSemanticOverlay(packet, semanticArtifacts);
+  });
+
+  const draftAnswer: GroundedRetrievalServiceShape["draftAnswer"] = Effect.fn("GroundedRetrieval.draftAnswer")(
+    (packet) => Effect.succeed(renderRetrievalPacketAnswer(packet))
+  );
+
+  const resolve: GroundedRetrievalServiceShape["resolve"] = Effect.fn("GroundedRetrieval.resolve")(function* (payload) {
+    const grounding = yield* ground(payload);
+    const evidence = yield* retrieve(grounding);
+    const packet = yield* materializePacket(evidence);
+    const answer = yield* draftAnswer(packet);
+    const outcome = queryResultOutcome(packet);
+
+    yield* Effect.annotateCurrentSpan({
+      query_kind: grounding.queryKind,
+      query_outcome: outcome,
+      citation_count: A.length(packet.citations),
+      retrieval_packet_citation_count: A.length(packet.citations),
+      retrieval_note_count: A.length(packet.notes),
+    });
+    yield* recordQueryResult(grounding.queryKind, outcome, A.length(packet.citations));
+
+    return new GroundedQueryResult({
+      answer,
+      citations: packet.citations,
+      packet,
+    });
+  });
+
+  return GroundedRetrievalService.of({ ground, retrieve, materializePacket, draftAnswer, resolve });
 });

--- a/packages/repo-memory/runtime/test/GroundedRetrieval.test.ts
+++ b/packages/repo-memory/runtime/test/GroundedRetrieval.test.ts
@@ -650,7 +650,7 @@ describe("repo-memory runtime grounded retrieval", () => {
         expect(exportsForIndex.run.citations.length).toBeGreaterThan(0);
         assertCitationAlignment({ events: exportsForIndex.events, run: exportsForIndex.run });
 
-        expect(O.getOrThrow(keyword.run.answer)).toContain("helper in");
+        expect(O.getOrThrow(keyword.run.answer)).toContain("helper (const) in");
         expect(O.getOrThrow(keyword.run.answer)).toContain("src/util.ts");
         expect(keyword.run.citations.length).toBeGreaterThan(0);
         assertCitationAlignment({ events: keyword.events, run: keyword.run });

--- a/packages/repo-memory/runtime/test/RunProjector.test.ts
+++ b/packages/repo-memory/runtime/test/RunProjector.test.ts
@@ -3,6 +3,7 @@ import {
   Citation,
   CitationSpan,
   RepoId,
+  RetrievalCountPayload,
   RetrievalPacket,
   RetrievalPacketMaterializedEvent,
   RunAcceptedEvent,
@@ -51,10 +52,20 @@ const makePacket = (retrievedAt: DateTime.Utc) =>
     repoId,
     sourceSnapshotId: O.none(),
     query: "describe symbol `answer`",
+    normalizedQuery: "describe symbol `answer`",
+    queryKind: "countSymbols",
     retrievedAt,
+    outcome: "resolved",
     summary: "Projector packet summary.",
     citations: [makeCitation()],
     notes: ["projector-note"],
+    payload: O.some(
+      new RetrievalCountPayload({
+        target: "symbols",
+        count: decodeNonNegativeInt(1),
+      })
+    ),
+    issue: O.none(),
   });
 
 describe("repo-memory run projector", () => {
@@ -72,7 +83,7 @@ describe("repo-memory run projector", () => {
         runId: queryRunId,
         sequence: decodeRunEventSequence(2),
         emittedAt: makeUtc(1_706_300_001_000),
-        phase: "retrieve",
+        phase: "retrieval",
         message: "Retrieving grounded evidence.",
         percent: O.some(decodeNonNegativeInt(60)),
       });

--- a/packages/repo-memory/runtime/test/RunStateMachine.test.ts
+++ b/packages/repo-memory/runtime/test/RunStateMachine.test.ts
@@ -4,10 +4,11 @@ import {
   IndexRepoRunInput,
   QueryRepoRunInput,
   RepoId,
+  RetrievalCountPayload,
   RetrievalPacket,
   RunId,
 } from "@beep/repo-memory-model";
-import { FilePath, PosInt } from "@beep/schema";
+import { FilePath, NonNegativeInt, PosInt } from "@beep/schema";
 import { describe, expect, it } from "@effect/vitest";
 import { DateTime, Effect } from "effect";
 import * as O from "effect/Option";
@@ -22,6 +23,7 @@ import {
 } from "../src/run/RunStateMachine.ts";
 
 const decodeFilePath = S.decodeUnknownSync(FilePath);
+const decodeNonNegativeInt = S.decodeUnknownSync(NonNegativeInt);
 const decodePosInt = S.decodeUnknownSync(PosInt);
 const decodeRepoId = S.decodeUnknownSync(RepoId);
 const decodeRunId = S.decodeUnknownSync(RunId);
@@ -53,10 +55,20 @@ const makePacket = (retrievedAt: DateTime.Utc) =>
     repoId,
     sourceSnapshotId: O.none(),
     query: "describe symbol `answer`",
+    normalizedQuery: "describe symbol `answer`",
+    queryKind: "countSymbols",
     retrievedAt,
+    outcome: "resolved",
     summary: "Grounded retrieval summary.",
     citations: [makeCitation()],
     notes: ["packet-note"],
+    payload: O.some(
+      new RetrievalCountPayload({
+        target: "symbols",
+        count: decodeNonNegativeInt(1),
+      })
+    ),
+    issue: O.none(),
   });
 
 describe("repo-memory run state machine", () => {

--- a/packages/repo-memory/sqlite/test/RepoMemorySqlLive.test.ts
+++ b/packages/repo-memory/sqlite/test/RepoMemorySqlLive.test.ts
@@ -13,6 +13,7 @@ import {
   RepoSourceSnapshot,
   RepoSymbolDocumentation,
   RepoSymbolRecord,
+  RetrievalCountPayload,
   RetrievalPacket,
   RunId,
   SourceSnapshotId,
@@ -221,7 +222,10 @@ const makePacket = (options: {
     repoId: decodeRepoId(options.registrationId),
     sourceSnapshotId: O.some(decodeSourceSnapshotId(options.snapshotId)),
     query: "How many files?",
+    normalizedQuery: "how many files?",
+    queryKind: "countFiles",
     retrievedAt: DateTime.makeUnsafe(1_706_000_000_000),
+    outcome: "resolved",
     summary: "A deterministic retrieval packet.",
     citations: [
       new Citation({
@@ -240,6 +244,13 @@ const makePacket = (options: {
       }),
     ],
     notes: A.make(options.note),
+    payload: O.some(
+      new RetrievalCountPayload({
+        target: "files",
+        count: decodeNonNegativeInt(3),
+      })
+    ),
+    issue: O.none(),
   });
 
 const makeSemanticArtifacts = (options: { readonly registrationId: string; readonly snapshotId: string }) =>
@@ -411,10 +422,20 @@ describe("RepoMemorySqlLive", () => {
           repoId: registration.id,
           sourceSnapshotId: O.some(decodeSourceSnapshotId("snapshot:test-packet")),
           query: "How many files?",
+          normalizedQuery: "how many files?",
+          queryKind: "countFiles",
           retrievedAt: DateTime.makeUnsafe(1_706_000_000_000),
+          outcome: "resolved",
           summary: "A deterministic retrieval packet.",
           citations: A.empty(),
           notes: A.make("local-driver test note"),
+          payload: O.some(
+            new RetrievalCountPayload({
+              target: "files",
+              count: decodeNonNegativeInt(0),
+            })
+          ),
+          issue: O.none(),
         });
 
         yield* run.saveRetrievalPacket(runId, packet);

--- a/packages/runtime/server/test/SidecarRuntime.test.ts
+++ b/packages/runtime/server/test/SidecarRuntime.test.ts
@@ -565,13 +565,23 @@ describe("spawned Bun sidecar lifecycle", () => {
               queryEvents,
               A.map((event) => event.kind)
             )
-          ).toEqual(["accepted", "started", "progress", "progress", "retrieval-packet", "answer", "completed"]);
+          ).toEqual([
+            "accepted",
+            "started",
+            "progress",
+            "progress",
+            "progress",
+            "progress",
+            "retrieval-packet",
+            "answer",
+            "completed",
+          ]);
 
           const metricsResponse = yield* requestText(`${sidecar.rootUrl}/metrics`);
           expect(metricsResponse.status).toBe(200);
           expect(metricsResponse.body).toContain("beep_repo_memory_http_requests_total");
           expect(metricsResponse.body).toContain("beep_repo_memory_runs_started_total");
-          expect(metricsResponse.body).toContain("beep_repo_memory_query_results_total");
+          expect(metricsResponse.body).toContain("beep_repo_memory_query_interpretations_total");
           expect(metricsResponse.body).toContain("beep_repo_memory_driver_operation_duration_ms");
           expect(metricsResponse.body).toContain("child_fibers_started");
         })
@@ -644,7 +654,17 @@ describe("spawned Bun sidecar lifecycle", () => {
               queryEvents,
               A.map((event) => event.kind)
             )
-          ).toEqual(["accepted", "started", "progress", "progress", "retrieval-packet", "answer", "completed"]);
+          ).toEqual([
+            "accepted",
+            "started",
+            "progress",
+            "progress",
+            "progress",
+            "progress",
+            "retrieval-packet",
+            "answer",
+            "completed",
+          ]);
 
           const replayCursorValue = pipe(
             queryEvents,
@@ -677,7 +697,7 @@ describe("spawned Bun sidecar lifecycle", () => {
           expect(restoredQueryRunResponse.status).toBe(200);
           const restoredQueryRun = expectQueryRun(restoredQueryRunResponse.body);
           expect(restoredQueryRun.status).toBe("completed");
-          expect(O.getOrThrow(restoredQueryRun.answer)).toContain('Symbol "answer" is a const.');
+          expect(O.getOrThrow(restoredQueryRun.answer)).toContain("Signature: answer = helper(41).");
           expect(O.getOrThrow(restoredQueryRun.retrievalPacket).summary).toContain('Described symbol "answer"');
 
           const secondRpcClient = yield* makeRepoRunRpcClient(secondSidecar.baseUrl);
@@ -692,13 +712,19 @@ describe("spawned Bun sidecar lifecycle", () => {
               replayedEvents,
               A.map((event) => event.kind)
             )
-          ).toEqual(["retrieval-packet", "answer", "completed"]);
+          ).toEqual(["progress", "progress", "retrieval-packet", "answer", "completed"]);
           expect(
             pipe(
               replayedEvents,
               A.map((event) => event.sequence)
             )
-          ).toEqual([decodeRunEventSequence(5), decodeRunEventSequence(6), decodeRunEventSequence(7)]);
+          ).toEqual([
+            decodeRunEventSequence(5),
+            decodeRunEventSequence(6),
+            decodeRunEventSequence(7),
+            decodeRunEventSequence(8),
+            decodeRunEventSequence(9),
+          ]);
 
           const postRestartAccepted = yield* secondRpcClient.StartQueryRepoRun({
             repoId,
@@ -716,7 +742,17 @@ describe("spawned Bun sidecar lifecycle", () => {
               postRestartEvents,
               A.map((event) => event.kind)
             )
-          ).toEqual(["accepted", "started", "progress", "progress", "retrieval-packet", "answer", "completed"]);
+          ).toEqual([
+            "accepted",
+            "started",
+            "progress",
+            "progress",
+            "progress",
+            "progress",
+            "retrieval-packet",
+            "answer",
+            "completed",
+          ]);
 
           const restoredRuns = yield* requestJson(S.Array(RepoRun), `${secondSidecar.baseUrl}/runs`);
           expect(restoredRuns.status).toBe(200);

--- a/specs/pending/expert-memory-big-picture/CLAIMS_AND_EVIDENCE.md
+++ b/specs/pending/expert-memory-big-picture/CLAIMS_AND_EVIDENCE.md
@@ -3,6 +3,16 @@
 ## Thesis
 If the expert-memory vision needs one central durable abstraction, it is probably not the raw node, edge, or embedding. It is the `claim` plus its `evidence`. That pair is what allows the system to preserve disagreement, explain answers, survive temporal change, and stay useful outside code.
 
+Repo-memory `v0` does not need to fully materialize that abstraction to prove the Memory Kernel.
+Its current proof is earlier and narrower:
+- deterministic artifacts
+- evidence-bearing retrieval
+- extraction provenance
+- query-time explainability
+- bounded retrieval packets
+
+`ClaimRecord` remains the likely broader cross-domain destination, not the immediate `v0` deliverable.
+
 ## Current Repo Reality
 The current repo-codegraph documents already lean toward claim-oriented architecture in the semantic integration work. The older `knowledge` slice makes this much more concrete:
 - [MentionRecord.model.ts](../../../.repos/beep-effect/packages/knowledge/domain/src/entities/MentionRecord/MentionRecord.model.ts)
@@ -38,6 +48,11 @@ That would let the system represent:
 - answer-time validations
 
 without pretending they all have the same epistemic status.
+
+The repo `v0` implication is:
+- prove `artifact-to-packet` first
+- keep extraction provenance and query-time explainability explicit
+- move to fuller `ClaimRecord` modeling when a second domain or real conflict-heavy workflow makes it necessary
 
 ## Why Raw Edges Are Not Enough
 A plain edge says:
@@ -102,6 +117,10 @@ That is exactly the kind of evidence pinning expert systems need.
 
 ### Citation validation as answer-time claim checking
 The older GraphRAG path did not stop at retrieval. It attempted to validate citations and reasoning before presenting an answer. That is a much stronger direction than typical RAG patterns.
+
+That same lesson also supports the current repo `v0` split:
+- extraction provenance belongs to the durable knowledge side
+- query-time explainability belongs to the run and packet side
 
 ### Reasoning traces as evidence of reasoning
 The older slice also treated reasoning traces as structured output rather than debug text.

--- a/specs/pending/expert-memory-big-picture/EXPERT_MEMORY_KERNEL.md
+++ b/specs/pending/expert-memory-big-picture/EXPERT_MEMORY_KERNEL.md
@@ -3,6 +3,18 @@
 ## Thesis
 The reusable asset behind the repo-codegraph exploration is an `expert-memory kernel`: a layered architecture that turns raw source material into bounded, evidence-bearing, temporally aware retrieval packets. The kernel matters more than any single parser, database, or domain ontology, but the kernel is only half the story. A serious expert-memory system also needs a control plane that keeps that kernel trustworthy in execution.
 
+Repo-memory `v0` proves that kernel at a narrower layer than the full long-term claim system.
+The concrete proof in this repo is:
+- deterministic artifacts
+- bounded source-grounded retrieval
+- extraction provenance
+- query-time explainability
+- retrieval packet freezing
+- answer rendering from packet only
+
+That does not replace `ClaimRecord` as the likely broader cross-domain destination.
+It means repo `v0` is allowed to prove the kernel earlier at `artifact-to-packet`.
+
 ## Current Repo Reality
 The current repo already points at most of the kernel shape:
 - deterministic extraction and certainty tiers in [Repo Codegraph Overview](../repo-codegraph-jsdoc/OVERVIEW.md)
@@ -19,6 +31,10 @@ The older `knowledge` slice adds the missing operational lesson:
 - [ReasoningTraceFormatter.ts](../../../.repos/beep-effect/packages/knowledge/server/src/GraphRAG/ReasoningTraceFormatter.ts)
 
 What is not yet fully unified is the language for describing these pieces as one portable system rather than separate experiments.
+The missing simplification is now clearer:
+- keep `claim + evidence` as the likely broader destination
+- let repo-memory `v0` prove the kernel one step earlier through `artifact-to-packet`
+- keep extraction provenance distinct from query-time explainability
 
 ## Strongly Supported Pattern
 A useful expert-memory system is best understood as two interacting layers:
@@ -36,6 +52,14 @@ A useful expert-memory system is best understood as two interacting layers:
 | `Provenance layer` | Preserve lineage and causal traceability | activity, input, derivation, actor, dependency chain |
 | `Temporal lifecycle layer` | Model what changed and when | asserted time, observed time, effective time, superseded time |
 | `Retrieval packet layer` | Prepare bounded context for use by agents or humans | small, evidence-bearing, query-shaped packets |
+
+For repo-memory `v0`, the currently proved path is intentionally smaller:
+- `grounding`
+- `retrieval`
+- `packet`
+- `answer`
+
+That is still a real kernel proof because it validates evidence discipline, packet freezing, and render-only answer assembly under a real control plane.
 
 ### Operational Control Plane
 | Component | Purpose | Output |
@@ -171,6 +195,10 @@ This is essential for AI-facing systems because the system must be able to expla
 - which inputs were used
 - which prior claims a derived claim depends on
 
+In repo-memory `v0`, keep two explainability surfaces separate:
+- extraction provenance: how deterministic artifacts and overlays were produced
+- query-time explainability: how one run grounded, selected, and packaged evidence for one answer
+
 ### 7. Temporal Lifecycle Layer
 The system should not act as though there is one timeless graph.
 
@@ -189,6 +217,9 @@ The main deliverable for AI systems is usually not a raw graph query result. It 
 - the right evidence attached
 - the right token budget
 - the right temporal scope
+
+For repo-memory `v0`, that packet is the public proof artifact.
+The answer stage should not add new support beyond what the packet already contains.
 
 ### 9. Why The Control Plane Belongs In The Architecture
 The older `knowledge` slice is useful because it shows that semantic quality alone is not enough. The system also needed:

--- a/specs/pending/expert-memory-big-picture/EXPERT_MEMORY_ONBOARDING.md
+++ b/specs/pending/expert-memory-big-picture/EXPERT_MEMORY_ONBOARDING.md
@@ -23,6 +23,8 @@ For the concrete repo expert-memory `v0`, the runtime shape is now also locked:
 - `@effect/vitest` for supporting tests and spawned Bun subprocess tests for real lifecycle proof
 - schema JSON codecs are required even in tests and fixtures; avoid native `JSON.parse` / `JSON.stringify`
 - keep `FileSystem`, `Path`, and `SqlClient` inside layers/services rather than leaking them into public helper signatures
+- repo-memory `v0` proves the kernel at `artifact-to-packet` before a full `ClaimRecord` implementation
+- extraction provenance and query-time explainability should stay explicit and separable
 
 ## Non-Negotiables
 Unless new evidence materially overturns them, keep these defaults:
@@ -45,12 +47,13 @@ Unless new evidence materially overturns them, keep these defaults:
 5. [DATABASE_AND_RUNTIME_CHOICES.md](./DATABASE_AND_RUNTIME_CHOICES.md)
 6. [LOCAL_FIRST_V0_ARCHITECTURE.md](./LOCAL_FIRST_V0_ARCHITECTURE.md)
 7. [README.md](../repo-expert-memory-local-first-v0/README.md)
-8. [CLUSTER_FIRST_SUBSTRATE_DECISION.md](../repo-expert-memory-local-first-v0/CLUSTER_FIRST_SUBSTRATE_DECISION.md)
-9. [HTTPAPI_RPC_PIVOT.md](../repo-expert-memory-local-first-v0/HTTPAPI_RPC_PIVOT.md)
-10. [CLUSTER_FIRST_REPO_EXPERT_MEMORY_PLAN.md](../repo-expert-memory-local-first-v0/CLUSTER_FIRST_REPO_EXPERT_MEMORY_PLAN.md)
-11. [OVERVIEW.md](../repo-codegraph-jsdoc/OVERVIEW.md)
-12. [OVERVIEW_SEMANTIC_KG_INTEGRATION_EXPLAINED.md](../repo-codegraph-jsdoc/OVERVIEW_SEMANTIC_KG_INTEGRATION_EXPLAINED.md)
-13. [README.md](../ip-law-knowledge-graph/README.md)
+8. [QUERY_STAGES_AND_RETRIEVAL_PACKET.md](../repo-expert-memory-local-first-v0/QUERY_STAGES_AND_RETRIEVAL_PACKET.md)
+9. [CLUSTER_FIRST_SUBSTRATE_DECISION.md](../repo-expert-memory-local-first-v0/CLUSTER_FIRST_SUBSTRATE_DECISION.md)
+10. [HTTPAPI_RPC_PIVOT.md](../repo-expert-memory-local-first-v0/HTTPAPI_RPC_PIVOT.md)
+11. [CLUSTER_FIRST_REPO_EXPERT_MEMORY_PLAN.md](../repo-expert-memory-local-first-v0/CLUSTER_FIRST_REPO_EXPERT_MEMORY_PLAN.md)
+12. [OVERVIEW.md](../repo-codegraph-jsdoc/OVERVIEW.md)
+13. [OVERVIEW_SEMANTIC_KG_INTEGRATION_EXPLAINED.md](../repo-codegraph-jsdoc/OVERVIEW_SEMANTIC_KG_INTEGRATION_EXPLAINED.md)
+14. [README.md](../ip-law-knowledge-graph/README.md)
 
 ## Working Vocabulary
 Keep these stable:
@@ -152,7 +155,7 @@ Default payload:
 ## Practical Orientation
 The fastest correct mental model is:
 - think `expert memory`, not `repo graph`
-- think `claim + evidence + provenance + time`, not edge soup
+- think `artifact -> packet` as the current repo proof and `claim + evidence + provenance + time` as the broader destination, not edge soup
 - think `control plane / epistemic runtime`, not graph romanticism
 - think `grounded answer substrate`, not generic RAG
 - think `local-first sidecar`, not browser-first SaaS

--- a/specs/pending/expert-memory-big-picture/GRAPHITI_MEMORY_BOOTSTRAP_AND_QUERY_CATALOG.md
+++ b/specs/pending/expert-memory-big-picture/GRAPHITI_MEMORY_BOOTSTRAP_AND_QUERY_CATALOG.md
@@ -29,7 +29,9 @@ The examples below assume a wrapper that expects the string form. If your wrappe
 | `Repo-codegraph as proving ground for expert memory` | Preserve the core thesis | `expert memory`, `proving ground`, `deterministic-first`, `code as first domain` | `repo-codegraph` |
 | `Expert-memory kernel centers on claims evidence provenance and time` | Preserve the semantic-kernel vocabulary | `claim`, `evidence`, `provenance`, `temporal lifecycle`, `retrieval packet`, `semantic kernel` | `—` |
 | `Old knowledge slice proved need for control plane and grounded answers` | Preserve the v3 knowledge-slice lesson | `control plane`, `epistemic runtime`, `citation validation`, `reasoning traces`, `grounded answers` | `knowledge slice` |
-| `ClaimRecord is the likely durable abstraction above raw edges` | Preserve claim-first modeling guidance | `ClaimRecord`, `mention record`, `relation evidence`, `supersession`, `conflict`, `evidence-of-record` | `—` |
+| `Repo v0 proves the kernel at artifact to packet before full ClaimRecord` | Preserve the narrower repo proof shape | `artifact-to-packet`, `retrieval packet`, `grounding`, `retrieval`, `packet`, `answer` | `packet-only answer rendering` |
+| `ClaimRecord is the likely broader abstraction beyond repo v0` | Preserve claim-first modeling guidance without over-claiming current v0 scope | `ClaimRecord`, `mention record`, `relation evidence`, `supersession`, `conflict`, `evidence-of-record` | `—` |
+| `Extraction provenance and query-time explainability should stay separate` | Preserve the explainability split | `extraction provenance`, `query-time explainability`, `retrieval packet`, `run-scoped explainability` | `—` |
 | `Time and contradiction are central not polish` | Preserve temporal/conflict modeling stance | `bitemporal`, `assertedAt`, `derivedAt`, `effectiveAt`, `supersededAt`, `what did we know when` | `—` |
 | `TSMorphService should use scoped project pools not one global Project` | Preserve ts-morph lifecycle guidance | `TSMorphService`, `ts-morph`, `Project lifecycle`, `memory footprint`, `project references`, `workspace scope` | `LRU`, `TTL` |
 | `Nomik uses tree-sitter because it is polyglot and extraction-first` | Preserve why Nomik chose tree-sitter | `Nomik`, `tree-sitter`, `polyglot`, `extraction-oriented`, `Neo4j`, `ts-morph` | `different problem` |
@@ -41,7 +43,7 @@ The examples below assume a wrapper that expects the string form. If your wrappe
 ### Core expert-memory cluster
 ```json
 mcp__graphiti-memory__search_memory_facts({
-  "query": "expert memory big picture knowledge slice claim evidence control plane epistemic runtime grounded answer verification",
+  "query": "expert memory big picture artifact-to-packet claim evidence control plane epistemic runtime grounded answer verification",
   "group_ids": "[\"beep-dev\"]",
   "max_facts": 10
 })
@@ -87,6 +89,15 @@ mcp__graphiti-memory__search_memory_facts({
 ```json
 mcp__graphiti-memory__search_memory_facts({
   "query": "expert memory domain transfer law wealth compliance claim evidence contradiction temporal lifecycle",
+  "group_ids": "[\"beep-dev\"]",
+  "max_facts": 10
+})
+```
+
+### Query-stage and packet cluster
+```json
+mcp__graphiti-memory__search_memory_facts({
+  "query": "repo expert memory query stages grounding retrieval packet answer extraction provenance explainability retrieval packet payload issue",
   "group_ids": "[\"beep-dev\"]",
   "max_facts": 10
 })

--- a/specs/pending/expert-memory-big-picture/README.md
+++ b/specs/pending/expert-memory-big-picture/README.md
@@ -3,6 +3,15 @@
 ## Thesis
 The repo-codegraph work in this repository is best understood as a proving ground for a broader `expert-memory` architecture. Code is the easiest domain to start with because it offers syntax, references, and feedback loops, but the more durable asset is the trust stack behind the graph: deterministic extraction, claims, evidence, ontology, validation, provenance, temporal lifecycle, bounded retrieval, and the control plane that keeps the whole system reliable.
 
+The important refinement is that repo-memory `v0` proves that architecture earlier than a full cross-domain `ClaimRecord` system.
+Its concrete proof is the `artifact-to-packet` path:
+- deterministic artifacts
+- evidence-bearing retrieval
+- extraction provenance
+- query-time explainability
+- bounded retrieval packets
+- packet-only answer rendering
+
 This folder is a reading set, not a phased implementation spec. Its purpose is to make the larger shape legible before any new package or domain commitment is made.
 When repo-specific `v0` runtime, protocol, package, or deliverable details are needed, [Repo Expert-Memory Local-First V0](../repo-expert-memory-local-first-v0/README.md) is the downstream authority and this folder should be treated as rationale only.
 
@@ -25,6 +34,12 @@ Taken together, those materials already establish several important ideas:
 - time and contradiction handling are architecture concerns, not polish
 - execution control, idempotency, progress, and LLM budgets are part of the product, not implementation noise
 
+The current repo-specific `v0` proves a smaller but still meaningful kernel:
+- extraction provenance stays explicit
+- query-time explainability stays run-scoped
+- the final public truth surface is a bounded retrieval packet
+- broader `ClaimRecord` modeling remains the likely next cross-domain generalization rather than the immediate `v0` requirement
+
 ## Strongly Supported Pattern
 A useful expert-memory system has six durable properties:
 - it separates mechanically grounded facts from interpreted claims
@@ -33,6 +48,9 @@ A useful expert-memory system has six durable properties:
 - it uses a bounded semantic overlay instead of ontology maximalism
 - it produces retrieval packets for AI and expert use rather than exposing raw graph state as the main interface
 - it has an operational control plane that keeps extraction, enrichment, and retrieval trustworthy under retries, failures, and budgets
+
+For repo-memory `v0`, one additional split now matters:
+- extraction provenance and query-time explainability are related, but they are not the same artifact and should stay separable
 
 ## Exploratory Direction
 The likely long-term platform is not `a repo graph` or `a legal graph`. It is a domain-adaptable expert-memory system with three major parts:
@@ -74,8 +92,8 @@ Read the diagram from left to right:
 - `Control Plane`: the execution and trust systems that keep the pipeline sane in production
 
 ## Reading Order
-1. [EXPERT_MEMORY_KERNEL.md](./EXPERT_MEMORY_KERNEL.md) for the core reusable architecture
-2. [CLAIMS_AND_EVIDENCE.md](./CLAIMS_AND_EVIDENCE.md) for the likely central abstraction
+1. [EXPERT_MEMORY_KERNEL.md](./EXPERT_MEMORY_KERNEL.md) for the core reusable architecture and the current `artifact-to-packet` proof posture
+2. [CLAIMS_AND_EVIDENCE.md](./CLAIMS_AND_EVIDENCE.md) for the likely broader durable abstraction beyond repo `v0`
 3. [EXPERT_MEMORY_CONTROL_PLANE.md](./EXPERT_MEMORY_CONTROL_PLANE.md) for the execution and trust runtime
 4. [REPRESENTATION_LAYERS.md](./REPRESENTATION_LAYERS.md) for the graph boundaries
 5. [TRUST_TIME_AND_CONFLICT.md](./TRUST_TIME_AND_CONFLICT.md) for the hardest modeling problem
@@ -89,7 +107,7 @@ Read the diagram from left to right:
 | Document | Purpose |
 |---|---|
 | [EXPERT_MEMORY_KERNEL.md](./EXPERT_MEMORY_KERNEL.md) | Defines the reusable expert-memory kernel and its boundaries |
-| [CLAIMS_AND_EVIDENCE.md](./CLAIMS_AND_EVIDENCE.md) | Explains why claim and evidence records are likely the central durable abstraction |
+| [CLAIMS_AND_EVIDENCE.md](./CLAIMS_AND_EVIDENCE.md) | Explains why claim and evidence records remain the likely broader durable abstraction beyond the repo `artifact-to-packet` proof |
 | [EXPERT_MEMORY_CONTROL_PLANE.md](./EXPERT_MEMORY_CONTROL_PLANE.md) | Frames idempotency, workflow state, progress, budgets, and audit as part of the architecture |
 | [DOMAIN_TRANSFER_MAP.md](./DOMAIN_TRANSFER_MAP.md) | Shows what transfers from repo intelligence into law, wealth, and compliance |
 | [REPRESENTATION_LAYERS.md](./REPRESENTATION_LAYERS.md) | Separates deterministic, semantic, claim, and provenance layers |

--- a/specs/pending/repo-expert-memory-local-first-v0/EVALUATION_AND_ACCEPTANCE.md
+++ b/specs/pending/repo-expert-memory-local-first-v0/EVALUATION_AND_ACCEPTANCE.md
@@ -49,6 +49,7 @@ At minimum, include questions like:
 ### 3. Query workflow lifecycle
 - start a query workflow and receive a deterministic `runId`
 - stream progress through `StreamRunEvents`
+- verify query progress uses `grounding`, `retrieval`, `packet`, and `answer`
 - verify disconnect does not kill the underlying run
 - reconnect from cursor and receive missing events cleanly
 - verify final run detail remains inspectable after completion
@@ -58,16 +59,19 @@ At minimum, include questions like:
 - final answer must correspond to the repo question
 - citations must point to real file spans or symbol-backed spans
 - retrieval packet must be visible and bounded
+- retrieval packet must expose normalized query, query kind, outcome, and structured payload or structured issue
 - unsupported confidence should not be presented as certainty
 - supported query classes must be source-grounded
 - unsupported query classes must fail safe instead of inventing answers
 - paraphrase, identifier-split, and relaxed file/module phrasings for supported queries should either collapse to the same grounded result or fail safe as unsupported
 - deterministic fallback behavior must remain available for the current exact-match query path
 - if retrieval-side NLP materially changes result selection, the explanation must remain inspectable through retrieval-packet notes and observability
+- the final answer must be derivable from packet payload plus packet citations alone
 
 ### 5. Projection integrity
 - `GET /runs` and `GET /runs/:runId` must reflect durable run state
 - final retrieval packet and final answer must match the run event history
+- packet payload, packet citations, and final answer must agree exactly
 - replay after restart must rebuild the same projection state
 - stream consumers must be able to rebuild equivalent run state from journal replay plus live events without relying on embedded run snapshots
 
@@ -94,6 +98,7 @@ At minimum, include questions like:
 - the spec set must not still recommend the superseded `HTTP + SSE` run model
 - the spec set must not still recommend a custom local workflow engine
 - the spec set must keep NLP scoped to retrieval-side enrichment and must not imply freeform semantic repo chat or NLP-derived canonical state
+- the spec set must keep the packet as the frozen evidence product and the answer stage as render-only
 
 ## Prototype-Grade, Not SLA-Grade
 This is still a research prototype.

--- a/specs/pending/repo-expert-memory-local-first-v0/IMPLEMENTATION_BREAKDOWN.md
+++ b/specs/pending/repo-expert-memory-local-first-v0/IMPLEMENTATION_BREAKDOWN.md
@@ -16,7 +16,7 @@ The point of this breakdown is to sequence the work so lifecycle, transport, and
 - Grounded retrieval: landed with bounded deterministic query interpretation, durable citations/retrieval packets, and repo-local resolved file dependency/dependent retrieval over persisted import-edge targets.
 - Retrieval-side NLP enrichment: not yet landed; it is the next bounded phase over the existing query-to-retrieval path and must preserve deterministic fallback plus citation-first grounding.
 - Test split and lifecycle proof: landed with `@effect/vitest` supporting tests and spawned Bun subprocess lifecycle tests.
-- Remaining `v0` closure: land retrieval-side NLP enrichment, then finish the broader projection bootstrap/cursor pipeline and decider-style runtime split without regressing the already-landed lifecycle behavior.
+- Remaining `v0` closure: finish the explicit `grounding -> retrieval -> packet -> answer` split, extend the packet into a structured durable evidence product, then finish the broader projection bootstrap/cursor pipeline and decider-style runtime split without regressing the already-landed lifecycle behavior.
 
 ## Workstream 1: Contracts
 Lock the public contracts first.
@@ -29,6 +29,14 @@ Define and keep stable:
 - `RunCursor`
 - `Citation`
 - `RetrievalPacket`
+- `RetrievalOutcome`
+- `RetrievalPayload`
+- `RetrievalIssue`
+- `RetrievalRequestedTarget`
+- `RetrievalSubject`
+- `RetrievalCandidate`
+- `RetrievalItem`
+- `RetrievalFacet`
 - workflow payloads for `IndexRepoRun` and `QueryRepoRun`
 
 ### `packages/repo-memory/store`
@@ -105,6 +113,7 @@ Use journal events to build run summaries and final answer detail views.
 Current reality:
 - lifecycle events are delta-shaped, not embedded full-run snapshots
 - the shared `RunProjector` in `packages/repo-memory/model` is already the canonical projection function for runtime and desktop consumers
+- `RetrievalPacketMaterialized` now conceptually freezes the packet before `AnswerDrafted`
 - the remaining architecture gap is not projector existence but durable projection bootstrap/cursor ownership and the broader decider split around `RepoRunService`
 
 ## Workstream 6: Shared router assembly
@@ -145,8 +154,9 @@ Also remove doc language that still treats those as the target design.
 The current next slice is no longer hypothetical. It is:
 - deterministic TypeScript extraction at index time
 - persisted source snapshots, source files, symbol records, and import edges in SQLite
-- bounded deterministic query interpretation
+- bounded deterministic grounding
 - source-grounded retrieval packets and citations for supported query classes
+- packet-only answer rendering from a frozen evidence product
 
 Current supported query classes:
 - `countFiles`
@@ -172,6 +182,19 @@ Current non-goals:
 This workstream establishes the accepted typed boundary for repo questions.
 Any later NLP work must sit on top of this path as bounded enrichment rather than replacing the source-grounded contract.
 
+The normative query-stage contract is now:
+- `grounding`
+- `retrieval`
+- `packet`
+- `answer`
+
+The packet contract is now:
+- bounded durable evidence product
+- packet-level citations
+- structured `payload` for resolved outcomes
+- structured `issue` for unresolved outcomes
+- answer derivable from packet only
+
 ## Workstream 10: Retrieval-side NLP enrichment
 The next `v0` phase should improve query ergonomics and recall without changing the truth boundary.
 
@@ -193,6 +216,7 @@ Rules:
 - `RetrievalPacket` remains the bounded evidence-bearing output.
 - deterministic fallback behavior must remain available for critical retrieval flows.
 - materially important normalization or ranking decisions should stay inspectable through retrieval-packet notes, structured logs, spans, and metrics.
+- NLP enrichment must not bypass packet freezing or cause the answer stage to add unstated support.
 
 Non-goals:
 - freeform semantic repo chat
@@ -210,6 +234,9 @@ Supporting tests:
 - use `sqlite-node` for local SQL integration in supporting tests
 - keep `FileSystem`, `Path`, and `SqlClient` requirements inside layers and shared harnesses rather than leaking them through helper method signatures
 - use schema JSON codecs in tests and fixtures; do not reintroduce native `JSON.parse` / `JSON.stringify`
+- prove that packet payload, citations, and final answer stay aligned
+- prove that replay rebuilds the same packet and the same final answer
+- prove that query-run progress phases use `grounding`, `retrieval`, `packet`, and `answer`
 - when workstream 10 lands, prove that paraphrase, identifier-split, and relaxed file/module phrasings either collapse to the same grounded result or fail safe as unsupported
 - when workstream 10 lands, prove that disabling enrichment preserves the current deterministic interpreter behavior
 

--- a/specs/pending/repo-expert-memory-local-first-v0/QUERY_STAGES_AND_RETRIEVAL_PACKET.md
+++ b/specs/pending/repo-expert-memory-local-first-v0/QUERY_STAGES_AND_RETRIEVAL_PACKET.md
@@ -1,0 +1,340 @@
+# Query Stages And Retrieval Packet
+
+## Thesis
+Repo expert-memory `v0` proves the Memory Kernel earlier than a full cross-domain `ClaimRecord` system.
+
+The concrete proof for this slice is:
+- deterministic repo artifacts
+- evidence anchors and citations
+- extraction lineage
+- query-time explainability
+- a frozen `RetrievalPacket`
+- an answer rendered from that packet only
+
+This document is the downstream authority for that contract.
+
+## Why Repo-Memory `v0` Proves The Kernel At `Artifact-To-Packet`
+The broad expert-memory direction still points toward `claim + evidence + provenance + time` as the likely reusable long-term center.
+
+Repo-memory `v0` does not need to prove all of that at once.
+It proves the kernel on a narrower but still meaningful path:
+- index deterministic repo artifacts
+- bind a question to a supported deterministic query shape
+- retrieve bounded source-backed evidence
+- freeze an inspectable packet
+- render the final answer from that packet
+
+That narrower proof is enough to validate:
+- bounded answer construction
+- packet inspectability
+- citation discipline
+- extraction provenance
+- run-scoped explainability
+- separation between retrieval truth and final rendering
+
+## Canonical Query-Stage Vocabulary
+Query runs use exactly four progress phases:
+- `grounding`
+- `retrieval`
+- `packet`
+- `answer`
+
+Use them as follows:
+- `grounding`: normalize the question and bind it to a supported deterministic query shape
+- `retrieval`: read persisted repo artifacts and resolve the bounded evidence set
+- `packet`: freeze the evidence-bearing retrieval packet, including packet notes and semantic overlay
+- `answer`: render the user-facing answer from the packet only
+
+These are progress stages, not new event kinds.
+The durable result events remain:
+- `RetrievalPacketMaterialized`
+- `AnswerDrafted`
+
+## Stage Contracts
+### 1. `grounding`
+Input:
+- `QueryRepoRunInput`
+
+Output:
+- run-scoped `GroundingArtifact`
+
+Allowed reads:
+- none from repo stores
+
+Responsibilities:
+- normalize question text
+- classify supported query kind
+- extract and normalize handles such as symbol, file, module, or keyword queries
+- attach concise grounding notes when normalization materially changes the request
+- return explicit unsupported reasons when the question does not map to a supported deterministic query shape
+
+Must not:
+- inspect snapshots
+- rank candidates
+- inspect semantic artifacts
+- assemble answer prose
+
+### 2. `retrieval`
+Input:
+- `GroundingArtifact`
+
+Output:
+- run-scoped `RetrievedEvidence`
+
+Allowed reads:
+- latest persisted snapshot and repo-memory artifact stores
+
+Responsibilities:
+- bind the request to a concrete snapshot
+- gather deterministic evidence
+- resolve ambiguity or fail safe
+- select bounded supporting citations
+- produce a structured retrieval outcome
+
+Must not:
+- emit final answer prose
+- reopen question normalization
+- depend on packet-only rendering behavior
+
+### 3. `packet`
+Input:
+- `RetrievedEvidence`
+
+Output:
+- durable `RetrievalPacket`
+
+Allowed reads:
+- semantic overlay artifacts and evidence anchors that are already snapshot-scoped and bounded
+
+Responsibilities:
+- freeze the normalized query, query kind, outcome, payload or issue, citations, and notes
+- attach concise inspectable overlay and provenance notes
+- produce the bounded evidence product consumed by the UI and answer renderer
+
+Must not:
+- reopen candidate selection
+- change snapshot binding
+- introduce unstated support
+
+### 4. `answer`
+Input:
+- `RetrievalPacket`
+
+Output:
+- final grounded answer text
+
+Allowed reads:
+- packet only
+
+Responsibilities:
+- render the user-facing answer from packet content alone
+- preserve packet citations exactly
+- render unresolved outcomes safely
+
+Must not:
+- hit repo stores
+- rerank candidates
+- add new evidence
+- add unstated claims
+
+## `RetrievalPacket` Envelope Contract
+`RetrievalPacket` is the bounded durable evidence product for query runs.
+
+It must include:
+- `repoId`
+- `sourceSnapshotId`
+- `query`
+- `normalizedQuery`
+- `queryKind`
+- `retrievedAt`
+- `outcome`
+- `summary`
+- `citations`
+- `notes`
+- `issue?`
+- `payload?`
+
+Rules:
+- `payload` exists only when `outcome = resolved`
+- `issue` exists only when `outcome = none | ambiguous | unsupported`
+- packet children refer back to packet-level citations by `citationIds`
+- `RetrievalPacketMaterialized` freezes the packet before `AnswerDrafted`
+- the final answer must be derivable from packet content alone
+
+`RetrievalPacket` is intentionally:
+- smaller than raw snapshot or semantic dumps
+- more inspectable than ad hoc answer prose
+- concrete enough to drive UI inspection and answer rendering
+
+## `RetrievalPayload` And `RetrievalIssue` Unions
+### `RetrievalOutcome`
+Use:
+- `resolved`
+- `none`
+- `ambiguous`
+- `unsupported`
+
+### `RetrievalPayload`
+Resolved packet payloads use these families:
+- `count`
+- `subject-detail`
+- `relation-list`
+- `search-results`
+
+Recommended variant shapes:
+
+`RetrievalCountPayload`
+- `family = "count"`
+- `target = "files" | "symbols"`
+- `count`
+
+`RetrievalSubjectDetailPayload`
+- `family = "subject-detail"`
+- `subject`
+- `facets`
+
+`RetrievalRelationListPayload`
+- `family = "relation-list"`
+- `relation`
+- `subject`
+- `items`
+
+`RetrievalSearchResultsPayload`
+- `family = "search-results"`
+- `query`
+- `items`
+
+### `RetrievalIssue`
+Non-resolved packets use these issue families:
+- `no-match`
+- `ambiguous`
+- `unsupported`
+
+Recommended variant shapes:
+
+`RetrievalNoMatchIssue`
+- `kind = "no-match"`
+- `requested`
+- `note`
+
+`RetrievalAmbiguousIssue`
+- `kind = "ambiguous"`
+- `requested`
+- `candidates`
+
+`RetrievalUnsupportedIssue`
+- `kind = "unsupported"`
+- `requested`
+- `reason`
+
+## Helper Role Vocabulary
+Use these role names consistently:
+- `requested`
+- `subject`
+- `candidate`
+- `item`
+- `facet`
+
+Meaning:
+- `requested`: what the user asked for before resolution
+- `subject`: the grounded file, symbol, or module the packet is about
+- `candidate`: an alternative grounded target shown in ambiguous outcomes
+- `item`: a renderable list element in a payload
+- `facet`: one aspect of a grounded subject such as location, declaration, documentation, parameters, returns, throws, or deprecation
+
+For `repo-memory`, keep the concrete variants repo-local:
+- file
+- symbol
+- module
+- location
+- declaration
+- documentation
+- parameters
+- returns
+- throws
+- deprecation
+
+Do not extract these helper structs into a shared kernel package yet.
+The reusable thing in `v0` is the role vocabulary and packet law, not a new cross-domain package.
+
+## Mapping From Current Query Kinds To Payload Families
+Current deterministic query kinds map as follows:
+
+`count`
+- `countFiles`
+- `countSymbols`
+
+`subject-detail`
+- `locateSymbol`
+- `describeSymbol`
+- `symbolParams`
+- `symbolReturns`
+- `symbolThrows`
+- `symbolDeprecation`
+
+`relation-list`
+- `listFileExports`
+- `listFileImports`
+- `listFileImporters`
+- `listSymbolImporters`
+- `listFileDependencies`
+- `listFileDependents`
+
+`search-results`
+- `keywordSearch`
+
+`unsupported`
+- `unsupported`
+
+Failure mapping rules:
+- no exact grounded subject becomes `outcome = none` with a `RetrievalNoMatchIssue`
+- multiple viable grounded subjects becomes `outcome = ambiguous` with a `RetrievalAmbiguousIssue`
+- unsupported question shapes become `outcome = unsupported` with a `RetrievalUnsupportedIssue`
+
+## Event And Projection Implications
+The query-run event vocabulary stays:
+- `RunAccepted`
+- `RunStarted`
+- `RunProgressUpdated`
+- `RetrievalPacketMaterialized`
+- `AnswerDrafted`
+- terminal lifecycle events
+
+The contract changes are:
+- `RunProgressUpdated.phase` uses the canonical four-stage vocabulary
+- `RetrievalPacketMaterialized` carries the frozen packet
+- `AnswerDrafted` must be renderable from that packet alone
+- replay plus projection must rebuild the same final packet and answer state
+
+## UI And Read-Model Implications
+The run detail view should treat the packet as a first-class inspection surface.
+
+At minimum, query-run detail should show:
+- normalized query
+- query kind
+- retrieval outcome
+- structured payload or structured issue
+- citations
+- notes
+- final answer
+
+The answer panel is a rendering of packet state, not a second retrieval system.
+
+## Non-Goals And Guardrails
+This contract does not require:
+- a cross-domain `ClaimRecord` package in `v0`
+- RDF or semantic-web internals as the runtime source of truth
+- freeform semantic repo chat
+- durable NLP-derived mention, entity, relation, or claim state
+- unbounded reasoning traces as the main answer surface
+
+Guardrails:
+- retrieval remains deterministic-first
+- semantic overlay remains bounded and inspectable
+- packet notes explain material normalization, ranking, or overlay behavior
+- the answer stage may not add support or selection logic
+
+## Open Questions Intentionally Deferred Past `v0`
+- When should `GroundingArtifact` and `RetrievedEvidence` become durable explainability products instead of run-scoped internal artifacts?
+- Which packet role names should extract into a shared kernel package once a second domain adapter exists?
+- When should broader cross-domain `ClaimRecord` modeling take over from the repo `artifact-to-packet` proof?

--- a/specs/pending/repo-expert-memory-local-first-v0/README.md
+++ b/specs/pending/repo-expert-memory-local-first-v0/README.md
@@ -30,6 +30,13 @@ This folder turns that thesis into a concrete, implementable `v0` for one narrow
 - the user asks questions about that repo
 - the app returns grounded answers with visible citations and retrieval context
 
+The current kernel proof for this slice is narrower than a full cross-domain claim system:
+- deterministic repo artifacts
+- bounded retrieval over those artifacts
+- a frozen `RetrievalPacket`
+- an answer rendered from that packet only
+- extraction provenance and query-time explainability kept explicit and inspectable
+
 This v0 is intentionally a `research prototype`, not a product-complete application.
 
 ## Current Architectural Authority
@@ -38,8 +45,9 @@ Use these documents as the normative current-state set:
 2. [TOPOLOGY.md](./TOPOLOGY.md)
 3. [SIDECAR_PROTOCOL.md](./SIDECAR_PROTOCOL.md)
 4. [VERTICAL_SLICE.md](./VERTICAL_SLICE.md)
-5. [EVALUATION_AND_ACCEPTANCE.md](./EVALUATION_AND_ACCEPTANCE.md)
-6. [IMPLEMENTATION_BREAKDOWN.md](./IMPLEMENTATION_BREAKDOWN.md)
+5. [QUERY_STAGES_AND_RETRIEVAL_PACKET.md](./QUERY_STAGES_AND_RETRIEVAL_PACKET.md)
+6. [EVALUATION_AND_ACCEPTANCE.md](./EVALUATION_AND_ACCEPTANCE.md)
+7. [IMPLEMENTATION_BREAKDOWN.md](./IMPLEMENTATION_BREAKDOWN.md)
 
 Historical and supporting context:
 - [HTTPAPI_RPC_PIVOT.md](./HTTPAPI_RPC_PIVOT.md) is transport evidence and guardrail, not the implementation checklist
@@ -66,6 +74,7 @@ Important reading posture:
 - `packages/runtime/protocol` now exposes `ControlPlaneApi`, `SidecarBootstrap`, `RepoRunRpcGroup`, `StartIndexRepoRun`, `StartQueryRepoRun`, `InterruptRepoRun`, `ResumeRepoRun`, and `StreamRunEvents` as the public sidecar boundary.
 - `packages/runtime/server` already mounts `"/__cluster"`, `"/api/v0"`, and `"/api/v0/rpc"` on one Bun server, emits a machine-readable bootstrap line on stdout, persists runtime state through `@effect/sql-sqlite-bun`, and serves local-origin CORS plus basic browser security headers.
 - `packages/repo-memory/runtime` already owns deterministic TypeScript indexing, workflow-backed run acceptance/execution, journal-backed stream replay, SQLite-backed run projections, and bounded grounded retrieval for the current supported query classes.
+- the current downstream contract now makes repo-memory `v0` the proving ground for the memory kernel at the `artifact-to-packet` stage rather than requiring a full `ClaimRecord` implementation inside this slice.
 - `packages/repo-memory/model` now defines a shared pure `RunProjector`, and lifecycle `RunStreamEvent` payloads are now durable deltas rather than embedded full `RepoRun` snapshots.
 - `packages/repo-memory/runtime` and `apps/desktop` now both project live run state from the same event stream instead of treating streamed lifecycle events as pre-materialized run snapshots.
 - grounded retrieval now includes repo-local resolved file dependency and dependent queries backed by persisted `resolvedTargetFilePath` import-edge state.
@@ -85,7 +94,8 @@ Important reading posture:
 
 ## Known Remaining P0 Gaps
 - `RunProjector` and `RunStateMachine` now exist as explicit seams, but the broader projection bootstrap/cursor pipeline and decider-style service split still live mostly inside `RepoRunService`.
-- Retrieval-side NLP enrichment is not yet integrated. It should land only as a bounded layer over query normalization, typed intent hints, ranking/query expansion, and grounded summarization after citations are fixed.
+- The concrete query-run contract now expects the canonical `grounding -> retrieval -> packet -> answer` stage split, structured retrieval-packet payloads/issues, and packet-only answer rendering; code should keep converging on that shape.
+- Extraction provenance and query-time explainability are now intentionally separated in the docs, but the runtime still needs to finish making that split obvious in its internal artifacts and UI rendering.
 - Grounded query expansion should continue only through deterministic source-backed additions, not freeform semantic repo chat.
 
 ## Relationship To Upstream Context

--- a/specs/pending/repo-expert-memory-local-first-v0/SIDECAR_PROTOCOL.md
+++ b/specs/pending/repo-expert-memory-local-first-v0/SIDECAR_PROTOCOL.md
@@ -151,6 +151,12 @@ Those do not replace the explicit desktop-facing run-control contract.
 - stream durable delta events, not embedded full `RepoRun` snapshots
 - remain sufficient for clients to rebuild local run state through the shared run projector
 
+For query runs, `RunProgressUpdated.phase` should use exactly:
+- `grounding`
+- `retrieval`
+- `packet`
+- `answer`
+
 ## Run Lifecycle Identity
 - `runId === executionId`
 - workflow execution IDs are deterministic from normalized payload + version stamp
@@ -186,6 +192,8 @@ Lifecycle event payload rules:
 - `RunAccepted` carries the minimum facts needed to bootstrap projection such as `runKind`, `repoId`, and query-specific fields like `question` when applicable
 - `RunCompleted` carries terminal deltas such as `indexedFileCount` for index runs, not a fully materialized run snapshot
 - `RetrievalPacketMaterialized` and `AnswerDrafted` remain bounded result deltas
+- `RetrievalPacketMaterialized` freezes the evidence product before `AnswerDrafted`
+- `AnswerDrafted` must be renderable from that packet alone
 - `GET /runs` and `GET /runs/:runId` remain the durable projected read surface; `StreamRunEvents` is the event history used to rebuild that state locally
 
 ## Retired Routes
@@ -210,7 +218,9 @@ Rules:
 - it should be durable enough to inspect after the run completes
 - it should be visible from both `GET /runs/:runId` and streamed execution output
 - it should remain smaller and more inspectable than a raw unbounded subgraph dump
+- it should freeze `normalizedQuery`, `queryKind`, `outcome`, packet-level citations, concise notes, and either a structured `payload` or a structured `issue`
 - if retrieval-side NLP materially affects normalization or result selection, the packet may expose concise inspectable notes rather than inventing a new public event family
+- the final answer may not add support or selection beyond what the packet already contains
 
 Retrieval-side NLP enrichment remains an internal runtime concern in `v0`.
 It may improve query preparation, ranking, and grounded summarization, but it does not add new public `HttpApi` routes, `Rpc` methods, or run-event kinds, and it must preserve deterministic fallback behavior.

--- a/specs/pending/repo-expert-memory-local-first-v0/TOPOLOGY.md
+++ b/specs/pending/repo-expert-memory-local-first-v0/TOPOLOGY.md
@@ -63,8 +63,9 @@ It currently defines:
 - `QueryRepoRun`
 - projection-building logic for run summaries and final answers
 - product-level run events
+- explicit query-stage responsibilities for `grounding`, `retrieval`, `packet`, and `answer`
 - retrieval packet materialization
-- citation-facing answer assembly boundaries
+- citation-facing answer assembly boundaries with packet-only answer rendering
 
 It should not own:
 - HTTP route registration
@@ -94,7 +95,7 @@ Current debt to keep explicit:
 - `packages/repo-memory/store` defines repo-memory storage contracts only
 - `packages/repo-memory/sqlite` stays below semantic/runtime layers and only knows local persistence concerns
 - `packages/repo-memory/runtime` depends on model/store contracts and owns repo-specific execution semantics
-- `packages/repo-memory/runtime` may compose shared helpers from `packages/common/nlp`, but it still owns repo-specific interpretation, grounding, and acceptance behavior
+- `packages/repo-memory/runtime` may compose shared helpers from `packages/common/nlp`, but it still owns repo-specific grounding, retrieval, packet assembly, answer rendering, and acceptance behavior
 - `packages/repo-memory/client` depends on protocol/model contracts, not runtime internals
 
 ### Common packages

--- a/specs/pending/repo-expert-memory-local-first-v0/VERTICAL_SLICE.md
+++ b/specs/pending/repo-expert-memory-local-first-v0/VERTICAL_SLICE.md
@@ -27,6 +27,7 @@ The first runnable slice is:
 - The sidecar already persists repo-memory artifacts and run projections in SQLite, and it already replays journaled run events after reconnect or restart.
 - Spawned Bun lifecycle tests already prove bootstrap discovery, same-port restart, replay, public-path interrupt/resume for durable index runs, and local-origin CORS/security headers against the real sidecar entrypoint.
 - The current query path already compiles natural-language repo questions into bounded deterministic query interpretations; the next retrieval-side NLP phase should enrich that path rather than replace it.
+- The current authority contract now treats the query path as `grounding -> retrieval -> packet -> answer`, with `RetrievalPacket` as the frozen evidence product and the final answer rendered from that packet only.
 
 ## Scope In
 Lock these in for `v0`:
@@ -83,11 +84,21 @@ The UI triggers `StartQueryRepoRun` and subscribes to `StreamRunEvents`.
 The front door may accept looser natural phrasing, but the runtime must still compile that phrasing into the existing bounded query classes or fail safe as unsupported.
 Retrieval-side NLP belongs here only as enrichment over query preparation and retrieval, not as a replacement for typed grounded plans.
 
+The progress story for query runs should be explicit:
+- `grounding`
+- `retrieval`
+- `packet`
+- `answer`
+
 ### 5. Inspect grounded result
 The final query view must show:
 - final answer
 - citations
 - retrieval packet
+- normalized query
+- query kind
+- retrieval outcome
+- structured packet payload or structured packet issue
 - any concise notes needed to explain materially important normalization or ranking behavior
 - run metadata
 - enough history to understand what happened
@@ -104,6 +115,9 @@ Supported query classes in the current grounded slice:
 - `listFileExports`
 - `listFileImports`
 - `listFileImporters`
+- `listSymbolImporters`
+- `listFileDependencies`
+- `listFileDependents`
 - `keywordSearch`
 
 Out of scope for this slice:
@@ -119,7 +133,7 @@ Testing posture for this slice:
 
 ## Remaining Slice Gaps
 - `RunProjector` and `RunStateMachine` still need to become real runtime seams instead of staying embedded in `RepoRunService`.
-- Retrieval-side NLP enrichment still needs to land as a bounded layer over query interpretation and packet assembly.
+- The runtime still needs to make the new stage split and structured packet contract explicit in code, replay, and UI rendering.
 
 ## Minimal Data Shown In The UI
 The first UI does not need to be broad, but it does need to be inspectable.


### PR DESCRIPTION
## What changed
- refined the repo-memory packet kernel design and aligned the concrete `v0` docs around the `grounding -> retrieval -> packet -> answer` stage vocabulary
- extended repo-memory model and runtime handling so `RetrievalPacket` is the frozen evidence product with structured payload and issue data, and updated the desktop read model/tests to match
- fixed repo-quality regressions uncovered during the sweep, including Effect v4 schedule composition, docgen `@since` coverage, test expectation drift, and the desktop portless probe now using the trusted `.localhost` hostname instead of bypassing TLS verification
- added an empty changeset so the branch satisfies the repo release-policy gate without forcing a package bump decision in this PR

## Why
- this makes repo-memory `v0` the concrete proving ground for the memory kernel at the artifact-to-packet boundary
- it keeps answer rendering bounded to packet state and makes query-time explainability more explicit and inspectable
- it leaves the branch green across the repo and removes a real Semgrep finding from the desktop dev helper

## Impact
- repo-memory query runs now expose the clarified packet-oriented stage model and packet schema
- the desktop repo-memory UI can inspect normalized query, query kind, outcome, payload, issue, citations, and packet-derived answers more directly
- the docs now point downstream to the repo-memory `v0` packet contract while keeping the big-picture kernel docs aligned with that smaller proof shape

## Validation
- `bun run check`
- `bun run lint`
- `bun run test`
- `bun run docgen`
- pre-push `github-checks` pass, including build, check, migration drift, lint, docgen, test, syncpack, audit, changeset status, gitleaks, OSV scan, Semgrep, and nix checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced retrieval results with structured metadata including query kind, outcome, and normalized query information.
  * Refined query progress tracking with four distinct stages for better visibility into query execution.
  * Enriched answer display with payload summaries (file counts, symbol details) and structured issue reporting.

* **Improvements**
  * Simplified development tooling with streamlined TLS configuration.
  * Standardized query stage terminology and contracts across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->