### PR TITLE
Harden AI metrics P6a proof workflow

### DIFF
--- a/.changeset/ai-metrics-p6a-hardening.md
+++ b/.changeset/ai-metrics-p6a-hardening.md
@@ -1,0 +1,6 @@
+---
+---
+
+Record AI metrics P6a hardening, including source attribution, timer planning,
+archive drill proofing, scorecard guardrails, and initiative documentation,
+without forcing package release bumps from this internal branch.

--- a/initiatives/ai-metrics-stack/PLAN.md
+++ b/initiatives/ai-metrics-stack/PLAN.md
@@ -1,12 +1,14 @@
 # AI Metrics Stack Plan
 
-This plan executes [SPEC.md](./SPEC.md). The current target phase is P6 because
-P0 bootstrap, P1 source/privacy proof, P2 durable ingest, P3 OTLP/backend
+This plan executes [SPEC.md](./SPEC.md). The current target phase is P6a because
+the fresh review found P6 should not be treated as merely operational yet. P0
+bootstrap, P1 source/privacy proof, P2 durable ingest, P3 OTLP/backend
 contracts, P4 report-first scorecards, and the P5a operator contract are
-complete. P5b implementation is in place, Phoenix is live on dankserver, the
-AI metrics 1Password refs resolve, and the first real redacted forwarder plus
-OTLP export has reached Phoenix. Pulumi state reconciliation still needs a
-shell with the Pulumi passphrase environment.
+complete. P5b implementation is in place, Phoenix is live on dankserver, the AI
+metrics 1Password refs resolve, and the first real redacted forwarder plus OTLP
+export has reached Phoenix. The current proof evidence is baseline pre-P6a
+evidence; the credited seven-day proof restarts after P6a gates pass. Pulumi
+state reconciliation still needs a shell with the Pulumi passphrase environment.
 
 ## P0: Initiative Bootstrap And Current State
 
@@ -122,18 +124,45 @@ Status: in progress
 
 ## P6: Seven-Day Proof And Hardening
 
+Status: paused for P6a
+
+- Preserve the first real collection/export proof as baseline evidence.
+- Restart the credited seven-day proof only after P6a hardening passes.
+- During the restarted window, keep live collection owned by the workstation
+  timer and generate a completion-creditable scorecard with real labels and a
+  benchmark run.
+
+## P6a: Fresh Review Data And Ops Hardening
+
 Status: in progress
 
-- Run live collection for seven days. The first real collection/export proof is
-  complete; the seven-day window is now the active proof target.
-- Generate the first weekly scorecard from real data. A baseline report exists
-  with expected `no_labels`, `no_benchmark_runs`, and sparse
-  model/tool-coverage gaps.
-- Verify raw archive, derived DuckDB/Parquet tables, OTLP traces, label queue,
-  baseline report, and Phoenix dashboard data.
-- Add outcome labels and benchmark runs for real tasks during the seven-day
-  window.
-- Document backup, restore, retention, and failure recovery.
+- Preserve Codex subagent attribution through source discovery, privacy
+  projection, derived DuckDB/Parquet, OTLP span attributes, and label queues
+  using source role plus hash-only parent/session/thread metadata.
+- Replace global forwarder source starvation with source-aware per-source
+  budgets and coverage reporting for Codex, Claude Code, and OpenClaw gateway
+  metadata.
+- Persist config snapshot manifests and latest pointers so scorecards can
+  distinguish included config files from actual added, modified, and removed
+  paths.
+- Make weekly scorecards report `completionReady=false` until at least one
+  outcome label and one benchmark run exist for the scored config snapshot.
+  Provider/model/tool/token/cost metrics remain explicit
+  `*_unavailable_not_scored` gaps until real integrations populate them.
+- Add an explicit OTLP metadata allowlist and keep subagent/source identifiers
+  hash-only in derived exports.
+- Add a workstation systemd user timer render path for live collection with
+  lock, retry/backoff, status artifact, and journal evidence. True server-owned
+  collection remains a P7 topology target.
+- Add an archive decrypt drill that verifies one encrypted raw archive object
+  without printing transcript text.
+- Update install/runbook commands so 1Password refs are separate from runtime
+  values: commands that need the raw archive key must export
+  `BEEP_AI_METRICS_RAW_ARCHIVE_KEY="$(op read '<ref>')"`.
+- Reconcile Pulumi before restarting the credited proof: preview/apply/health
+  must be green and the live Phoenix version must match declared stack config.
+- Document retention, deletion, archive decrypt, backup, restore, and proof
+  restart policy in the P6a output.
 
 ## Required Checks
 
@@ -142,6 +171,6 @@ Status: in progress
 - `@beep/repo-ai-metrics`: `check`, `test`, `lint`, `docgen`
 - `@beep/repo-cli`: `check`, `test`, `lint`
 - `@beep/infra`: `check`, `test`, `lint`
-- CLI smoke for source discovery, ingest, install plan/doctor, labels,
-  benchmarks, and report generation
+- CLI smoke for source discovery, ingest, install plan/doctor, forwarder timer
+  rendering, archive drill, labels, benchmarks, and report generation
 - Pulumi preview and apply for the dankserver target

--- a/initiatives/ai-metrics-stack/README.md
+++ b/initiatives/ai-metrics-stack/README.md
@@ -13,8 +13,8 @@ and weekly scorecards that answer whether agent-facing config changes improved
 coding-agent performance.
 
 Production-complete means the dankserver tailnet stack is deployed, local smoke
-collection works, real sources are flowing, and one seven-day config-impact
-scorecard has been generated from live data.
+collection works, P6a hardening gates pass, real sources are flowing, and one
+restarted seven-day config-impact scorecard has been generated from live data.
 
 ## Read This First
 
@@ -41,6 +41,9 @@ scorecard has been generated from live data.
 - [history/outputs/p5b-real-pulumi-remote-apply.md](./history/outputs/p5b-real-pulumi-remote-apply.md)
   - Pulumi remote Phoenix apply resources, dedicated tailnet HTTPS route, and
     live deployment evidence
+- [history/outputs/p6a-fresh-review-hardening.md](./history/outputs/p6a-fresh-review-hardening.md)
+  - fresh review findings, P6a hardening decisions, implementation evidence,
+    and proof restart gates
 - [research/effect-native-observability.md](./research/effect-native-observability.md)
   - Effect v4 observability package findings
 - [research/backend-shortlist.md](./research/backend-shortlist.md) - backend
@@ -50,8 +53,9 @@ scorecard has been generated from live data.
 
 P0, P1, P2, P3, P4, P5a, and the P5b live Phoenix deployment are complete
 enough to use as the starting checkpoint. The first real collection/export
-proof is complete and P6 is underway. Pulumi state reconciliation is still gated
-on the local Pulumi passphrase environment:
+proof is baseline evidence, not the credited seven-day proof. P6 is paused for
+P6a data and ops hardening. Pulumi state reconciliation is still gated on the
+local Pulumi passphrase environment:
 
 - `@beep/repo-ai-metrics` exists with schema-first models, tolerant transcript
   ingest summaries, target-agnostic install specs, benchmark and scorecard
@@ -69,6 +73,10 @@ on the local Pulumi passphrase environment:
   envelopes, with synthetic and real local smoke evidence.
 - The durable forwarder writes AES-256-GCM encrypted raw archive objects,
   derived DuckDB tables, and per-run Parquet exports.
+- P6a adds source-aware forwarder budgets, hash-only Codex subagent parentage,
+  config snapshot diff artifacts, scorecard completion readiness, an OTLP
+  metadata allowlist, a workstation timer render path, and an archive decrypt
+  drill.
 - P3 adds install-owned OTLP/Phoenix contracts, generated local Phoenix compose
   smoke, trace-only `@beep/observability` wiring, redacted DuckDB-to-OTLP span
   export, CLI `otlp export`, and import-safe Pulumi backend outputs.
@@ -88,10 +96,11 @@ on the local Pulumi passphrase environment:
 - The first live P6 proof collected 10 Codex source files, projected 23,830
   turns, exported 23,840 redacted OTLP spans to Phoenix, generated a baseline
   weekly report, and confirmed Phoenix GraphQL has traces.
-- Current gaps are explicit in the packet: reconcile the live host mutation with
-  Pulumi from a shell with `PULUMI_CONFIG_PASSPHRASE` or
-  `PULUMI_CONFIG_PASSPHRASE_FILE`, keep live collection running for seven days,
-  add outcome labels and benchmark runs, and document backup/restore/retention.
+- Current gates are explicit in the packet: reconcile the live host mutation
+  with Pulumi from a shell with `PULUMI_CONFIG_PASSPHRASE` or
+  `PULUMI_CONFIG_PASSPHRASE_FILE`, install/run the workstation timer, run the
+  archive drill, add outcome labels and benchmark runs, document
+  backup/restore/retention/deletion, and then restart the seven-day proof.
 
 ## Completion Standard
 
@@ -100,8 +109,12 @@ This initiative is done only when all are true:
 - dankserver tailnet deployment is applied and verified
 - Phoenix is receiving real traces or derived exports
 - raw encrypted archive and redacted derived views are populated
+- P6a hardening gates pass, including subagent attribution, source-aware
+  coverage, config diffs, metadata allowlist, timer ownership, and archive
+  decrypt drill
 - Codex, Claude Code, OpenClaw, and optional gateway sources have discovery and
   ingest coverage
 - config snapshots are linked to real sessions and benchmark runs
 - CLI label review produces outcome labels for real work
-- one weekly config-impact scorecard is generated from seven days of live data
+- one weekly config-impact scorecard is generated from a restarted seven-day
+  live window and is marked completion-ready with labels plus benchmark evidence

--- a/initiatives/ai-metrics-stack/SPEC.md
+++ b/initiatives/ai-metrics-stack/SPEC.md
@@ -11,7 +11,7 @@
 ## Created / Updated
 
 - **Created:** 2026-05-05
-- **Updated:** 2026-05-06
+- **Updated:** 2026-05-09
 
 ## Purpose
 
@@ -83,7 +83,8 @@ output.
   with internal EventLog projection proof.
 - Benchmark lane: curated cases plus real outcome labels.
 - Labeling workflow: CLI review queue.
-- Completion evidence: deployed stack plus one seven-day real-data scorecard.
+- Completion evidence: P6a hardening gates, deployed stack, and one restarted
+  seven-day real-data scorecard.
 
 ## Data Products
 
@@ -100,7 +101,14 @@ Minimum scorecard dimensions:
 - model/provider/gateway path
 - token and cost metrics when available
 - transcript source and agent tool
-- config snapshot hash and changed paths
+- primary/subagent source role and hashed parentage when available
+- config snapshot hash, included paths, and actual changed paths
+
+A weekly report is completion-creditable only when it has at least one real
+outcome label and at least one benchmark run linked to the scored config
+snapshot. Model-call, tool-invocation, token, latency, and cost fields may be
+reported as unavailable/not-scored until a real provider/gateway source is
+integrated, but they must not be silently treated as measured values.
 
 ## Privacy Contract
 
@@ -108,6 +116,13 @@ Raw transcripts and provider payloads are private. They may be retained only in
 the encrypted raw archive under the selected target data root. Derived tables,
 OTLP payloads, and dashboard events must use redacted text, hashed identifiers,
 bounded low-cardinality attributes, and explicit allowlists.
+
+Derived metadata is part of the privacy boundary. Session ids, parent thread
+ids, fork ids, local paths, source paths, agent roles/nicknames, raw event ids,
+timestamps, tool names, labels, and exception text must be explicitly reviewed
+before entering derived DuckDB, Parquet, OTLP, or report payloads. P6a derived
+attribution preserves source role and hash-only parentage for Codex subagents;
+raw transcript bodies and raw local paths remain excluded from derived outputs.
 
 The default privacy mode is `encrypted_raw_redacted_ui`.
 
@@ -131,16 +146,27 @@ enrichment is deferred until after Phoenix is live.
 Manual host commands may appear as debugging aids but must not be the final
 deployment mechanism.
 
+P6a live collection is workstation-owned because Codex and Claude raw sources
+live on the workstation. The credited proof window must use a local scheduled
+runner with a lock, retry/backoff, status artifact, and journal evidence.
+Server-owned collection is a P7 topology target and requires a separate
+transcript access/sync and privacy design.
+
 ## Completion Criteria
 
 The initiative is complete only when:
 
 - `beep-cli ai-metrics install doctor --target dankserver` passes
 - Pulumi preview and apply succeed for the dankserver target
-- live collectors populate raw and derived storage
+- P6a source-aware collection, subagent attribution, scorecard readiness,
+  config diffs, metadata allowlist, and archive drill gates pass
+- live collection is owned by the workstation timer for the restarted seven-day
+  proof and populates raw and derived storage
 - Phoenix or the selected default UI shows real data
 - source discovery covers Codex, Claude Code, OpenClaw, and optional gateway
   logs
 - the CLI label queue can record real outcome labels
 - benchmark runs are linked to config snapshots
-- a seven-day weekly report exists in derived storage and as a readable output
+- a restarted seven-day weekly report exists in derived storage and as a
+  readable output, with labels and benchmark evidence sufficient for completion
+  credit

--- a/initiatives/ai-metrics-stack/history/outputs/p6a-fresh-review-hardening.md
+++ b/initiatives/ai-metrics-stack/history/outputs/p6a-fresh-review-hardening.md
@@ -1,0 +1,90 @@
+# P6a Fresh Review And Hardening
+
+## Status
+
+Implemented and review-gated on branch
+`feature/ai-metrics-p6a-hardening`.
+
+The fresh review found the initiative is directionally correct, but P6 should
+pause before its seven-day proof is credited. The current `.beep/ai-metrics`
+evidence is baseline pre-P6a evidence. The official seven-day window restarts
+after the P6a gates below pass.
+
+## Review Findings
+
+- Codex subagent sessions were detectable in raw `session_meta` lines but were
+  flattened into ordinary Codex sessions in derived tables.
+- The forwarder was runnable on demand, but the credited proof needed an owned
+  scheduler, lock, retry/backoff, status artifact, and journal evidence.
+- Scorecards could render with neutral placeholder scores while labels,
+  benchmarks, model/tool rows, token/cost, and latency metrics were empty.
+- Config snapshots listed included paths as changed paths, so scorecards could
+  not mechanically explain before/after config causality.
+- Forwarder file selection used a global limit that could crowd out lower
+  recency sources.
+- Phoenix was live, but Pulumi state reconciliation and live-version alignment
+  remained gates before restarting the proof.
+- Secret references were mixed with runtime secret values in operator examples;
+  commands that decrypt or archive raw transcripts need actual
+  `BEEP_AI_METRICS_RAW_ARCHIVE_KEY` values.
+- Privacy needed to treat metadata as part of the derived boundary, not only
+  prompt/output text.
+- Backup, restore, retention, deletion, and archive decrypt proof were
+  under-specified.
+
+## Implemented P6a Hardening
+
+- Added hash-only source attribution for primary vs subagent work, including
+  available Codex session/thread/fork/role/nickname metadata.
+- Persisted attribution through sanitized privacy projections, derived DuckDB
+  source/session/turn tables, Parquet exports, label queues, and OTLP span
+  projections.
+- Added per-source forwarder coverage so `maxFiles` limits Codex, Claude Code,
+  and OpenClaw independently.
+- Added config snapshot manifests, `latest.json`, included paths, actual
+  changed paths, and added/modified/removed/unchanged diff fields.
+- Added scorecard `completionReady`; missing labels or benchmark runs now block
+  completion credit instead of silently passing as neutral data.
+- Added explicit not-scored coverage gaps for unavailable model/tool/cost data.
+- Added an OTLP attribute allowlist for derived AI metrics spans.
+- Added a workstation systemd user timer render path with lock, retry/backoff,
+  status file, and journal commands.
+- Added an archive decrypt drill that verifies one raw archive object without
+  printing transcript text.
+- Updated install-plan commands to use `op read` for runtime secret values
+  while preserving secret refs as metadata.
+
+## Review Loop Evidence
+
+- `quality-review-fix-loop` reviewer rerounds closed the P6a blockers for
+  subagent attribution, operator workflow, privacy/security, data correctness,
+  and migration defaults.
+- The secret-backed archive drill passed with matching plaintext hash and did
+  not print transcript bodies or secret values.
+- Focused `@beep/repo-ai-metrics` and `@beep/repo-cli` check, test, lint, and
+  docgen lanes passed.
+- Full `bash scripts/run-github-checks.sh quality` passed after the final
+  source-role migration fallback fix.
+
+## Restart Gates
+
+- `@beep/repo-ai-metrics` check, test, lint, and docgen pass.
+- `@beep/repo-cli` check, test, and lint pass.
+- Source discovery and forwarder JSON show source-aware coverage.
+- DuckDB rows can distinguish primary and subagent sessions without raw text or
+  raw local paths.
+- Weekly scorecard has `completionReady=true` for the scored config snapshot.
+- Workstation timer units are rendered, installed, and visible in the user
+  journal before the credited window starts.
+- Archive decrypt drill passes without printing transcript text.
+- Pulumi preview/apply/health pass for `beep-ai-metrics-dankserver`, and live
+  Phoenix version drift is resolved.
+- Retention, deletion, backup, restore, and archive decrypt runbook text is in
+  the initiative packet.
+
+## Deferred P7 Follow-Ups
+
+- True server-owned collection with a transcript access/sync and privacy
+  topology.
+- Real provider/gateway model-call, token, cost, and latency integrations for
+  xAI, Venice.ai, LiteLLM, OpenClaw enrichment, Langfuse, Opik, and PostHog.

--- a/initiatives/ai-metrics-stack/ops/handoffs/HANDOFF_P0-P6.md
+++ b/initiatives/ai-metrics-stack/ops/handoffs/HANDOFF_P0-P6.md
@@ -3,16 +3,18 @@
 ## Mission
 
 Complete the developer AI metrics stack from current scaffold to deployed
-dankserver tailnet service with one seven-day real-data config-impact
-scorecard.
+dankserver tailnet service with P6a hardening and one restarted seven-day
+real-data config-impact scorecard.
 
 ## Starting State
 
 P0 through P4 plus P5a are already credited. P5b implementation exists, the
 Phoenix backend is live on dankserver at
 `https://dankserver.tailc7c348.ts.net:8447`, and the first P6 real-data
-forwarder/export proof has reached Phoenix. Pulumi state reconciliation still
-needs the local Pulumi passphrase environment. The repo contains:
+forwarder/export proof has reached Phoenix. Fresh review moved that proof to
+baseline evidence and inserted P6a before the credited seven-day window.
+Pulumi state reconciliation still needs the local Pulumi passphrase
+environment. The repo contains:
 
 - `packages/tooling/library/ai-metrics`
 - `packages/tooling/tool/cli/src/commands/AIMetrics`
@@ -39,7 +41,8 @@ resources for Phoenix compose/systemd apply, dedicated Tailscale Serve HTTPS on
 - Config snapshots plus outcome-heavy scorecards.
 - JSONL/Parquet archive is the deploy-safe raw source of record.
 - EventLog is an internal projection proof until it earns promotion.
-- Completion requires one weekly report from seven days of real data.
+- Completion requires P6a gates plus one weekly report from a restarted seven
+  days of real data.
 
 ## Phase Instructions
 
@@ -99,10 +102,14 @@ P6 proof and hardening:
 
 - first live collection/export proof completed; see
   `history/outputs/p6-seven-day-proof-and-hardening.md`
-- continue collecting seven days of live data
-- publish first seven-day weekly scorecard
-- add outcome labels and benchmark runs for real tasks
-- verify backup, restore, retention, and failure recovery
+- paused until P6a gates pass; current evidence is baseline pre-P6a evidence
+- P6a output is `history/outputs/p6a-fresh-review-hardening.md`
+- preserve hash-only Codex subagent attribution in derived tables and OTLP
+- use source-aware forwarder coverage instead of global max-file starvation
+- render and install the workstation timer before restarting the proof
+- run the archive decrypt drill without printing transcript text
+- add outcome labels and benchmark runs before any scorecard is credited
+- verify backup, restore, retention, deletion, and failure recovery
 
 ## Stop Conditions
 

--- a/initiatives/ai-metrics-stack/ops/manifest.json
+++ b/initiatives/ai-metrics-stack/ops/manifest.json
@@ -5,12 +5,12 @@
     "title": "AI Metrics Stack",
     "status": "active",
     "created": "2026-05-05",
-    "updated": "2026-05-07",
+    "updated": "2026-05-09",
     "packetAnchorDocument": "SPEC.md"
   },
   "currentSourceOfTruth": "SPEC.md",
-  "currentTargetPhase": "P6",
-  "completionEvidence": "dankserver deployment plus one seven-day real-data config-impact scorecard",
+  "currentTargetPhase": "P6a",
+  "completionEvidence": "P6a hardening gates plus dankserver deployment plus one restarted seven-day real-data config-impact scorecard",
   "targets": {
     "production": "dankserver",
     "smoke": "local",
@@ -85,8 +85,16 @@
     {
       "id": "P6",
       "name": "Seven-Day Proof And Hardening",
-      "status": "in_progress",
-      "output": "history/outputs/p6-seven-day-proof-and-hardening.md"
+      "status": "paused",
+      "output": "history/outputs/p6-seven-day-proof-and-hardening.md",
+      "subphases": [
+        {
+          "id": "P6a",
+          "name": "Fresh Review Data And Ops Hardening",
+          "status": "in_progress",
+          "output": "history/outputs/p6a-fresh-review-hardening.md"
+        }
+      ]
     }
   ],
   "commandGates": [
@@ -111,6 +119,14 @@
       "command": "cd packages/tooling/tool/cli && bun run check && bun run test && bun run lint"
     },
     {
+      "id": "ai-metrics-forwarder-timer-smoke",
+      "command": "bun run beep ai-metrics forwarder timer --target dankserver --data-root .beep/ai-metrics --hash-salt-secret-ref 'op://TBK/ai-metrics/hash-salt' --raw-archive-key-secret-ref 'op://TBK/ai-metrics/raw-archive-key' --json"
+    },
+    {
+      "id": "ai-metrics-archive-drill",
+      "command": "BEEP_AI_METRICS_RAW_ARCHIVE_KEY=\"$(op read 'op://TBK/ai-metrics/raw-archive-key')\" bun run beep ai-metrics archive drill --target dankserver --data-root .beep/ai-metrics --hash-salt-secret-ref 'op://TBK/ai-metrics/hash-salt' --raw-archive-key-secret-ref 'op://TBK/ai-metrics/raw-archive-key' --json"
+    },
+    {
       "id": "infra-package",
       "command": "cd infra && bun run check && bun run test && bun run lint"
     },
@@ -125,12 +141,13 @@
   ],
   "knownGaps": [
     "P5b Phoenix is live and verified on dankserver, but Pulumi state reconciliation is blocked until PULUMI_CONFIG_PASSPHRASE or PULUMI_CONFIG_PASSPHRASE_FILE is present",
-    "P6 needs seven days of live collection before the completion scorecard can be credited",
-    "Real outcome labels and benchmark runs still need to be added for the live tasks collected during the proof window",
-    "Backup, restore, retention, and failure recovery documentation remains pending",
+    "P6 is paused until P6a hardening gates pass; the existing collection evidence is baseline pre-P6a evidence",
+    "The credited seven-day proof must restart after P6a with workstation timer ownership",
+    "Real outcome labels and benchmark runs still need to be added before a scorecard can be completionReady",
+    "Backup, restore, retention, deletion, and failure recovery documentation remains pending",
     "Optional LiteLLM deployment remains deferred beyond the Phoenix-only P5b slice",
     "xAI, Venice, LiteLLM, and gateway enrichment remain deferred beyond P2",
-    "raw archive decrypt tooling is intentionally not exposed in P2"
+    "Server-owned collection remains a P7 topology target requiring transcript access/sync and privacy design"
   ],
-  "nextAction": "Keep the P6 live collector running for seven days, add outcome labels and benchmark runs for real tasks, document backup/restore/retention, and reconcile Pulumi state from a shell with the Pulumi passphrase environment."
+  "nextAction": "Finish P6a hardening checks, reconcile Pulumi state from a shell with the Pulumi passphrase environment, install the workstation timer, run the archive drill, add labels and benchmark runs, then restart the credited seven-day proof."
 }

--- a/packages/tooling/library/ai-metrics/src/config-snapshot.ts
+++ b/packages/tooling/library/ai-metrics/src/config-snapshot.ts
@@ -51,10 +51,34 @@ export class AiMetricsConfigSnapshotInput extends S.Class<AiMetricsConfigSnapsho
       S.withConstructorDefault(Effect.succeed("repo-local-agent-config")),
       S.withDecodingDefaultKey(Effect.succeed("repo-local-agent-config"))
     ),
+    previousSnapshotPath: S.optionalKey(S.String),
     repoRoot: S.String,
   },
   $I.annote("AiMetricsConfigSnapshotInput", {
     description: "Repo root and label used to build an agent-facing configuration snapshot.",
+  })
+) {}
+
+/**
+ * Diff between the current and previous AI metrics config snapshot.
+ *
+ * @example
+ * ```ts
+ * import { AiMetricsConfigSnapshotDiff } from "@beep/repo-ai-metrics"
+ * console.log(AiMetricsConfigSnapshotDiff)
+ * ```
+ * @category models
+ * @since 0.0.0
+ */
+export class AiMetricsConfigSnapshotDiff extends S.Class<AiMetricsConfigSnapshotDiff>($I`AiMetricsConfigSnapshotDiff`)(
+  {
+    addedPaths: S.Array(S.String),
+    modifiedPaths: S.Array(S.String),
+    removedPaths: S.Array(S.String),
+    unchangedPaths: S.Array(S.String),
+  },
+  $I.annote("AiMetricsConfigSnapshotDiff", {
+    description: "Path-level before/after diff for agent-facing configuration snapshots.",
   })
 ) {}
 
@@ -96,8 +120,10 @@ export class AiMetricsConfigSnapshotResult extends S.Class<AiMetricsConfigSnapsh
 )(
   {
     excludedDirectoryNames: S.Array(S.String),
+    diff: AiMetricsConfigSnapshotDiff,
     fileCount: S.Number,
     files: S.Array(AiMetricsConfigSnapshotFile),
+    previousSnapshotId: S.optionalKey(S.String),
     snapshot: ConfigSnapshot,
   },
   $I.annote("AiMetricsConfigSnapshotResult", {
@@ -130,6 +156,7 @@ export class AiMetricsConfigSnapshotError extends TaggedErrorClass<AiMetricsConf
 ) {}
 
 const encodeConfigSnapshotJson = S.encodeUnknownEffect(S.fromJsonString(AiMetricsConfigSnapshotResult));
+const decodeConfigSnapshotJson = S.decodeUnknownEffect(S.fromJsonString(AiMetricsConfigSnapshotResult));
 
 const byRelativePathAscending: Order.Order<AiMetricsConfigSnapshotFile> = Order.mapInput(
   Order.String,
@@ -274,6 +301,114 @@ const snapshotHashInput: (files: ReadonlyArray<AiMetricsConfigSnapshotFile>) => 
   A.join("\n")
 );
 
+const fileByRelativePath = (
+  files: ReadonlyArray<AiMetricsConfigSnapshotFile>,
+  relativePath: string
+): O.Option<AiMetricsConfigSnapshotFile> => A.findFirst(files, (file) => file.relativePath === relativePath);
+
+const snapshotDiff = (
+  files: ReadonlyArray<AiMetricsConfigSnapshotFile>,
+  previousFiles: ReadonlyArray<AiMetricsConfigSnapshotFile>
+): AiMetricsConfigSnapshotDiff => {
+  const currentPaths = pipe(
+    A.map(files, (file) => file.relativePath),
+    A.sort(Order.String)
+  );
+  const previousPaths = pipe(
+    A.map(previousFiles, (file) => file.relativePath),
+    A.sort(Order.String)
+  );
+  const addedPaths = pipe(
+    currentPaths,
+    A.filter((relativePath) => O.isNone(fileByRelativePath(previousFiles, relativePath))),
+    A.sort(Order.String)
+  );
+  const removedPaths = pipe(
+    previousPaths,
+    A.filter((relativePath) => O.isNone(fileByRelativePath(files, relativePath))),
+    A.sort(Order.String)
+  );
+  const modifiedPaths = pipe(
+    files,
+    A.filter((file) =>
+      pipe(
+        fileByRelativePath(previousFiles, file.relativePath),
+        O.exists((previousFile) => previousFile.contentHash !== file.contentHash)
+      )
+    ),
+    A.map((file) => file.relativePath),
+    A.sort(Order.String)
+  );
+  const unchangedPaths = pipe(
+    files,
+    A.filter((file) =>
+      pipe(
+        fileByRelativePath(previousFiles, file.relativePath),
+        O.exists((previousFile) => previousFile.contentHash === file.contentHash)
+      )
+    ),
+    A.map((file) => file.relativePath),
+    A.sort(Order.String)
+  );
+
+  return new AiMetricsConfigSnapshotDiff({
+    addedPaths,
+    modifiedPaths,
+    removedPaths,
+    unchangedPaths,
+  });
+};
+
+const changedPathsFor = (diff: AiMetricsConfigSnapshotDiff): ReadonlyArray<string> =>
+  pipe(
+    A.appendAll(A.appendAll(diff.addedPaths, diff.modifiedPaths), diff.removedPaths),
+    A.dedupe,
+    A.sort(Order.String)
+  );
+
+const readPreviousSnapshot = Effect.fn("AiMetrics.readPreviousConfigSnapshot")(function* (
+  previousSnapshotPath: string | undefined
+) {
+  if (previousSnapshotPath === undefined) {
+    return O.none<AiMetricsConfigSnapshotResult>();
+  }
+
+  const fs = yield* FileSystem.FileSystem;
+  const exists = yield* fs.exists(previousSnapshotPath).pipe(
+    Effect.mapError(
+      (cause) =>
+        new AiMetricsConfigSnapshotError({
+          cause,
+          message: "Failed to inspect previous AI metrics config snapshot artifact.",
+        })
+    )
+  );
+  if (!exists) {
+    return O.none<AiMetricsConfigSnapshotResult>();
+  }
+
+  const content = yield* fs.readFileString(previousSnapshotPath).pipe(
+    Effect.mapError(
+      (cause) =>
+        new AiMetricsConfigSnapshotError({
+          cause,
+          message: "Failed to read previous AI metrics config snapshot artifact.",
+        })
+    )
+  );
+
+  return yield* decodeConfigSnapshotJson(content).pipe(
+    Effect.map(O.some),
+    Effect.mapError(
+      (cause) =>
+        new AiMetricsConfigSnapshotError({
+          cause,
+          message: "Failed to decode previous AI metrics config snapshot artifact.",
+        })
+    )
+  );
+});
+
 /**
  * Build a deterministic snapshot of repo-owned agent-facing configuration.
  *
@@ -297,19 +432,95 @@ export const makeAiMetricsConfigSnapshot = Effect.fn("AiMetrics.makeAiMetricsCon
   );
   const snapshotHash = yield* hashPublicTextSha256(`ai-metrics-config-snapshot-v1\n${snapshotHashInput(files)}`);
   const relativePaths = A.map(files, (file) => file.relativePath);
+  const previous = yield* readPreviousSnapshot(input.previousSnapshotPath);
+  const previousFiles = pipe(
+    previous,
+    O.map((snapshot) => snapshot.files),
+    O.getOrElse(A.empty<AiMetricsConfigSnapshotFile>)
+  );
+  const diff = snapshotDiff(files, previousFiles);
+  const changedPaths = changedPathsFor(diff);
+  const previousSnapshotId = pipe(
+    previous,
+    O.map((snapshot) => snapshot.snapshot.snapshotId)
+  );
 
   return new AiMetricsConfigSnapshotResult({
     excludedDirectoryNames: EXCLUDED_DIR_NAMES,
+    diff,
     fileCount: A.length(files),
     files,
+    ...(O.isSome(previousSnapshotId) ? { previousSnapshotId: previousSnapshotId.value } : {}),
     snapshot: new ConfigSnapshot({
-      changedPaths: relativePaths,
+      changedPaths,
       configHash: snapshotHash,
+      includedPaths: relativePaths,
       label: input.label,
+      ...(O.isSome(previousSnapshotId) ? { previousSnapshotId: previousSnapshotId.value } : {}),
       snapshotId: `config-${snapshotHash}`,
     }),
   });
 });
+
+/**
+ * Persist a config snapshot manifest and latest pointer for future diff attribution.
+ *
+ * @example
+ * ```ts
+ * import { writeAiMetricsConfigSnapshotArtifacts } from "@beep/repo-ai-metrics"
+ * console.log(writeAiMetricsConfigSnapshotArtifacts)
+ * ```
+ * @category services
+ * @since 0.0.0
+ */
+export const writeAiMetricsConfigSnapshotArtifacts = Effect.fn("AiMetrics.writeAiMetricsConfigSnapshotArtifacts")(
+  function* ({
+    commitLatest = true,
+    outputDir,
+    result,
+  }: {
+    readonly commitLatest?: boolean;
+    readonly outputDir: string;
+    readonly result: AiMetricsConfigSnapshotResult;
+  }) {
+    const fs = yield* FileSystem.FileSystem;
+    const pathApi = yield* Path.Path;
+    const content = yield* configSnapshotToJson(result);
+    const manifestPath = pathApi.join(outputDir, `${result.snapshot.snapshotId}.json`);
+    const latestPath = pathApi.join(outputDir, "latest.json");
+    yield* fs.makeDirectory(outputDir, { recursive: true }).pipe(
+      Effect.mapError(
+        (cause) =>
+          new AiMetricsConfigSnapshotError({
+            cause,
+            message: "Failed to create AI metrics config snapshot artifact directory.",
+          })
+      )
+    );
+    yield* fs.writeFileString(manifestPath, content).pipe(
+      Effect.mapError(
+        (cause) =>
+          new AiMetricsConfigSnapshotError({
+            cause,
+            message: "Failed to write AI metrics config snapshot manifest.",
+          })
+      )
+    );
+    if (commitLatest) {
+      yield* fs.writeFileString(latestPath, content).pipe(
+        Effect.mapError(
+          (cause) =>
+            new AiMetricsConfigSnapshotError({
+              cause,
+              message: "Failed to write AI metrics latest config snapshot pointer.",
+            })
+        )
+      );
+    }
+
+    return { latestPath, manifestPath };
+  }
+);
 
 /**
  * Render a config snapshot result as JSON.

--- a/packages/tooling/library/ai-metrics/src/config-snapshot.ts
+++ b/packages/tooling/library/ai-metrics/src/config-snapshot.ts
@@ -82,6 +82,13 @@ export class AiMetricsConfigSnapshotDiff extends S.Class<AiMetricsConfigSnapshot
   })
 ) {}
 
+const emptyConfigSnapshotDiff = new AiMetricsConfigSnapshotDiff({
+  addedPaths: [],
+  modifiedPaths: [],
+  removedPaths: [],
+  unchangedPaths: [],
+});
+
 /**
  * One file included in an AI metrics config snapshot.
  *
@@ -120,7 +127,7 @@ export class AiMetricsConfigSnapshotResult extends S.Class<AiMetricsConfigSnapsh
 )(
   {
     excludedDirectoryNames: S.Array(S.String),
-    diff: AiMetricsConfigSnapshotDiff,
+    diff: AiMetricsConfigSnapshotDiff.pipe(S.withDecodingDefaultKey(Effect.succeed(emptyConfigSnapshotDiff))),
     fileCount: S.Number,
     files: S.Array(AiMetricsConfigSnapshotFile),
     previousSnapshotId: S.optionalKey(S.String),
@@ -488,6 +495,7 @@ export const writeAiMetricsConfigSnapshotArtifacts = Effect.fn("AiMetrics.writeA
     const content = yield* configSnapshotToJson(result);
     const manifestPath = pathApi.join(outputDir, `${result.snapshot.snapshotId}.json`);
     const latestPath = pathApi.join(outputDir, "latest.json");
+    const latestTmpPath = pathApi.join(outputDir, "latest.json.tmp");
     yield* fs.makeDirectory(outputDir, { recursive: true }).pipe(
       Effect.mapError(
         (cause) =>
@@ -507,12 +515,21 @@ export const writeAiMetricsConfigSnapshotArtifacts = Effect.fn("AiMetrics.writeA
       )
     );
     if (commitLatest) {
-      yield* fs.writeFileString(latestPath, content).pipe(
+      yield* fs.writeFileString(latestTmpPath, content).pipe(
         Effect.mapError(
           (cause) =>
             new AiMetricsConfigSnapshotError({
               cause,
-              message: "Failed to write AI metrics latest config snapshot pointer.",
+              message: "Failed to write AI metrics latest config snapshot temporary pointer.",
+            })
+        )
+      );
+      yield* fs.rename(latestTmpPath, latestPath).pipe(
+        Effect.mapError(
+          (cause) =>
+            new AiMetricsConfigSnapshotError({
+              cause,
+              message: "Failed to promote AI metrics latest config snapshot pointer.",
             })
         )
       );

--- a/packages/tooling/library/ai-metrics/src/derived-storage.ts
+++ b/packages/tooling/library/ai-metrics/src/derived-storage.ts
@@ -51,6 +51,14 @@ const createTableStatements = [
     ingest_run_id VARCHAR NOT NULL,
     source_kind VARCHAR NOT NULL,
     source_path_hash VARCHAR NOT NULL,
+    source_role VARCHAR NOT NULL,
+    session_id_hash VARCHAR,
+    parent_session_id_hash VARCHAR,
+    parent_thread_id_hash VARCHAR,
+    forked_from_id_hash VARCHAR,
+    thread_spawn BOOLEAN,
+    agent_role_hash VARCHAR,
+    agent_nickname_hash VARCHAR,
     total_lines INTEGER NOT NULL,
     accepted_events INTEGER NOT NULL,
     rejected_lines INTEGER NOT NULL,
@@ -76,6 +84,7 @@ const createTableStatements = [
     title VARCHAR NOT NULL,
     source_kind VARCHAR NOT NULL,
     source_path_hash VARCHAR NOT NULL,
+    source_role VARCHAR NOT NULL,
     repo_root_hash VARCHAR NOT NULL,
     config_snapshot_id VARCHAR NOT NULL,
     created_at_epoch_ms DOUBLE NOT NULL,
@@ -88,6 +97,14 @@ const createTableStatements = [
     ingest_run_id VARCHAR NOT NULL,
     source_kind VARCHAR NOT NULL,
     source_path_hash VARCHAR NOT NULL,
+    source_role VARCHAR NOT NULL,
+    session_id_hash VARCHAR,
+    parent_session_id_hash VARCHAR,
+    parent_thread_id_hash VARCHAR,
+    forked_from_id_hash VARCHAR,
+    thread_spawn BOOLEAN,
+    agent_role_hash VARCHAR,
+    agent_nickname_hash VARCHAR,
     started_at VARCHAR,
     config_snapshot_id VARCHAR NOT NULL
   )`,
@@ -97,6 +114,7 @@ const createTableStatements = [
     agent_session_id VARCHAR NOT NULL,
     source_kind VARCHAR NOT NULL,
     source_path_hash VARCHAR NOT NULL,
+    source_role VARCHAR NOT NULL,
     line_number INTEGER NOT NULL,
     event_name VARCHAR NOT NULL,
     raw_event_hash VARCHAR NOT NULL,
@@ -158,15 +176,106 @@ const createTableStatements = [
     task_count INTEGER NOT NULL,
     label_count INTEGER NOT NULL,
     benchmark_run_count INTEGER NOT NULL,
+    completion_ready BOOLEAN NOT NULL,
     coverage_gaps_json VARCHAR NOT NULL
   )`,
 ] as const;
 
 const migrationColumns = [
   {
+    columnDefinition: "source_role VARCHAR DEFAULT 'primary'",
+    columnName: "source_role",
+    tableName: "ai_metrics_source_files",
+  },
+  {
+    columnDefinition: "session_id_hash VARCHAR",
+    columnName: "session_id_hash",
+    tableName: "ai_metrics_source_files",
+  },
+  {
+    columnDefinition: "parent_session_id_hash VARCHAR",
+    columnName: "parent_session_id_hash",
+    tableName: "ai_metrics_source_files",
+  },
+  {
+    columnDefinition: "parent_thread_id_hash VARCHAR",
+    columnName: "parent_thread_id_hash",
+    tableName: "ai_metrics_source_files",
+  },
+  {
+    columnDefinition: "forked_from_id_hash VARCHAR",
+    columnName: "forked_from_id_hash",
+    tableName: "ai_metrics_source_files",
+  },
+  {
+    columnDefinition: "thread_spawn BOOLEAN",
+    columnName: "thread_spawn",
+    tableName: "ai_metrics_source_files",
+  },
+  {
+    columnDefinition: "agent_role_hash VARCHAR",
+    columnName: "agent_role_hash",
+    tableName: "ai_metrics_source_files",
+  },
+  {
+    columnDefinition: "agent_nickname_hash VARCHAR",
+    columnName: "agent_nickname_hash",
+    tableName: "ai_metrics_source_files",
+  },
+  {
+    columnDefinition: "source_role VARCHAR DEFAULT 'primary'",
+    columnName: "source_role",
+    tableName: "ai_metrics_agent_tasks",
+  },
+  {
     columnDefinition: "agent_task_id VARCHAR",
     columnName: "agent_task_id",
     tableName: "ai_metrics_sessions",
+  },
+  {
+    columnDefinition: "source_role VARCHAR DEFAULT 'primary'",
+    columnName: "source_role",
+    tableName: "ai_metrics_sessions",
+  },
+  {
+    columnDefinition: "session_id_hash VARCHAR",
+    columnName: "session_id_hash",
+    tableName: "ai_metrics_sessions",
+  },
+  {
+    columnDefinition: "parent_session_id_hash VARCHAR",
+    columnName: "parent_session_id_hash",
+    tableName: "ai_metrics_sessions",
+  },
+  {
+    columnDefinition: "parent_thread_id_hash VARCHAR",
+    columnName: "parent_thread_id_hash",
+    tableName: "ai_metrics_sessions",
+  },
+  {
+    columnDefinition: "forked_from_id_hash VARCHAR",
+    columnName: "forked_from_id_hash",
+    tableName: "ai_metrics_sessions",
+  },
+  {
+    columnDefinition: "thread_spawn BOOLEAN",
+    columnName: "thread_spawn",
+    tableName: "ai_metrics_sessions",
+  },
+  {
+    columnDefinition: "agent_role_hash VARCHAR",
+    columnName: "agent_role_hash",
+    tableName: "ai_metrics_sessions",
+  },
+  {
+    columnDefinition: "agent_nickname_hash VARCHAR",
+    columnName: "agent_nickname_hash",
+    tableName: "ai_metrics_sessions",
+  },
+  {
+    columnDefinition: "source_role VARCHAR DEFAULT 'primary'",
+    columnName: "source_role",
+    tableName: "ai_metrics_turns",
   },
   {
     columnDefinition: "quality_gate VARCHAR",
@@ -239,10 +348,24 @@ const migrationColumns = [
     tableName: "ai_metrics_scorecards",
   },
   {
-    columnDefinition: "coverage_gaps_json VARCHAR",
+    columnDefinition: "completion_ready BOOLEAN DEFAULT FALSE",
+    columnName: "completion_ready",
+    tableName: "ai_metrics_scorecards",
+  },
+  {
+    columnDefinition: "coverage_gaps_json VARCHAR DEFAULT '[]'",
     columnName: "coverage_gaps_json",
     tableName: "ai_metrics_scorecards",
   },
+] as const;
+
+const migrationBackfillStatements = [
+  "UPDATE ai_metrics_source_files SET source_role = 'primary' WHERE source_role IS NULL",
+  "UPDATE ai_metrics_agent_tasks SET source_role = 'primary' WHERE source_role IS NULL",
+  "UPDATE ai_metrics_sessions SET source_role = 'primary' WHERE source_role IS NULL",
+  "UPDATE ai_metrics_turns SET source_role = 'primary' WHERE source_role IS NULL",
+  "UPDATE ai_metrics_scorecards SET completion_ready = FALSE WHERE completion_ready IS NULL",
+  "UPDATE ai_metrics_scorecards SET coverage_gaps_json = '[]' WHERE coverage_gaps_json IS NULL",
 ] as const;
 
 type MigrationColumn = {
@@ -395,6 +518,7 @@ const ensureAiMetricsDerivedStorageRaw = Effect.fn("AiMetrics.derivedStorage.ens
   const duckdb = yield* DuckDb;
   yield* duckdb.runMany(createTableStatements);
   yield* Effect.forEach(migrationColumns, addColumnIfMissing, { discard: true });
+  yield* duckdb.runMany(migrationBackfillStatements);
 });
 
 /**
@@ -415,6 +539,7 @@ export const ensureAiMetricsDerivedStorage: Effect.Effect<void, AiMetricsDerived
   );
 
 const optionalStringOrNull = (value: string | undefined): string | null => value ?? null;
+const optionalBooleanOrNull = (value: boolean | undefined): boolean | null => value ?? null;
 
 const epochMillisParam = (value: number): string => globalThis.String(value);
 
@@ -465,16 +590,17 @@ const upsertRun = Effect.fn("AiMetrics.derivedStorage.upsertRun")(function* (
 });
 
 const agentTaskIdFor = Effect.fn("AiMetrics.derivedStorage.agentTaskIdFor")(function* (
+  input: AiMetricsDerivedStorageWriteInput,
   record: AiMetricsDerivedTranscriptRecord
 ) {
   const sanitized = record.privacy.sanitized;
-  return yield* rowId("agent-task", [sanitized.sourceKind, sanitized.sourcePathHash]);
+  return yield* rowId("agent-task", [input.configSnapshot.snapshotId, sanitized.sourceKind, sanitized.sourcePathHash]);
 });
 
 const taskTitleFor = (record: AiMetricsDerivedTranscriptRecord): string => {
   const sanitized = record.privacy.sanitized;
   const sourceSuffix = pipe(sanitized.sourcePathHash, Str.takeLeft(12));
-  return `${sanitized.sourceKind} task ${sourceSuffix}`;
+  return `${sanitized.sourceKind} ${sanitized.sourceRole} task ${sourceSuffix}`;
 };
 
 const upsertAgentTask = Effect.fn("AiMetrics.derivedStorage.upsertAgentTask")(function* (
@@ -483,7 +609,7 @@ const upsertAgentTask = Effect.fn("AiMetrics.derivedStorage.upsertAgentTask")(fu
 ) {
   const duckdb = yield* DuckDb;
   const sanitized = record.privacy.sanitized;
-  const agentTaskId = yield* agentTaskIdFor(record);
+  const agentTaskId = yield* agentTaskIdFor(input, record);
 
   yield* duckdb.run(
     `INSERT OR REPLACE INTO ai_metrics_agent_tasks (
@@ -491,6 +617,7 @@ const upsertAgentTask = Effect.fn("AiMetrics.derivedStorage.upsertAgentTask")(fu
       title,
       source_kind,
       source_path_hash,
+      source_role,
       repo_root_hash,
       config_snapshot_id,
       created_at_epoch_ms,
@@ -501,6 +628,7 @@ const upsertAgentTask = Effect.fn("AiMetrics.derivedStorage.upsertAgentTask")(fu
       $title,
       $sourceKind,
       $sourcePathHash,
+      $sourceRole,
       $repoRootHash,
       $configSnapshotId,
       $createdAtEpochMillis,
@@ -516,6 +644,7 @@ const upsertAgentTask = Effect.fn("AiMetrics.derivedStorage.upsertAgentTask")(fu
       repoRootHash: input.repoRootHash,
       sourceKind: sanitized.sourceKind,
       sourcePathHash: sanitized.sourcePathHash,
+      sourceRole: sanitized.sourceRole,
       title: taskTitleFor(record),
     }
   );
@@ -538,6 +667,14 @@ const upsertSourceFile = Effect.fn("AiMetrics.derivedStorage.upsertSourceFile")(
       ingest_run_id,
       source_kind,
       source_path_hash,
+      source_role,
+      session_id_hash,
+      parent_session_id_hash,
+      parent_thread_id_hash,
+      forked_from_id_hash,
+      thread_spawn,
+      agent_role_hash,
+      agent_nickname_hash,
       total_lines,
       accepted_events,
       rejected_lines,
@@ -551,6 +688,14 @@ const upsertSourceFile = Effect.fn("AiMetrics.derivedStorage.upsertSourceFile")(
       $ingestRunId,
       $sourceKind,
       $sourcePathHash,
+      $sourceRole,
+      $sessionIdHash,
+      $parentSessionIdHash,
+      $parentThreadIdHash,
+      $forkedFromIdHash,
+      $threadSpawn,
+      $agentRoleHash,
+      $agentNicknameHash,
       $totalLines,
       $acceptedEvents,
       $rejectedLines,
@@ -562,16 +707,24 @@ const upsertSourceFile = Effect.fn("AiMetrics.derivedStorage.upsertSourceFile")(
     )`,
     {
       acceptedEvents: sanitized.acceptedEvents,
+      agentNicknameHash: optionalStringOrNull(sanitized.agentNicknameHash),
+      agentRoleHash: optionalStringOrNull(sanitized.agentRoleHash),
       configSnapshotId: input.configSnapshot.snapshotId,
       eventNamesJson,
       firstTimestamp: optionalStringOrNull(sanitized.firstTimestamp),
+      forkedFromIdHash: optionalStringOrNull(sanitized.forkedFromIdHash),
       ingestRunId: input.ingestRunId,
       lastTimestamp: optionalStringOrNull(sanitized.lastTimestamp),
+      parentSessionIdHash: optionalStringOrNull(sanitized.parentSessionIdHash),
+      parentThreadIdHash: optionalStringOrNull(sanitized.parentThreadIdHash),
       redactionSafeForDerivedUi: record.privacy.redaction.safeForDerivedUi,
       rejectedLines: sanitized.rejectedLines,
+      sessionIdHash: optionalStringOrNull(sanitized.sessionIdHash),
       sourceFileId,
       sourceKind: sanitized.sourceKind,
       sourcePathHash: sanitized.sourcePathHash,
+      sourceRole: sanitized.sourceRole,
+      threadSpawn: optionalBooleanOrNull(sanitized.threadSpawn),
       totalLines: sanitized.totalLines,
     }
   );
@@ -635,6 +788,14 @@ const upsertSessionAndTurns = Effect.fn("AiMetrics.derivedStorage.upsertSessionA
       ingest_run_id,
       source_kind,
       source_path_hash,
+      source_role,
+      session_id_hash,
+      parent_session_id_hash,
+      parent_thread_id_hash,
+      forked_from_id_hash,
+      thread_spawn,
+      agent_role_hash,
+      agent_nickname_hash,
       started_at,
       config_snapshot_id
     ) VALUES (
@@ -643,17 +804,33 @@ const upsertSessionAndTurns = Effect.fn("AiMetrics.derivedStorage.upsertSessionA
       $ingestRunId,
       $sourceKind,
       $sourcePathHash,
+      $sourceRole,
+      $sessionIdHash,
+      $parentSessionIdHash,
+      $parentThreadIdHash,
+      $forkedFromIdHash,
+      $threadSpawn,
+      $agentRoleHash,
+      $agentNicknameHash,
       $startedAt,
       $configSnapshotId
     )`,
     {
       agentSessionId,
       agentTaskId,
+      agentNicknameHash: optionalStringOrNull(sanitized.agentNicknameHash),
+      agentRoleHash: optionalStringOrNull(sanitized.agentRoleHash),
       configSnapshotId: input.configSnapshot.snapshotId,
+      forkedFromIdHash: optionalStringOrNull(sanitized.forkedFromIdHash),
       ingestRunId: input.ingestRunId,
+      parentSessionIdHash: optionalStringOrNull(sanitized.parentSessionIdHash),
+      parentThreadIdHash: optionalStringOrNull(sanitized.parentThreadIdHash),
+      sessionIdHash: optionalStringOrNull(sanitized.sessionIdHash),
       sourceKind: sanitized.sourceKind,
       sourcePathHash: sanitized.sourcePathHash,
+      sourceRole: sanitized.sourceRole,
       startedAt: optionalStringOrNull(sanitized.firstTimestamp),
+      threadSpawn: optionalBooleanOrNull(sanitized.threadSpawn),
     }
   );
 
@@ -674,6 +851,7 @@ const upsertSessionAndTurns = Effect.fn("AiMetrics.derivedStorage.upsertSessionA
           agent_session_id,
           source_kind,
           source_path_hash,
+          source_role,
           line_number,
           event_name,
           raw_event_hash,
@@ -684,6 +862,7 @@ const upsertSessionAndTurns = Effect.fn("AiMetrics.derivedStorage.upsertSessionA
           $agentSessionId,
           $sourceKind,
           $sourcePathHash,
+          $sourceRole,
           $lineNumber,
           $eventName,
           $rawEventHash,
@@ -697,6 +876,7 @@ const upsertSessionAndTurns = Effect.fn("AiMetrics.derivedStorage.upsertSessionA
           rawEventHash: envelope.rawEventHash,
           sourceKind: envelope.sourceKind,
           sourcePathHash: envelope.sourcePathHash,
+          sourceRole: envelope.sourceRole,
           timestamp: optionalStringOrNull(envelope.timestamp),
           turnId,
         }

--- a/packages/tooling/library/ai-metrics/src/derived-storage.ts
+++ b/packages/tooling/library/ai-metrics/src/derived-storage.ts
@@ -179,6 +179,10 @@ const createTableStatements = [
     completion_ready BOOLEAN NOT NULL,
     coverage_gaps_json VARCHAR NOT NULL
   )`,
+  `CREATE TABLE IF NOT EXISTS ai_metrics_schema_migrations (
+    migration_id VARCHAR PRIMARY KEY,
+    applied_at_epoch_ms DOUBLE NOT NULL
+  )`,
 ] as const;
 
 const migrationColumns = [
@@ -368,11 +372,55 @@ const migrationBackfillStatements = [
   "UPDATE ai_metrics_scorecards SET coverage_gaps_json = '[]' WHERE coverage_gaps_json IS NULL",
 ] as const;
 
+const legacyAgentTaskIdExpression = (tableAlias: string): string =>
+  `concat('agent-task-', sha256(concat('agent-task', chr(0), ${tableAlias}.source_kind, chr(0), ${tableAlias}.source_path_hash)))`;
+
+const currentAgentTaskIdExpression = (tableAlias: string): string =>
+  `concat('agent-task-', sha256(concat('agent-task', chr(0), ${tableAlias}.config_snapshot_id, chr(0), ${tableAlias}.source_kind, chr(0), ${tableAlias}.source_role, chr(0), ${tableAlias}.source_path_hash)))`;
+
+const legacyAgentTaskIdMigrationStatements = [
+  `DELETE FROM ai_metrics_agent_tasks AS legacy
+   WHERE legacy.agent_task_id = ${legacyAgentTaskIdExpression("legacy")}
+     AND EXISTS (
+       SELECT 1
+       FROM ai_metrics_agent_tasks AS current
+       WHERE current.agent_task_id = ${currentAgentTaskIdExpression("legacy")}
+         AND current.agent_task_id <> legacy.agent_task_id
+     )`,
+  `UPDATE ai_metrics_agent_tasks AS task
+   SET agent_task_id = ${currentAgentTaskIdExpression("task")}
+   WHERE task.agent_task_id = ${legacyAgentTaskIdExpression("task")}`,
+] as const;
+
 type MigrationColumn = {
   readonly columnDefinition: string;
   readonly columnName: string;
   readonly tableName: string;
 };
+
+type DerivedStorageMigration = {
+  readonly migrationId: string;
+  readonly requiredColumns?: ReadonlyArray<Pick<MigrationColumn, "columnName" | "tableName">>;
+  readonly statements: ReadonlyArray<string>;
+};
+
+const derivedStorageMigrations = [
+  {
+    migrationId: "ai-metrics-p6a-default-backfill-v1",
+    statements: migrationBackfillStatements,
+  },
+  {
+    migrationId: "ai-metrics-agent-task-id-v2",
+    requiredColumns: [
+      { columnName: "agent_task_id", tableName: "ai_metrics_agent_tasks" },
+      { columnName: "config_snapshot_id", tableName: "ai_metrics_agent_tasks" },
+      { columnName: "source_kind", tableName: "ai_metrics_agent_tasks" },
+      { columnName: "source_path_hash", tableName: "ai_metrics_agent_tasks" },
+      { columnName: "source_role", tableName: "ai_metrics_agent_tasks" },
+    ],
+    statements: legacyAgentTaskIdMigrationStatements,
+  },
+] as const satisfies ReadonlyArray<DerivedStorageMigration>;
 
 /**
  * Error raised by the DuckDB derived storage projection.
@@ -514,11 +562,72 @@ const addColumnIfMissing: (input: MigrationColumn) => Effect.Effect<void, DuckDb
   yield* duckdb.run(`ALTER TABLE ${tableName} ADD COLUMN ${columnDefinition}`);
 });
 
+const migrationColumnExists: (
+  input: Pick<MigrationColumn, "columnName" | "tableName">
+) => Effect.Effect<boolean, DuckDbError, DuckDb> = Effect.fn("AiMetrics.derivedStorage.migrationColumnExists")(
+  function* ({ columnName, tableName }) {
+    const duckdb = yield* DuckDb;
+    const rows = yield* duckdb.query(
+      `SELECT column_name AS "columnName"
+     FROM information_schema.columns
+      WHERE table_name = $tableName AND column_name = $columnName`,
+      { columnName, tableName }
+    );
+
+    return A.isReadonlyArrayNonEmpty(rows);
+  }
+);
+
+const migrationHasRequiredColumns: (migration: DerivedStorageMigration) => Effect.Effect<boolean, DuckDbError, DuckDb> =
+  Effect.fn("AiMetrics.derivedStorage.migrationHasRequiredColumns")(function* (migration) {
+    if (migration.requiredColumns === undefined || migration.requiredColumns.length === 0) {
+      return true;
+    }
+
+    const columnResults = yield* Effect.forEach(migration.requiredColumns, migrationColumnExists);
+    return A.every(columnResults, (exists) => exists);
+  });
+
+const runDerivedStorageMigrationOnce: (migration: DerivedStorageMigration) => Effect.Effect<void, DuckDbError, DuckDb> =
+  Effect.fn("AiMetrics.derivedStorage.runMigrationOnce")(function* (migration) {
+    const duckdb = yield* DuckDb;
+    const appliedRows = yield* duckdb.query(
+      `SELECT migration_id AS "migrationId"
+     FROM ai_metrics_schema_migrations
+     WHERE migration_id = $migrationId`,
+      { migrationId: migration.migrationId }
+    );
+
+    if (A.isReadonlyArrayNonEmpty(appliedRows)) {
+      return;
+    }
+
+    const hasRequiredColumns = yield* migrationHasRequiredColumns(migration);
+    if (!hasRequiredColumns) {
+      return;
+    }
+
+    yield* duckdb.runMany(migration.statements);
+    yield* duckdb.run(
+      `INSERT OR REPLACE INTO ai_metrics_schema_migrations (
+      migration_id,
+      applied_at_epoch_ms
+    ) VALUES (
+      $migrationId,
+      $appliedAtEpochMillis
+    )`,
+      {
+        appliedAtEpochMillis: globalThis.String(yield* Clock.currentTimeMillis),
+        migrationId: migration.migrationId,
+      }
+    );
+  });
+
 const ensureAiMetricsDerivedStorageRaw = Effect.fn("AiMetrics.derivedStorage.ensureRaw")(function* () {
   const duckdb = yield* DuckDb;
   yield* duckdb.runMany(createTableStatements);
   yield* Effect.forEach(migrationColumns, addColumnIfMissing, { discard: true });
-  yield* duckdb.runMany(migrationBackfillStatements);
+  yield* Effect.forEach(derivedStorageMigrations, runDerivedStorageMigrationOnce, { discard: true });
 });
 
 /**

--- a/packages/tooling/library/ai-metrics/src/derived-storage.ts
+++ b/packages/tooling/library/ai-metrics/src/derived-storage.ts
@@ -594,7 +594,12 @@ const agentTaskIdFor = Effect.fn("AiMetrics.derivedStorage.agentTaskIdFor")(func
   record: AiMetricsDerivedTranscriptRecord
 ) {
   const sanitized = record.privacy.sanitized;
-  return yield* rowId("agent-task", [input.configSnapshot.snapshotId, sanitized.sourceKind, sanitized.sourcePathHash]);
+  return yield* rowId("agent-task", [
+    input.configSnapshot.snapshotId,
+    sanitized.sourceKind,
+    sanitized.sourceRole,
+    sanitized.sourcePathHash,
+  ]);
 });
 
 const taskTitleFor = (record: AiMetricsDerivedTranscriptRecord): string => {

--- a/packages/tooling/library/ai-metrics/src/forwarder.ts
+++ b/packages/tooling/library/ai-metrics/src/forwarder.ts
@@ -223,6 +223,7 @@ const encodeForwarderTimerPlanJson = S.encodeUnknownEffect(S.fromJsonString(AiMe
 
 type ForwarderSourceFile = {
   readonly modifiedAtMillis: number;
+  readonly relativePath: string;
   readonly sourceKind: AiMetricsTranscriptSource;
   readonly sourcePath: string;
 };
@@ -236,6 +237,9 @@ const forwarderFailure = (message: string, cause: unknown): AiMetricsForwarderEr
   new AiMetricsForwarderError({ cause, message });
 
 const repoPathToClaudeProjectName: (repoRoot: string) => string = Str.replace(/[/\\]/gu, "-");
+
+const normalizedRelativePath = (pathApi: Path.Path, root: string, filePath: string): string =>
+  pipe(pathApi.relative(root, filePath), Str.replace(/\\/gu, "/"));
 
 const shellQuote = (value: string): string => `'${Str.replace(/'/gu, "'\\''")(value)}'`;
 
@@ -272,18 +276,24 @@ export const renderAiMetricsForwarderTimerPlan = (input: AiMetricsForwarderTimer
   const serviceUnitName = `${input.serviceName}.service`;
   const timerUnitName = `${input.serviceName}.timer`;
   const statusTmpPath = `${input.statusPath}.tmp`;
+  const stderrTmpPath = `${input.statusPath}.stderr.tmp`;
   const envFileShellPath = "~/.config/beep/ai-metrics.env";
   const envFileUnitPath = "%h/.config/beep/ai-metrics.env";
   const execCommand = [
     "set -euo pipefail",
     `mkdir -p "$(dirname ${shellQuote(input.statusPath)})" "$(dirname ${shellQuote(input.lockPath)})"`,
-    `flock -n ${shellQuote(input.lockPath)} ${input.command} > ${shellQuote(statusTmpPath)}`,
+    "exit_code=0",
+    `if flock -n ${shellQuote(input.lockPath)} ${input.command} > ${shellQuote(statusTmpPath)} 2> ${shellQuote(stderrTmpPath)}; then :; else exit_code=$?; stderr="$(head -c 2000 ${shellQuote(stderrTmpPath)} | sed 's/\\\\/\\\\\\\\/g; s/"/\\\\"/g' | tr '\\n' ' ')"; printf '{"status":"failed","exitCode":%s,"stderr":"%s"}\\n' "$exit_code" "$stderr" > ${shellQuote(statusTmpPath)}; fi`,
+    `rm -f ${shellQuote(stderrTmpPath)}`,
     `mv ${shellQuote(statusTmpPath)} ${shellQuote(input.statusPath)}`,
+    'exit "$exit_code"',
   ].join("; ");
   const serviceUnit = [
     "[Unit]",
     "Description=Beep AI metrics forwarder collection",
     "Documentation=AGENTS.md",
+    "StartLimitBurst=3",
+    "StartLimitIntervalSec=30m",
     "",
     "[Service]",
     "Type=oneshot",
@@ -292,8 +302,6 @@ export const renderAiMetricsForwarderTimerPlan = (input: AiMetricsForwarderTimer
     `ExecStart=/usr/bin/env bash -lc ${shellQuote(execCommand)}`,
     "Restart=on-failure",
     "RestartSec=5m",
-    "StartLimitBurst=3",
-    "StartLimitIntervalSec=30m",
     "",
   ].join("\n");
   const timerUnit = [
@@ -420,6 +428,7 @@ const jsonlSourceFiles = Effect.fn("AiMetrics.forwarder.jsonlSourceFiles")(funct
   sourceKind: AiMetricsTranscriptSource
 ) {
   const fs = yield* FileSystem.FileSystem;
+  const pathApi = yield* Path.Path;
   const sourcePaths = yield* collectJsonlFiles(root);
   const files = yield* Effect.forEach(
     sourcePaths,
@@ -431,6 +440,7 @@ const jsonlSourceFiles = Effect.fn("AiMetrics.forwarder.jsonlSourceFiles")(funct
 
       return O.some({
         modifiedAtMillis: modifiedAtMillis(info.value),
+        relativePath: normalizedRelativePath(pathApi, root, sourcePath),
         sourceKind,
         sourcePath,
       });
@@ -454,6 +464,7 @@ const openClawSourceFiles = Effect.fn("AiMetrics.forwarder.openClawSourceFiles")
 
   return A.of({
     modifiedAtMillis: modifiedAtMillis(info.value),
+    relativePath: pathApi.basename(unitPath),
     sourceKind: AiMetricsTranscriptSource.Enum.openclaw,
     sourcePath: unitPath,
   });
@@ -548,6 +559,7 @@ const processSourceFile = Effect.fn("AiMetrics.forwarder.processSourceFile")(
     const privacy = yield* makeAiMetricsPrivacyCheckResult({
       content,
       ...(input.hashSalt === undefined ? {} : { hashSalt: input.hashSalt }),
+      relativePath: sourceFile.relativePath,
       sourcePath: sourceFile.sourcePath,
       summary,
     }).pipe(Effect.mapError((cause) => forwarderFailure("Failed to build AI metrics privacy projection.", cause)));

--- a/packages/tooling/library/ai-metrics/src/forwarder.ts
+++ b/packages/tooling/library/ai-metrics/src/forwarder.ts
@@ -13,7 +13,11 @@ import * as O from "effect/Option";
 import * as S from "effect/Schema";
 import * as Str from "effect/String";
 import { AiMetricsRawArchiveKey, writeEncryptedRawArchiveObject } from "./archive.ts";
-import { AiMetricsConfigSnapshotInput, makeAiMetricsConfigSnapshot } from "./config-snapshot.ts";
+import {
+  AiMetricsConfigSnapshotInput,
+  makeAiMetricsConfigSnapshot,
+  writeAiMetricsConfigSnapshotArtifacts,
+} from "./config-snapshot.ts";
 import {
   AiMetricsDerivedStorageWriteInput,
   AiMetricsDerivedTranscriptRecord,
@@ -96,6 +100,31 @@ export class AiMetricsForwarderInput extends S.Class<AiMetricsForwarderInput>($I
 ) {}
 
 /**
+ * Per-source coverage selected by one durable forwarder run.
+ *
+ * @example
+ * ```ts
+ * import { AiMetricsForwarderSourceCoverage } from "@beep/repo-ai-metrics"
+ * console.log(AiMetricsForwarderSourceCoverage)
+ * ```
+ * @category models
+ * @since 0.0.0
+ */
+export class AiMetricsForwarderSourceCoverage extends S.Class<AiMetricsForwarderSourceCoverage>(
+  $I`AiMetricsForwarderSourceCoverage`
+)(
+  {
+    candidateFileCount: S.Number,
+    includedFileCount: S.Number,
+    limitedByMaxFiles: S.Boolean,
+    sourceKind: AiMetricsTranscriptSource,
+  },
+  $I.annote("AiMetricsForwarderSourceCoverage", {
+    description: "Source-aware file selection counts used to detect maxFiles starvation.",
+  })
+) {}
+
+/**
  * Safe result emitted by one durable AI metrics forwarder run.
  *
  * @example
@@ -115,6 +144,10 @@ export class AiMetricsForwarderRunResult extends S.Class<AiMetricsForwarderRunRe
     parquetExportDir: S.String,
     parquetTables: S.Array(S.String),
     rawArchiveDir: S.String,
+    sourceCoverage: S.Array(AiMetricsForwarderSourceCoverage).pipe(
+      S.withConstructorDefault(Effect.succeed([])),
+      S.withDecodingDefaultKey(Effect.succeed([]))
+    ),
     sourceFileCount: S.Number,
     target: AiMetricsDeployTarget,
     turnCount: S.Number,
@@ -124,7 +157,69 @@ export class AiMetricsForwarderRunResult extends S.Class<AiMetricsForwarderRunRe
   })
 ) {}
 
+/**
+ * Input for rendering a workstation-owned forwarder timer.
+ *
+ * @example
+ * ```ts
+ * import { AiMetricsForwarderTimerInput } from "@beep/repo-ai-metrics"
+ * console.log(AiMetricsForwarderTimerInput)
+ * ```
+ * @category models
+ * @since 0.0.0
+ */
+export class AiMetricsForwarderTimerInput extends S.Class<AiMetricsForwarderTimerInput>(
+  $I`AiMetricsForwarderTimerInput`
+)(
+  {
+    command: S.String,
+    hashSaltSecretRef: S.optionalKey(S.String),
+    intervalMinutes: S.Number.pipe(
+      S.withConstructorDefault(Effect.succeed(30)),
+      S.withDecodingDefaultKey(Effect.succeed(30))
+    ),
+    lockPath: S.String,
+    rawArchiveKeySecretRef: S.optionalKey(S.String),
+    serviceName: S.String.pipe(
+      S.withConstructorDefault(Effect.succeed("beep-ai-metrics-forwarder")),
+      S.withDecodingDefaultKey(Effect.succeed("beep-ai-metrics-forwarder"))
+    ),
+    statusPath: S.String,
+    workingDirectory: S.String,
+  },
+  $I.annote("AiMetricsForwarderTimerInput", {
+    description: "Workstation timer parameters for scheduled AI metrics forwarder collection.",
+  })
+) {}
+
+/**
+ * Rendered systemd user units for the workstation-owned forwarder timer.
+ *
+ * @example
+ * ```ts
+ * import { AiMetricsForwarderTimerPlan } from "@beep/repo-ai-metrics"
+ * console.log(AiMetricsForwarderTimerPlan)
+ * ```
+ * @category models
+ * @since 0.0.0
+ */
+export class AiMetricsForwarderTimerPlan extends S.Class<AiMetricsForwarderTimerPlan>($I`AiMetricsForwarderTimerPlan`)(
+  {
+    installCommands: S.Array(S.String),
+    lockPath: S.String,
+    serviceUnit: S.String,
+    serviceUnitName: S.String,
+    statusPath: S.String,
+    timerUnit: S.String,
+    timerUnitName: S.String,
+  },
+  $I.annote("AiMetricsForwarderTimerPlan", {
+    description: "Systemd user timer artifacts that own P6a live collection on the workstation.",
+  })
+) {}
+
 const encodeForwarderResultJson = S.encodeUnknownEffect(S.fromJsonString(AiMetricsForwarderRunResult));
+const encodeForwarderTimerPlanJson = S.encodeUnknownEffect(S.fromJsonString(AiMetricsForwarderTimerPlan));
 
 type ForwarderSourceFile = {
   readonly modifiedAtMillis: number;
@@ -132,10 +227,122 @@ type ForwarderSourceFile = {
   readonly sourcePath: string;
 };
 
+type ForwarderSourceSelection = {
+  readonly coverage: AiMetricsForwarderSourceCoverage;
+  readonly files: ReadonlyArray<ForwarderSourceFile>;
+};
+
 const forwarderFailure = (message: string, cause: unknown): AiMetricsForwarderError =>
   new AiMetricsForwarderError({ cause, message });
 
 const repoPathToClaudeProjectName: (repoRoot: string) => string = Str.replace(/[/\\]/gu, "-");
+
+const shellQuote = (value: string): string => `'${Str.replace(/'/gu, "'\\''")(value)}'`;
+
+const requireForwarderHashSalt = Effect.fn("AiMetrics.forwarder.requireHashSalt")(function* (
+  input: AiMetricsForwarderInput
+) {
+  if (
+    input.target === AiMetricsDeployTarget.Enum.local ||
+    (input.hashSalt !== undefined && Str.isNonEmpty(Str.trim(input.hashSalt)))
+  ) {
+    return;
+  }
+
+  return yield* forwarderFailure(
+    "AI metrics non-local forwarder runs require a resolved hash salt value.",
+    input.target
+  );
+});
+
+/**
+ * Render a systemd user timer that repeatedly runs the forwarder with locking and status evidence.
+ *
+ * @param input - Timer rendering input with service names, command text, status path, and secret references.
+ * @returns A render-only systemd timer/service plan for operator installation.
+ * @example
+ * ```ts
+ * import { renderAiMetricsForwarderTimerPlan } from "@beep/repo-ai-metrics"
+ * console.log(renderAiMetricsForwarderTimerPlan)
+ * ```
+ * @category services
+ * @since 0.0.0
+ */
+export const renderAiMetricsForwarderTimerPlan = (input: AiMetricsForwarderTimerInput): AiMetricsForwarderTimerPlan => {
+  const serviceUnitName = `${input.serviceName}.service`;
+  const timerUnitName = `${input.serviceName}.timer`;
+  const statusTmpPath = `${input.statusPath}.tmp`;
+  const envFileShellPath = "~/.config/beep/ai-metrics.env";
+  const envFileUnitPath = "%h/.config/beep/ai-metrics.env";
+  const execCommand = [
+    "set -euo pipefail",
+    `mkdir -p "$(dirname ${shellQuote(input.statusPath)})" "$(dirname ${shellQuote(input.lockPath)})"`,
+    `flock -n ${shellQuote(input.lockPath)} ${input.command} > ${shellQuote(statusTmpPath)}`,
+    `mv ${shellQuote(statusTmpPath)} ${shellQuote(input.statusPath)}`,
+  ].join("; ");
+  const serviceUnit = [
+    "[Unit]",
+    "Description=Beep AI metrics forwarder collection",
+    "Documentation=AGENTS.md",
+    "",
+    "[Service]",
+    "Type=oneshot",
+    `WorkingDirectory=${input.workingDirectory}`,
+    `EnvironmentFile=${envFileUnitPath}`,
+    `ExecStart=/usr/bin/env bash -lc ${shellQuote(execCommand)}`,
+    "Restart=on-failure",
+    "RestartSec=5m",
+    "StartLimitBurst=3",
+    "StartLimitIntervalSec=30m",
+    "",
+  ].join("\n");
+  const timerUnit = [
+    "[Unit]",
+    "Description=Run Beep AI metrics forwarder collection",
+    "",
+    "[Timer]",
+    "OnBootSec=5m",
+    `OnUnitInactiveSec=${input.intervalMinutes}m`,
+    "RandomizedDelaySec=2m",
+    "Persistent=true",
+    "",
+    "[Install]",
+    "WantedBy=timers.target",
+    "",
+  ].join("\n");
+  const writeEnvFileCommands = [
+    `install -m 0600 /dev/null ${envFileShellPath}`,
+    ...(input.hashSaltSecretRef === undefined
+      ? []
+      : [
+          `printf 'BEEP_AI_METRICS_HASH_SALT=%s\\n' "$(op read ${shellQuote(input.hashSaltSecretRef)})" >> ${envFileShellPath}`,
+        ]),
+    ...(input.rawArchiveKeySecretRef === undefined
+      ? []
+      : [
+          `printf 'BEEP_AI_METRICS_RAW_ARCHIVE_KEY=%s\\n' "$(op read ${shellQuote(input.rawArchiveKeySecretRef)})" >> ${envFileShellPath}`,
+        ]),
+  ];
+
+  return new AiMetricsForwarderTimerPlan({
+    installCommands: [
+      `mkdir -p ~/.config/systemd/user ~/.config/beep "$(dirname ${shellQuote(input.statusPath)})"`,
+      ...writeEnvFileCommands,
+      `printf '%s\\n' ${shellQuote(serviceUnit)} > ~/.config/systemd/user/${serviceUnitName}`,
+      `printf '%s\\n' ${shellQuote(timerUnit)} > ~/.config/systemd/user/${timerUnitName}`,
+      `systemctl --user daemon-reload`,
+      `systemctl --user enable --now ${timerUnitName}`,
+      `systemctl --user status ${timerUnitName}`,
+      `journalctl --user -u ${serviceUnitName} -n 80 --no-pager`,
+    ],
+    lockPath: input.lockPath,
+    serviceUnit,
+    serviceUnitName,
+    statusPath: input.statusPath,
+    timerUnit,
+    timerUnitName,
+  });
+};
 
 const statOption = Effect.fn("AiMetrics.forwarder.statOption")(function* (pathName: string) {
   const fs = yield* FileSystem.FileSystem;
@@ -257,6 +464,25 @@ const byModifiedDescending: Order.Order<ForwarderSourceFile> = Order.mapInput(
   (file) => -file.modifiedAtMillis
 );
 
+const selectSourceFiles = (
+  sourceKind: AiMetricsTranscriptSource,
+  files: ReadonlyArray<ForwarderSourceFile>,
+  maxFiles: number
+): ForwarderSourceSelection => {
+  const sortedFiles = pipe(files, A.sort(byModifiedDescending));
+  const includedFiles = A.take(sortedFiles, maxFiles);
+
+  return {
+    coverage: new AiMetricsForwarderSourceCoverage({
+      candidateFileCount: A.length(sortedFiles),
+      includedFileCount: A.length(includedFiles),
+      limitedByMaxFiles: A.length(sortedFiles) > A.length(includedFiles),
+      sourceKind,
+    }),
+    files: includedFiles,
+  };
+};
+
 const discoverForwarderSourceFiles = Effect.fn("AiMetrics.forwarder.discoverSourceFiles")(function* (
   input: AiMetricsForwarderInput
 ) {
@@ -266,16 +492,28 @@ const discoverForwarderSourceFiles = Effect.fn("AiMetrics.forwarder.discoverSour
   const codexRoot = input.codexSessionsRoot ?? pathApi.join(homeDir, ".codex/sessions");
   const claudeRoot =
     input.claudeProjectsRoot ?? pathApi.join(homeDir, ".claude/projects", repoPathToClaudeProjectName(repoRoot));
-  const sources = yield* Effect.all(
+  const [codexFiles, claudeFiles, openClawFiles] = yield* Effect.all(
     [
       jsonlSourceFiles(input, codexRoot, AiMetricsTranscriptSource.Enum.codex),
       jsonlSourceFiles(input, claudeRoot, AiMetricsTranscriptSource.Enum.claude),
       openClawSourceFiles(input),
-    ],
+    ] as const,
     { concurrency: 3 }
   );
+  const selections = [
+    selectSourceFiles(AiMetricsTranscriptSource.Enum.codex, codexFiles, input.maxFiles),
+    selectSourceFiles(AiMetricsTranscriptSource.Enum.claude, claudeFiles, input.maxFiles),
+    selectSourceFiles(AiMetricsTranscriptSource.Enum.openclaw, openClawFiles, input.maxFiles),
+  ] as const;
 
-  return pipe(A.flatten(sources), A.sort(byModifiedDescending), A.take(input.maxFiles));
+  return {
+    coverage: A.map(selections, (selection) => selection.coverage),
+    files: pipe(
+      selections,
+      A.flatMap((selection) => selection.files),
+      A.sort(byModifiedDescending)
+    ),
+  };
 });
 
 const processSourceFile = Effect.fn("AiMetrics.forwarder.processSourceFile")(
@@ -350,6 +588,7 @@ const processSourceFile = Effect.fn("AiMetrics.forwarder.processSourceFile")(
 export const runAiMetricsForwarder = Effect.fn("AiMetrics.runAiMetricsForwarder")(
   function* (input: AiMetricsForwarderInput) {
     const startedAtEpochMillis = yield* Clock.currentTimeMillis;
+    yield* requireForwarderHashSalt(input);
     const installSpec = yield* makeAiMetricsInstallSpec(
       new AiMetricsInstallInput({
         ...(input.dataRoot === undefined ? {} : { dataRoot: input.dataRoot }),
@@ -358,18 +597,25 @@ export const runAiMetricsForwarder = Effect.fn("AiMetrics.runAiMetricsForwarder"
         target: input.target,
       })
     ).pipe(Effect.mapError((cause) => forwarderFailure("Failed to resolve AI metrics install storage layout.", cause)));
+    const pathApi = yield* Path.Path;
+    const configSnapshotDir = pathApi.join(installSpec.storage.dataRoot, "config-snapshots");
     const configSnapshot = yield* makeAiMetricsConfigSnapshot(
       new AiMetricsConfigSnapshotInput({
+        previousSnapshotPath: pathApi.join(configSnapshotDir, "latest.json"),
         repoRoot: input.repoRoot,
       })
     ).pipe(Effect.mapError((cause) => forwarderFailure("Failed to build AI metrics config snapshot.", cause)));
-    const pathApi = yield* Path.Path;
+    yield* writeAiMetricsConfigSnapshotArtifacts({
+      commitLatest: false,
+      outputDir: configSnapshotDir,
+      result: configSnapshot,
+    }).pipe(Effect.mapError((cause) => forwarderFailure("Failed to persist AI metrics config snapshot.", cause)));
     const repoRootHash = yield* hashPrivateIdentifier(pathApi.resolve(input.repoRoot), input.hashSalt).pipe(
       Effect.mapError((cause) => forwarderFailure("Failed to hash AI metrics repo root.", cause))
     );
-    const sourceFiles = yield* discoverForwarderSourceFiles(input);
+    const sourceSelection = yield* discoverForwarderSourceFiles(input);
     const records = yield* Effect.forEach(
-      sourceFiles,
+      sourceSelection.files,
       (sourceFile) => processSourceFile(input, installSpec.storage.rawArchiveDir, sourceFile),
       { concurrency: 4 }
     );
@@ -385,6 +631,10 @@ export const runAiMetricsForwarder = Effect.fn("AiMetrics.runAiMetricsForwarder"
         target: input.target,
       })
     ).pipe(Effect.mapError((cause) => forwarderFailure("Failed to write AI metrics derived storage.", cause)));
+    yield* writeAiMetricsConfigSnapshotArtifacts({
+      outputDir: configSnapshotDir,
+      result: configSnapshot,
+    }).pipe(Effect.mapError((cause) => forwarderFailure("Failed to commit latest AI metrics config snapshot.", cause)));
 
     return new AiMetricsForwarderRunResult({
       archiveObjectCount: derived.archiveObjectCount,
@@ -394,6 +644,7 @@ export const runAiMetricsForwarder = Effect.fn("AiMetrics.runAiMetricsForwarder"
       parquetExportDir: derived.parquetExportDir,
       parquetTables: derived.parquetTables,
       rawArchiveDir: installSpec.storage.rawArchiveDir,
+      sourceCoverage: sourceSelection.coverage,
       sourceFileCount: derived.sourceFileCount,
       target: input.target,
       turnCount: derived.turnCount,
@@ -444,6 +695,27 @@ export const forwarderRunResultToJson: (
   function* (result) {
     return yield* encodeForwarderResultJson(result).pipe(
       Effect.mapError((cause) => forwarderFailure("Failed to encode AI metrics forwarder result as JSON.", cause))
+    );
+  }
+);
+
+/**
+ * Render a forwarder timer plan as JSON.
+ *
+ * @example
+ * ```ts
+ * import { forwarderTimerPlanToJson } from "@beep/repo-ai-metrics"
+ * console.log(forwarderTimerPlanToJson)
+ * ```
+ * @category utilities
+ * @since 0.0.0
+ */
+export const forwarderTimerPlanToJson: (
+  result: AiMetricsForwarderTimerPlan
+) => Effect.Effect<string, AiMetricsForwarderError> = Effect.fn("AiMetrics.forwarderTimerPlanToJson")(
+  function* (result) {
+    return yield* encodeForwarderTimerPlanJson(result).pipe(
+      Effect.mapError((cause) => forwarderFailure("Failed to encode AI metrics forwarder timer plan as JSON.", cause))
     );
   }
 );

--- a/packages/tooling/library/ai-metrics/src/forwarder.ts
+++ b/packages/tooling/library/ai-metrics/src/forwarder.ts
@@ -285,6 +285,7 @@ export const renderAiMetricsForwarderTimerPlan = (input: AiMetricsForwarderTimer
     "set -euo pipefail",
     `mkdir -p "$(dirname ${shellQuote(input.statusPath)})" "$(dirname ${shellQuote(input.lockPath)})"`,
     "exit_code=0",
+    `> ${shellQuote(stderrTmpPath)}`,
     `if flock -n ${shellQuote(input.lockPath)} ${input.command} > ${shellQuote(statusTmpPath)} 2> ${shellQuote(stderrTmpPath)}; then :; else exit_code=$?; python3 -c ${shellQuote(failureStatusPython)} "$exit_code" ${shellQuote(stderrTmpPath)} > ${shellQuote(statusTmpPath)}; fi`,
     `rm -f ${shellQuote(stderrTmpPath)}`,
     `mv ${shellQuote(statusTmpPath)} ${shellQuote(input.statusPath)}`,

--- a/packages/tooling/library/ai-metrics/src/forwarder.ts
+++ b/packages/tooling/library/ai-metrics/src/forwarder.ts
@@ -27,6 +27,7 @@ import { summarizeTranscriptText } from "./ingest.ts";
 import { AiMetricsInstallInput, makeAiMetricsInstallSpec } from "./install.ts";
 import { AiMetricsDeployTarget, AiMetricsTranscriptSource } from "./models.ts";
 import { hashPrivateIdentifier, makeAiMetricsPrivacyCheckResult } from "./privacy.ts";
+import { shellQuote } from "./shell.ts";
 
 const $I = $RepoAiMetricsId.create("forwarder");
 const DEFAULT_MAX_FILES = 200;
@@ -240,8 +241,6 @@ const repoPathToClaudeProjectName: (repoRoot: string) => string = Str.replace(/[
 
 const normalizedRelativePath = (pathApi: Path.Path, root: string, filePath: string): string =>
   pipe(pathApi.relative(root, filePath), Str.replace(/\\/gu, "/"));
-
-const shellQuote = (value: string): string => `'${Str.replace(/'/gu, "'\\''")(value)}'`;
 
 const requireForwarderHashSalt = Effect.fn("AiMetrics.forwarder.requireHashSalt")(function* (
   input: AiMetricsForwarderInput

--- a/packages/tooling/library/ai-metrics/src/forwarder.ts
+++ b/packages/tooling/library/ai-metrics/src/forwarder.ts
@@ -279,11 +279,13 @@ export const renderAiMetricsForwarderTimerPlan = (input: AiMetricsForwarderTimer
   const stderrTmpPath = `${input.statusPath}.stderr.tmp`;
   const envFileShellPath = "~/.config/beep/ai-metrics.env";
   const envFileUnitPath = "%h/.config/beep/ai-metrics.env";
+  const failureStatusPython =
+    'import json,sys; data=open(sys.argv[2],"rb").read(2000).decode("utf-8","replace"); print(json.dumps({"status":"failed","exitCode":int(sys.argv[1]),"stderr":data},separators=(",",":")))';
   const execCommand = [
     "set -euo pipefail",
     `mkdir -p "$(dirname ${shellQuote(input.statusPath)})" "$(dirname ${shellQuote(input.lockPath)})"`,
     "exit_code=0",
-    `if flock -n ${shellQuote(input.lockPath)} ${input.command} > ${shellQuote(statusTmpPath)} 2> ${shellQuote(stderrTmpPath)}; then :; else exit_code=$?; stderr="$(head -c 2000 ${shellQuote(stderrTmpPath)} | sed 's/\\\\/\\\\\\\\/g; s/"/\\\\"/g' | tr '\\n' ' ')"; printf '{"status":"failed","exitCode":%s,"stderr":"%s"}\\n' "$exit_code" "$stderr" > ${shellQuote(statusTmpPath)}; fi`,
+    `if flock -n ${shellQuote(input.lockPath)} ${input.command} > ${shellQuote(statusTmpPath)} 2> ${shellQuote(stderrTmpPath)}; then :; else exit_code=$?; python3 -c ${shellQuote(failureStatusPython)} "$exit_code" ${shellQuote(stderrTmpPath)} > ${shellQuote(statusTmpPath)}; fi`,
     `rm -f ${shellQuote(stderrTmpPath)}`,
     `mv ${shellQuote(statusTmpPath)} ${shellQuote(input.statusPath)}`,
     'exit "$exit_code"',

--- a/packages/tooling/library/ai-metrics/src/index.ts
+++ b/packages/tooling/library/ai-metrics/src/index.ts
@@ -138,6 +138,18 @@ export * from "./privacy.ts";
  */
 export * from "./scorecard.ts";
 /**
+ * Shell rendering helpers for operator commands.
+ *
+ * @example
+ * ```ts
+ * import { shellQuote } from "@beep/repo-ai-metrics"
+ * console.log(shellQuote("op://vault/item/field"))
+ * ```
+ * @category utilities
+ * @since 0.0.0
+ */
+export * from "./shell.ts";
+/**
  * Local AI-agent source discovery helpers.
  *
  * @example

--- a/packages/tooling/library/ai-metrics/src/install.ts
+++ b/packages/tooling/library/ai-metrics/src/install.ts
@@ -272,8 +272,10 @@ export const AiMetricsInstallPlanStepKind = LiteralKit([
   "config_snapshot",
   "privacy_check",
   "forwarder",
+  "forwarder_timer",
   "otlp_export",
   "label_queue",
+  "retention_drill",
   "weekly_report",
   "pulumi",
 ] as const).annotate(
@@ -598,6 +600,8 @@ const makeServiceSpec =
     });
   };
 
+const shellQuote = (value: string): string => `'${Str.replace(/'/gu, "'\\''")(value)}'`;
+
 const withHashSaltSecret =
   (hashSaltSecretRef: O.Option<string>) =>
   (command: string): string =>
@@ -605,9 +609,12 @@ const withHashSaltSecret =
       hashSaltSecretRef,
       O.match({
         onNone: () => command,
-        onSome: (ref) => `BEEP_AI_METRICS_HASH_SALT=<secret:${ref}> ${command}`,
+        onSome: (ref) => `BEEP_AI_METRICS_HASH_SALT="$(op read ${shellQuote(ref)})" ${command}`,
       })
     );
+
+const rawArchiveKeyPrefix = (rawRef: string): string =>
+  `BEEP_AI_METRICS_RAW_ARCHIVE_KEY="$(op read ${shellQuote(rawRef)})"`;
 
 const withInstallSecretRefFlags =
   (hashSaltSecretRef: O.Option<string>, rawArchiveKeySecretRef: O.Option<string>) =>
@@ -616,11 +623,11 @@ const withInstallSecretRefFlags =
       [
         pipe(
           hashSaltSecretRef,
-          O.map((ref) => `--hash-salt-secret-ref ${ref}`)
+          O.map((ref) => `--hash-salt-secret-ref ${shellQuote(ref)}`)
         ),
         pipe(
           rawArchiveKeySecretRef,
-          O.map((ref) => `--raw-archive-key-secret-ref ${ref}`)
+          O.map((ref) => `--raw-archive-key-secret-ref ${shellQuote(ref)}`)
         ),
       ],
       A.getSomes,
@@ -756,7 +763,7 @@ const makeInstallPlanSteps = (
             ),
           onSome: (rawRef) =>
             withHashSaltSecret(hashSaltSecretRef)(
-              `BEEP_AI_METRICS_RAW_ARCHIVE_KEY=<secret:${rawRef}> beep-cli ai-metrics forwarder run --target ${spec.target}${collectorDataRootFlag} --raw-archive-key-secret-ref ${rawRef}${spec.target === AiMetricsDeployTarget.Enum.dankserver ? " --otlp" : ""}${otlpBaseUrlFlag}`
+              `${rawArchiveKeyPrefix(rawRef)} beep-cli ai-metrics forwarder run --target ${spec.target}${collectorDataRootFlag} --raw-archive-key-secret-ref ${shellQuote(rawRef)}${spec.target === AiMetricsDeployTarget.Enum.dankserver ? " --otlp" : ""}${otlpBaseUrlFlag}`
             ),
         })
       ),
@@ -773,6 +780,19 @@ const makeInstallPlanSteps = (
     }),
     planStep({
       command: installFlags(
+        `beep-cli ai-metrics forwarder timer --target ${spec.target}${collectorDataRootFlag}${otlpBaseUrlFlag}`
+      ),
+      description:
+        "Render the workstation systemd user timer that owns repeated P6a collection with lock, retry, status, and journal evidence.",
+      kind: AiMetricsInstallPlanStepKind.Enum.forwarder_timer,
+      mutatesHost: false,
+      order: 65,
+      requiresRemote: false,
+      stepId: "forwarder.timer",
+      title: "Render forwarder timer",
+    }),
+    planStep({
+      command: installFlags(
         `beep-cli ai-metrics otlp export --target ${spec.target}${collectorDataRootFlag} --ingest-run latest${otlpBaseUrlFlag}`
       ),
       description: "Export redacted derived spans to the Phoenix OTLP trace endpoint.",
@@ -784,7 +804,9 @@ const makeInstallPlanSteps = (
       title: "Export derived OTLP spans",
     }),
     planStep({
-      command: installFlags(`beep-cli ai-metrics label queue --target ${spec.target} --limit 20`),
+      command: installFlags(
+        `beep-cli ai-metrics label queue --target ${spec.target}${collectorDataRootFlag} --limit 20`
+      ),
       description: "Review real tasks that need outcome labels before weekly scoring.",
       kind: AiMetricsInstallPlanStepKind.Enum.label_queue,
       mutatesHost: false,
@@ -794,7 +816,7 @@ const makeInstallPlanSteps = (
       title: "Review outcome label queue",
     }),
     planStep({
-      command: installFlags(`beep-cli ai-metrics report weekly --target ${spec.target}`),
+      command: installFlags(`beep-cli ai-metrics report weekly --target ${spec.target}${collectorDataRootFlag}`),
       description: "Generate the weekly config-impact scorecard from derived data.",
       kind: AiMetricsInstallPlanStepKind.Enum.weekly_report,
       mutatesHost: false,
@@ -802,6 +824,28 @@ const makeInstallPlanSteps = (
       requiresRemote: false,
       stepId: "report.weekly",
       title: "Generate weekly scorecard",
+    }),
+    planStep({
+      command: pipe(
+        rawArchiveKeySecretRef,
+        O.match({
+          onNone: () =>
+            withHashSaltSecret(hashSaltSecretRef)(
+              `BEEP_AI_METRICS_RAW_ARCHIVE_KEY=<base64-32-byte-key> ${installFlags(`beep-cli ai-metrics archive drill --target ${spec.target}${collectorDataRootFlag}`)}`
+            ),
+          onSome: (rawRef) =>
+            `${rawArchiveKeyPrefix(rawRef)} ${withHashSaltSecret(hashSaltSecretRef)(
+              installFlags(`beep-cli ai-metrics archive drill --target ${spec.target}${collectorDataRootFlag}`)
+            )}`,
+        })
+      ),
+      description: "Run a small archive decrypt or restore drill before restarting the credited seven-day proof.",
+      kind: AiMetricsInstallPlanStepKind.Enum.retention_drill,
+      mutatesHost: false,
+      order: 95,
+      requiresRemote: false,
+      stepId: "archive.drill",
+      title: "Run archive drill",
     }),
     planStep({
       command:
@@ -844,9 +888,15 @@ const plannedCommands = (
         ),
       onSome: (rawRef) =>
         withHashSaltSecret(hashSaltSecretRef)(
-          `BEEP_AI_METRICS_RAW_ARCHIVE_KEY=<secret:${rawRef}> beep-cli ai-metrics forwarder run --target ${target}${target === AiMetricsDeployTarget.Enum.dankserver ? ` --data-root ${localCollectorDataRoot}` : ""} --raw-archive-key-secret-ref ${rawRef}${target === AiMetricsDeployTarget.Enum.dankserver ? ` --otlp --otlp-base-url ${publicBaseUrl}` : ""}`
+          `${rawArchiveKeyPrefix(rawRef)} beep-cli ai-metrics forwarder run --target ${target}${target === AiMetricsDeployTarget.Enum.dankserver ? ` --data-root ${localCollectorDataRoot}` : ""} --raw-archive-key-secret-ref ${shellQuote(rawRef)}${target === AiMetricsDeployTarget.Enum.dankserver ? ` --otlp --otlp-base-url ${publicBaseUrl}` : ""}`
         ),
     })
+  ),
+  withInstallSecretRefFlags(
+    hashSaltSecretRef,
+    rawArchiveKeySecretRef
+  )(
+    `beep-cli ai-metrics forwarder timer --target ${target}${target === AiMetricsDeployTarget.Enum.dankserver ? ` --data-root ${localCollectorDataRoot} --otlp-base-url ${publicBaseUrl}` : ""}`
   ),
   withInstallSecretRefFlags(
     hashSaltSecretRef,
@@ -857,11 +907,38 @@ const plannedCommands = (
   withInstallSecretRefFlags(
     hashSaltSecretRef,
     rawArchiveKeySecretRef
-  )(`beep-cli ai-metrics label queue --target ${target} --limit 20`),
+  )(
+    `beep-cli ai-metrics label queue --target ${target}${target === AiMetricsDeployTarget.Enum.dankserver ? ` --data-root ${localCollectorDataRoot}` : ""} --limit 20`
+  ),
   withInstallSecretRefFlags(
     hashSaltSecretRef,
     rawArchiveKeySecretRef
-  )(`beep-cli ai-metrics report weekly --target ${target}`),
+  )(
+    `beep-cli ai-metrics report weekly --target ${target}${target === AiMetricsDeployTarget.Enum.dankserver ? ` --data-root ${localCollectorDataRoot}` : ""}`
+  ),
+  pipe(
+    rawArchiveKeySecretRef,
+    O.match({
+      onNone: () =>
+        withHashSaltSecret(hashSaltSecretRef)(
+          `BEEP_AI_METRICS_RAW_ARCHIVE_KEY=<base64-32-byte-key> ${withInstallSecretRefFlags(
+            hashSaltSecretRef,
+            rawArchiveKeySecretRef
+          )(
+            `beep-cli ai-metrics archive drill --target ${target}${target === AiMetricsDeployTarget.Enum.dankserver ? ` --data-root ${localCollectorDataRoot}` : ""}`
+          )}`
+        ),
+      onSome: (rawRef) =>
+        `${rawArchiveKeyPrefix(rawRef)} ${withHashSaltSecret(hashSaltSecretRef)(
+          withInstallSecretRefFlags(
+            hashSaltSecretRef,
+            rawArchiveKeySecretRef
+          )(
+            `beep-cli ai-metrics archive drill --target ${target}${target === AiMetricsDeployTarget.Enum.dankserver ? ` --data-root ${localCollectorDataRoot}` : ""}`
+          )
+        )}`,
+    })
+  ),
 ];
 
 const encodeInstallPlanJson = S.encodeUnknownEffect(S.fromJsonString(AiMetricsInstallPlan));

--- a/packages/tooling/library/ai-metrics/src/install.ts
+++ b/packages/tooling/library/ai-metrics/src/install.ts
@@ -22,6 +22,7 @@ import {
   AiMetricsScoreWeights,
   AiMetricsTool,
 } from "./models.ts";
+import { shellQuote } from "./shell.ts";
 import { AiMetricsSourceDiscoveryResult, AiMetricsSourceStatus } from "./source-discovery.ts";
 
 const $I = $RepoAiMetricsId.create("install");
@@ -599,8 +600,6 @@ const makeServiceSpec =
       tool,
     });
   };
-
-const shellQuote = (value: string): string => `'${Str.replace(/'/gu, "'\\''")(value)}'`;
 
 const withHashSaltSecret =
   (hashSaltSecretRef: O.Option<string>) =>

--- a/packages/tooling/library/ai-metrics/src/models.ts
+++ b/packages/tooling/library/ai-metrics/src/models.ts
@@ -106,6 +106,64 @@ export const AiMetricsTranscriptSource = LiteralKit(["codex", "claude", "opencla
 export type AiMetricsTranscriptSource = typeof AiMetricsTranscriptSource.Type;
 
 /**
+ * Role of a discovered source file within the source's local storage.
+ *
+ * @example
+ * ```ts
+ * import { AiMetricsSourceRole } from "@beep/repo-ai-metrics"
+ * console.log(AiMetricsSourceRole.Enum.primary)
+ * ```
+ * @category models
+ * @since 0.0.0
+ */
+export const AiMetricsSourceRole = LiteralKit(["primary", "subagent", "gateway_metadata"] as const).annotate(
+  $I.annote("AiMetricsSourceRole", {
+    description: "Privacy-safe role of a discovered source file or metadata record.",
+  })
+);
+
+/**
+ * Runtime type for {@link AiMetricsSourceRole}.
+ *
+ * @example
+ * ```ts
+ * import type { AiMetricsSourceRole } from "@beep/repo-ai-metrics"
+ * const role: AiMetricsSourceRole = "primary"
+ * console.log(role)
+ * ```
+ * @category models
+ * @since 0.0.0
+ */
+export type AiMetricsSourceRole = typeof AiMetricsSourceRole.Type;
+
+/**
+ * Privacy-preserving source attribution derived from transcript metadata.
+ *
+ * @example
+ * ```ts
+ * import { AiMetricsSourceAttribution } from "@beep/repo-ai-metrics"
+ * console.log(new AiMetricsSourceAttribution({ sourceRole: "primary" }).sourceRole)
+ * ```
+ * @category models
+ * @since 0.0.0
+ */
+export class AiMetricsSourceAttribution extends S.Class<AiMetricsSourceAttribution>($I`AiMetricsSourceAttribution`)(
+  {
+    agentNicknameHash: S.optionalKey(S.String),
+    agentRoleHash: S.optionalKey(S.String),
+    forkedFromIdHash: S.optionalKey(S.String),
+    parentSessionIdHash: S.optionalKey(S.String),
+    parentThreadIdHash: S.optionalKey(S.String),
+    sessionIdHash: S.optionalKey(S.String),
+    sourceRole: AiMetricsSourceRole,
+    threadSpawn: S.optionalKey(S.Boolean),
+  },
+  $I.annote("AiMetricsSourceAttribution", {
+    description: "Hash-only metadata that distinguishes primary sessions from delegated subagent work.",
+  })
+) {}
+
+/**
  * Raw transcript retention and derived-dashboard privacy posture.
  *
  * @example
@@ -298,11 +356,16 @@ export class ConfigSnapshot extends S.Class<ConfigSnapshot>($I`ConfigSnapshot`)(
     changedPaths: S.Array(S.String),
     configHash: S.String,
     gitCommit: S.optionalKey(S.String),
+    includedPaths: S.Array(S.String).pipe(
+      S.withConstructorDefault(Effect.succeed([])),
+      S.withDecodingDefaultKey(Effect.succeed([]))
+    ),
     label: S.String,
+    previousSnapshotId: S.optionalKey(S.String),
     snapshotId: S.String,
   },
   $I.annote("ConfigSnapshot", {
-    description: "Hashed snapshot of Codex, Claude, assistant, and repo guidance configuration.",
+    description: "Hashed snapshot of Codex, Claude, assistant, and repo guidance configuration with diff attribution.",
   })
 ) {}
 
@@ -327,6 +390,10 @@ export class AgentTask extends S.Class<AgentTask>($I`AgentTask`)(
     repoRootHash: S.String,
     sourceKind: AiMetricsTranscriptSource,
     sourcePathHash: S.String,
+    sourceRole: AiMetricsSourceRole.pipe(
+      S.withConstructorDefault(Effect.succeed(AiMetricsSourceRole.Enum.primary)),
+      S.withDecodingDefaultKey(Effect.succeed(AiMetricsSourceRole.Enum.primary))
+    ),
     title: S.String,
   },
   $I.annote("AgentTask", {
@@ -349,9 +416,20 @@ export class AgentSession extends S.Class<AgentSession>($I`AgentSession`)(
   {
     agentSessionId: S.String,
     agentTaskId: S.optionalKey(S.String),
+    agentNicknameHash: S.optionalKey(S.String),
+    agentRoleHash: S.optionalKey(S.String),
+    forkedFromIdHash: S.optionalKey(S.String),
+    parentSessionIdHash: S.optionalKey(S.String),
+    parentThreadIdHash: S.optionalKey(S.String),
+    sessionIdHash: S.optionalKey(S.String),
     sourceKind: AiMetricsTranscriptSource,
     sourcePathHash: S.String,
+    sourceRole: AiMetricsSourceRole.pipe(
+      S.withConstructorDefault(Effect.succeed(AiMetricsSourceRole.Enum.primary)),
+      S.withDecodingDefaultKey(Effect.succeed(AiMetricsSourceRole.Enum.primary))
+    ),
     startedAt: S.optionalKey(S.String),
+    threadSpawn: S.optionalKey(S.Boolean),
   },
   $I.annote("AgentSession", {
     description:
@@ -376,6 +454,10 @@ export class AgentTurn extends S.Class<AgentTurn>($I`AgentTurn`)(
     lineNumber: S.Number,
     sourceKind: AiMetricsTranscriptSource,
     sourcePathHash: S.String,
+    sourceRole: AiMetricsSourceRole.pipe(
+      S.withConstructorDefault(Effect.succeed(AiMetricsSourceRole.Enum.primary)),
+      S.withDecodingDefaultKey(Effect.succeed(AiMetricsSourceRole.Enum.primary))
+    ),
     timestamp: S.optionalKey(S.String),
   },
   $I.annote("AgentTurn", {
@@ -523,6 +605,10 @@ export class BenchmarkRun extends S.Class<BenchmarkRun>($I`BenchmarkRun`)(
 export class Scorecard extends S.Class<Scorecard>($I`Scorecard`)(
   {
     benchmarkRunCount: S.Number,
+    completionReady: S.Boolean.pipe(
+      S.withConstructorDefault(Effect.succeed(false)),
+      S.withDecodingDefaultKey(Effect.succeed(false))
+    ),
     configSnapshotId: S.String,
     costScore: S.Number,
     coverageGaps: S.Array(S.String),

--- a/packages/tooling/library/ai-metrics/src/otlp.ts
+++ b/packages/tooling/library/ai-metrics/src/otlp.ts
@@ -8,15 +8,56 @@
 import { DuckDb } from "@beep/duckdb";
 import { $RepoAiMetricsId } from "@beep/identity/packages";
 import { TaggedErrorClass } from "@beep/schema";
-import { Effect, pipe } from "effect";
+import { Effect, flow, pipe } from "effect";
 import * as A from "effect/Array";
 import * as O from "effect/Option";
 import * as R from "effect/Record";
 import * as S from "effect/Schema";
 import * as Str from "effect/String";
-import { AiMetricsDeployTarget, AiMetricsOtlpEndpointSpec, AiMetricsTranscriptSource } from "./models.ts";
+import {
+  AiMetricsDeployTarget,
+  AiMetricsOtlpEndpointSpec,
+  AiMetricsSourceRole,
+  AiMetricsTranscriptSource,
+} from "./models.ts";
 
 const $I = $RepoAiMetricsId.create("otlp");
+
+/**
+ * OTLP attributes approved for redacted AI metrics span export.
+ *
+ * @example
+ * ```ts
+ * import { AI_METRICS_OTLP_ATTRIBUTE_ALLOWLIST } from "@beep/repo-ai-metrics"
+ * console.log(AI_METRICS_OTLP_ATTRIBUTE_ALLOWLIST)
+ * ```
+ * @category constants
+ * @since 0.0.0
+ */
+export const AI_METRICS_OTLP_ATTRIBUTE_ALLOWLIST = [
+  "ai_metrics.agent_nickname_hash",
+  "ai_metrics.agent_role_hash",
+  "ai_metrics.config_snapshot_id",
+  "ai_metrics.event_name",
+  "ai_metrics.forked_from_id_hash",
+  "ai_metrics.ingest_run_id",
+  "ai_metrics.line_number",
+  "ai_metrics.parent_session_id_hash",
+  "ai_metrics.parent_thread_id_hash",
+  "ai_metrics.provider",
+  "ai_metrics.raw_event_hash",
+  "ai_metrics.session_id_hash",
+  "ai_metrics.source_kind",
+  "ai_metrics.source_path_hash",
+  "ai_metrics.source_role",
+  "ai_metrics.thread_spawn",
+  "ai_metrics.timestamp",
+  "ai_metrics.tool_name",
+  "ai_metrics.turn_id",
+  "openinference.span.kind",
+  "session.id",
+  "tool.name",
+] as const;
 
 /**
  * Attribute value variants allowed on redacted AI metrics OTLP spans.
@@ -188,14 +229,22 @@ class LatestIngestRunRow extends S.Class<LatestIngestRunRow>($I`LatestIngestRunR
 
 class AiMetricsOtlpTurnExportRow extends S.Class<AiMetricsOtlpTurnExportRow>($I`AiMetricsOtlpTurnExportRow`)(
   {
+    agentNicknameHash: S.NullOr(S.String),
+    agentRoleHash: S.NullOr(S.String),
     agentSessionId: S.String,
     configSnapshotId: S.String,
     eventName: S.String,
+    forkedFromIdHash: S.NullOr(S.String),
     ingestRunId: S.String,
     lineNumber: S.Number,
+    parentSessionIdHash: S.NullOr(S.String),
+    parentThreadIdHash: S.NullOr(S.String),
     rawEventHash: S.String,
+    sessionIdHash: S.NullOr(S.String),
     sourceKind: AiMetricsTranscriptSource,
     sourcePathHash: S.String,
+    sourceRole: AiMetricsSourceRole,
+    threadSpawn: S.NullOr(S.Boolean),
     timestamp: S.NullOr(S.String),
     turnId: S.String,
   },
@@ -223,6 +272,12 @@ const providerFor = (row: AiMetricsOtlpTurnExportRow): string => {
 
 const toolNameFor = (row: AiMetricsOtlpTurnExportRow): O.Option<string> =>
   pipe(row.eventName, Str.toLowerCase, Str.includes("tool")) ? O.some(row.eventName) : O.none();
+
+const allowlistedAttributes: (
+  attributes: Record<string, AiMetricsOtlpAttributeValue>
+) => Record<string, AiMetricsOtlpAttributeValue> = flow(
+  R.filter((_value, key) => A.contains(AI_METRICS_OTLP_ATTRIBUTE_ALLOWLIST as ReadonlyArray<string>, key))
+);
 
 const llmEventNameFragments = [
   "assistant",
@@ -281,10 +336,18 @@ const readTurnRows = Effect.fn("AiMetrics.otlp.readTurnRows")(function* (ingestR
          t.agent_session_id AS "agentSessionId",
          t.source_kind AS "sourceKind",
          t.source_path_hash AS "sourcePathHash",
+         COALESCE(t.source_role, s.source_role, 'primary') AS "sourceRole",
          t.line_number AS "lineNumber",
          t.event_name AS "eventName",
          t.raw_event_hash AS "rawEventHash",
          t.timestamp AS "timestamp",
+         s.session_id_hash AS "sessionIdHash",
+         s.parent_session_id_hash AS "parentSessionIdHash",
+         s.parent_thread_id_hash AS "parentThreadIdHash",
+         s.forked_from_id_hash AS "forkedFromIdHash",
+         s.thread_spawn AS "threadSpawn",
+         s.agent_role_hash AS "agentRoleHash",
+         s.agent_nickname_hash AS "agentNicknameHash",
          s.config_snapshot_id AS "configSnapshotId"
        FROM ai_metrics_turns t
        JOIN ai_metrics_sessions s ON s.agent_session_id = t.agent_session_id
@@ -301,14 +364,24 @@ const readTurnRows = Effect.fn("AiMetrics.otlp.readTurnRows")(function* (ingestR
 
 const sessionProjection = (row: AiMetricsOtlpTurnExportRow): AiMetricsOtlpSpanProjection =>
   new AiMetricsOtlpSpanProjection({
-    attributes: {
+    attributes: allowlistedAttributes({
+      ...R.getSomes({
+        "ai_metrics.agent_nickname_hash": O.fromNullishOr(row.agentNicknameHash),
+        "ai_metrics.agent_role_hash": O.fromNullishOr(row.agentRoleHash),
+        "ai_metrics.forked_from_id_hash": O.fromNullishOr(row.forkedFromIdHash),
+        "ai_metrics.parent_session_id_hash": O.fromNullishOr(row.parentSessionIdHash),
+        "ai_metrics.parent_thread_id_hash": O.fromNullishOr(row.parentThreadIdHash),
+        "ai_metrics.session_id_hash": O.fromNullishOr(row.sessionIdHash),
+      }),
+      ...(row.threadSpawn === null ? {} : { "ai_metrics.thread_spawn": row.threadSpawn }),
       "ai_metrics.config_snapshot_id": row.configSnapshotId,
       "ai_metrics.ingest_run_id": row.ingestRunId,
       "ai_metrics.source_kind": row.sourceKind,
       "ai_metrics.source_path_hash": row.sourcePathHash,
+      "ai_metrics.source_role": row.sourceRole,
       "openinference.span.kind": "AGENT",
       "session.id": row.agentSessionId,
-    },
+    }),
     spanName: "ai_metrics.agent.session",
   });
 
@@ -316,7 +389,7 @@ const turnProjection = (row: AiMetricsOtlpTurnExportRow): AiMetricsOtlpSpanProje
   const toolName = toolNameFor(row);
 
   return new AiMetricsOtlpSpanProjection({
-    attributes: {
+    attributes: allowlistedAttributes({
       ...R.getSomes({
         "ai_metrics.timestamp": O.fromNullishOr(row.timestamp),
         "ai_metrics.tool_name": toolName,
@@ -330,10 +403,11 @@ const turnProjection = (row: AiMetricsOtlpTurnExportRow): AiMetricsOtlpSpanProje
       "ai_metrics.raw_event_hash": row.rawEventHash,
       "ai_metrics.source_kind": row.sourceKind,
       "ai_metrics.source_path_hash": row.sourcePathHash,
+      "ai_metrics.source_role": row.sourceRole,
       "ai_metrics.turn_id": row.turnId,
       "openinference.span.kind": openInferenceSpanKindFor(row),
       "session.id": row.agentSessionId,
-    },
+    }),
     spanName: "ai_metrics.agent.turn",
   });
 };

--- a/packages/tooling/library/ai-metrics/src/privacy.ts
+++ b/packages/tooling/library/ai-metrics/src/privacy.ts
@@ -402,8 +402,20 @@ const firstCodexSubagentSource: (lines: ReadonlyArray<CodexSessionMetaLine>) => 
   A.head
 );
 
-const pathRoleFor = (relativePath: string): AiMetricsSourceRole =>
-  Str.includes("/subagents/")(relativePath) ? AiMetricsSourceRole.Enum.subagent : AiMetricsSourceRole.Enum.primary;
+const normalizeAttributionPath = flow(
+  Str.replace(/\\/gu, "/"),
+  Str.replace(/^[A-Za-z]:/u, ""),
+  Str.replace(/^\/+/u, "")
+);
+
+const basenameAttributionPath = flow(normalizeAttributionPath, Str.replace(/^.*\//u, ""));
+
+const pathRoleFor = (relativePath: string): AiMetricsSourceRole => {
+  const normalizedPath = normalizeAttributionPath(relativePath);
+  return Str.startsWith("subagents/")(normalizedPath) || Str.includes("/subagents/")(normalizedPath)
+    ? AiMetricsSourceRole.Enum.subagent
+    : AiMetricsSourceRole.Enum.primary;
+};
 
 /**
  * Derive privacy-safe source attribution from local transcript metadata.
@@ -589,18 +601,20 @@ const rawEventEnvelopes = Effect.fn("AiMetrics.rawEventEnvelopes")(function* ({
 export const makeSanitizedTranscript = Effect.fn("AiMetrics.makeSanitizedTranscript")(function* ({
   content,
   hashSalt,
+  relativePath,
   sourcePath,
   summary,
 }: {
   readonly content: string;
   readonly hashSalt?: string;
+  readonly relativePath?: string;
   readonly sourcePath: string;
   readonly summary: TranscriptIngestSummary;
 }) {
   const attribution = yield* makeAiMetricsSourceAttribution({
     content,
     ...(hashSalt === undefined ? {} : { hashSalt }),
-    relativePath: sourcePath,
+    relativePath: relativePath ?? basenameAttributionPath(sourcePath),
     sourceKind: summary.sourceKind,
     sourcePath,
   });
@@ -647,11 +661,13 @@ export const makeSanitizedTranscript = Effect.fn("AiMetrics.makeSanitizedTranscr
 export const makeAiMetricsPrivacyCheckResult = Effect.fn("AiMetrics.makeAiMetricsPrivacyCheckResult")(function* ({
   content,
   hashSalt,
+  relativePath,
   sourcePath,
   summary,
 }: {
   readonly content: string;
   readonly hashSalt?: string;
+  readonly relativePath?: string;
   readonly sourcePath: string;
   readonly summary: TranscriptIngestSummary;
 }) {
@@ -661,6 +677,7 @@ export const makeAiMetricsPrivacyCheckResult = Effect.fn("AiMetrics.makeAiMetric
     redaction: redactionResultFor(content),
     sanitized: yield* makeSanitizedTranscript({
       content,
+      ...(relativePath === undefined ? {} : { relativePath }),
       sourcePath,
       summary,
       ...(hashSalt === undefined ? {} : { hashSalt }),

--- a/packages/tooling/library/ai-metrics/src/privacy.ts
+++ b/packages/tooling/library/ai-metrics/src/privacy.ts
@@ -14,7 +14,12 @@ import * as O from "effect/Option";
 import * as S from "effect/Schema";
 import * as Str from "effect/String";
 import { firstString, metricEventName, optionalTimestamp, transcriptLines } from "./internal/transcript-utils.ts";
-import { AiMetricsTranscriptSource, type TranscriptIngestSummary } from "./models.ts";
+import {
+  AiMetricsSourceAttribution,
+  AiMetricsSourceRole,
+  AiMetricsTranscriptSource,
+  type TranscriptIngestSummary,
+} from "./models.ts";
 
 const $I = $RepoAiMetricsId.create("privacy");
 
@@ -116,6 +121,10 @@ export class AiMetricsRawEventEnvelope extends S.Class<AiMetricsRawEventEnvelope
     rawEventHash: S.String,
     sourceKind: AiMetricsTranscriptSource,
     sourcePathHash: S.String,
+    sourceRole: AiMetricsSourceRole.pipe(
+      S.withConstructorDefault(Effect.succeed(AiMetricsSourceRole.Enum.primary)),
+      S.withDecodingDefaultKey(Effect.succeed(AiMetricsSourceRole.Enum.primary))
+    ),
     timestamp: S.optionalKey(S.String),
   },
   $I.annote("AiMetricsRawEventEnvelope", {
@@ -139,13 +148,24 @@ export class AiMetricsSanitizedTranscript extends S.Class<AiMetricsSanitizedTran
 )(
   {
     acceptedEvents: S.Number,
+    agentNicknameHash: S.optionalKey(S.String),
+    agentRoleHash: S.optionalKey(S.String),
     eventNames: S.Array(S.String),
     firstTimestamp: S.optionalKey(S.String),
+    forkedFromIdHash: S.optionalKey(S.String),
     lastTimestamp: S.optionalKey(S.String),
+    parentSessionIdHash: S.optionalKey(S.String),
+    parentThreadIdHash: S.optionalKey(S.String),
     rawEventEnvelopes: S.Array(AiMetricsRawEventEnvelope),
     rejectedLines: S.Number,
+    sessionIdHash: S.optionalKey(S.String),
     sourceKind: AiMetricsTranscriptSource,
     sourcePathHash: S.String,
+    sourceRole: AiMetricsSourceRole.pipe(
+      S.withConstructorDefault(Effect.succeed(AiMetricsSourceRole.Enum.primary)),
+      S.withDecodingDefaultKey(Effect.succeed(AiMetricsSourceRole.Enum.primary))
+    ),
+    threadSpawn: S.optionalKey(S.Boolean),
     totalLines: S.Number,
   },
   $I.annote("AiMetricsSanitizedTranscript", {
@@ -211,7 +231,53 @@ class GenericTranscriptLine extends S.Class<GenericTranscriptLine>($I`GenericTra
   })
 ) {}
 
+class CodexSubagentSource extends S.Class<CodexSubagentSource>($I`CodexSubagentSource`)(
+  {
+    agent_nickname: S.optionalKey(S.String),
+    agent_role: S.optionalKey(S.String),
+    forked_from_id: S.optionalKey(S.String),
+    parent_session_id: S.optionalKey(S.String),
+    parent_thread_id: S.optionalKey(S.String),
+    thread_spawn: S.optionalKey(S.Boolean),
+  },
+  $I.annote("CodexSubagentSource", {
+    description: "Hash-only source metadata shape decoded from Codex session_meta lines.",
+  })
+) {}
+
+class CodexSessionSource extends S.Class<CodexSessionSource>($I`CodexSessionSource`)(
+  {
+    subagent: S.optionalKey(CodexSubagentSource),
+  },
+  $I.annote("CodexSessionSource", {
+    description: "Codex session_meta source metadata used for attribution.",
+  })
+) {}
+
+class CodexSessionPayload extends S.Class<CodexSessionPayload>($I`CodexSessionPayload`)(
+  {
+    id: S.optionalKey(S.String),
+    parent_session_id: S.optionalKey(S.String),
+    parent_thread_id: S.optionalKey(S.String),
+    source: S.optionalKey(CodexSessionSource),
+  },
+  $I.annote("CodexSessionPayload", {
+    description: "Codex session_meta payload fields used for privacy-preserving attribution.",
+  })
+) {}
+
+class CodexSessionMetaLine extends S.Class<CodexSessionMetaLine>($I`CodexSessionMetaLine`)(
+  {
+    payload: S.optionalKey(CodexSessionPayload),
+    type: S.String,
+  },
+  $I.annote("CodexSessionMetaLine", {
+    description: "Codex JSONL session_meta line used to detect delegated subagent transcripts.",
+  })
+) {}
+
 const decodeGenericTranscriptLine = S.decodeUnknownOption(S.fromJsonString(GenericTranscriptLine));
+const decodeCodexSessionMetaLine = S.decodeUnknownOption(S.fromJsonString(CodexSessionMetaLine));
 const encodePrivacyCheckJson = S.encodeUnknownEffect(S.fromJsonString(AiMetricsPrivacyCheckResult));
 
 /**
@@ -293,6 +359,129 @@ export const hashPrivateIdentifier: {
   })
 );
 
+const firstNonEmptyString = (...values: ReadonlyArray<string | undefined>): O.Option<string> =>
+  pipe(
+    values,
+    A.map((value) =>
+      pipe(
+        O.fromNullishOr(value),
+        O.filter((candidate) => Str.isNonEmpty(Str.trim(candidate)))
+      )
+    ),
+    A.getSomes,
+    A.head
+  );
+
+const optionalHashPrivateIdentifier = Effect.fn("AiMetrics.optionalHashPrivateIdentifier")(function* (
+  value: O.Option<string>,
+  hashSalt: string | undefined
+) {
+  if (O.isNone(value)) {
+    return undefined;
+  }
+
+  return yield* hashPrivateIdentifier(value.value, hashSalt);
+});
+
+const codexSessionMetaLines: (content: string) => ReadonlyArray<CodexSessionMetaLine> = flow(
+  transcriptLines,
+  A.map((line) => decodeCodexSessionMetaLine(line)),
+  A.getSomes,
+  A.filter((line) => line.type === "session_meta")
+);
+
+const firstCodexSessionPayload: (lines: ReadonlyArray<CodexSessionMetaLine>) => O.Option<CodexSessionPayload> = flow(
+  A.map((line) => O.fromNullishOr(line.payload)),
+  A.getSomes,
+  A.head
+);
+
+const firstCodexSubagentSource: (lines: ReadonlyArray<CodexSessionMetaLine>) => O.Option<CodexSubagentSource> = flow(
+  A.map((line) => O.fromNullishOr(line.payload?.source?.subagent)),
+  A.getSomes,
+  A.head
+);
+
+const pathRoleFor = (relativePath: string): AiMetricsSourceRole =>
+  Str.includes("/subagents/")(relativePath) ? AiMetricsSourceRole.Enum.subagent : AiMetricsSourceRole.Enum.primary;
+
+/**
+ * Derive privacy-safe source attribution from local transcript metadata.
+ *
+ * @example
+ * ```ts
+ * import { makeAiMetricsSourceAttribution } from "@beep/repo-ai-metrics"
+ * console.log(makeAiMetricsSourceAttribution)
+ * ```
+ * @category constructors
+ * @since 0.0.0
+ */
+export const makeAiMetricsSourceAttribution = Effect.fn("AiMetrics.makeAiMetricsSourceAttribution")(function* ({
+  content,
+  hashSalt,
+  relativePath,
+  sourceKind,
+  sourcePath,
+}: {
+  readonly content: string;
+  readonly hashSalt?: string;
+  readonly relativePath: string;
+  readonly sourceKind: AiMetricsTranscriptSource;
+  readonly sourcePath: string;
+}) {
+  if (sourceKind === AiMetricsTranscriptSource.Enum.openclaw) {
+    return new AiMetricsSourceAttribution({
+      sessionIdHash: yield* hashPrivateIdentifier("openclaw-gateway.service", hashSalt),
+      sourceRole: AiMetricsSourceRole.Enum.gateway_metadata,
+    });
+  }
+
+  if (sourceKind === AiMetricsTranscriptSource.Enum.claude) {
+    return new AiMetricsSourceAttribution({
+      sessionIdHash: yield* hashPrivateIdentifier(sourcePath, hashSalt),
+      sourceRole: pathRoleFor(relativePath),
+    });
+  }
+
+  const sessionMetaLines = codexSessionMetaLines(content);
+  const payload = firstCodexSessionPayload(sessionMetaLines);
+  const subagent = firstCodexSubagentSource(sessionMetaLines);
+  const subagentValue = O.getOrUndefined(subagent);
+  const payloadValue = O.getOrUndefined(payload);
+  const sourceRole =
+    O.isSome(subagent) || subagentValue?.thread_spawn === true
+      ? AiMetricsSourceRole.Enum.subagent
+      : AiMetricsSourceRole.Enum.primary;
+  const parentSessionId = firstNonEmptyString(subagentValue?.parent_session_id, payloadValue?.parent_session_id);
+  const parentThreadId = firstNonEmptyString(subagentValue?.parent_thread_id, payloadValue?.parent_thread_id);
+  const agentNicknameHash = yield* optionalHashPrivateIdentifier(
+    firstNonEmptyString(subagentValue?.agent_nickname),
+    hashSalt
+  );
+  const agentRoleHash = yield* optionalHashPrivateIdentifier(firstNonEmptyString(subagentValue?.agent_role), hashSalt);
+  const forkedFromIdHash = yield* optionalHashPrivateIdentifier(
+    firstNonEmptyString(subagentValue?.forked_from_id),
+    hashSalt
+  );
+  const parentSessionIdHash = yield* optionalHashPrivateIdentifier(parentSessionId, hashSalt);
+  const parentThreadIdHash = yield* optionalHashPrivateIdentifier(parentThreadId, hashSalt);
+  const sessionIdHash = yield* optionalHashPrivateIdentifier(
+    firstNonEmptyString(payloadValue?.id, sourcePath),
+    hashSalt
+  );
+
+  return new AiMetricsSourceAttribution({
+    ...(subagentValue?.thread_spawn === undefined ? {} : { threadSpawn: subagentValue.thread_spawn }),
+    ...(agentNicknameHash === undefined ? {} : { agentNicknameHash }),
+    ...(agentRoleHash === undefined ? {} : { agentRoleHash }),
+    ...(forkedFromIdHash === undefined ? {} : { forkedFromIdHash }),
+    ...(parentSessionIdHash === undefined ? {} : { parentSessionIdHash }),
+    ...(parentThreadIdHash === undefined ? {} : { parentThreadIdHash }),
+    ...(sessionIdHash === undefined ? {} : { sessionIdHash }),
+    sourceRole,
+  });
+});
+
 /**
  * Redact secret-shaped text before any diagnostic rendering.
  *
@@ -347,11 +536,13 @@ const eventNameList: (envelopes: ReadonlyArray<AiMetricsRawEventEnvelope>) => Re
 );
 
 const rawEventEnvelopes = Effect.fn("AiMetrics.rawEventEnvelopes")(function* ({
+  attribution,
   content,
   hashSalt,
   sourceKind,
   sourcePathHash,
 }: {
+  readonly attribution: AiMetricsSourceAttribution;
   readonly content: string;
   readonly hashSalt?: string;
   readonly sourceKind: AiMetricsTranscriptSource;
@@ -373,6 +564,7 @@ const rawEventEnvelopes = Effect.fn("AiMetrics.rawEventEnvelopes")(function* ({
           rawEventHash: yield* hashPrivateIdentifier(line, hashSalt),
           sourceKind,
           sourcePathHash,
+          sourceRole: attribution.sourceRole,
           ...optionalTimestamp(decoded.value.timestamp),
         })
       );
@@ -397,13 +589,23 @@ const rawEventEnvelopes = Effect.fn("AiMetrics.rawEventEnvelopes")(function* ({
 export const makeSanitizedTranscript = Effect.fn("AiMetrics.makeSanitizedTranscript")(function* ({
   content,
   hashSalt,
+  sourcePath,
   summary,
 }: {
   readonly content: string;
   readonly hashSalt?: string;
+  readonly sourcePath: string;
   readonly summary: TranscriptIngestSummary;
 }) {
+  const attribution = yield* makeAiMetricsSourceAttribution({
+    content,
+    ...(hashSalt === undefined ? {} : { hashSalt }),
+    relativePath: sourcePath,
+    sourceKind: summary.sourceKind,
+    sourcePath,
+  });
   const envelopes = yield* rawEventEnvelopes({
+    attribution,
     content,
     sourceKind: summary.sourceKind,
     sourcePathHash: summary.sourcePathHash,
@@ -412,11 +614,19 @@ export const makeSanitizedTranscript = Effect.fn("AiMetrics.makeSanitizedTranscr
 
   return new AiMetricsSanitizedTranscript({
     acceptedEvents: summary.acceptedEvents,
+    ...(attribution.agentNicknameHash === undefined ? {} : { agentNicknameHash: attribution.agentNicknameHash }),
+    ...(attribution.agentRoleHash === undefined ? {} : { agentRoleHash: attribution.agentRoleHash }),
     eventNames: eventNameList(envelopes),
+    ...(attribution.forkedFromIdHash === undefined ? {} : { forkedFromIdHash: attribution.forkedFromIdHash }),
     rawEventEnvelopes: envelopes,
     rejectedLines: summary.rejectedLines,
+    ...(attribution.parentSessionIdHash === undefined ? {} : { parentSessionIdHash: attribution.parentSessionIdHash }),
+    ...(attribution.parentThreadIdHash === undefined ? {} : { parentThreadIdHash: attribution.parentThreadIdHash }),
+    ...(attribution.sessionIdHash === undefined ? {} : { sessionIdHash: attribution.sessionIdHash }),
     sourceKind: summary.sourceKind,
     sourcePathHash: summary.sourcePathHash,
+    sourceRole: attribution.sourceRole,
+    ...(attribution.threadSpawn === undefined ? {} : { threadSpawn: attribution.threadSpawn }),
     totalLines: summary.totalLines,
     ...(summary.firstTimestamp === undefined ? {} : { firstTimestamp: summary.firstTimestamp }),
     ...(summary.lastTimestamp === undefined ? {} : { lastTimestamp: summary.lastTimestamp }),
@@ -449,7 +659,12 @@ export const makeAiMetricsPrivacyCheckResult = Effect.fn("AiMetrics.makeAiMetric
     hashSaltStatus: resolveAiMetricsHashSaltStatus(hashSalt),
     inputPathHash: yield* hashPrivateIdentifier(sourcePath, hashSalt),
     redaction: redactionResultFor(content),
-    sanitized: yield* makeSanitizedTranscript({ content, summary, ...(hashSalt === undefined ? {} : { hashSalt }) }),
+    sanitized: yield* makeSanitizedTranscript({
+      content,
+      sourcePath,
+      summary,
+      ...(hashSalt === undefined ? {} : { hashSalt }),
+    }),
     sourceKind: summary.sourceKind,
   });
 });

--- a/packages/tooling/library/ai-metrics/src/privacy.ts
+++ b/packages/tooling/library/ai-metrics/src/privacy.ts
@@ -460,10 +460,7 @@ export const makeAiMetricsSourceAttribution = Effect.fn("AiMetrics.makeAiMetrics
   const subagent = firstCodexSubagentSource(sessionMetaLines);
   const subagentValue = O.getOrUndefined(subagent);
   const payloadValue = O.getOrUndefined(payload);
-  const sourceRole =
-    O.isSome(subagent) || subagentValue?.thread_spawn === true
-      ? AiMetricsSourceRole.Enum.subagent
-      : AiMetricsSourceRole.Enum.primary;
+  const sourceRole = O.isSome(subagent) ? AiMetricsSourceRole.Enum.subagent : AiMetricsSourceRole.Enum.primary;
   const parentSessionId = firstNonEmptyString(subagentValue?.parent_session_id, payloadValue?.parent_session_id);
   const parentThreadId = firstNonEmptyString(subagentValue?.parent_thread_id, payloadValue?.parent_thread_id);
   const agentNicknameHash = yield* optionalHashPrivateIdentifier(

--- a/packages/tooling/library/ai-metrics/src/scorecard.ts
+++ b/packages/tooling/library/ai-metrics/src/scorecard.ts
@@ -18,6 +18,7 @@ import {
   AiMetricsDeployTarget,
   AiMetricsQualityGateStatus,
   AiMetricsScoreWeights,
+  AiMetricsSourceRole,
   AiMetricsTranscriptSource,
   BenchmarkCase,
   BenchmarkRun,
@@ -68,6 +69,10 @@ export class AiMetricsLabelQueueItem extends S.Class<AiMetricsLabelQueueItem>($I
     createdAtEpochMillis: S.Number,
     sourceKind: AiMetricsTranscriptSource,
     sourcePathHash: S.String,
+    sourceRole: AiMetricsSourceRole.pipe(
+      S.withConstructorDefault(Effect.succeed(AiMetricsSourceRole.Enum.primary)),
+      S.withDecodingDefaultKey(Effect.succeed(AiMetricsSourceRole.Enum.primary))
+    ),
     title: S.String,
     turnCount: S.Number,
   },
@@ -342,6 +347,10 @@ class LabelQueueRow extends S.Class<LabelQueueRow>($I`LabelQueueRow`)(
     createdAtEpochMillis: S.Number,
     sourceKind: AiMetricsTranscriptSource,
     sourcePathHash: S.String,
+    sourceRole: AiMetricsSourceRole.pipe(
+      S.withConstructorDefault(Effect.succeed(AiMetricsSourceRole.Enum.primary)),
+      S.withDecodingDefaultKey(Effect.succeed(AiMetricsSourceRole.Enum.primary))
+    ),
     title: S.String,
     turnCount: S.Number,
   },
@@ -531,6 +540,7 @@ export const queueAiMetricsLabels: (
            t.title AS "title",
            t.source_kind AS "sourceKind",
            t.source_path_hash AS "sourcePathHash",
+           COALESCE(t.source_role, 'primary') AS "sourceRole",
            t.config_snapshot_id AS "configSnapshotId",
            t.created_at_epoch_ms::DOUBLE AS "createdAtEpochMillis",
            count(turns.turn_id)::INTEGER AS "turnCount"
@@ -546,6 +556,7 @@ export const queueAiMetricsLabels: (
            t.title,
            t.source_kind,
            t.source_path_hash,
+           t.source_role,
            t.config_snapshot_id,
            t.created_at_epoch_ms
          ORDER BY t.created_at_epoch_ms DESC
@@ -1024,11 +1035,23 @@ const coverageGapsFor = ({
       taskCount === 0 ? O.some("no_tasks") : O.none<string>(),
       labelCount === 0 ? O.some("no_labels") : O.none<string>(),
       benchmarkRunCount === 0 ? O.some("no_benchmark_runs") : O.none<string>(),
-      coverage.modelCallCount === 0 ? O.some("model_call_metrics_missing") : O.none<string>(),
-      coverage.toolInvocationCount === 0 ? O.some("tool_invocation_metrics_missing") : O.none<string>(),
+      labelCount === 0 || benchmarkRunCount === 0 ? O.some("scorecard_completion_credit_blocked") : O.none<string>(),
+      coverage.modelCallCount === 0 ? O.some("model_call_metrics_unavailable_not_scored") : O.none<string>(),
+      coverage.toolInvocationCount === 0 ? O.some("tool_invocation_metrics_unavailable_not_scored") : O.none<string>(),
+      O.some("cost_metrics_unavailable_not_scored"),
     ],
     A.getSomes
   );
+
+const scorecardCompletionReady = ({
+  benchmarkRunCount,
+  labelCount,
+  taskCount,
+}: {
+  readonly benchmarkRunCount: number;
+  readonly labelCount: number;
+  readonly taskCount: number;
+}): boolean => taskCount > 0 && labelCount > 0 && benchmarkRunCount > 0;
 
 const scorecardFor = Effect.fn("AiMetrics.scorecard.scorecardFor")(function* ({
   benchmark,
@@ -1053,9 +1076,11 @@ const scorecardFor = Effect.fn("AiMetrics.scorecard.scorecardFor")(function* ({
   const labelCount = countFromTask(task, "labelCount");
   const benchmarkRunCount = benchmarkCount(benchmark);
   const coverageGaps = coverageGapsFor({ benchmarkRunCount, coverage, labelCount, taskCount });
+  const completionReady = scorecardCompletionReady({ benchmarkRunCount, labelCount, taskCount });
 
   return new Scorecard({
     benchmarkRunCount,
+    completionReady,
     configSnapshotId,
     costScore,
     coverageGaps,
@@ -1087,6 +1112,7 @@ const writeScorecard = Effect.fn("AiMetrics.scorecard.writeScorecard")(function*
         task_count,
         label_count,
         benchmark_run_count,
+        completion_ready,
         coverage_gaps_json
       ) VALUES (
         $scorecardId,
@@ -1100,10 +1126,12 @@ const writeScorecard = Effect.fn("AiMetrics.scorecard.writeScorecard")(function*
         $taskCount,
         $labelCount,
         $benchmarkRunCount,
+        $completionReady,
         $coverageGapsJson
       )`,
       {
         benchmarkRunCount: scorecard.benchmarkRunCount,
+        completionReady: scorecard.completionReady,
         configSnapshotId: scorecard.configSnapshotId,
         costScore: scorecard.costScore,
         coverageGapsJson: yield* jsonString(scorecard.coverageGaps),
@@ -1129,7 +1157,9 @@ const renderMarkdownReport = (document: AiMetricsWeeklyReportDocument): string =
           3
         )} | ${scorecard.flowScore.toFixed(3)} | ${scorecard.costScore.toFixed(3)} | ${scorecard.taskCount} | ${
           scorecard.labelCount
-        } | ${scorecard.benchmarkRunCount} | ${pipe(scorecard.coverageGaps, A.join(", ")) || "none"} |`
+        } | ${scorecard.benchmarkRunCount} | ${scorecard.completionReady ? "yes" : "no"} | ${
+          pipe(scorecard.coverageGaps, A.join(", ")) || "none"
+        } |`
     ),
     A.join("\n")
   );
@@ -1144,9 +1174,9 @@ const renderMarkdownReport = (document: AiMetricsWeeklyReportDocument): string =
     `generatedAtEpochMillis: ${document.generatedAtEpochMillis}`,
     `coverageGaps: ${Str.isNonEmpty(coverage) ? coverage : "none"}`,
     "",
-    "| configSnapshotId | total | outcome | flow | cost | tasks | labels | benchmarks | gaps |",
-    "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
-    Str.isNonEmpty(rows) ? rows : "| none | 0.000 | 0.000 | 0.000 | 0.000 | 0 | 0 | 0 | no_data |",
+    "| configSnapshotId | total | outcome | flow | cost | tasks | labels | benchmarks | completionReady | gaps |",
+    "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |",
+    Str.isNonEmpty(rows) ? rows : "| none | 0.000 | 0.000 | 0.000 | 0.000 | 0 | 0 | 0 | no | no_data |",
     "",
   ].join("\n")}`;
 };
@@ -1225,7 +1255,15 @@ export const generateAiMetricsWeeklyReport: (
         A.appendAll(
           A.isReadonlyArrayNonEmpty(scorecards)
             ? A.empty<string>()
-            : ["no_tasks", "no_labels", "no_benchmark_runs", "model_call_metrics_missing"]
+            : [
+                "no_tasks",
+                "no_labels",
+                "no_benchmark_runs",
+                "scorecard_completion_credit_blocked",
+                "model_call_metrics_unavailable_not_scored",
+                "tool_invocation_metrics_unavailable_not_scored",
+                "cost_metrics_unavailable_not_scored",
+              ]
         ),
         A.dedupe,
         A.sort(Order.String)

--- a/packages/tooling/library/ai-metrics/src/shell.ts
+++ b/packages/tooling/library/ai-metrics/src/shell.ts
@@ -1,0 +1,22 @@
+/**
+ * Shell rendering helpers for AI metrics operator commands.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import * as Str from "effect/String";
+
+/**
+ * Quote a value as one POSIX shell token.
+ *
+ * @example
+ * ```ts
+ * import { shellQuote } from "@beep/repo-ai-metrics"
+ *
+ * console.log(shellQuote("op://vault/item/field"))
+ * ```
+ * @category utilities
+ * @since 0.0.0
+ */
+export const shellQuote = (value: string): string => `'${Str.replace(/'/gu, "'\\''")(value)}'`;

--- a/packages/tooling/library/ai-metrics/src/source-discovery.ts
+++ b/packages/tooling/library/ai-metrics/src/source-discovery.ts
@@ -12,8 +12,13 @@ import * as A from "effect/Array";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
 import * as Str from "effect/String";
-import { AiMetricsDeployTarget, AiMetricsTranscriptSource } from "./models.ts";
-import { AiMetricsHashSaltStatus, hashPrivateIdentifier, resolveAiMetricsHashSaltStatus } from "./privacy.ts";
+import { AiMetricsDeployTarget, AiMetricsSourceRole, AiMetricsTranscriptSource } from "./models.ts";
+import {
+  AiMetricsHashSaltStatus,
+  hashPrivateIdentifier,
+  makeAiMetricsSourceAttribution,
+  resolveAiMetricsHashSaltStatus,
+} from "./privacy.ts";
 
 const $I = $RepoAiMetricsId.create("source-discovery");
 
@@ -49,37 +54,6 @@ export const AiMetricsSourceStatus = LiteralKit(["available", "missing", "unavai
  * @since 0.0.0
  */
 export type AiMetricsSourceStatus = typeof AiMetricsSourceStatus.Type;
-
-/**
- * Role of a discovered source file within the source's local storage.
- *
- * @example
- * ```ts
- * import { AiMetricsSourceRole } from "@beep/repo-ai-metrics"
- * console.log(AiMetricsSourceRole.Enum.primary)
- * ```
- * @category models
- * @since 0.0.0
- */
-export const AiMetricsSourceRole = LiteralKit(["primary", "subagent", "gateway_metadata"] as const).annotate(
-  $I.annote("AiMetricsSourceRole", {
-    description: "Role of a discovered source file or metadata record.",
-  })
-);
-
-/**
- * Runtime type for {@link AiMetricsSourceRole}.
- *
- * @example
- * ```ts
- * import type { AiMetricsSourceRole } from "@beep/repo-ai-metrics"
- * const role: AiMetricsSourceRole = "primary"
- * console.log(role)
- * ```
- * @category models
- * @since 0.0.0
- */
-export type AiMetricsSourceRole = typeof AiMetricsSourceRole.Type;
 
 /**
  * Input for local AI metrics source discovery.
@@ -136,12 +110,18 @@ export class AiMetricsDiscoveredTranscriptFile extends S.Class<AiMetricsDiscover
   $I`AiMetricsDiscoveredTranscriptFile`
 )(
   {
+    agentNicknameHash: S.optionalKey(S.String),
+    agentRoleHash: S.optionalKey(S.String),
+    forkedFromIdHash: S.optionalKey(S.String),
     modifiedAtMillis: S.Number,
+    parentSessionIdHash: S.optionalKey(S.String),
+    parentThreadIdHash: S.optionalKey(S.String),
     sessionIdHash: S.optionalKey(S.String),
     sizeBytes: S.Number,
     sourceKind: AiMetricsTranscriptSource,
     sourcePathHash: S.String,
     sourceRole: AiMetricsSourceRole,
+    threadSpawn: S.optionalKey(S.Boolean),
   },
   $I.annote("AiMetricsDiscoveredTranscriptFile", {
     description: "Discovered local source file with private identifiers represented by salted hashes.",
@@ -161,8 +141,20 @@ export class AiMetricsDiscoveredTranscriptFile extends S.Class<AiMetricsDiscover
  */
 export class AiMetricsDiscoveredSource extends S.Class<AiMetricsDiscoveredSource>($I`AiMetricsDiscoveredSource`)(
   {
+    candidateFileCount: S.Number.pipe(
+      S.withConstructorDefault(Effect.succeed(0)),
+      S.withDecodingDefaultKey(Effect.succeed(0))
+    ),
     fileCount: S.Number,
     files: S.Array(AiMetricsDiscoveredTranscriptFile),
+    includedFileCount: S.Number.pipe(
+      S.withConstructorDefault(Effect.succeed(0)),
+      S.withDecodingDefaultKey(Effect.succeed(0))
+    ),
+    limitedByMaxFiles: S.Boolean.pipe(
+      S.withConstructorDefault(Effect.succeed(false)),
+      S.withDecodingDefaultKey(Effect.succeed(false))
+    ),
     message: S.optionalKey(S.String),
     newestModifiedAtMillis: S.optionalKey(S.Number),
     rootPathHash: S.String,
@@ -240,6 +232,20 @@ const byModifiedDescending: Order.Order<AiMetricsDiscoveredTranscriptFile> = Ord
   (file) => -file.modifiedAtMillis
 );
 
+type SourceCandidateFile = {
+  readonly modifiedAtMillis: number;
+  readonly sourcePath: string;
+};
+
+const byCandidatePathAscending: Order.Order<SourceCandidateFile> = Order.mapInput(
+  Order.String,
+  (file) => file.sourcePath
+);
+const byCandidateModifiedDescending: Order.Order<SourceCandidateFile> = Order.mapInput(
+  Order.Number,
+  (file) => -file.modifiedAtMillis
+);
+
 const fileSystemFailure = (message: string, cause: unknown): AiMetricsSourceDiscoveryError =>
   new AiMetricsSourceDiscoveryError({ cause, message });
 
@@ -264,9 +270,6 @@ const shouldIncludeModifiedAt =
   (input: AiMetricsSourceDiscoveryInput) =>
   (info: FileSystem.File.Info): boolean =>
     input.includeAll || input.sinceEpochMillis === undefined || modifiedAtMillis(info) >= input.sinceEpochMillis;
-
-const sourceRoleFor = (relativePath: string): AiMetricsSourceRole =>
-  Str.includes("/subagents/")(relativePath) ? AiMetricsSourceRole.Enum.subagent : AiMetricsSourceRole.Enum.primary;
 
 const sessionIdFromPath = (pathApi: Path.Path, sourcePath: string): string =>
   pipe(pathApi.basename(sourcePath), Str.replace(/\.jsonl$/u, ""));
@@ -330,18 +333,33 @@ const makeDiscoveredTranscriptFile = Effect.fn("AiMetrics.makeDiscoveredTranscri
   const pathApi = yield* Path.Path;
   const info = yield* fs
     .stat(sourcePath)
-    .pipe(
-      Effect.mapError((cause) => fileSystemFailure(`Failed to stat AI metrics source file "${sourcePath}".`, cause))
-    );
+    .pipe(Effect.mapError((cause) => fileSystemFailure("Failed to stat AI metrics source file.", cause)));
+  const content = yield* fs
+    .readFileString(sourcePath)
+    .pipe(Effect.mapError((cause) => fileSystemFailure("Failed to read AI metrics source file.", cause)));
   const relativePath = normalizedRelativePath(pathApi, root, sourcePath);
+  const attribution = yield* makeAiMetricsSourceAttribution({
+    content,
+    ...(hashSalt === undefined ? {} : { hashSalt }),
+    relativePath,
+    sourceKind,
+    sourcePath,
+  }).pipe(Effect.mapError((cause) => fileSystemFailure("Failed to derive AI metrics source attribution.", cause)));
+  const fallbackSessionIdHash = yield* hashPrivateIdentifier(sessionIdFromPath(pathApi, sourcePath), hashSalt);
 
   return new AiMetricsDiscoveredTranscriptFile({
+    ...(attribution.agentNicknameHash === undefined ? {} : { agentNicknameHash: attribution.agentNicknameHash }),
+    ...(attribution.agentRoleHash === undefined ? {} : { agentRoleHash: attribution.agentRoleHash }),
+    ...(attribution.forkedFromIdHash === undefined ? {} : { forkedFromIdHash: attribution.forkedFromIdHash }),
     modifiedAtMillis: modifiedAtMillis(info),
-    sessionIdHash: yield* hashPrivateIdentifier(sessionIdFromPath(pathApi, sourcePath), hashSalt),
+    ...(attribution.parentSessionIdHash === undefined ? {} : { parentSessionIdHash: attribution.parentSessionIdHash }),
+    ...(attribution.parentThreadIdHash === undefined ? {} : { parentThreadIdHash: attribution.parentThreadIdHash }),
+    sessionIdHash: attribution.sessionIdHash ?? fallbackSessionIdHash,
     sizeBytes: globalThis.Number(info.size),
     sourceKind,
     sourcePathHash: yield* hashPrivateIdentifier(sourcePath, hashSalt),
-    sourceRole: sourceRoleFor(relativePath),
+    sourceRole: attribution.sourceRole,
+    ...(attribution.threadSpawn === undefined ? {} : { threadSpawn: attribution.threadSpawn }),
   });
 });
 
@@ -394,39 +412,47 @@ const discoverJsonlSource = Effect.fn("AiMetrics.discoverJsonlSource")(function*
 
   const fs = yield* FileSystem.FileSystem;
   const allFiles = yield* collectJsonlFiles(root);
-  const filtered = yield* Effect.forEach(
-    allFiles,
-    Effect.fnUntraced(function* (sourcePath) {
-      const info = yield* fs.stat(sourcePath).pipe(Effect.option);
-      if (O.isNone(info) || info.value.type !== "File" || !shouldIncludeModifiedAt(input)(info.value)) {
-        return O.none<AiMetricsDiscoveredTranscriptFile>();
-      }
+  const candidates = pipe(
+    yield* Effect.forEach(
+      allFiles,
+      Effect.fnUntraced(function* (sourcePath) {
+        const info = yield* fs.stat(sourcePath).pipe(Effect.option);
+        if (O.isNone(info) || info.value.type !== "File" || !shouldIncludeModifiedAt(input)(info.value)) {
+          return O.none<SourceCandidateFile>();
+        }
 
-      return O.some(
-        yield* makeDiscoveredTranscriptFile({
-          root,
-          sourceKind,
-          sourcePath,
-          ...(input.hashSalt === undefined ? {} : { hashSalt: input.hashSalt }),
-        })
-      );
-    }),
+        return O.some({ modifiedAtMillis: modifiedAtMillis(info.value), sourcePath });
+      }),
+      { concurrency: 16 }
+    ),
+    A.getSomes,
+    A.sort(byCandidatePathAscending),
+    A.sort(byCandidateModifiedDescending)
+  );
+  const includedCandidates = A.take(candidates, input.maxFiles);
+  const files = yield* Effect.forEach(
+    includedCandidates,
+    (candidate) =>
+      makeDiscoveredTranscriptFile({
+        root,
+        sourceKind,
+        sourcePath: candidate.sourcePath,
+        ...(input.hashSalt === undefined ? {} : { hashSalt: input.hashSalt }),
+      }),
     { concurrency: 16 }
   );
-  const files = pipe(
-    A.getSomes(filtered),
-    A.sort(byPathHashAscending),
-    A.sort(byModifiedDescending),
-    A.take(input.maxFiles)
-  );
+  const includedFiles = pipe(files, A.sort(byPathHashAscending), A.sort(byModifiedDescending));
 
   return new AiMetricsDiscoveredSource({
-    fileCount: A.length(files),
-    files,
+    candidateFileCount: A.length(candidates),
+    fileCount: A.length(includedFiles),
+    files: includedFiles,
+    includedFileCount: A.length(includedFiles),
+    limitedByMaxFiles: A.length(candidates) > A.length(includedFiles),
     rootPathHash,
     sourceKind,
     status: AiMetricsSourceStatus.Enum.available,
-    ...newestModifiedAtFields(files),
+    ...newestModifiedAtFields(includedFiles),
   });
 });
 
@@ -461,6 +487,20 @@ const discoverOpenClawSource = Effect.fn("AiMetrics.discoverOpenClawSource")(fun
     });
   }
 
+  if (!shouldIncludeModifiedAt(input)(unitInfo.value)) {
+    return new AiMetricsDiscoveredSource({
+      candidateFileCount: 0,
+      fileCount: 0,
+      files: [],
+      includedFileCount: 0,
+      limitedByMaxFiles: false,
+      message: "OpenClaw user systemd gateway metadata is outside the selected modified-time window",
+      rootPathHash,
+      sourceKind: AiMetricsTranscriptSource.Enum.openclaw,
+      status: AiMetricsSourceStatus.Enum.available,
+    });
+  }
+
   const file = new AiMetricsDiscoveredTranscriptFile({
     modifiedAtMillis: modifiedAtMillis(unitInfo.value),
     sessionIdHash: yield* hashPrivateIdentifier("openclaw-gateway.service", input.hashSalt),
@@ -471,8 +511,11 @@ const discoverOpenClawSource = Effect.fn("AiMetrics.discoverOpenClawSource")(fun
   });
 
   return new AiMetricsDiscoveredSource({
+    candidateFileCount: 1,
     fileCount: 1,
     files: [file],
+    includedFileCount: 1,
+    limitedByMaxFiles: false,
     message: "OpenClaw discovery is limited to safe gateway metadata in P1",
     newestModifiedAtMillis: file.modifiedAtMillis,
     rootPathHash,

--- a/packages/tooling/library/ai-metrics/src/source-discovery.ts
+++ b/packages/tooling/library/ai-metrics/src/source-discovery.ts
@@ -7,7 +7,7 @@
 
 import { $RepoAiMetricsId } from "@beep/identity/packages";
 import { LiteralKit, TaggedErrorClass } from "@beep/schema";
-import { Clock, Effect, FileSystem, Order, Path, pipe } from "effect";
+import { Clock, Effect, FileSystem, Order, Path, pipe, Stream } from "effect";
 import * as A from "effect/Array";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
@@ -252,6 +252,25 @@ const fileSystemFailure = (message: string, cause: unknown): AiMetricsSourceDisc
 const normalizedRelativePath = (pathApi: Path.Path, root: string, filePath: string): string =>
   pipe(pathApi.relative(root, filePath), Str.replace(/\\/gu, "/"));
 
+const readAttributionContent = (
+  fs: FileSystem.FileSystem,
+  sourceKind: AiMetricsTranscriptSource,
+  sourcePath: string
+) => {
+  if (sourceKind !== AiMetricsTranscriptSource.Enum.codex) {
+    return fs.readFileString(sourcePath);
+  }
+
+  return fs.stream(sourcePath, { chunkSize: 64 * 1024 }).pipe(
+    Stream.decodeText(),
+    Stream.takeUntil(Str.includes("session_meta")),
+    Stream.runFold(
+      () => "",
+      (content, chunk) => `${content}${chunk}`
+    )
+  );
+};
+
 const repoPathToClaudeProjectName: (repoRoot: string) => string = Str.replace(/[/\\]/gu, "-");
 
 const optionalModifiedAtMillis = (info: FileSystem.File.Info): O.Option<number> =>
@@ -334,9 +353,9 @@ const makeDiscoveredTranscriptFile = Effect.fn("AiMetrics.makeDiscoveredTranscri
   const info = yield* fs
     .stat(sourcePath)
     .pipe(Effect.mapError((cause) => fileSystemFailure("Failed to stat AI metrics source file.", cause)));
-  const content = yield* fs
-    .readFileString(sourcePath)
-    .pipe(Effect.mapError((cause) => fileSystemFailure("Failed to read AI metrics source file.", cause)));
+  const content = yield* readAttributionContent(fs, sourceKind, sourcePath).pipe(
+    Effect.mapError((cause) => fileSystemFailure("Failed to read AI metrics source file.", cause))
+  );
   const relativePath = normalizedRelativePath(pathApi, root, sourcePath);
   const attribution = yield* makeAiMetricsSourceAttribution({
     content,
@@ -430,16 +449,19 @@ const discoverJsonlSource = Effect.fn("AiMetrics.discoverJsonlSource")(function*
     A.sort(byCandidateModifiedDescending)
   );
   const includedCandidates = A.take(candidates, input.maxFiles);
-  const files = yield* Effect.forEach(
-    includedCandidates,
-    (candidate) =>
-      makeDiscoveredTranscriptFile({
-        root,
-        sourceKind,
-        sourcePath: candidate.sourcePath,
-        ...(input.hashSalt === undefined ? {} : { hashSalt: input.hashSalt }),
-      }),
-    { concurrency: 16 }
+  const files = pipe(
+    yield* Effect.forEach(
+      includedCandidates,
+      (candidate) =>
+        makeDiscoveredTranscriptFile({
+          root,
+          sourceKind,
+          sourcePath: candidate.sourcePath,
+          ...(input.hashSalt === undefined ? {} : { hashSalt: input.hashSalt }),
+        }).pipe(Effect.option),
+      { concurrency: 16 }
+    ),
+    A.getSomes
   );
   const includedFiles = pipe(files, A.sort(byPathHashAscending), A.sort(byModifiedDescending));
 
@@ -448,7 +470,7 @@ const discoverJsonlSource = Effect.fn("AiMetrics.discoverJsonlSource")(function*
     fileCount: A.length(includedFiles),
     files: includedFiles,
     includedFileCount: A.length(includedFiles),
-    limitedByMaxFiles: A.length(candidates) > A.length(includedFiles),
+    limitedByMaxFiles: A.length(candidates) > A.length(includedCandidates),
     rootPathHash,
     sourceKind,
     status: AiMetricsSourceStatus.Enum.available,

--- a/packages/tooling/library/ai-metrics/src/source-discovery.ts
+++ b/packages/tooling/library/ai-metrics/src/source-discovery.ts
@@ -277,7 +277,7 @@ const readAttributionContent = (
   sourcePath: string
 ) => {
   if (sourceKind !== AiMetricsTranscriptSource.Enum.codex) {
-    return fs.readFileString(sourcePath);
+    return Effect.succeed("");
   }
 
   return fs.stream(sourcePath, { chunkSize: 64 * 1024 }).pipe(

--- a/packages/tooling/library/ai-metrics/src/source-discovery.ts
+++ b/packages/tooling/library/ai-metrics/src/source-discovery.ts
@@ -12,7 +12,13 @@ import * as A from "effect/Array";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
 import * as Str from "effect/String";
-import { AiMetricsDeployTarget, AiMetricsSourceRole, AiMetricsTranscriptSource } from "./models.ts";
+import { transcriptLines } from "./internal/transcript-utils.ts";
+import {
+  AiMetricsDeployTarget,
+  AiMetricsSourceRole,
+  AiMetricsTranscriptSource,
+  CodexTranscriptLine,
+} from "./models.ts";
 import {
   AiMetricsHashSaltStatus,
   hashPrivateIdentifier,
@@ -222,6 +228,7 @@ export class AiMetricsSourceDiscoveryError extends TaggedErrorClass<AiMetricsSou
 ) {}
 
 const encodeSourceDiscoveryJson = S.encodeUnknownEffect(S.fromJsonString(AiMetricsSourceDiscoveryResult));
+const decodeCodexTranscriptLine = S.decodeUnknownOption(S.fromJsonString(CodexTranscriptLine));
 
 const byPathHashAscending: Order.Order<AiMetricsDiscoveredTranscriptFile> = Order.mapInput(
   Order.String,
@@ -252,6 +259,18 @@ const fileSystemFailure = (message: string, cause: unknown): AiMetricsSourceDisc
 const normalizedRelativePath = (pathApi: Path.Path, root: string, filePath: string): string =>
   pipe(pathApi.relative(root, filePath), Str.replace(/\\/gu, "/"));
 
+const contentHasCodexSessionMetaLine = (content: string): boolean =>
+  pipe(
+    content,
+    transcriptLines,
+    A.some((line) =>
+      pipe(
+        decodeCodexTranscriptLine(line),
+        O.exists((decoded) => decoded.type === "session_meta")
+      )
+    )
+  );
+
 const readAttributionContent = (
   fs: FileSystem.FileSystem,
   sourceKind: AiMetricsTranscriptSource,
@@ -263,11 +282,10 @@ const readAttributionContent = (
 
   return fs.stream(sourcePath, { chunkSize: 64 * 1024 }).pipe(
     Stream.decodeText(),
-    Stream.takeUntil(Str.includes("session_meta")),
-    Stream.runFold(
-      () => "",
-      (content, chunk) => `${content}${chunk}`
-    )
+    Stream.scan("", (content, chunk) => `${content}${chunk}`),
+    Stream.takeUntil(contentHasCodexSessionMetaLine),
+    Stream.runLast,
+    Effect.map(O.getOrElse(() => ""))
   );
 };
 

--- a/packages/tooling/library/ai-metrics/test/ingest.test.ts
+++ b/packages/tooling/library/ai-metrics/test/ingest.test.ts
@@ -31,6 +31,7 @@ import {
   forwarderRunResultToJson,
   forwarderTimerPlanToJson,
   generateAiMetricsWeeklyReport,
+  hashPublicTextSha256,
   listAiMetricsBenchmarkCases,
   makeAiMetricsConfigSnapshot,
   makeAiMetricsInstallApplyDryRunResult,
@@ -1061,6 +1062,93 @@ volumes:
 
             expect(sourceRows).toEqual([{ sourceRole: "primary" }]);
             expect(scorecardRows).toEqual([{ completionReady: false, coverageGapsJson: "[]" }]);
+          }).pipe(Effect.provide(DuckDb.makeNodeLayer(new DuckDbConnectionOptions({ databasePath: duckDbPath }))));
+        })
+      ).pipe(Effect.provide(NodeServices.layer));
+    })
+  );
+
+  it.effect(
+    "deduplicates legacy agent task ids during derived storage migration",
+    Effect.fn(function* () {
+      yield* withTempDirectory(
+        Effect.fn(function* (tmpDir) {
+          const path = yield* Path.Path;
+          const duckDbPath = path.join(tmpDir, "ai-metrics.duckdb");
+
+          yield* Effect.gen(function* () {
+            const duckdb = yield* DuckDb;
+            const legacyTaskId = `agent-task-${yield* hashPublicTextSha256("agent-task\u0000codex\u0000source-hash")}`;
+            const currentTaskId = `agent-task-${yield* hashPublicTextSha256(
+              "agent-task\u0000snapshot-1\u0000codex\u0000primary\u0000source-hash"
+            )}`;
+            yield* duckdb.run(
+              `CREATE TABLE ai_metrics_agent_tasks (
+                agent_task_id VARCHAR PRIMARY KEY,
+                title VARCHAR NOT NULL,
+                source_kind VARCHAR NOT NULL,
+                source_path_hash VARCHAR NOT NULL,
+                source_role VARCHAR NOT NULL,
+                repo_root_hash VARCHAR NOT NULL,
+                config_snapshot_id VARCHAR NOT NULL,
+                created_at_epoch_ms DOUBLE NOT NULL,
+                first_seen_at VARCHAR,
+                last_seen_at VARCHAR
+              )`
+            );
+            yield* duckdb.run(
+              `INSERT INTO ai_metrics_agent_tasks (
+                agent_task_id,
+                title,
+                source_kind,
+                source_path_hash,
+                source_role,
+                repo_root_hash,
+                config_snapshot_id,
+                created_at_epoch_ms,
+                first_seen_at,
+                last_seen_at
+              ) VALUES (
+                $legacyTaskId,
+                'legacy task',
+                'codex',
+                'source-hash',
+                'primary',
+                'repo-hash',
+                'snapshot-1',
+                1,
+                NULL,
+                NULL
+              ), (
+                $currentTaskId,
+                'current task',
+                'codex',
+                'source-hash',
+                'primary',
+                'repo-hash',
+                'snapshot-1',
+                2,
+                NULL,
+                NULL
+              )`,
+              { currentTaskId, legacyTaskId }
+            );
+
+            yield* ensureAiMetricsDerivedStorage;
+
+            const taskRows = yield* duckdb.query(
+              `SELECT agent_task_id AS "agentTaskId"
+               FROM ai_metrics_agent_tasks
+               ORDER BY agent_task_id`
+            );
+            const migrationRows = yield* duckdb.query(
+              `SELECT migration_id AS "migrationId"
+               FROM ai_metrics_schema_migrations
+               WHERE migration_id = 'ai-metrics-agent-task-id-v2'`
+            );
+
+            expect(taskRows).toEqual([{ agentTaskId: currentTaskId }]);
+            expect(migrationRows).toEqual([{ migrationId: "ai-metrics-agent-task-id-v2" }]);
           }).pipe(Effect.provide(DuckDb.makeNodeLayer(new DuckDbConnectionOptions({ databasePath: duckDbPath }))));
         })
       ).pipe(Effect.provide(NodeServices.layer));

--- a/packages/tooling/library/ai-metrics/test/ingest.test.ts
+++ b/packages/tooling/library/ai-metrics/test/ingest.test.ts
@@ -1345,28 +1345,12 @@ volumes:
           const homeDir = path.join(tmpDir, "home");
           const repoRoot = path.join(tmpDir, "repo");
           const codexRoot = path.join(homeDir, ".codex/sessions");
-          const decoy = JSON.stringify({
-            payload: {
-              message: `not metadata session_meta ${pipe("x", Str.repeat(70_000))}`,
-            },
-            timestamp: "2026-05-05T10:00:00Z",
-            type: "event_msg",
-          });
-          const actual = JSON.stringify({
-            payload: {
-              id: "child-session",
-              source: {
-                subagent: {
-                  agent_nickname: "worker-one",
-                  agent_role: "worker",
-                  parent_thread_id: "parent-thread",
-                  thread_spawn: true,
-                },
-              },
-            },
-            timestamp: "2026-05-05T10:01:00Z",
-            type: "session_meta",
-          });
+          const decoy = `{"payload":{"message":"not metadata session_meta ${pipe(
+            "x",
+            Str.repeat(70_000)
+          )}"},"timestamp":"2026-05-05T10:00:00Z","type":"event_msg"}`;
+          const actual =
+            '{"payload":{"id":"child-session","source":{"subagent":{"agent_nickname":"worker-one","agent_role":"worker","parent_thread_id":"parent-thread","thread_spawn":true}}},"timestamp":"2026-05-05T10:01:00Z","type":"session_meta"}';
           yield* writeText(path.join(codexRoot, "codex-subagent.jsonl"), `${decoy}\n${actual}\n`);
           yield* writeText(path.join(repoRoot, "AGENTS.md"), "root agent guide\n");
 

--- a/packages/tooling/library/ai-metrics/test/ingest.test.ts
+++ b/packages/tooling/library/ai-metrics/test/ingest.test.ts
@@ -649,6 +649,9 @@ describe("@beep/repo-ai-metrics", () => {
 
       expect(plan.serviceUnit).toContain("flock -n");
       expect(plan.serviceUnit).toContain('"status":"failed"');
+      expect(plan.serviceUnit).toContain("json.dumps");
+      expect(plan.serviceUnit).toContain('decode("utf-8","replace")');
+      expect(plan.serviceUnit).not.toContain("sed 's/");
       expect(plan.serviceUnit).toContain("StartLimitBurst=3\nStartLimitIntervalSec=30m\n\n[Service]");
       expect(plan.serviceUnit).toContain("Restart=on-failure");
       expect(plan.timerUnit).toContain("OnUnitInactiveSec=15m");
@@ -1328,6 +1331,67 @@ volumes:
           expect(codex.value.includedFileCount).toBe(1);
           expect(codex.value.limitedByMaxFiles).toBe(false);
           expect(result.discoveredFileCount).toBe(1);
+        })
+      ).pipe(Effect.provide(NodeServices.layer));
+    })
+  );
+
+  it.effect(
+    "streams Codex attribution until a parsed session_meta line is present",
+    Effect.fn(function* () {
+      yield* withTempDirectory(
+        Effect.fn(function* (tmpDir) {
+          const path = yield* Path.Path;
+          const homeDir = path.join(tmpDir, "home");
+          const repoRoot = path.join(tmpDir, "repo");
+          const codexRoot = path.join(homeDir, ".codex/sessions");
+          const decoy = JSON.stringify({
+            payload: {
+              message: `not metadata session_meta ${pipe("x", Str.repeat(70_000))}`,
+            },
+            timestamp: "2026-05-05T10:00:00Z",
+            type: "event_msg",
+          });
+          const actual = JSON.stringify({
+            payload: {
+              id: "child-session",
+              source: {
+                subagent: {
+                  agent_nickname: "worker-one",
+                  agent_role: "worker",
+                  parent_thread_id: "parent-thread",
+                  thread_spawn: true,
+                },
+              },
+            },
+            timestamp: "2026-05-05T10:01:00Z",
+            type: "session_meta",
+          });
+          yield* writeText(path.join(codexRoot, "codex-subagent.jsonl"), `${decoy}\n${actual}\n`);
+          yield* writeText(path.join(repoRoot, "AGENTS.md"), "root agent guide\n");
+
+          const result = yield* discoverAiMetricsSources(
+            new AiMetricsSourceDiscoveryInput({
+              codexSessionsRoot: codexRoot,
+              hashSalt: "test-salt",
+              homeDir,
+              includeAll: true,
+              repoRoot,
+            })
+          );
+          const codex = pipe(
+            result.sources,
+            A.findFirst((source) => source.sourceKind === AiMetricsTranscriptSource.Enum.codex)
+          );
+
+          expect(O.isSome(codex)).toBe(true);
+          if (O.isNone(codex)) {
+            return;
+          }
+          expect(codex.value.files).toHaveLength(1);
+          expect(codex.value.files[0]?.agentRoleHash).toBeDefined();
+          expect(codex.value.files[0]?.sourceRole).toBe("subagent");
+          expect(codex.value.files[0]?.threadSpawn).toBe(true);
         })
       ).pipe(Effect.provide(NodeServices.layer));
     })

--- a/packages/tooling/library/ai-metrics/test/ingest.test.ts
+++ b/packages/tooling/library/ai-metrics/test/ingest.test.ts
@@ -651,6 +651,7 @@ describe("@beep/repo-ai-metrics", () => {
       expect(plan.serviceUnit).toContain('"status":"failed"');
       expect(plan.serviceUnit).toContain("json.dumps");
       expect(plan.serviceUnit).toContain('decode("utf-8","replace")');
+      expect(plan.serviceUnit).toMatch(/exit_code=0; > .*latest\.json\.stderr\.tmp.*; if flock -n/su);
       expect(plan.serviceUnit).not.toContain("sed 's/");
       expect(plan.serviceUnit).toContain("StartLimitBurst=3\nStartLimitIntervalSec=30m\n\n[Service]");
       expect(plan.serviceUnit).toContain("Restart=on-failure");
@@ -1286,6 +1287,48 @@ volumes:
           expect(json).toContain("gateway_metadata");
           expect(json).not.toContain(tmpDir);
           expect(json).not.toContain("super-secret-token");
+        })
+      ).pipe(Effect.provide(NodeServices.layer));
+    })
+  );
+
+  it.effect(
+    "does not read Claude transcript bodies during source attribution",
+    Effect.fn(function* () {
+      yield* withTempDirectory(
+        Effect.fn(function* (tmpDir) {
+          const path = yield* Path.Path;
+          const fs = yield* FileSystem.FileSystem;
+          const homeDir = path.join(tmpDir, "home");
+          const repoRoot = path.join(tmpDir, "repo");
+          const claudeRoot = path.join(homeDir, ".claude/projects/repo");
+          const claudePath = path.join(claudeRoot, "claude-unreadable.jsonl");
+          yield* writeText(claudePath, '{"sessionId":"claude-session","timestamp":"2026-05-05T11:00:00Z"}\n');
+          yield* writeText(path.join(repoRoot, "AGENTS.md"), "root agent guide\n");
+          yield* fs.chmod(claudePath, 0);
+
+          const result = yield* discoverAiMetricsSources(
+            new AiMetricsSourceDiscoveryInput({
+              claudeProjectsRoot: claudeRoot,
+              hashSalt: "test-salt",
+              homeDir,
+              includeAll: true,
+              repoRoot,
+            })
+          );
+          yield* fs.chmod(claudePath, 0o600).pipe(Effect.ignore);
+          const claude = pipe(
+            result.sources,
+            A.findFirst((source) => source.sourceKind === AiMetricsTranscriptSource.Enum.claude)
+          );
+
+          expect(O.isSome(claude)).toBe(true);
+          if (O.isNone(claude)) {
+            return;
+          }
+          expect(claude.value.candidateFileCount).toBe(1);
+          expect(claude.value.includedFileCount).toBe(1);
+          expect(claude.value.files[0]?.sourceRole).toBe("primary");
         })
       ).pipe(Effect.provide(NodeServices.layer));
     })

--- a/packages/tooling/library/ai-metrics/test/ingest.test.ts
+++ b/packages/tooling/library/ai-metrics/test/ingest.test.ts
@@ -7,6 +7,7 @@ import {
   AiMetricsDerivedStorageWriteInput,
   AiMetricsDerivedTranscriptRecord,
   AiMetricsForwarderInput,
+  AiMetricsForwarderTimerInput,
   AiMetricsInstallDoctorInput,
   AiMetricsInstallInput,
   AiMetricsLabelQueueInput,
@@ -26,7 +27,9 @@ import {
   configSnapshotToJson,
   decryptEncryptedRawArchiveEnvelope,
   discoverAiMetricsSources,
+  ensureAiMetricsDerivedStorage,
   forwarderRunResultToJson,
+  forwarderTimerPlanToJson,
   generateAiMetricsWeeklyReport,
   listAiMetricsBenchmarkCases,
   makeAiMetricsConfigSnapshot,
@@ -41,12 +44,14 @@ import {
   readAiMetricsOtlpSpanProjections,
   readEncryptedRawArchiveEnvelope,
   recordAiMetricsBenchmarkRun,
+  renderAiMetricsForwarderTimerPlan,
   renderAiMetricsLocalPhoenixCompose,
   runAiMetricsForwarder,
   runAiMetricsOtlpExport,
   sourceDiscoveryToJson,
   summarizeTranscriptText,
   upsertAiMetricsBenchmarkCase,
+  writeAiMetricsConfigSnapshotArtifacts,
   writeAiMetricsDerivedStorage,
 } from "@beep/repo-ai-metrics";
 import { NodeServices } from "@effect/platform-node";
@@ -181,12 +186,23 @@ describe("@beep/repo-ai-metrics", () => {
             expect(result.sourceFileCount).toBe(2);
             expect(result.archiveObjectCount).toBe(2);
             expect(result.turnCount).toBe(3);
+            expect(result.sourceCoverage).toEqual(
+              expect.arrayContaining([
+                expect.objectContaining({ candidateFileCount: 1, includedFileCount: 1, sourceKind: "codex" }),
+                expect.objectContaining({ candidateFileCount: 1, includedFileCount: 1, sourceKind: "claude" }),
+              ])
+            );
             expect(yield* forwarderRunResultToJson(result)).toContain(result.ingestRunId);
             expect(yield* fs.exists(path.join(result.parquetExportDir, "ai_metrics_turns.parquet"))).toBe(true);
+            expect(yield* fs.exists(path.join(dataRoot, "config-snapshots/latest.json"))).toBe(true);
 
             const duckdb = yield* DuckDb;
             const turnRows = yield* duckdb.query("SELECT count(*) AS count FROM ai_metrics_turns");
             expect(turnRows).toEqual([{ count: "3" }]);
+            const sourceRoleRows = yield* duckdb.query(
+              "SELECT source_role AS sourceRole FROM ai_metrics_sessions ORDER BY source_kind"
+            );
+            expect(sourceRoleRows).toEqual([{ sourceRole: "primary" }, { sourceRole: "primary" }]);
             const archiveRows = yield* duckdb.query(
               "SELECT archive_path FROM ai_metrics_raw_archive_objects WHERE source_kind = 'codex'"
             );
@@ -197,6 +213,77 @@ describe("@beep/repo-ai-metrics", () => {
             const envelope = yield* readEncryptedRawArchiveEnvelope(archivePath);
             const plaintext = yield* decryptEncryptedRawArchiveEnvelope({ envelope, rawArchiveKey });
             expect(plaintext).toContain("secret-value");
+          }).pipe(Effect.provide(DuckDb.makeNodeLayer(new DuckDbConnectionOptions({ databasePath: duckDbPath }))));
+        })
+      ).pipe(Effect.provide(NodeServices.layer));
+    })
+  );
+
+  it.effect(
+    "applies maxFiles per source instead of starving lower-recency sources globally",
+    Effect.fn(function* () {
+      yield* withTempDirectory(
+        Effect.fn(function* (tmpDir) {
+          const path = yield* Path.Path;
+          const homeDir = path.join(tmpDir, "home");
+          const repoRoot = path.join(tmpDir, "repo");
+          const dataRoot = path.join(tmpDir, "metrics");
+          const codexRoot = path.join(homeDir, ".codex/sessions");
+          const claudeRoot = path.join(homeDir, ".claude/projects/repo");
+          const duckDbPath = path.join(dataRoot, "derived/ai-metrics.duckdb");
+          const rawArchiveKey = Redacted.make(Encoding.encodeBase64(new Uint8Array(32).fill(9)));
+
+          yield* writeText(
+            path.join(codexRoot, "codex-a.jsonl"),
+            '{"type":"event_msg","timestamp":"2026-05-05T10:00:00Z"}'
+          );
+          yield* writeText(
+            path.join(codexRoot, "codex-b.jsonl"),
+            '{"type":"event_msg","timestamp":"2026-05-05T10:01:00Z"}'
+          );
+          yield* writeText(
+            path.join(claudeRoot, "claude-a.jsonl"),
+            '{"type":"assistant","timestamp":"2026-05-05T10:02:00Z"}'
+          );
+          yield* writeText(
+            path.join(claudeRoot, "claude-b.jsonl"),
+            '{"type":"assistant","timestamp":"2026-05-05T10:03:00Z"}'
+          );
+          yield* writeText(path.join(repoRoot, "AGENTS.md"), "# Test agent guide\n");
+
+          yield* Effect.gen(function* () {
+            const result = yield* runAiMetricsForwarder(
+              new AiMetricsForwarderInput({
+                claudeProjectsRoot: claudeRoot,
+                codexSessionsRoot: codexRoot,
+                dataRoot,
+                hashSalt: "test-salt",
+                homeDir,
+                includeAll: true,
+                maxFiles: 1,
+                rawArchiveKey,
+                repoRoot,
+                target: AiMetricsDeployTarget.Enum.local,
+              })
+            );
+
+            expect(result.sourceFileCount).toBe(2);
+            expect(result.sourceCoverage).toEqual(
+              expect.arrayContaining([
+                expect.objectContaining({
+                  candidateFileCount: 2,
+                  includedFileCount: 1,
+                  limitedByMaxFiles: true,
+                  sourceKind: "codex",
+                }),
+                expect.objectContaining({
+                  candidateFileCount: 2,
+                  includedFileCount: 1,
+                  limitedByMaxFiles: true,
+                  sourceKind: "claude",
+                }),
+              ])
+            );
           }).pipe(Effect.provide(DuckDb.makeNodeLayer(new DuckDbConnectionOptions({ databasePath: duckDbPath }))));
         })
       ).pipe(Effect.provide(NodeServices.layer));
@@ -274,6 +361,20 @@ describe("@beep/repo-ai-metrics", () => {
                 ingestRunId: "forwarder-2",
               })
             );
+            yield* writeText(path.join(tmpDir, "repo", "AGENTS.md"), "# Changed agent guide\n");
+            const changedConfigSnapshot = yield* makeAiMetricsConfigSnapshot(
+              new AiMetricsConfigSnapshotInput({
+                repoRoot: path.join(tmpDir, "repo"),
+              })
+            );
+            yield* writeAiMetricsDerivedStorage(
+              new AiMetricsDerivedStorageWriteInput({
+                ...baseInput,
+                configSnapshot: changedConfigSnapshot.snapshot,
+                ingestRunId: "forwarder-3",
+                startedAtEpochMillis: 2,
+              })
+            );
 
             const duckdb = yield* DuckDb;
             const runRows = yield* duckdb.query("SELECT count(*) AS count FROM ai_metrics_ingest_runs");
@@ -282,15 +383,23 @@ describe("@beep/repo-ai-metrics", () => {
             );
             const sourceRows = yield* duckdb.query("SELECT count(*) AS count FROM ai_metrics_source_files");
             const archiveRows = yield* duckdb.query("SELECT count(*) AS count FROM ai_metrics_raw_archive_objects");
+            const agentTaskRows = yield* duckdb.query(
+              "SELECT count(*) AS count, count(DISTINCT config_snapshot_id)::integer AS configSnapshotCount FROM ai_metrics_agent_tasks"
+            );
             const sessionRows = yield* duckdb.query("SELECT count(*) AS count FROM ai_metrics_sessions");
             const turnRows = yield* duckdb.query("SELECT count(*) AS count FROM ai_metrics_turns");
 
-            expect(runRows).toEqual([{ count: "2" }]);
-            expect(runArchiveCounts).toEqual([{ archiveObjectCount: 0 }, { archiveObjectCount: 0 }]);
-            expect(sourceRows).toEqual([{ count: "2" }]);
-            expect(archiveRows).toEqual([{ count: "2" }]);
-            expect(sessionRows).toEqual([{ count: "2" }]);
-            expect(turnRows).toEqual([{ count: "2" }]);
+            expect(runRows).toEqual([{ count: "3" }]);
+            expect(runArchiveCounts).toEqual([
+              { archiveObjectCount: 0 },
+              { archiveObjectCount: 0 },
+              { archiveObjectCount: 0 },
+            ]);
+            expect(sourceRows).toEqual([{ count: "3" }]);
+            expect(archiveRows).toEqual([{ count: "3" }]);
+            expect(agentTaskRows).toEqual([{ configSnapshotCount: 2, count: "2" }]);
+            expect(sessionRows).toEqual([{ count: "3" }]);
+            expect(turnRows).toEqual([{ count: "3" }]);
           }).pipe(Effect.provide(DuckDb.makeNodeLayer(new DuckDbConnectionOptions({ databasePath: duckDbPath }))));
         })
       ).pipe(Effect.provide(NodeServices.layer));
@@ -393,6 +502,7 @@ describe("@beep/repo-ai-metrics", () => {
             expect(benchmarkRun.passed).toBe(true);
             expect(listedCases.cases).toHaveLength(1);
             expect(report.document.scores).toHaveLength(1);
+            expect(report.document.scores[0]?.scorecard.completionReady).toBe(true);
             expect(reportJson).toContain(forwarder.configSnapshotId);
             expect(reportJson).not.toContain("private benchmark prompt");
             expect(reportJson).not.toContain("secret-scorecard-fixture");
@@ -443,12 +553,18 @@ describe("@beep/repo-ai-metrics", () => {
               Str.includes("ai-metrics otlp export --target dankserver"),
               Str.includes("--data-root .beep/ai-metrics"),
               Str.includes("--otlp-base-url https://dankserver.tailc7c348.ts.net:8447"),
-              Str.includes("--hash-salt-secret-ref op://TBK/ai-metrics/hash-salt"),
-              Str.includes("--raw-archive-key-secret-ref op://TBK/ai-metrics/raw-archive-key"),
+              Str.includes("--hash-salt-secret-ref 'op://TBK/ai-metrics/hash-salt'"),
+              Str.includes("--raw-archive-key-secret-ref 'op://TBK/ai-metrics/raw-archive-key'"),
             ])
           )
         )
       ).toBe(true);
+      expect(spec.plannedCommands).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining("ai-metrics label queue --target dankserver --data-root .beep/ai-metrics"),
+          expect.stringContaining("ai-metrics report weekly --target dankserver --data-root .beep/ai-metrics"),
+        ])
+      );
     })
   );
 
@@ -511,6 +627,40 @@ describe("@beep/repo-ai-metrics", () => {
           expect(doctorJson).not.toContain(tmpDir);
         })
       ).pipe(Effect.provide(NodeServices.layer));
+    })
+  );
+
+  it.effect(
+    "renders a workstation forwarder timer with lock, retry, status, and journal commands",
+    Effect.fn(function* () {
+      const plan = renderAiMetricsForwarderTimerPlan(
+        new AiMetricsForwarderTimerInput({
+          command:
+            "bun run beep ai-metrics forwarder run --target dankserver --data-root .beep/ai-metrics --otlp --json",
+          hashSaltSecretRef: "op://TBK/ai-metrics/hash-salt",
+          intervalMinutes: 15,
+          lockPath: "%t/beep-ai-metrics-forwarder.lock",
+          rawArchiveKeySecretRef: "op://TBK/ai-metrics/raw-archive-key",
+          statusPath: ".beep/ai-metrics/forwarder/status/latest.json",
+          workingDirectory: "/repo/beep-effect",
+        })
+      );
+      const json = yield* forwarderTimerPlanToJson(plan);
+
+      expect(plan.serviceUnit).toContain("flock -n");
+      expect(plan.serviceUnit).toContain("Restart=on-failure");
+      expect(plan.timerUnit).toContain("OnUnitInactiveSec=15m");
+      expect(plan.statusPath).toBe(".beep/ai-metrics/forwarder/status/latest.json");
+      expect(plan.installCommands).toEqual(expect.arrayContaining([expect.stringContaining("journalctl --user")]));
+      expect(plan.installCommands).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining("beep-ai-metrics-forwarder.service"),
+          expect.stringContaining("beep-ai-metrics-forwarder.timer"),
+          expect.stringContaining("BEEP_AI_METRICS_HASH_SALT=%s"),
+          expect.stringContaining("BEEP_AI_METRICS_RAW_ARCHIVE_KEY=%s"),
+        ])
+      );
+      expect(json).not.toContain("base64-32-byte-key");
     })
   );
 
@@ -654,6 +804,7 @@ volumes:
               expect.arrayContaining([
                 expect.objectContaining({
                   attributes: expect.objectContaining({
+                    "ai_metrics.source_role": "primary",
                     "openinference.span.kind": "AGENT",
                   }),
                   spanName: "ai_metrics.agent.session",
@@ -700,6 +851,27 @@ volumes:
       );
 
       expect(error.message).toContain("non-local installs require hashSaltSecretRef");
+    })
+  );
+
+  it.effect(
+    "rejects non-local forwarder runs without a resolved hash salt value",
+    Effect.fn(function* () {
+      const error = yield* Effect.flip(
+        runAiMetricsForwarder(
+          new AiMetricsForwarderInput({
+            dataRoot: ".beep/ai-metrics",
+            hashSaltSecretRef: "op://TBK/ai-metrics/hash-salt",
+            homeDir: "/tmp/home",
+            rawArchiveKey: Redacted.make(Encoding.encodeBase64(new Uint8Array(32).fill(1))),
+            rawArchiveKeySecretRef: "op://TBK/ai-metrics/raw-archive-key",
+            repoRoot: "/tmp/repo",
+            target: AiMetricsDeployTarget.Enum.dankserver,
+          })
+        )
+      );
+
+      expect(error.message).toContain("non-local forwarder runs require a resolved hash salt value");
     })
   );
 
@@ -758,6 +930,138 @@ volumes:
   );
 
   it.effect(
+    "preserves Codex subagent attribution as hashed derived metadata",
+    Effect.fn(function* () {
+      yield* withTempDirectory(
+        Effect.fn(function* (tmpDir) {
+          const path = yield* Path.Path;
+          const dataRoot = path.join(tmpDir, "metrics");
+          const duckDbPath = path.join(dataRoot, "derived/ai-metrics.duckdb");
+          const sourcePath = path.join(tmpDir, "home/.codex/sessions/subagent.jsonl");
+          const content = [
+            '{"type":"session_meta","timestamp":"2026-05-05T10:00:00Z","payload":{"id":"child-session","source":{"subagent":{"thread_spawn":true,"parent_thread_id":"parent-thread","agent_role":"worker","agent_nickname":"worker-one"}}}}',
+            '{"type":"event_msg","timestamp":"2026-05-05T10:01:00Z"}',
+          ].join("\n");
+
+          yield* writeText(path.join(tmpDir, "repo", "AGENTS.md"), "# Test agent guide\n");
+
+          yield* Effect.gen(function* () {
+            const summary = yield* summarizeTranscriptText({
+              content,
+              hashSalt: "test-salt",
+              sourceKind: AiMetricsTranscriptSource.Enum.codex,
+              sourcePath,
+            });
+            const privacy = yield* makeAiMetricsPrivacyCheckResult({
+              content,
+              hashSalt: "test-salt",
+              sourcePath,
+              summary,
+            });
+            const installSpec = yield* makeAiMetricsInstallSpec(
+              new AiMetricsInstallInput({
+                dataRoot,
+                target: AiMetricsDeployTarget.Enum.local,
+              })
+            );
+            const configSnapshot = yield* makeAiMetricsConfigSnapshot(
+              new AiMetricsConfigSnapshotInput({
+                repoRoot: path.join(tmpDir, "repo"),
+              })
+            );
+
+            expect(privacy.sanitized.sourceRole).toBe("subagent");
+            expect(privacy.sanitized.threadSpawn).toBe(true);
+            expect(privacy.sanitized.sessionIdHash).not.toBe("child-session");
+            expect(privacy.sanitized.parentThreadIdHash).not.toBe("parent-thread");
+            expect(privacy.sanitized.agentRoleHash).not.toBe("worker");
+            expect(privacy.sanitized.rawEventEnvelopes[0]?.sourceRole).toBe("subagent");
+
+            yield* writeAiMetricsDerivedStorage(
+              new AiMetricsDerivedStorageWriteInput({
+                configSnapshot: configSnapshot.snapshot,
+                ingestRunId: "forwarder-subagent",
+                records: [
+                  new AiMetricsDerivedTranscriptRecord({
+                    archiveObject: new AiMetricsRawArchiveObject({
+                      algorithm: "AES-256-GCM",
+                      archiveObjectId: "raw-subagent",
+                      archivePath: path.join(dataRoot, "raw/codex/raw-subagent.json"),
+                      created: false,
+                      encryptedAtEpochMillis: 1,
+                      plaintextContentHash: "plaintext-content-hash",
+                      sourceKind: AiMetricsTranscriptSource.Enum.codex,
+                      sourcePathHash: summary.sourcePathHash,
+                    }),
+                    privacy,
+                  }),
+                ],
+                repoRootHash: "repo-root-hash",
+                startedAtEpochMillis: 1,
+                storage: installSpec.storage,
+                target: AiMetricsDeployTarget.Enum.local,
+              })
+            );
+
+            const duckdb = yield* DuckDb;
+            const sessionRows = yield* duckdb.query(
+              "SELECT source_role AS sourceRole, thread_spawn AS threadSpawn, parent_thread_id_hash AS parentThreadIdHash FROM ai_metrics_sessions"
+            );
+            const turnRows = yield* duckdb.query("SELECT DISTINCT source_role AS sourceRole FROM ai_metrics_turns");
+
+            expect(sessionRows).toEqual([
+              expect.objectContaining({
+                parentThreadIdHash: privacy.sanitized.parentThreadIdHash,
+                sourceRole: "subagent",
+                threadSpawn: true,
+              }),
+            ]);
+            expect(turnRows).toEqual([{ sourceRole: "subagent" }]);
+          }).pipe(Effect.provide(DuckDb.makeNodeLayer(new DuckDbConnectionOptions({ databasePath: duckDbPath }))));
+        })
+      ).pipe(Effect.provide(NodeServices.layer));
+    })
+  );
+
+  it.effect(
+    "backfills P6a readiness and source-role columns for existing DuckDB rows",
+    Effect.fn(function* () {
+      yield* withTempDirectory(
+        Effect.fn(function* (tmpDir) {
+          const path = yield* Path.Path;
+          const duckDbPath = path.join(tmpDir, "ai-metrics.duckdb");
+
+          yield* Effect.gen(function* () {
+            const duckdb = yield* DuckDb;
+            yield* duckdb.run("CREATE TABLE ai_metrics_source_files (source_file_id VARCHAR PRIMARY KEY)");
+            yield* duckdb.run("INSERT INTO ai_metrics_source_files (source_file_id) VALUES ('source-1')");
+            yield* duckdb.run("CREATE TABLE ai_metrics_agent_tasks (agent_task_id VARCHAR PRIMARY KEY)");
+            yield* duckdb.run("INSERT INTO ai_metrics_agent_tasks (agent_task_id) VALUES ('task-1')");
+            yield* duckdb.run("CREATE TABLE ai_metrics_sessions (session_run_id VARCHAR PRIMARY KEY)");
+            yield* duckdb.run("INSERT INTO ai_metrics_sessions (session_run_id) VALUES ('session-1')");
+            yield* duckdb.run("CREATE TABLE ai_metrics_turns (turn_id VARCHAR PRIMARY KEY)");
+            yield* duckdb.run("INSERT INTO ai_metrics_turns (turn_id) VALUES ('turn-1')");
+            yield* duckdb.run("CREATE TABLE ai_metrics_scorecards (scorecard_id VARCHAR PRIMARY KEY)");
+            yield* duckdb.run("INSERT INTO ai_metrics_scorecards (scorecard_id) VALUES ('scorecard-1')");
+
+            yield* ensureAiMetricsDerivedStorage;
+
+            const sourceRows = yield* duckdb.query(
+              "SELECT source_role AS sourceRole FROM ai_metrics_source_files WHERE source_file_id = 'source-1'"
+            );
+            const scorecardRows = yield* duckdb.query(
+              "SELECT completion_ready AS completionReady, coverage_gaps_json AS coverageGapsJson FROM ai_metrics_scorecards WHERE scorecard_id = 'scorecard-1'"
+            );
+
+            expect(sourceRows).toEqual([{ sourceRole: "primary" }]);
+            expect(scorecardRows).toEqual([{ completionReady: false, coverageGapsJson: "[]" }]);
+          }).pipe(Effect.provide(DuckDb.makeNodeLayer(new DuckDbConnectionOptions({ databasePath: duckDbPath }))));
+        })
+      ).pipe(Effect.provide(NodeServices.layer));
+    })
+  );
+
+  it.effect(
     "reports derived UI as safe when secret-shaped values are absent",
     Effect.fn(function* () {
       const content = '{"type":"session_meta","timestamp":"2026-05-05T12:00:00Z"}';
@@ -792,7 +1096,9 @@ volumes:
           yield* writeText(path.join(tmpDir, ".repos/effect-v4/AGENTS.md"), "vendored guide\n");
           yield* writeText(path.join(tmpDir, "node_modules/pkg/CLAUDE.md"), "dependency guide\n");
 
+          const snapshotDir = path.join(tmpDir, ".beep/ai-metrics/config-snapshots");
           const result = yield* makeAiMetricsConfigSnapshot(new AiMetricsConfigSnapshotInput({ repoRoot: tmpDir }));
+          yield* writeAiMetricsConfigSnapshotArtifacts({ outputDir: snapshotDir, result });
           const again = yield* makeAiMetricsConfigSnapshot(new AiMetricsConfigSnapshotInput({ repoRoot: tmpDir }));
           const json = yield* configSnapshotToJson(result);
 
@@ -803,13 +1109,90 @@ volumes:
             "AGENTS.md",
             "packages/demo/AGENTS.md",
           ]);
+          expect(result.snapshot.includedPaths).toEqual(relativeSnapshotPaths(result.files));
+          expect(result.snapshot.changedPaths).toEqual(relativeSnapshotPaths(result.files));
           expect(result.snapshot.configHash).toBe(again.snapshot.configHash);
           expect(json).not.toContain(".repos/effect-v4/AGENTS.md");
           expect(json).not.toContain("node_modules/pkg/CLAUDE.md");
 
           yield* writeText(path.join(tmpDir, ".codex/config.toml"), 'model = "gpt-5.1"\n');
-          const changed = yield* makeAiMetricsConfigSnapshot(new AiMetricsConfigSnapshotInput({ repoRoot: tmpDir }));
+          const changed = yield* makeAiMetricsConfigSnapshot(
+            new AiMetricsConfigSnapshotInput({
+              previousSnapshotPath: path.join(snapshotDir, "latest.json"),
+              repoRoot: tmpDir,
+            })
+          );
           expect(changed.snapshot.configHash).not.toBe(result.snapshot.configHash);
+          expect(changed.snapshot.changedPaths).toEqual([".codex/config.toml"]);
+          expect(changed.diff.modifiedPaths).toEqual([".codex/config.toml"]);
+          expect(changed.snapshot.previousSnapshotId).toBe(result.snapshot.snapshotId);
+        })
+      ).pipe(Effect.provide(NodeServices.layer));
+    })
+  );
+
+  it.effect(
+    "fails malformed previous config snapshots instead of treating them as first-run state",
+    Effect.fn(function* () {
+      yield* withTempDirectory(
+        Effect.fn(function* (tmpDir) {
+          const path = yield* Path.Path;
+          yield* writeText(path.join(tmpDir, "AGENTS.md"), "root agent guide\n");
+          yield* writeText(path.join(tmpDir, ".beep/ai-metrics/config-snapshots/latest.json"), "{not-json");
+
+          const error = yield* Effect.flip(
+            makeAiMetricsConfigSnapshot(
+              new AiMetricsConfigSnapshotInput({
+                previousSnapshotPath: path.join(tmpDir, ".beep/ai-metrics/config-snapshots/latest.json"),
+                repoRoot: tmpDir,
+              })
+            )
+          );
+
+          expect(error.message).toContain("Failed to decode previous AI metrics config snapshot artifact");
+        })
+      ).pipe(Effect.provide(NodeServices.layer));
+    })
+  );
+
+  it.effect(
+    "does not advance the latest config snapshot pointer until a forwarder run succeeds",
+    Effect.fn(function* () {
+      yield* withTempDirectory(
+        Effect.fn(function* (tmpDir) {
+          const path = yield* Path.Path;
+          const fs = yield* FileSystem.FileSystem;
+          const homeDir = path.join(tmpDir, "home");
+          const repoRoot = path.join(tmpDir, "repo");
+          const dataRoot = path.join(tmpDir, "metrics");
+          const codexRoot = path.join(homeDir, ".codex/sessions");
+
+          yield* writeText(
+            path.join(codexRoot, "codex.jsonl"),
+            '{"type":"event_msg","timestamp":"2026-05-05T10:01:00Z"}'
+          );
+          yield* writeText(path.join(repoRoot, "AGENTS.md"), "# Test agent guide\n");
+
+          const error = yield* Effect.flip(
+            runAiMetricsForwarder(
+              new AiMetricsForwarderInput({
+                codexSessionsRoot: codexRoot,
+                dataRoot,
+                hashSalt: "test-salt",
+                homeDir,
+                includeAll: true,
+                rawArchiveKey: Redacted.make("not-valid-base64"),
+                repoRoot,
+                target: AiMetricsDeployTarget.Enum.local,
+              })
+            )
+          );
+          const snapshotDir = path.join(dataRoot, "config-snapshots");
+          const snapshotFiles = yield* fs.readDirectory(snapshotDir);
+
+          expect(error.message).toContain("Failed to write encrypted AI metrics raw archive object");
+          expect(yield* fs.exists(path.join(snapshotDir, "latest.json"))).toBe(false);
+          expect(A.some(snapshotFiles, Str.endsWith(".json"))).toBe(true);
         })
       ).pipe(Effect.provide(NodeServices.layer));
     })

--- a/packages/tooling/library/ai-metrics/test/ingest.test.ts
+++ b/packages/tooling/library/ai-metrics/test/ingest.test.ts
@@ -648,6 +648,8 @@ describe("@beep/repo-ai-metrics", () => {
       const json = yield* forwarderTimerPlanToJson(plan);
 
       expect(plan.serviceUnit).toContain("flock -n");
+      expect(plan.serviceUnit).toContain('"status":"failed"');
+      expect(plan.serviceUnit).toContain("StartLimitBurst=3\nStartLimitIntervalSec=30m\n\n[Service]");
       expect(plan.serviceUnit).toContain("Restart=on-failure");
       expect(plan.timerUnit).toContain("OnUnitInactiveSec=15m");
       expect(plan.statusPath).toBe(".beep/ai-metrics/forwarder/status/latest.json");
@@ -1088,6 +1090,7 @@ volumes:
       yield* withTempDirectory(
         Effect.fn(function* (tmpDir) {
           const path = yield* Path.Path;
+          const fs = yield* FileSystem.FileSystem;
           yield* writeText(path.join(tmpDir, ".codex/config.toml"), 'model = "gpt-5"\n');
           yield* writeText(path.join(tmpDir, ".claude/settings.json"), '{"hooks":[]}\n');
           yield* writeText(path.join(tmpDir, ".aiassistant/rules/agent-instructions.md"), "agent rules\n");
@@ -1114,6 +1117,7 @@ volumes:
           expect(result.snapshot.configHash).toBe(again.snapshot.configHash);
           expect(json).not.toContain(".repos/effect-v4/AGENTS.md");
           expect(json).not.toContain("node_modules/pkg/CLAUDE.md");
+          expect(yield* fs.exists(path.join(snapshotDir, "latest.json.tmp"))).toBe(false);
 
           yield* writeText(path.join(tmpDir, ".codex/config.toml"), 'model = "gpt-5.1"\n');
           const changed = yield* makeAiMetricsConfigSnapshot(
@@ -1126,6 +1130,43 @@ volumes:
           expect(changed.snapshot.changedPaths).toEqual([".codex/config.toml"]);
           expect(changed.diff.modifiedPaths).toEqual([".codex/config.toml"]);
           expect(changed.snapshot.previousSnapshotId).toBe(result.snapshot.snapshotId);
+        })
+      ).pipe(Effect.provide(NodeServices.layer));
+    })
+  );
+
+  it.effect(
+    "reads legacy config snapshots without a diff field as previous state",
+    Effect.fn(function* () {
+      yield* withTempDirectory(
+        Effect.fn(function* (tmpDir) {
+          const path = yield* Path.Path;
+          yield* writeText(path.join(tmpDir, "AGENTS.md"), "current agent guide\n");
+          yield* writeText(
+            path.join(tmpDir, ".beep/ai-metrics/config-snapshots/latest.json"),
+            globalThis.JSON.stringify({
+              excludedDirectoryNames: [],
+              fileCount: 1,
+              files: [{ contentHash: "legacy-hash", relativePath: "AGENTS.md", sizeBytes: 18 }],
+              snapshot: {
+                changedPaths: ["AGENTS.md"],
+                configHash: "legacy-hash",
+                includedPaths: ["AGENTS.md"],
+                label: "repo-local-agent-config",
+                snapshotId: "config-legacy",
+              },
+            })
+          );
+
+          const result = yield* makeAiMetricsConfigSnapshot(
+            new AiMetricsConfigSnapshotInput({
+              previousSnapshotPath: path.join(tmpDir, ".beep/ai-metrics/config-snapshots/latest.json"),
+              repoRoot: tmpDir,
+            })
+          );
+
+          expect(result.snapshot.previousSnapshotId).toBe("config-legacy");
+          expect(result.diff.modifiedPaths).toEqual(["AGENTS.md"]);
         })
       ).pipe(Effect.provide(NodeServices.layer));
     })
@@ -1244,6 +1285,80 @@ volumes:
           expect(json).not.toContain("super-secret-token");
         })
       ).pipe(Effect.provide(NodeServices.layer));
+    })
+  );
+
+  it.effect(
+    "skips transcript files that become unreadable during source discovery",
+    Effect.fn(function* () {
+      yield* withTempDirectory(
+        Effect.fn(function* (tmpDir) {
+          const path = yield* Path.Path;
+          const fs = yield* FileSystem.FileSystem;
+          const homeDir = path.join(tmpDir, "home");
+          const repoRoot = path.join(tmpDir, "repo");
+          const codexRoot = path.join(homeDir, ".codex/sessions");
+          const readablePath = path.join(codexRoot, "readable.jsonl");
+          const unreadablePath = path.join(codexRoot, "unreadable.jsonl");
+          yield* writeText(readablePath, '{"type":"session_meta","timestamp":"2026-05-05T10:00:00Z"}\n');
+          yield* writeText(unreadablePath, '{"type":"session_meta","timestamp":"2026-05-05T10:01:00Z"}\n');
+          yield* writeText(path.join(repoRoot, "AGENTS.md"), "root agent guide\n");
+          yield* fs.chmod(unreadablePath, 0);
+
+          const result = yield* discoverAiMetricsSources(
+            new AiMetricsSourceDiscoveryInput({
+              codexSessionsRoot: codexRoot,
+              hashSalt: "test-salt",
+              homeDir,
+              includeAll: true,
+              repoRoot,
+            })
+          );
+          yield* fs.chmod(unreadablePath, 0o600).pipe(Effect.ignore);
+          const codex = pipe(
+            result.sources,
+            A.findFirst((source) => source.sourceKind === AiMetricsTranscriptSource.Enum.codex)
+          );
+
+          expect(O.isSome(codex)).toBe(true);
+          if (O.isNone(codex)) {
+            return;
+          }
+          expect(codex.value.candidateFileCount).toBe(2);
+          expect(codex.value.includedFileCount).toBe(1);
+          expect(codex.value.limitedByMaxFiles).toBe(false);
+          expect(result.discoveredFileCount).toBe(1);
+        })
+      ).pipe(Effect.provide(NodeServices.layer));
+    })
+  );
+
+  it.effect(
+    "uses caller-relative paths for Claude source role attribution",
+    Effect.fn(function* () {
+      const content = '{"sessionId":"claude-session","timestamp":"2026-05-05T11:00:00Z"}';
+      const primarySummary = yield* summarizeTranscriptText({
+        content,
+        hashSalt: "test-salt",
+        sourceKind: AiMetricsTranscriptSource.Enum.claude,
+        sourcePath: "/tmp/subagents/workspace/claude.jsonl",
+      });
+      const primary = yield* makeAiMetricsPrivacyCheckResult({
+        content,
+        hashSalt: "test-salt",
+        sourcePath: "/tmp/subagents/workspace/claude.jsonl",
+        summary: primarySummary,
+      });
+      const subagent = yield* makeAiMetricsPrivacyCheckResult({
+        content,
+        hashSalt: "test-salt",
+        relativePath: "subagents/claude.jsonl",
+        sourcePath: "/tmp/workspace/subagents/claude.jsonl",
+        summary: primarySummary,
+      });
+
+      expect(primary.sanitized.sourceRole).toBe("primary");
+      expect(subagent.sanitized.sourceRole).toBe("subagent");
     })
   );
 });

--- a/packages/tooling/tool/cli/src/commands/AIMetrics/index.ts
+++ b/packages/tooling/tool/cli/src/commands/AIMetrics/index.ts
@@ -1280,7 +1280,7 @@ const makeForwarderTimerProgram = Effect.fn("AIMetrics.makeForwarderTimerProgram
     rawArchiveKeySecretRef: yield* resolveRawArchiveKeySecretRef(rawArchiveKeySecretRef),
     target,
   });
-  const dataRootFlag = ` --data-root ${spec.storage.dataRoot}`;
+  const dataRootFlag = ` --data-root ${shellQuote(spec.storage.dataRoot)}`;
   const hashSaltSecretRefFlagText =
     resolvedHashSaltSecretRef === undefined ? "" : ` --hash-salt-secret-ref ${shellQuote(resolvedHashSaltSecretRef)}`;
   const rawArchiveKeySecretRefFlagText =
@@ -1288,7 +1288,7 @@ const makeForwarderTimerProgram = Effect.fn("AIMetrics.makeForwarderTimerProgram
       ? ""
       : ` --raw-archive-key-secret-ref ${shellQuote(resolvedRawArchiveKeySecretRef)}`;
   const otlpFlagText =
-    target === AiMetricsDeployTarget.Enum.dankserver ? ` --otlp --otlp-base-url ${endpoint.baseUrl}` : "";
+    target === AiMetricsDeployTarget.Enum.dankserver ? ` --otlp --otlp-base-url ${shellQuote(endpoint.baseUrl)}` : "";
   const plan = renderAiMetricsForwarderTimerPlan(
     new AiMetricsForwarderTimerInput({
       command: `bun run beep ai-metrics forwarder run --target ${target}${dataRootFlag}${hashSaltSecretRefFlagText}${rawArchiveKeySecretRefFlagText}${otlpFlagText} --json`,
@@ -2394,7 +2394,7 @@ const archiveCommand = Command.make(
     yield* Console.log("AI metrics archive commands:");
     yield* Console.log("- bun run beep ai-metrics archive drill");
     yield* Console.log(
-      "- bun run beep ai-metrics archive drill --target dankserver --data-root .beep/ai-metrics --hash-salt-secret-ref op://TBK/ai-metrics/hash-salt --raw-archive-key-secret-ref op://TBK/ai-metrics/raw-archive-key"
+      `- BEEP_AI_METRICS_RAW_ARCHIVE_KEY="$(op read 'op://TBK/ai-metrics/raw-archive-key')" bun run beep ai-metrics archive drill --target dankserver --data-root .beep/ai-metrics --hash-salt-secret-ref op://TBK/ai-metrics/hash-salt --raw-archive-key-secret-ref op://TBK/ai-metrics/raw-archive-key`
     );
   })
 ).pipe(

--- a/packages/tooling/tool/cli/src/commands/AIMetrics/index.ts
+++ b/packages/tooling/tool/cli/src/commands/AIMetrics/index.ts
@@ -73,6 +73,7 @@ import {
   renderAiMetricsLocalPhoenixCompose,
   runAiMetricsForwarder,
   runAiMetricsOtlpExport,
+  shellQuote,
   sourceDiscoveryToJson,
   summarizeTranscriptText,
   summaryToJson,
@@ -104,7 +105,6 @@ const $I = $RepoCliId.create("commands/AIMetrics");
 const encodeJson = S.encodeUnknownEffect(S.UnknownFromJsonString);
 const encodeInstallSpecJson = S.encodeUnknownEffect(S.fromJsonString(AiMetricsInstallSpec));
 const localCollectorDataRoot = ".beep/ai-metrics";
-const shellQuote = (value: string): string => `'${Str.replace(/'/gu, "'\\''")(value)}'`;
 
 /**
  * Error raised by the AI metrics CLI.

--- a/packages/tooling/tool/cli/src/commands/AIMetrics/index.ts
+++ b/packages/tooling/tool/cli/src/commands/AIMetrics/index.ts
@@ -9,6 +9,7 @@ import { DuckDb, DuckDbConnectionOptions } from "@beep/duckdb";
 import { $RepoCliId } from "@beep/identity/packages";
 import { layerNodeSdkServerTraces, ServerObservabilityConfig } from "@beep/observability/server";
 import {
+  type AiMetricsArchiveError,
   AiMetricsBenchmarkCaseInput,
   AiMetricsBenchmarkRunInput,
   type AiMetricsConfigSnapshotError,
@@ -16,6 +17,7 @@ import {
   AiMetricsDeployTarget,
   type AiMetricsForwarderError,
   AiMetricsForwarderInput,
+  AiMetricsForwarderTimerInput,
   type AiMetricsIngestError,
   type AiMetricsInstallConfigurationError,
   AiMetricsInstallDoctorInput,
@@ -49,9 +51,12 @@ import {
   aiMetricsOutcomeLabelToJson,
   aiMetricsWeeklyReportToJson,
   configSnapshotToJson,
+  decryptEncryptedRawArchiveEnvelope,
   discoverAiMetricsSources,
   forwarderRunResultToJson,
+  forwarderTimerPlanToJson,
   generateAiMetricsWeeklyReport,
+  hashPublicTextSha256,
   listAiMetricsBenchmarkCases,
   makeAiMetricsConfigSnapshot,
   makeAiMetricsInstallApplyDryRunResult,
@@ -62,7 +67,9 @@ import {
   otlpExportResultToJson,
   privacyCheckToJson,
   queueAiMetricsLabels,
+  readEncryptedRawArchiveEnvelope,
   recordAiMetricsBenchmarkRun,
+  renderAiMetricsForwarderTimerPlan,
   renderAiMetricsLocalPhoenixCompose,
   runAiMetricsForwarder,
   runAiMetricsOtlpExport,
@@ -96,6 +103,8 @@ const $I = $RepoCliId.create("commands/AIMetrics");
 
 const encodeJson = S.encodeUnknownEffect(S.UnknownFromJsonString);
 const encodeInstallSpecJson = S.encodeUnknownEffect(S.fromJsonString(AiMetricsInstallSpec));
+const localCollectorDataRoot = ".beep/ai-metrics";
+const shellQuote = (value: string): string => `'${Str.replace(/'/gu, "'\\''")(value)}'`;
 
 /**
  * Error raised by the AI metrics CLI.
@@ -118,6 +127,19 @@ export class AiMetricsCommandError extends TaggedErrorClass<AiMetricsCommandErro
     description: "User-facing failure raised by the AI metrics CLI command suite.",
   })
 ) {}
+
+class AiMetricsArchiveDrillRow extends S.Class<AiMetricsArchiveDrillRow>($I`AiMetricsArchiveDrillRow`)(
+  {
+    archiveObjectId: S.String,
+    archivePath: S.String,
+    plaintextContentHash: S.String,
+  },
+  $I.annote("AiMetricsArchiveDrillRow", {
+    description: "Latest encrypted raw archive row selected for a non-printing decrypt drill.",
+  })
+) {}
+
+const decodeArchiveDrillRows = S.decodeUnknownEffect(S.Array(AiMetricsArchiveDrillRow));
 
 const jsonFlag = Flag.boolean("json").pipe(Flag.withDescription("Emit machine-readable JSON output"));
 const inputFlag = Flag.string("input").pipe(
@@ -159,6 +181,10 @@ const interventionsFlag = Flag.integer("interventions").pipe(
 );
 const elapsedMsFlag = Flag.integer("elapsed-ms").pipe(Flag.withDescription("Benchmark elapsed milliseconds"));
 const limitFlag = Flag.integer("limit").pipe(Flag.withDefault(20), Flag.withDescription("Maximum rows to return"));
+const intervalMinutesFlag = Flag.integer("interval-minutes").pipe(
+  Flag.withDefault(30),
+  Flag.withDescription("Minutes between scheduled forwarder runs")
+);
 const passedValueFlag = Flag.choiceWithValue("passed", [
   ["true", true],
   ["false", false],
@@ -265,6 +291,7 @@ const encodeInstallSpecCommandJson = Effect.fn("AIMetrics.encodeInstallSpecComma
 });
 
 type AiMetricsProgramError =
+  | AiMetricsArchiveError
   | AiMetricsCommandError
   | AiMetricsConfigSnapshotError
   | AiMetricsForwarderError
@@ -278,6 +305,10 @@ type AiMetricsProgramError =
 const runAiMetricsProgram = <A, R>(effect: Effect.Effect<A, AiMetricsProgramError, R>): Effect.Effect<void, never, R> =>
   effect.pipe(
     Effect.catchTags({
+      AiMetricsArchiveError: Effect.fn(function* (error) {
+        process.exitCode = 1;
+        yield* Console.error(`ai-metrics: ${error.message}`);
+      }),
       AiMetricsCommandError: Effect.fn(function* (error) {
         process.exitCode = 1;
         yield* Console.error(`ai-metrics: ${error.message}`);
@@ -547,6 +578,9 @@ const parseWindow = Effect.fn("AIMetrics.parseWindow")(function* ({
 
 const parseChecks = (checks: string): ReadonlyArray<string> =>
   pipe(Str.split(checks, ","), A.map(Str.trim), A.filter(Str.isNonEmpty));
+
+const p6aCollectorDataRoot = (dataRoot: O.Option<string>, target: AiMetricsDeployTarget): O.Option<string> =>
+  O.isSome(dataRoot) || target === AiMetricsDeployTarget.Enum.local ? dataRoot : O.some(localCollectorDataRoot);
 
 const makeCommandInstallInput = Effect.fn("AIMetrics.makeCommandInstallInput")(function* ({
   dataRoot,
@@ -1035,7 +1069,9 @@ const makeSourcesDiscoverProgram = Effect.fn("AIMetrics.makeSourcesDiscoverProgr
   yield* Console.log(`hash salt: ${result.hashSaltStatus}`);
   yield* Console.log(`discovered files: ${result.discoveredFileCount}`);
   for (const source of result.sources) {
-    yield* Console.log(`${source.sourceKind}: ${source.status} files=${source.fileCount}`);
+    yield* Console.log(
+      `${source.sourceKind}: ${source.status} files=${source.fileCount} candidates=${source.candidateFileCount} limited=${source.limitedByMaxFiles}`
+    );
   }
 });
 
@@ -1142,7 +1178,7 @@ const makeForwarderRunProgram = Effect.fn("AIMetrics.makeForwarderRunProgram")(f
     rawArchiveKeySecretRef: yield* resolveRawArchiveKeySecretRef(rawArchiveKeySecretRef),
     target,
   });
-  const resolvedDataRoot = O.getOrUndefined(dataRoot);
+  const resolvedDataRoot = O.getOrUndefined(p6aCollectorDataRoot(dataRoot, target));
   const spec = yield* makeAiMetricsInstallSpec(
     new AiMetricsInstallInput({
       ...(resolvedDataRoot === undefined ? {} : { dataRoot: resolvedDataRoot }),
@@ -1198,10 +1234,88 @@ const makeForwarderRunProgram = Effect.fn("AIMetrics.makeForwarderRunProgram")(f
   yield* Console.log(`archive objects: ${result.archiveObjectCount}`);
   yield* Console.log(`turns: ${result.turnCount}`);
   yield* Console.log(`raw archive: ${result.rawArchiveDir}`);
+  for (const source of result.sourceCoverage) {
+    yield* Console.log(
+      `${source.sourceKind}: included=${source.includedFileCount} candidates=${source.candidateFileCount} limited=${source.limitedByMaxFiles}`
+    );
+  }
   const duckDbLocation = result.duckDbPath;
   const parquetLocation = result.parquetExportDir;
   yield* Console.log(`derived duckdb: ${duckDbLocation}`);
   yield* Console.log(`parquet export: ${parquetLocation}`);
+});
+
+const makeForwarderTimerProgram = Effect.fn("AIMetrics.makeForwarderTimerProgram")(function* ({
+  dataRoot,
+  hashSaltSecretRef,
+  intervalMinutes,
+  json,
+  otlpBaseUrl,
+  rawArchiveKeySecretRef,
+  repoRoot,
+  target,
+}: {
+  readonly dataRoot: O.Option<string>;
+  readonly hashSaltSecretRef: O.Option<string>;
+  readonly intervalMinutes: number;
+  readonly json: boolean;
+  readonly otlpBaseUrl: O.Option<string>;
+  readonly rawArchiveKeySecretRef: O.Option<string>;
+  readonly repoRoot: O.Option<string>;
+  readonly target: AiMetricsDeployTarget;
+}) {
+  const resolvedDataRoot = p6aCollectorDataRoot(dataRoot, target);
+  const spec = yield* makeCommandInstallSpec({
+    dataRoot: resolvedDataRoot,
+    hashSaltSecretRef,
+    rawArchiveKeySecretRef,
+    target,
+  });
+  const endpoint = yield* defaultServiceEndpoint(spec, otlpBaseUrl);
+  const resolvedHashSaltSecretRef = yield* requireHashSaltSecretRefForTarget({
+    hashSaltSecretRef: yield* resolveHashSaltSecretRef(hashSaltSecretRef),
+    target,
+  });
+  const resolvedRawArchiveKeySecretRef = yield* requireRawArchiveKeySecretRefForTarget({
+    rawArchiveKeySecretRef: yield* resolveRawArchiveKeySecretRef(rawArchiveKeySecretRef),
+    target,
+  });
+  const dataRootFlag = ` --data-root ${spec.storage.dataRoot}`;
+  const hashSaltSecretRefFlagText =
+    resolvedHashSaltSecretRef === undefined ? "" : ` --hash-salt-secret-ref ${shellQuote(resolvedHashSaltSecretRef)}`;
+  const rawArchiveKeySecretRefFlagText =
+    resolvedRawArchiveKeySecretRef === undefined
+      ? ""
+      : ` --raw-archive-key-secret-ref ${shellQuote(resolvedRawArchiveKeySecretRef)}`;
+  const otlpFlagText =
+    target === AiMetricsDeployTarget.Enum.dankserver ? ` --otlp --otlp-base-url ${endpoint.baseUrl}` : "";
+  const plan = renderAiMetricsForwarderTimerPlan(
+    new AiMetricsForwarderTimerInput({
+      command: `bun run beep ai-metrics forwarder run --target ${target}${dataRootFlag}${hashSaltSecretRefFlagText}${rawArchiveKeySecretRefFlagText}${otlpFlagText} --json`,
+      ...(resolvedHashSaltSecretRef === undefined ? {} : { hashSaltSecretRef: resolvedHashSaltSecretRef }),
+      intervalMinutes,
+      lockPath: "%t/beep-ai-metrics-forwarder.lock",
+      ...(resolvedRawArchiveKeySecretRef === undefined
+        ? {}
+        : { rawArchiveKeySecretRef: resolvedRawArchiveKeySecretRef }),
+      statusPath: `${spec.storage.dataRoot}/forwarder/status/latest.json`,
+      workingDirectory: yield* resolveRepoRoot(repoRoot),
+    })
+  );
+
+  if (json) {
+    yield* Console.log(yield* forwarderTimerPlanToJson(plan));
+    return;
+  }
+
+  yield* Console.log(`# ${plan.serviceUnitName}`);
+  yield* Console.log(plan.serviceUnit);
+  yield* Console.log(`# ${plan.timerUnitName}`);
+  yield* Console.log(plan.timerUnit);
+  yield* Console.log("# install commands");
+  for (const command of plan.installCommands) {
+    yield* Console.log(command);
+  }
 });
 
 const makeOtlpExportProgram = Effect.fn("AIMetrics.makeOtlpExportProgram")(function* ({
@@ -1221,7 +1335,7 @@ const makeOtlpExportProgram = Effect.fn("AIMetrics.makeOtlpExportProgram")(funct
   readonly rawArchiveKeySecretRef: O.Option<string>;
   readonly target: AiMetricsDeployTarget;
 }) {
-  const resolvedDataRoot = O.getOrUndefined(dataRoot);
+  const resolvedDataRoot = O.getOrUndefined(p6aCollectorDataRoot(dataRoot, target));
   const resolvedHashSaltSecretRef = yield* requireHashSaltSecretRefForTarget({
     hashSaltSecretRef: yield* resolveHashSaltSecretRef(hashSaltSecretRef),
     target,
@@ -1296,7 +1410,12 @@ const makeBenchmarkRunProgram = Effect.fn("AIMetrics.makeBenchmarkRunProgram")(f
   readonly rawArchiveKeySecretRef: O.Option<string>;
   readonly target: AiMetricsDeployTarget;
 }) {
-  const spec = yield* makeCommandInstallSpec({ dataRoot, hashSaltSecretRef, rawArchiveKeySecretRef, target });
+  const spec = yield* makeCommandInstallSpec({
+    dataRoot: p6aCollectorDataRoot(dataRoot, target),
+    hashSaltSecretRef,
+    rawArchiveKeySecretRef,
+    target,
+  });
   const result = yield* recordAiMetricsBenchmarkRun(
     new AiMetricsBenchmarkRunInput({
       benchmarkCaseId: caseId,
@@ -1354,7 +1473,12 @@ const makeLabelQueueProgram = Effect.fn("AIMetrics.makeLabelQueueProgram")(funct
   readonly target: AiMetricsDeployTarget;
   readonly until: O.Option<string>;
 }) {
-  const spec = yield* makeCommandInstallSpec({ dataRoot, hashSaltSecretRef, rawArchiveKeySecretRef, target });
+  const spec = yield* makeCommandInstallSpec({
+    dataRoot: p6aCollectorDataRoot(dataRoot, target),
+    hashSaltSecretRef,
+    rawArchiveKeySecretRef,
+    target,
+  });
   const window = yield* parseWindow({ since, until });
   const result = yield* queueAiMetricsLabels(
     new AiMetricsLabelQueueInput({
@@ -1407,7 +1531,12 @@ const makeLabelAddProgram = Effect.fn("AIMetrics.makeLabelAddProgram")(function*
   readonly target: AiMetricsDeployTarget;
   readonly taskId: string;
 }) {
-  const spec = yield* makeCommandInstallSpec({ dataRoot, hashSaltSecretRef, rawArchiveKeySecretRef, target });
+  const spec = yield* makeCommandInstallSpec({
+    dataRoot: p6aCollectorDataRoot(dataRoot, target),
+    hashSaltSecretRef,
+    rawArchiveKeySecretRef,
+    target,
+  });
   const result = yield* addAiMetricsOutcomeLabel(
     new AiMetricsOutcomeLabelInput({
       agentTaskId: taskId,
@@ -1456,7 +1585,12 @@ const makeBenchmarkCaseAddProgram = Effect.fn("AIMetrics.makeBenchmarkCaseAddPro
   readonly target: AiMetricsDeployTarget;
   readonly title: string;
 }) {
-  const spec = yield* makeCommandInstallSpec({ dataRoot, hashSaltSecretRef, rawArchiveKeySecretRef, target });
+  const spec = yield* makeCommandInstallSpec({
+    dataRoot: p6aCollectorDataRoot(dataRoot, target),
+    hashSaltSecretRef,
+    rawArchiveKeySecretRef,
+    target,
+  });
   const result = yield* upsertAiMetricsBenchmarkCase(
     new AiMetricsBenchmarkCaseInput({
       benchmarkCaseId: caseId,
@@ -1492,7 +1626,12 @@ const makeBenchmarkCaseListProgram = Effect.fn("AIMetrics.makeBenchmarkCaseListP
   readonly rawArchiveKeySecretRef: O.Option<string>;
   readonly target: AiMetricsDeployTarget;
 }) {
-  const spec = yield* makeCommandInstallSpec({ dataRoot, hashSaltSecretRef, rawArchiveKeySecretRef, target });
+  const spec = yield* makeCommandInstallSpec({
+    dataRoot: p6aCollectorDataRoot(dataRoot, target),
+    hashSaltSecretRef,
+    rawArchiveKeySecretRef,
+    target,
+  });
   const result = yield* listAiMetricsBenchmarkCases.pipe(
     // @effect-diagnostics-next-line strictEffectProvide:off
     Effect.provide(DuckDb.makeNodeLayer(new DuckDbConnectionOptions({ databasePath: spec.storage.duckDbPath })))
@@ -1527,7 +1666,12 @@ const makeWeeklyReportProgram = Effect.fn("AIMetrics.makeWeeklyReportProgram")(f
   readonly until: O.Option<string>;
 }) {
   const path = yield* Path.Path;
-  const spec = yield* makeCommandInstallSpec({ dataRoot, hashSaltSecretRef, rawArchiveKeySecretRef, target });
+  const spec = yield* makeCommandInstallSpec({
+    dataRoot: p6aCollectorDataRoot(dataRoot, target),
+    hashSaltSecretRef,
+    rawArchiveKeySecretRef,
+    target,
+  });
   const window = yield* parseWindow({ since, until });
   const result = yield* generateAiMetricsWeeklyReport(
     new AiMetricsWeeklyReportInput({
@@ -1550,6 +1694,96 @@ const makeWeeklyReportProgram = Effect.fn("AIMetrics.makeWeeklyReportProgram")(f
   yield* Console.log(`scorecards: ${A.length(result.document.scores)}`);
   yield* Console.log(`markdown: ${result.markdownPath}`);
   yield* Console.log(`json: ${result.jsonPath}`);
+});
+
+const makeArchiveDrillProgram = Effect.fn("AIMetrics.makeArchiveDrillProgram")(function* ({
+  dataRoot,
+  hashSaltSecretRef,
+  json,
+  rawArchiveKeySecretRef,
+  target,
+}: {
+  readonly dataRoot: O.Option<string>;
+  readonly hashSaltSecretRef: O.Option<string>;
+  readonly json: boolean;
+  readonly rawArchiveKeySecretRef: O.Option<string>;
+  readonly target: AiMetricsDeployTarget;
+}) {
+  const spec = yield* makeCommandInstallSpec({
+    dataRoot: p6aCollectorDataRoot(dataRoot, target),
+    hashSaltSecretRef,
+    rawArchiveKeySecretRef,
+    target,
+  });
+  const rawArchiveKey = yield* resolveRawArchiveKey();
+  const result = yield* Effect.gen(function* () {
+    const duckdb = yield* DuckDb;
+    const rows = yield* duckdb
+      .query(
+        `SELECT archive_object_id AS "archiveObjectId",
+                archive_path AS "archivePath",
+                plaintext_content_hash AS "plaintextContentHash"
+         FROM ai_metrics_raw_archive_objects
+         ORDER BY encrypted_at_epoch_ms DESC
+         LIMIT 1`
+      )
+      .pipe(
+        Effect.mapError(
+          (cause) =>
+            new AiMetricsCommandError({
+              cause,
+              message: "Failed to select an AI metrics archive object for the decrypt drill.",
+            })
+        )
+      );
+    const decoded = yield* decodeArchiveDrillRows(rows).pipe(
+      Effect.mapError(
+        (cause) =>
+          new AiMetricsCommandError({
+            cause,
+            message: "Failed to decode AI metrics archive drill rows.",
+          })
+      )
+    );
+    const row = A.head(decoded);
+    if (O.isNone(row)) {
+      return yield* new AiMetricsCommandError({
+        cause: "ai_metrics_raw_archive_objects",
+        message: "No AI metrics raw archive object is available for a decrypt drill.",
+      });
+    }
+
+    const envelope = yield* readEncryptedRawArchiveEnvelope(row.value.archivePath);
+    const plaintext = yield* decryptEncryptedRawArchiveEnvelope({ envelope, rawArchiveKey });
+    const plaintextHash = yield* hashPublicTextSha256(plaintext);
+    const plaintextHashMatches = plaintextHash === row.value.plaintextContentHash;
+    if (!plaintextHashMatches) {
+      return yield* new AiMetricsCommandError({
+        cause: row.value.archiveObjectId,
+        message: "AI metrics archive decrypt drill failed plaintext hash verification.",
+      });
+    }
+
+    return {
+      archiveObjectId: row.value.archiveObjectId,
+      decryptedByteCount: new TextEncoder().encode(plaintext).byteLength,
+      plaintextHashMatches,
+      target,
+    };
+  }).pipe(
+    // @effect-diagnostics-next-line strictEffectProvide:off
+    Effect.provide(DuckDb.makeNodeLayer(new DuckDbConnectionOptions({ databasePath: spec.storage.duckDbPath })))
+  );
+
+  if (json) {
+    yield* Console.log(yield* encodeCommandJson(result));
+    return;
+  }
+
+  yield* Console.log(`ai-metrics archive drill: target=${target}`);
+  yield* Console.log(`archive object: ${result.archiveObjectId}`);
+  yield* Console.log(`decrypted bytes: ${result.decryptedByteCount}`);
+  yield* Console.log(`plaintext hash matches: ${result.plaintextHashMatches}`);
 });
 
 const installPreviewCommand = Command.make(
@@ -1816,14 +2050,47 @@ const forwarderRunCommand = Command.make(
   Command.withDescription("Run durable local transcript ingest into encrypted raw archive and derived DuckDB storage")
 );
 
+const forwarderTimerCommand = Command.make(
+  "timer",
+  {
+    dataRoot: dataRootFlag,
+    hashSaltSecretRef: hashSaltSecretRefFlag,
+    intervalMinutes: intervalMinutesFlag,
+    json: jsonFlag,
+    otlpBaseUrl: otlpBaseUrlFlag,
+    rawArchiveKeySecretRef: rawArchiveKeySecretRefFlag,
+    repoRoot: repoRootFlag,
+    target: targetFlag,
+  },
+  ({ dataRoot, hashSaltSecretRef, intervalMinutes, json, otlpBaseUrl, rawArchiveKeySecretRef, repoRoot, target }) =>
+    runAiMetricsProgram(
+      makeForwarderTimerProgram({
+        dataRoot,
+        hashSaltSecretRef,
+        intervalMinutes,
+        json,
+        otlpBaseUrl,
+        rawArchiveKeySecretRef,
+        repoRoot,
+        target,
+      })
+    )
+).pipe(Command.withDescription("Render a workstation systemd user timer for live AI metrics collection"));
+
 const forwarderCommand = Command.make(
   "forwarder",
   {},
   Effect.fn(function* () {
     yield* Console.log("AI metrics forwarder commands:");
     yield* Console.log("- bun run beep ai-metrics forwarder run --target local");
+    yield* Console.log(
+      "- bun run beep ai-metrics forwarder timer --target dankserver --hash-salt-secret-ref op://TBK/ai-metrics/hash-salt --raw-archive-key-secret-ref op://TBK/ai-metrics/raw-archive-key"
+    );
   })
-).pipe(Command.withDescription("AI metrics local forwarder workflow"), Command.withSubcommands([forwarderRunCommand]));
+).pipe(
+  Command.withDescription("AI metrics local forwarder workflow"),
+  Command.withSubcommands([forwarderRunCommand, forwarderTimerCommand])
+);
 
 const otlpExportCommand = Command.make(
   "export",
@@ -2068,6 +2335,9 @@ const labelCommand = Command.make(
   Effect.fn(function* () {
     yield* Console.log("AI metrics label commands:");
     yield* Console.log("- bun run beep ai-metrics label queue");
+    yield* Console.log(
+      "- bun run beep ai-metrics label queue --target dankserver --data-root .beep/ai-metrics --hash-salt-secret-ref op://TBK/ai-metrics/hash-salt --raw-archive-key-secret-ref op://TBK/ai-metrics/raw-archive-key"
+    );
     yield* Console.log("- bun run beep ai-metrics label add --task <id> --passed true --rating 5");
   })
 ).pipe(
@@ -2098,8 +2368,39 @@ const reportCommand = Command.make(
   Effect.fn(function* () {
     yield* Console.log("AI metrics report commands:");
     yield* Console.log("- bun run beep ai-metrics report weekly");
+    yield* Console.log(
+      "- bun run beep ai-metrics report weekly --target dankserver --data-root .beep/ai-metrics --hash-salt-secret-ref op://TBK/ai-metrics/hash-salt --raw-archive-key-secret-ref op://TBK/ai-metrics/raw-archive-key"
+    );
   })
 ).pipe(Command.withDescription("AI metrics report workflow"), Command.withSubcommands([reportWeeklyCommand]));
+
+const archiveDrillCommand = Command.make(
+  "drill",
+  {
+    dataRoot: dataRootFlag,
+    hashSaltSecretRef: hashSaltSecretRefFlag,
+    json: jsonFlag,
+    rawArchiveKeySecretRef: rawArchiveKeySecretRefFlag,
+    target: targetFlag,
+  },
+  ({ dataRoot, hashSaltSecretRef, json, rawArchiveKeySecretRef, target }) =>
+    runAiMetricsProgram(makeArchiveDrillProgram({ dataRoot, hashSaltSecretRef, json, rawArchiveKeySecretRef, target }))
+).pipe(Command.withDescription("Decrypt one encrypted raw archive object without printing transcript text"));
+
+const archiveCommand = Command.make(
+  "archive",
+  {},
+  Effect.fn(function* () {
+    yield* Console.log("AI metrics archive commands:");
+    yield* Console.log("- bun run beep ai-metrics archive drill");
+    yield* Console.log(
+      "- bun run beep ai-metrics archive drill --target dankserver --data-root .beep/ai-metrics --hash-salt-secret-ref op://TBK/ai-metrics/hash-salt --raw-archive-key-secret-ref op://TBK/ai-metrics/raw-archive-key"
+    );
+  })
+).pipe(
+  Command.withDescription("AI metrics archive verification workflow"),
+  Command.withSubcommands([archiveDrillCommand])
+);
 
 /**
  * AI metrics root command.
@@ -2129,6 +2430,7 @@ export const aiMetricsCommand = Command.make(
     yield* Console.log("- benchmark run");
     yield* Console.log("- benchmark compare");
     yield* Console.log("- report weekly");
+    yield* Console.log("- archive drill");
   })
 ).pipe(
   Command.withDescription("Collect, normalize, and plan deployment for AI-agent metrics"),
@@ -2143,5 +2445,6 @@ export const aiMetricsCommand = Command.make(
     labelCommand,
     benchmarkCommand,
     reportCommand,
+    archiveCommand,
   ])
 );


### PR DESCRIPTION
## Summary

- Harden AI metrics P6a proof workflow for subagent attribution, source-aware discovery, config snapshot causality, completion readiness, metadata privacy, and operator scheduling.
- Add systemd user timer render/install guidance with lock, retry/backoff, status artifact, journal evidence, and 1Password-backed secret resolution.
- Add archive decrypt drill coverage, P6a history report, initiative packet updates, and regression tests around migration backfills and latest snapshot commit behavior.

## Validation

- Secret-backed smoke: `bun run beep ai-metrics archive drill --target dankserver --data-root .beep/ai-metrics ... --json` passed with `plaintextHashMatches=true` and no transcript/secret output.
- Focused gates: `@beep/repo-ai-metrics` check/test/lint/docgen passed; `@beep/repo-cli` check/test/lint passed.
- Full gate: `bash scripts/run-github-checks.sh quality` passed.
- `$quality-review-fix-loop`: reviewer rerounds closed required findings; final source-role migration reround reported 0 required findings.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kriegcloud/codesmith/beep-effect/pr/121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added workstation timer support for scheduled AI metrics collection with lock/retry/journal evidence.
  * Introduced archive integrity verification drill command.
  * Added configuration snapshot diffing to track changed/added/removed paths.
  * Enhanced scorecard completion readiness indicators and coverage gap reporting.
  * Implemented per-source file selection coverage tracking.
  * Added explicit OTLP span attribute allowlisting for privacy protection.

* **Documentation**
  * Updated initiative roadmap to reflect P6a hardening phase gates and restart criteria.
  * Documented fresh review findings and hardening requirements.
  * Expanded completion standards and operational handoff guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->