### PR TITLE
Fix AI metrics P6a review findings

### DIFF
--- a/packages/epistemic/domain/src/entities/UsageRecord/UsageRecord.values.ts
+++ b/packages/epistemic/domain/src/entities/UsageRecord/UsageRecord.values.ts
@@ -1,9 +1,0 @@
-/**
- * Usage Record value schemas.
- *
- * @packageDocumentation
- * @category value-objects
- * @since 0.0.0
- */
-
-export {};

--- a/packages/tooling/library/ai-metrics/src/config-snapshot.ts
+++ b/packages/tooling/library/ai-metrics/src/config-snapshot.ts
@@ -82,6 +82,13 @@ export class AiMetricsConfigSnapshotDiff extends S.Class<AiMetricsConfigSnapshot
   })
 ) {}
 
+const emptyConfigSnapshotDiff = new AiMetricsConfigSnapshotDiff({
+  addedPaths: [],
+  modifiedPaths: [],
+  removedPaths: [],
+  unchangedPaths: [],
+});
+
 /**
  * One file included in an AI metrics config snapshot.
  *
@@ -120,7 +127,7 @@ export class AiMetricsConfigSnapshotResult extends S.Class<AiMetricsConfigSnapsh
 )(
   {
     excludedDirectoryNames: S.Array(S.String),
-    diff: AiMetricsConfigSnapshotDiff,
+    diff: AiMetricsConfigSnapshotDiff.pipe(S.withDecodingDefaultKey(Effect.succeed(emptyConfigSnapshotDiff))),
     fileCount: S.Number,
     files: S.Array(AiMetricsConfigSnapshotFile),
     previousSnapshotId: S.optionalKey(S.String),
@@ -488,6 +495,7 @@ export const writeAiMetricsConfigSnapshotArtifacts = Effect.fn("AiMetrics.writeA
     const content = yield* configSnapshotToJson(result);
     const manifestPath = pathApi.join(outputDir, `${result.snapshot.snapshotId}.json`);
     const latestPath = pathApi.join(outputDir, "latest.json");
+    const latestTmpPath = pathApi.join(outputDir, "latest.json.tmp");
     yield* fs.makeDirectory(outputDir, { recursive: true }).pipe(
       Effect.mapError(
         (cause) =>
@@ -507,12 +515,21 @@ export const writeAiMetricsConfigSnapshotArtifacts = Effect.fn("AiMetrics.writeA
       )
     );
     if (commitLatest) {
-      yield* fs.writeFileString(latestPath, content).pipe(
+      yield* fs.writeFileString(latestTmpPath, content).pipe(
         Effect.mapError(
           (cause) =>
             new AiMetricsConfigSnapshotError({
               cause,
-              message: "Failed to write AI metrics latest config snapshot pointer.",
+              message: "Failed to write AI metrics latest config snapshot temporary pointer.",
+            })
+        )
+      );
+      yield* fs.rename(latestTmpPath, latestPath).pipe(
+        Effect.mapError(
+          (cause) =>
+            new AiMetricsConfigSnapshotError({
+              cause,
+              message: "Failed to promote AI metrics latest config snapshot pointer.",
             })
         )
       );

--- a/packages/tooling/library/ai-metrics/src/derived-storage.ts
+++ b/packages/tooling/library/ai-metrics/src/derived-storage.ts
@@ -179,6 +179,10 @@ const createTableStatements = [
     completion_ready BOOLEAN NOT NULL,
     coverage_gaps_json VARCHAR NOT NULL
   )`,
+  `CREATE TABLE IF NOT EXISTS ai_metrics_schema_migrations (
+    migration_id VARCHAR PRIMARY KEY,
+    applied_at_epoch_ms DOUBLE NOT NULL
+  )`,
 ] as const;
 
 const migrationColumns = [
@@ -368,11 +372,55 @@ const migrationBackfillStatements = [
   "UPDATE ai_metrics_scorecards SET coverage_gaps_json = '[]' WHERE coverage_gaps_json IS NULL",
 ] as const;
 
+const legacyAgentTaskIdExpression = (tableAlias: string): string =>
+  `concat('agent-task-', sha256(concat('agent-task', chr(0), ${tableAlias}.source_kind, chr(0), ${tableAlias}.source_path_hash)))`;
+
+const currentAgentTaskIdExpression = (tableAlias: string): string =>
+  `concat('agent-task-', sha256(concat('agent-task', chr(0), ${tableAlias}.config_snapshot_id, chr(0), ${tableAlias}.source_kind, chr(0), ${tableAlias}.source_role, chr(0), ${tableAlias}.source_path_hash)))`;
+
+const legacyAgentTaskIdMigrationStatements = [
+  `DELETE FROM ai_metrics_agent_tasks AS legacy
+   WHERE legacy.agent_task_id = ${legacyAgentTaskIdExpression("legacy")}
+     AND EXISTS (
+       SELECT 1
+       FROM ai_metrics_agent_tasks AS current
+       WHERE current.agent_task_id = ${currentAgentTaskIdExpression("legacy")}
+         AND current.agent_task_id <> legacy.agent_task_id
+     )`,
+  `UPDATE ai_metrics_agent_tasks AS task
+   SET agent_task_id = ${currentAgentTaskIdExpression("task")}
+   WHERE task.agent_task_id = ${legacyAgentTaskIdExpression("task")}`,
+] as const;
+
 type MigrationColumn = {
   readonly columnDefinition: string;
   readonly columnName: string;
   readonly tableName: string;
 };
+
+type DerivedStorageMigration = {
+  readonly migrationId: string;
+  readonly requiredColumns?: ReadonlyArray<Pick<MigrationColumn, "columnName" | "tableName">>;
+  readonly statements: ReadonlyArray<string>;
+};
+
+const derivedStorageMigrations = [
+  {
+    migrationId: "ai-metrics-p6a-default-backfill-v1",
+    statements: migrationBackfillStatements,
+  },
+  {
+    migrationId: "ai-metrics-agent-task-id-v2",
+    requiredColumns: [
+      { columnName: "agent_task_id", tableName: "ai_metrics_agent_tasks" },
+      { columnName: "config_snapshot_id", tableName: "ai_metrics_agent_tasks" },
+      { columnName: "source_kind", tableName: "ai_metrics_agent_tasks" },
+      { columnName: "source_path_hash", tableName: "ai_metrics_agent_tasks" },
+      { columnName: "source_role", tableName: "ai_metrics_agent_tasks" },
+    ],
+    statements: legacyAgentTaskIdMigrationStatements,
+  },
+] as const satisfies ReadonlyArray<DerivedStorageMigration>;
 
 /**
  * Error raised by the DuckDB derived storage projection.
@@ -514,11 +562,72 @@ const addColumnIfMissing: (input: MigrationColumn) => Effect.Effect<void, DuckDb
   yield* duckdb.run(`ALTER TABLE ${tableName} ADD COLUMN ${columnDefinition}`);
 });
 
+const migrationColumnExists: (
+  input: Pick<MigrationColumn, "columnName" | "tableName">
+) => Effect.Effect<boolean, DuckDbError, DuckDb> = Effect.fn("AiMetrics.derivedStorage.migrationColumnExists")(
+  function* ({ columnName, tableName }) {
+    const duckdb = yield* DuckDb;
+    const rows = yield* duckdb.query(
+      `SELECT column_name AS "columnName"
+     FROM information_schema.columns
+      WHERE table_name = $tableName AND column_name = $columnName`,
+      { columnName, tableName }
+    );
+
+    return A.isReadonlyArrayNonEmpty(rows);
+  }
+);
+
+const migrationHasRequiredColumns: (migration: DerivedStorageMigration) => Effect.Effect<boolean, DuckDbError, DuckDb> =
+  Effect.fn("AiMetrics.derivedStorage.migrationHasRequiredColumns")(function* (migration) {
+    if (migration.requiredColumns === undefined || migration.requiredColumns.length === 0) {
+      return true;
+    }
+
+    const columnResults = yield* Effect.forEach(migration.requiredColumns, migrationColumnExists);
+    return A.every(columnResults, (exists) => exists);
+  });
+
+const runDerivedStorageMigrationOnce: (migration: DerivedStorageMigration) => Effect.Effect<void, DuckDbError, DuckDb> =
+  Effect.fn("AiMetrics.derivedStorage.runMigrationOnce")(function* (migration) {
+    const duckdb = yield* DuckDb;
+    const appliedRows = yield* duckdb.query(
+      `SELECT migration_id AS "migrationId"
+     FROM ai_metrics_schema_migrations
+     WHERE migration_id = $migrationId`,
+      { migrationId: migration.migrationId }
+    );
+
+    if (A.isReadonlyArrayNonEmpty(appliedRows)) {
+      return;
+    }
+
+    const hasRequiredColumns = yield* migrationHasRequiredColumns(migration);
+    if (!hasRequiredColumns) {
+      return;
+    }
+
+    yield* duckdb.runMany(migration.statements);
+    yield* duckdb.run(
+      `INSERT OR REPLACE INTO ai_metrics_schema_migrations (
+      migration_id,
+      applied_at_epoch_ms
+    ) VALUES (
+      $migrationId,
+      $appliedAtEpochMillis
+    )`,
+      {
+        appliedAtEpochMillis: globalThis.String(yield* Clock.currentTimeMillis),
+        migrationId: migration.migrationId,
+      }
+    );
+  });
+
 const ensureAiMetricsDerivedStorageRaw = Effect.fn("AiMetrics.derivedStorage.ensureRaw")(function* () {
   const duckdb = yield* DuckDb;
   yield* duckdb.runMany(createTableStatements);
   yield* Effect.forEach(migrationColumns, addColumnIfMissing, { discard: true });
-  yield* duckdb.runMany(migrationBackfillStatements);
+  yield* Effect.forEach(derivedStorageMigrations, runDerivedStorageMigrationOnce, { discard: true });
 });
 
 /**

--- a/packages/tooling/library/ai-metrics/src/derived-storage.ts
+++ b/packages/tooling/library/ai-metrics/src/derived-storage.ts
@@ -594,7 +594,12 @@ const agentTaskIdFor = Effect.fn("AiMetrics.derivedStorage.agentTaskIdFor")(func
   record: AiMetricsDerivedTranscriptRecord
 ) {
   const sanitized = record.privacy.sanitized;
-  return yield* rowId("agent-task", [input.configSnapshot.snapshotId, sanitized.sourceKind, sanitized.sourcePathHash]);
+  return yield* rowId("agent-task", [
+    input.configSnapshot.snapshotId,
+    sanitized.sourceKind,
+    sanitized.sourceRole,
+    sanitized.sourcePathHash,
+  ]);
 });
 
 const taskTitleFor = (record: AiMetricsDerivedTranscriptRecord): string => {

--- a/packages/tooling/library/ai-metrics/src/forwarder.ts
+++ b/packages/tooling/library/ai-metrics/src/forwarder.ts
@@ -223,6 +223,7 @@ const encodeForwarderTimerPlanJson = S.encodeUnknownEffect(S.fromJsonString(AiMe
 
 type ForwarderSourceFile = {
   readonly modifiedAtMillis: number;
+  readonly relativePath: string;
   readonly sourceKind: AiMetricsTranscriptSource;
   readonly sourcePath: string;
 };
@@ -236,6 +237,9 @@ const forwarderFailure = (message: string, cause: unknown): AiMetricsForwarderEr
   new AiMetricsForwarderError({ cause, message });
 
 const repoPathToClaudeProjectName: (repoRoot: string) => string = Str.replace(/[/\\]/gu, "-");
+
+const normalizedRelativePath = (pathApi: Path.Path, root: string, filePath: string): string =>
+  pipe(pathApi.relative(root, filePath), Str.replace(/\\/gu, "/"));
 
 const shellQuote = (value: string): string => `'${Str.replace(/'/gu, "'\\''")(value)}'`;
 
@@ -272,18 +276,24 @@ export const renderAiMetricsForwarderTimerPlan = (input: AiMetricsForwarderTimer
   const serviceUnitName = `${input.serviceName}.service`;
   const timerUnitName = `${input.serviceName}.timer`;
   const statusTmpPath = `${input.statusPath}.tmp`;
+  const stderrTmpPath = `${input.statusPath}.stderr.tmp`;
   const envFileShellPath = "~/.config/beep/ai-metrics.env";
   const envFileUnitPath = "%h/.config/beep/ai-metrics.env";
   const execCommand = [
     "set -euo pipefail",
     `mkdir -p "$(dirname ${shellQuote(input.statusPath)})" "$(dirname ${shellQuote(input.lockPath)})"`,
-    `flock -n ${shellQuote(input.lockPath)} ${input.command} > ${shellQuote(statusTmpPath)}`,
+    "exit_code=0",
+    `if flock -n ${shellQuote(input.lockPath)} ${input.command} > ${shellQuote(statusTmpPath)} 2> ${shellQuote(stderrTmpPath)}; then :; else exit_code=$?; stderr="$(head -c 2000 ${shellQuote(stderrTmpPath)} | sed 's/\\\\/\\\\\\\\/g; s/"/\\\\"/g' | tr '\\n' ' ')"; printf '{"status":"failed","exitCode":%s,"stderr":"%s"}\\n' "$exit_code" "$stderr" > ${shellQuote(statusTmpPath)}; fi`,
+    `rm -f ${shellQuote(stderrTmpPath)}`,
     `mv ${shellQuote(statusTmpPath)} ${shellQuote(input.statusPath)}`,
+    'exit "$exit_code"',
   ].join("; ");
   const serviceUnit = [
     "[Unit]",
     "Description=Beep AI metrics forwarder collection",
     "Documentation=AGENTS.md",
+    "StartLimitBurst=3",
+    "StartLimitIntervalSec=30m",
     "",
     "[Service]",
     "Type=oneshot",
@@ -292,8 +302,6 @@ export const renderAiMetricsForwarderTimerPlan = (input: AiMetricsForwarderTimer
     `ExecStart=/usr/bin/env bash -lc ${shellQuote(execCommand)}`,
     "Restart=on-failure",
     "RestartSec=5m",
-    "StartLimitBurst=3",
-    "StartLimitIntervalSec=30m",
     "",
   ].join("\n");
   const timerUnit = [
@@ -420,6 +428,7 @@ const jsonlSourceFiles = Effect.fn("AiMetrics.forwarder.jsonlSourceFiles")(funct
   sourceKind: AiMetricsTranscriptSource
 ) {
   const fs = yield* FileSystem.FileSystem;
+  const pathApi = yield* Path.Path;
   const sourcePaths = yield* collectJsonlFiles(root);
   const files = yield* Effect.forEach(
     sourcePaths,
@@ -431,6 +440,7 @@ const jsonlSourceFiles = Effect.fn("AiMetrics.forwarder.jsonlSourceFiles")(funct
 
       return O.some({
         modifiedAtMillis: modifiedAtMillis(info.value),
+        relativePath: normalizedRelativePath(pathApi, root, sourcePath),
         sourceKind,
         sourcePath,
       });
@@ -454,6 +464,7 @@ const openClawSourceFiles = Effect.fn("AiMetrics.forwarder.openClawSourceFiles")
 
   return A.of({
     modifiedAtMillis: modifiedAtMillis(info.value),
+    relativePath: pathApi.basename(unitPath),
     sourceKind: AiMetricsTranscriptSource.Enum.openclaw,
     sourcePath: unitPath,
   });
@@ -548,6 +559,7 @@ const processSourceFile = Effect.fn("AiMetrics.forwarder.processSourceFile")(
     const privacy = yield* makeAiMetricsPrivacyCheckResult({
       content,
       ...(input.hashSalt === undefined ? {} : { hashSalt: input.hashSalt }),
+      relativePath: sourceFile.relativePath,
       sourcePath: sourceFile.sourcePath,
       summary,
     }).pipe(Effect.mapError((cause) => forwarderFailure("Failed to build AI metrics privacy projection.", cause)));

--- a/packages/tooling/library/ai-metrics/src/forwarder.ts
+++ b/packages/tooling/library/ai-metrics/src/forwarder.ts
@@ -285,6 +285,7 @@ export const renderAiMetricsForwarderTimerPlan = (input: AiMetricsForwarderTimer
     "set -euo pipefail",
     `mkdir -p "$(dirname ${shellQuote(input.statusPath)})" "$(dirname ${shellQuote(input.lockPath)})"`,
     "exit_code=0",
+    `> ${shellQuote(stderrTmpPath)}`,
     `if flock -n ${shellQuote(input.lockPath)} ${input.command} > ${shellQuote(statusTmpPath)} 2> ${shellQuote(stderrTmpPath)}; then :; else exit_code=$?; python3 -c ${shellQuote(failureStatusPython)} "$exit_code" ${shellQuote(stderrTmpPath)} > ${shellQuote(statusTmpPath)}; fi`,
     `rm -f ${shellQuote(stderrTmpPath)}`,
     `mv ${shellQuote(statusTmpPath)} ${shellQuote(input.statusPath)}`,

--- a/packages/tooling/library/ai-metrics/src/forwarder.ts
+++ b/packages/tooling/library/ai-metrics/src/forwarder.ts
@@ -27,6 +27,7 @@ import { summarizeTranscriptText } from "./ingest.ts";
 import { AiMetricsInstallInput, makeAiMetricsInstallSpec } from "./install.ts";
 import { AiMetricsDeployTarget, AiMetricsTranscriptSource } from "./models.ts";
 import { hashPrivateIdentifier, makeAiMetricsPrivacyCheckResult } from "./privacy.ts";
+import { shellQuote } from "./shell.ts";
 
 const $I = $RepoAiMetricsId.create("forwarder");
 const DEFAULT_MAX_FILES = 200;
@@ -240,8 +241,6 @@ const repoPathToClaudeProjectName: (repoRoot: string) => string = Str.replace(/[
 
 const normalizedRelativePath = (pathApi: Path.Path, root: string, filePath: string): string =>
   pipe(pathApi.relative(root, filePath), Str.replace(/\\/gu, "/"));
-
-const shellQuote = (value: string): string => `'${Str.replace(/'/gu, "'\\''")(value)}'`;
 
 const requireForwarderHashSalt = Effect.fn("AiMetrics.forwarder.requireHashSalt")(function* (
   input: AiMetricsForwarderInput

--- a/packages/tooling/library/ai-metrics/src/forwarder.ts
+++ b/packages/tooling/library/ai-metrics/src/forwarder.ts
@@ -279,11 +279,13 @@ export const renderAiMetricsForwarderTimerPlan = (input: AiMetricsForwarderTimer
   const stderrTmpPath = `${input.statusPath}.stderr.tmp`;
   const envFileShellPath = "~/.config/beep/ai-metrics.env";
   const envFileUnitPath = "%h/.config/beep/ai-metrics.env";
+  const failureStatusPython =
+    'import json,sys; data=open(sys.argv[2],"rb").read(2000).decode("utf-8","replace"); print(json.dumps({"status":"failed","exitCode":int(sys.argv[1]),"stderr":data},separators=(",",":")))';
   const execCommand = [
     "set -euo pipefail",
     `mkdir -p "$(dirname ${shellQuote(input.statusPath)})" "$(dirname ${shellQuote(input.lockPath)})"`,
     "exit_code=0",
-    `if flock -n ${shellQuote(input.lockPath)} ${input.command} > ${shellQuote(statusTmpPath)} 2> ${shellQuote(stderrTmpPath)}; then :; else exit_code=$?; stderr="$(head -c 2000 ${shellQuote(stderrTmpPath)} | sed 's/\\\\/\\\\\\\\/g; s/"/\\\\"/g' | tr '\\n' ' ')"; printf '{"status":"failed","exitCode":%s,"stderr":"%s"}\\n' "$exit_code" "$stderr" > ${shellQuote(statusTmpPath)}; fi`,
+    `if flock -n ${shellQuote(input.lockPath)} ${input.command} > ${shellQuote(statusTmpPath)} 2> ${shellQuote(stderrTmpPath)}; then :; else exit_code=$?; python3 -c ${shellQuote(failureStatusPython)} "$exit_code" ${shellQuote(stderrTmpPath)} > ${shellQuote(statusTmpPath)}; fi`,
     `rm -f ${shellQuote(stderrTmpPath)}`,
     `mv ${shellQuote(statusTmpPath)} ${shellQuote(input.statusPath)}`,
     'exit "$exit_code"',

--- a/packages/tooling/library/ai-metrics/src/index.ts
+++ b/packages/tooling/library/ai-metrics/src/index.ts
@@ -138,6 +138,18 @@ export * from "./privacy.ts";
  */
 export * from "./scorecard.ts";
 /**
+ * Shell rendering helpers for operator commands.
+ *
+ * @example
+ * ```ts
+ * import { shellQuote } from "@beep/repo-ai-metrics"
+ * console.log(shellQuote("op://vault/item/field"))
+ * ```
+ * @category utilities
+ * @since 0.0.0
+ */
+export * from "./shell.ts";
+/**
  * Local AI-agent source discovery helpers.
  *
  * @example

--- a/packages/tooling/library/ai-metrics/src/install.ts
+++ b/packages/tooling/library/ai-metrics/src/install.ts
@@ -22,6 +22,7 @@ import {
   AiMetricsScoreWeights,
   AiMetricsTool,
 } from "./models.ts";
+import { shellQuote } from "./shell.ts";
 import { AiMetricsSourceDiscoveryResult, AiMetricsSourceStatus } from "./source-discovery.ts";
 
 const $I = $RepoAiMetricsId.create("install");
@@ -599,8 +600,6 @@ const makeServiceSpec =
       tool,
     });
   };
-
-const shellQuote = (value: string): string => `'${Str.replace(/'/gu, "'\\''")(value)}'`;
 
 const withHashSaltSecret =
   (hashSaltSecretRef: O.Option<string>) =>

--- a/packages/tooling/library/ai-metrics/src/privacy.ts
+++ b/packages/tooling/library/ai-metrics/src/privacy.ts
@@ -402,8 +402,20 @@ const firstCodexSubagentSource: (lines: ReadonlyArray<CodexSessionMetaLine>) => 
   A.head
 );
 
-const pathRoleFor = (relativePath: string): AiMetricsSourceRole =>
-  Str.includes("/subagents/")(relativePath) ? AiMetricsSourceRole.Enum.subagent : AiMetricsSourceRole.Enum.primary;
+const normalizeAttributionPath = flow(
+  Str.replace(/\\/gu, "/"),
+  Str.replace(/^[A-Za-z]:/u, ""),
+  Str.replace(/^\/+/u, "")
+);
+
+const basenameAttributionPath = flow(normalizeAttributionPath, Str.replace(/^.*\//u, ""));
+
+const pathRoleFor = (relativePath: string): AiMetricsSourceRole => {
+  const normalizedPath = normalizeAttributionPath(relativePath);
+  return Str.startsWith("subagents/")(normalizedPath) || Str.includes("/subagents/")(normalizedPath)
+    ? AiMetricsSourceRole.Enum.subagent
+    : AiMetricsSourceRole.Enum.primary;
+};
 
 /**
  * Derive privacy-safe source attribution from local transcript metadata.
@@ -589,18 +601,20 @@ const rawEventEnvelopes = Effect.fn("AiMetrics.rawEventEnvelopes")(function* ({
 export const makeSanitizedTranscript = Effect.fn("AiMetrics.makeSanitizedTranscript")(function* ({
   content,
   hashSalt,
+  relativePath,
   sourcePath,
   summary,
 }: {
   readonly content: string;
   readonly hashSalt?: string;
+  readonly relativePath?: string;
   readonly sourcePath: string;
   readonly summary: TranscriptIngestSummary;
 }) {
   const attribution = yield* makeAiMetricsSourceAttribution({
     content,
     ...(hashSalt === undefined ? {} : { hashSalt }),
-    relativePath: sourcePath,
+    relativePath: relativePath ?? basenameAttributionPath(sourcePath),
     sourceKind: summary.sourceKind,
     sourcePath,
   });
@@ -647,11 +661,13 @@ export const makeSanitizedTranscript = Effect.fn("AiMetrics.makeSanitizedTranscr
 export const makeAiMetricsPrivacyCheckResult = Effect.fn("AiMetrics.makeAiMetricsPrivacyCheckResult")(function* ({
   content,
   hashSalt,
+  relativePath,
   sourcePath,
   summary,
 }: {
   readonly content: string;
   readonly hashSalt?: string;
+  readonly relativePath?: string;
   readonly sourcePath: string;
   readonly summary: TranscriptIngestSummary;
 }) {
@@ -661,6 +677,7 @@ export const makeAiMetricsPrivacyCheckResult = Effect.fn("AiMetrics.makeAiMetric
     redaction: redactionResultFor(content),
     sanitized: yield* makeSanitizedTranscript({
       content,
+      ...(relativePath === undefined ? {} : { relativePath }),
       sourcePath,
       summary,
       ...(hashSalt === undefined ? {} : { hashSalt }),

--- a/packages/tooling/library/ai-metrics/src/privacy.ts
+++ b/packages/tooling/library/ai-metrics/src/privacy.ts
@@ -460,10 +460,7 @@ export const makeAiMetricsSourceAttribution = Effect.fn("AiMetrics.makeAiMetrics
   const subagent = firstCodexSubagentSource(sessionMetaLines);
   const subagentValue = O.getOrUndefined(subagent);
   const payloadValue = O.getOrUndefined(payload);
-  const sourceRole =
-    O.isSome(subagent) || subagentValue?.thread_spawn === true
-      ? AiMetricsSourceRole.Enum.subagent
-      : AiMetricsSourceRole.Enum.primary;
+  const sourceRole = O.isSome(subagent) ? AiMetricsSourceRole.Enum.subagent : AiMetricsSourceRole.Enum.primary;
   const parentSessionId = firstNonEmptyString(subagentValue?.parent_session_id, payloadValue?.parent_session_id);
   const parentThreadId = firstNonEmptyString(subagentValue?.parent_thread_id, payloadValue?.parent_thread_id);
   const agentNicknameHash = yield* optionalHashPrivateIdentifier(

--- a/packages/tooling/library/ai-metrics/src/shell.ts
+++ b/packages/tooling/library/ai-metrics/src/shell.ts
@@ -1,0 +1,22 @@
+/**
+ * Shell rendering helpers for AI metrics operator commands.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import * as Str from "effect/String";
+
+/**
+ * Quote a value as one POSIX shell token.
+ *
+ * @example
+ * ```ts
+ * import { shellQuote } from "@beep/repo-ai-metrics"
+ *
+ * console.log(shellQuote("op://vault/item/field"))
+ * ```
+ * @category utilities
+ * @since 0.0.0
+ */
+export const shellQuote = (value: string): string => `'${Str.replace(/'/gu, "'\\''")(value)}'`;

--- a/packages/tooling/library/ai-metrics/src/source-discovery.ts
+++ b/packages/tooling/library/ai-metrics/src/source-discovery.ts
@@ -7,7 +7,7 @@
 
 import { $RepoAiMetricsId } from "@beep/identity/packages";
 import { LiteralKit, TaggedErrorClass } from "@beep/schema";
-import { Clock, Effect, FileSystem, Order, Path, pipe } from "effect";
+import { Clock, Effect, FileSystem, Order, Path, pipe, Stream } from "effect";
 import * as A from "effect/Array";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
@@ -252,6 +252,25 @@ const fileSystemFailure = (message: string, cause: unknown): AiMetricsSourceDisc
 const normalizedRelativePath = (pathApi: Path.Path, root: string, filePath: string): string =>
   pipe(pathApi.relative(root, filePath), Str.replace(/\\/gu, "/"));
 
+const readAttributionContent = (
+  fs: FileSystem.FileSystem,
+  sourceKind: AiMetricsTranscriptSource,
+  sourcePath: string
+) => {
+  if (sourceKind !== AiMetricsTranscriptSource.Enum.codex) {
+    return fs.readFileString(sourcePath);
+  }
+
+  return fs.stream(sourcePath, { chunkSize: 64 * 1024 }).pipe(
+    Stream.decodeText(),
+    Stream.takeUntil(Str.includes("session_meta")),
+    Stream.runFold(
+      () => "",
+      (content, chunk) => `${content}${chunk}`
+    )
+  );
+};
+
 const repoPathToClaudeProjectName: (repoRoot: string) => string = Str.replace(/[/\\]/gu, "-");
 
 const optionalModifiedAtMillis = (info: FileSystem.File.Info): O.Option<number> =>
@@ -334,9 +353,9 @@ const makeDiscoveredTranscriptFile = Effect.fn("AiMetrics.makeDiscoveredTranscri
   const info = yield* fs
     .stat(sourcePath)
     .pipe(Effect.mapError((cause) => fileSystemFailure("Failed to stat AI metrics source file.", cause)));
-  const content = yield* fs
-    .readFileString(sourcePath)
-    .pipe(Effect.mapError((cause) => fileSystemFailure("Failed to read AI metrics source file.", cause)));
+  const content = yield* readAttributionContent(fs, sourceKind, sourcePath).pipe(
+    Effect.mapError((cause) => fileSystemFailure("Failed to read AI metrics source file.", cause))
+  );
   const relativePath = normalizedRelativePath(pathApi, root, sourcePath);
   const attribution = yield* makeAiMetricsSourceAttribution({
     content,
@@ -430,16 +449,19 @@ const discoverJsonlSource = Effect.fn("AiMetrics.discoverJsonlSource")(function*
     A.sort(byCandidateModifiedDescending)
   );
   const includedCandidates = A.take(candidates, input.maxFiles);
-  const files = yield* Effect.forEach(
-    includedCandidates,
-    (candidate) =>
-      makeDiscoveredTranscriptFile({
-        root,
-        sourceKind,
-        sourcePath: candidate.sourcePath,
-        ...(input.hashSalt === undefined ? {} : { hashSalt: input.hashSalt }),
-      }),
-    { concurrency: 16 }
+  const files = pipe(
+    yield* Effect.forEach(
+      includedCandidates,
+      (candidate) =>
+        makeDiscoveredTranscriptFile({
+          root,
+          sourceKind,
+          sourcePath: candidate.sourcePath,
+          ...(input.hashSalt === undefined ? {} : { hashSalt: input.hashSalt }),
+        }).pipe(Effect.option),
+      { concurrency: 16 }
+    ),
+    A.getSomes
   );
   const includedFiles = pipe(files, A.sort(byPathHashAscending), A.sort(byModifiedDescending));
 
@@ -448,7 +470,7 @@ const discoverJsonlSource = Effect.fn("AiMetrics.discoverJsonlSource")(function*
     fileCount: A.length(includedFiles),
     files: includedFiles,
     includedFileCount: A.length(includedFiles),
-    limitedByMaxFiles: A.length(candidates) > A.length(includedFiles),
+    limitedByMaxFiles: A.length(candidates) > A.length(includedCandidates),
     rootPathHash,
     sourceKind,
     status: AiMetricsSourceStatus.Enum.available,

--- a/packages/tooling/library/ai-metrics/src/source-discovery.ts
+++ b/packages/tooling/library/ai-metrics/src/source-discovery.ts
@@ -277,7 +277,7 @@ const readAttributionContent = (
   sourcePath: string
 ) => {
   if (sourceKind !== AiMetricsTranscriptSource.Enum.codex) {
-    return fs.readFileString(sourcePath);
+    return Effect.succeed("");
   }
 
   return fs.stream(sourcePath, { chunkSize: 64 * 1024 }).pipe(

--- a/packages/tooling/library/ai-metrics/src/source-discovery.ts
+++ b/packages/tooling/library/ai-metrics/src/source-discovery.ts
@@ -12,7 +12,13 @@ import * as A from "effect/Array";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
 import * as Str from "effect/String";
-import { AiMetricsDeployTarget, AiMetricsSourceRole, AiMetricsTranscriptSource } from "./models.ts";
+import { transcriptLines } from "./internal/transcript-utils.ts";
+import {
+  AiMetricsDeployTarget,
+  AiMetricsSourceRole,
+  AiMetricsTranscriptSource,
+  CodexTranscriptLine,
+} from "./models.ts";
 import {
   AiMetricsHashSaltStatus,
   hashPrivateIdentifier,
@@ -222,6 +228,7 @@ export class AiMetricsSourceDiscoveryError extends TaggedErrorClass<AiMetricsSou
 ) {}
 
 const encodeSourceDiscoveryJson = S.encodeUnknownEffect(S.fromJsonString(AiMetricsSourceDiscoveryResult));
+const decodeCodexTranscriptLine = S.decodeUnknownOption(S.fromJsonString(CodexTranscriptLine));
 
 const byPathHashAscending: Order.Order<AiMetricsDiscoveredTranscriptFile> = Order.mapInput(
   Order.String,
@@ -252,6 +259,18 @@ const fileSystemFailure = (message: string, cause: unknown): AiMetricsSourceDisc
 const normalizedRelativePath = (pathApi: Path.Path, root: string, filePath: string): string =>
   pipe(pathApi.relative(root, filePath), Str.replace(/\\/gu, "/"));
 
+const contentHasCodexSessionMetaLine = (content: string): boolean =>
+  pipe(
+    content,
+    transcriptLines,
+    A.some((line) =>
+      pipe(
+        decodeCodexTranscriptLine(line),
+        O.exists((decoded) => decoded.type === "session_meta")
+      )
+    )
+  );
+
 const readAttributionContent = (
   fs: FileSystem.FileSystem,
   sourceKind: AiMetricsTranscriptSource,
@@ -263,11 +282,10 @@ const readAttributionContent = (
 
   return fs.stream(sourcePath, { chunkSize: 64 * 1024 }).pipe(
     Stream.decodeText(),
-    Stream.takeUntil(Str.includes("session_meta")),
-    Stream.runFold(
-      () => "",
-      (content, chunk) => `${content}${chunk}`
-    )
+    Stream.scan("", (content, chunk) => `${content}${chunk}`),
+    Stream.takeUntil(contentHasCodexSessionMetaLine),
+    Stream.runLast,
+    Effect.map(O.getOrElse(() => ""))
   );
 };
 

--- a/packages/tooling/library/ai-metrics/test/ingest.test.ts
+++ b/packages/tooling/library/ai-metrics/test/ingest.test.ts
@@ -31,6 +31,7 @@ import {
   forwarderRunResultToJson,
   forwarderTimerPlanToJson,
   generateAiMetricsWeeklyReport,
+  hashPublicTextSha256,
   listAiMetricsBenchmarkCases,
   makeAiMetricsConfigSnapshot,
   makeAiMetricsInstallApplyDryRunResult,
@@ -1061,6 +1062,93 @@ volumes:
 
             expect(sourceRows).toEqual([{ sourceRole: "primary" }]);
             expect(scorecardRows).toEqual([{ completionReady: false, coverageGapsJson: "[]" }]);
+          }).pipe(Effect.provide(DuckDb.makeNodeLayer(new DuckDbConnectionOptions({ databasePath: duckDbPath }))));
+        })
+      ).pipe(Effect.provide(NodeServices.layer));
+    })
+  );
+
+  it.effect(
+    "deduplicates legacy agent task ids during derived storage migration",
+    Effect.fn(function* () {
+      yield* withTempDirectory(
+        Effect.fn(function* (tmpDir) {
+          const path = yield* Path.Path;
+          const duckDbPath = path.join(tmpDir, "ai-metrics.duckdb");
+
+          yield* Effect.gen(function* () {
+            const duckdb = yield* DuckDb;
+            const legacyTaskId = `agent-task-${yield* hashPublicTextSha256("agent-task\u0000codex\u0000source-hash")}`;
+            const currentTaskId = `agent-task-${yield* hashPublicTextSha256(
+              "agent-task\u0000snapshot-1\u0000codex\u0000primary\u0000source-hash"
+            )}`;
+            yield* duckdb.run(
+              `CREATE TABLE ai_metrics_agent_tasks (
+                agent_task_id VARCHAR PRIMARY KEY,
+                title VARCHAR NOT NULL,
+                source_kind VARCHAR NOT NULL,
+                source_path_hash VARCHAR NOT NULL,
+                source_role VARCHAR NOT NULL,
+                repo_root_hash VARCHAR NOT NULL,
+                config_snapshot_id VARCHAR NOT NULL,
+                created_at_epoch_ms DOUBLE NOT NULL,
+                first_seen_at VARCHAR,
+                last_seen_at VARCHAR
+              )`
+            );
+            yield* duckdb.run(
+              `INSERT INTO ai_metrics_agent_tasks (
+                agent_task_id,
+                title,
+                source_kind,
+                source_path_hash,
+                source_role,
+                repo_root_hash,
+                config_snapshot_id,
+                created_at_epoch_ms,
+                first_seen_at,
+                last_seen_at
+              ) VALUES (
+                $legacyTaskId,
+                'legacy task',
+                'codex',
+                'source-hash',
+                'primary',
+                'repo-hash',
+                'snapshot-1',
+                1,
+                NULL,
+                NULL
+              ), (
+                $currentTaskId,
+                'current task',
+                'codex',
+                'source-hash',
+                'primary',
+                'repo-hash',
+                'snapshot-1',
+                2,
+                NULL,
+                NULL
+              )`,
+              { currentTaskId, legacyTaskId }
+            );
+
+            yield* ensureAiMetricsDerivedStorage;
+
+            const taskRows = yield* duckdb.query(
+              `SELECT agent_task_id AS "agentTaskId"
+               FROM ai_metrics_agent_tasks
+               ORDER BY agent_task_id`
+            );
+            const migrationRows = yield* duckdb.query(
+              `SELECT migration_id AS "migrationId"
+               FROM ai_metrics_schema_migrations
+               WHERE migration_id = 'ai-metrics-agent-task-id-v2'`
+            );
+
+            expect(taskRows).toEqual([{ agentTaskId: currentTaskId }]);
+            expect(migrationRows).toEqual([{ migrationId: "ai-metrics-agent-task-id-v2" }]);
           }).pipe(Effect.provide(DuckDb.makeNodeLayer(new DuckDbConnectionOptions({ databasePath: duckDbPath }))));
         })
       ).pipe(Effect.provide(NodeServices.layer));

--- a/packages/tooling/library/ai-metrics/test/ingest.test.ts
+++ b/packages/tooling/library/ai-metrics/test/ingest.test.ts
@@ -1345,28 +1345,12 @@ volumes:
           const homeDir = path.join(tmpDir, "home");
           const repoRoot = path.join(tmpDir, "repo");
           const codexRoot = path.join(homeDir, ".codex/sessions");
-          const decoy = JSON.stringify({
-            payload: {
-              message: `not metadata session_meta ${pipe("x", Str.repeat(70_000))}`,
-            },
-            timestamp: "2026-05-05T10:00:00Z",
-            type: "event_msg",
-          });
-          const actual = JSON.stringify({
-            payload: {
-              id: "child-session",
-              source: {
-                subagent: {
-                  agent_nickname: "worker-one",
-                  agent_role: "worker",
-                  parent_thread_id: "parent-thread",
-                  thread_spawn: true,
-                },
-              },
-            },
-            timestamp: "2026-05-05T10:01:00Z",
-            type: "session_meta",
-          });
+          const decoy = `{"payload":{"message":"not metadata session_meta ${pipe(
+            "x",
+            Str.repeat(70_000)
+          )}"},"timestamp":"2026-05-05T10:00:00Z","type":"event_msg"}`;
+          const actual =
+            '{"payload":{"id":"child-session","source":{"subagent":{"agent_nickname":"worker-one","agent_role":"worker","parent_thread_id":"parent-thread","thread_spawn":true}}},"timestamp":"2026-05-05T10:01:00Z","type":"session_meta"}';
           yield* writeText(path.join(codexRoot, "codex-subagent.jsonl"), `${decoy}\n${actual}\n`);
           yield* writeText(path.join(repoRoot, "AGENTS.md"), "root agent guide\n");
 

--- a/packages/tooling/library/ai-metrics/test/ingest.test.ts
+++ b/packages/tooling/library/ai-metrics/test/ingest.test.ts
@@ -649,6 +649,9 @@ describe("@beep/repo-ai-metrics", () => {
 
       expect(plan.serviceUnit).toContain("flock -n");
       expect(plan.serviceUnit).toContain('"status":"failed"');
+      expect(plan.serviceUnit).toContain("json.dumps");
+      expect(plan.serviceUnit).toContain('decode("utf-8","replace")');
+      expect(plan.serviceUnit).not.toContain("sed 's/");
       expect(plan.serviceUnit).toContain("StartLimitBurst=3\nStartLimitIntervalSec=30m\n\n[Service]");
       expect(plan.serviceUnit).toContain("Restart=on-failure");
       expect(plan.timerUnit).toContain("OnUnitInactiveSec=15m");
@@ -1328,6 +1331,67 @@ volumes:
           expect(codex.value.includedFileCount).toBe(1);
           expect(codex.value.limitedByMaxFiles).toBe(false);
           expect(result.discoveredFileCount).toBe(1);
+        })
+      ).pipe(Effect.provide(NodeServices.layer));
+    })
+  );
+
+  it.effect(
+    "streams Codex attribution until a parsed session_meta line is present",
+    Effect.fn(function* () {
+      yield* withTempDirectory(
+        Effect.fn(function* (tmpDir) {
+          const path = yield* Path.Path;
+          const homeDir = path.join(tmpDir, "home");
+          const repoRoot = path.join(tmpDir, "repo");
+          const codexRoot = path.join(homeDir, ".codex/sessions");
+          const decoy = JSON.stringify({
+            payload: {
+              message: `not metadata session_meta ${pipe("x", Str.repeat(70_000))}`,
+            },
+            timestamp: "2026-05-05T10:00:00Z",
+            type: "event_msg",
+          });
+          const actual = JSON.stringify({
+            payload: {
+              id: "child-session",
+              source: {
+                subagent: {
+                  agent_nickname: "worker-one",
+                  agent_role: "worker",
+                  parent_thread_id: "parent-thread",
+                  thread_spawn: true,
+                },
+              },
+            },
+            timestamp: "2026-05-05T10:01:00Z",
+            type: "session_meta",
+          });
+          yield* writeText(path.join(codexRoot, "codex-subagent.jsonl"), `${decoy}\n${actual}\n`);
+          yield* writeText(path.join(repoRoot, "AGENTS.md"), "root agent guide\n");
+
+          const result = yield* discoverAiMetricsSources(
+            new AiMetricsSourceDiscoveryInput({
+              codexSessionsRoot: codexRoot,
+              hashSalt: "test-salt",
+              homeDir,
+              includeAll: true,
+              repoRoot,
+            })
+          );
+          const codex = pipe(
+            result.sources,
+            A.findFirst((source) => source.sourceKind === AiMetricsTranscriptSource.Enum.codex)
+          );
+
+          expect(O.isSome(codex)).toBe(true);
+          if (O.isNone(codex)) {
+            return;
+          }
+          expect(codex.value.files).toHaveLength(1);
+          expect(codex.value.files[0]?.agentRoleHash).toBeDefined();
+          expect(codex.value.files[0]?.sourceRole).toBe("subagent");
+          expect(codex.value.files[0]?.threadSpawn).toBe(true);
         })
       ).pipe(Effect.provide(NodeServices.layer));
     })

--- a/packages/tooling/library/ai-metrics/test/ingest.test.ts
+++ b/packages/tooling/library/ai-metrics/test/ingest.test.ts
@@ -651,6 +651,7 @@ describe("@beep/repo-ai-metrics", () => {
       expect(plan.serviceUnit).toContain('"status":"failed"');
       expect(plan.serviceUnit).toContain("json.dumps");
       expect(plan.serviceUnit).toContain('decode("utf-8","replace")');
+      expect(plan.serviceUnit).toMatch(/exit_code=0; > .*latest\.json\.stderr\.tmp.*; if flock -n/su);
       expect(plan.serviceUnit).not.toContain("sed 's/");
       expect(plan.serviceUnit).toContain("StartLimitBurst=3\nStartLimitIntervalSec=30m\n\n[Service]");
       expect(plan.serviceUnit).toContain("Restart=on-failure");
@@ -1286,6 +1287,48 @@ volumes:
           expect(json).toContain("gateway_metadata");
           expect(json).not.toContain(tmpDir);
           expect(json).not.toContain("super-secret-token");
+        })
+      ).pipe(Effect.provide(NodeServices.layer));
+    })
+  );
+
+  it.effect(
+    "does not read Claude transcript bodies during source attribution",
+    Effect.fn(function* () {
+      yield* withTempDirectory(
+        Effect.fn(function* (tmpDir) {
+          const path = yield* Path.Path;
+          const fs = yield* FileSystem.FileSystem;
+          const homeDir = path.join(tmpDir, "home");
+          const repoRoot = path.join(tmpDir, "repo");
+          const claudeRoot = path.join(homeDir, ".claude/projects/repo");
+          const claudePath = path.join(claudeRoot, "claude-unreadable.jsonl");
+          yield* writeText(claudePath, '{"sessionId":"claude-session","timestamp":"2026-05-05T11:00:00Z"}\n');
+          yield* writeText(path.join(repoRoot, "AGENTS.md"), "root agent guide\n");
+          yield* fs.chmod(claudePath, 0);
+
+          const result = yield* discoverAiMetricsSources(
+            new AiMetricsSourceDiscoveryInput({
+              claudeProjectsRoot: claudeRoot,
+              hashSalt: "test-salt",
+              homeDir,
+              includeAll: true,
+              repoRoot,
+            })
+          );
+          yield* fs.chmod(claudePath, 0o600).pipe(Effect.ignore);
+          const claude = pipe(
+            result.sources,
+            A.findFirst((source) => source.sourceKind === AiMetricsTranscriptSource.Enum.claude)
+          );
+
+          expect(O.isSome(claude)).toBe(true);
+          if (O.isNone(claude)) {
+            return;
+          }
+          expect(claude.value.candidateFileCount).toBe(1);
+          expect(claude.value.includedFileCount).toBe(1);
+          expect(claude.value.files[0]?.sourceRole).toBe("primary");
         })
       ).pipe(Effect.provide(NodeServices.layer));
     })

--- a/packages/tooling/library/ai-metrics/test/ingest.test.ts
+++ b/packages/tooling/library/ai-metrics/test/ingest.test.ts
@@ -648,6 +648,8 @@ describe("@beep/repo-ai-metrics", () => {
       const json = yield* forwarderTimerPlanToJson(plan);
 
       expect(plan.serviceUnit).toContain("flock -n");
+      expect(plan.serviceUnit).toContain('"status":"failed"');
+      expect(plan.serviceUnit).toContain("StartLimitBurst=3\nStartLimitIntervalSec=30m\n\n[Service]");
       expect(plan.serviceUnit).toContain("Restart=on-failure");
       expect(plan.timerUnit).toContain("OnUnitInactiveSec=15m");
       expect(plan.statusPath).toBe(".beep/ai-metrics/forwarder/status/latest.json");
@@ -1088,6 +1090,7 @@ volumes:
       yield* withTempDirectory(
         Effect.fn(function* (tmpDir) {
           const path = yield* Path.Path;
+          const fs = yield* FileSystem.FileSystem;
           yield* writeText(path.join(tmpDir, ".codex/config.toml"), 'model = "gpt-5"\n');
           yield* writeText(path.join(tmpDir, ".claude/settings.json"), '{"hooks":[]}\n');
           yield* writeText(path.join(tmpDir, ".aiassistant/rules/agent-instructions.md"), "agent rules\n");
@@ -1114,6 +1117,7 @@ volumes:
           expect(result.snapshot.configHash).toBe(again.snapshot.configHash);
           expect(json).not.toContain(".repos/effect-v4/AGENTS.md");
           expect(json).not.toContain("node_modules/pkg/CLAUDE.md");
+          expect(yield* fs.exists(path.join(snapshotDir, "latest.json.tmp"))).toBe(false);
 
           yield* writeText(path.join(tmpDir, ".codex/config.toml"), 'model = "gpt-5.1"\n');
           const changed = yield* makeAiMetricsConfigSnapshot(
@@ -1126,6 +1130,43 @@ volumes:
           expect(changed.snapshot.changedPaths).toEqual([".codex/config.toml"]);
           expect(changed.diff.modifiedPaths).toEqual([".codex/config.toml"]);
           expect(changed.snapshot.previousSnapshotId).toBe(result.snapshot.snapshotId);
+        })
+      ).pipe(Effect.provide(NodeServices.layer));
+    })
+  );
+
+  it.effect(
+    "reads legacy config snapshots without a diff field as previous state",
+    Effect.fn(function* () {
+      yield* withTempDirectory(
+        Effect.fn(function* (tmpDir) {
+          const path = yield* Path.Path;
+          yield* writeText(path.join(tmpDir, "AGENTS.md"), "current agent guide\n");
+          yield* writeText(
+            path.join(tmpDir, ".beep/ai-metrics/config-snapshots/latest.json"),
+            globalThis.JSON.stringify({
+              excludedDirectoryNames: [],
+              fileCount: 1,
+              files: [{ contentHash: "legacy-hash", relativePath: "AGENTS.md", sizeBytes: 18 }],
+              snapshot: {
+                changedPaths: ["AGENTS.md"],
+                configHash: "legacy-hash",
+                includedPaths: ["AGENTS.md"],
+                label: "repo-local-agent-config",
+                snapshotId: "config-legacy",
+              },
+            })
+          );
+
+          const result = yield* makeAiMetricsConfigSnapshot(
+            new AiMetricsConfigSnapshotInput({
+              previousSnapshotPath: path.join(tmpDir, ".beep/ai-metrics/config-snapshots/latest.json"),
+              repoRoot: tmpDir,
+            })
+          );
+
+          expect(result.snapshot.previousSnapshotId).toBe("config-legacy");
+          expect(result.diff.modifiedPaths).toEqual(["AGENTS.md"]);
         })
       ).pipe(Effect.provide(NodeServices.layer));
     })
@@ -1244,6 +1285,80 @@ volumes:
           expect(json).not.toContain("super-secret-token");
         })
       ).pipe(Effect.provide(NodeServices.layer));
+    })
+  );
+
+  it.effect(
+    "skips transcript files that become unreadable during source discovery",
+    Effect.fn(function* () {
+      yield* withTempDirectory(
+        Effect.fn(function* (tmpDir) {
+          const path = yield* Path.Path;
+          const fs = yield* FileSystem.FileSystem;
+          const homeDir = path.join(tmpDir, "home");
+          const repoRoot = path.join(tmpDir, "repo");
+          const codexRoot = path.join(homeDir, ".codex/sessions");
+          const readablePath = path.join(codexRoot, "readable.jsonl");
+          const unreadablePath = path.join(codexRoot, "unreadable.jsonl");
+          yield* writeText(readablePath, '{"type":"session_meta","timestamp":"2026-05-05T10:00:00Z"}\n');
+          yield* writeText(unreadablePath, '{"type":"session_meta","timestamp":"2026-05-05T10:01:00Z"}\n');
+          yield* writeText(path.join(repoRoot, "AGENTS.md"), "root agent guide\n");
+          yield* fs.chmod(unreadablePath, 0);
+
+          const result = yield* discoverAiMetricsSources(
+            new AiMetricsSourceDiscoveryInput({
+              codexSessionsRoot: codexRoot,
+              hashSalt: "test-salt",
+              homeDir,
+              includeAll: true,
+              repoRoot,
+            })
+          );
+          yield* fs.chmod(unreadablePath, 0o600).pipe(Effect.ignore);
+          const codex = pipe(
+            result.sources,
+            A.findFirst((source) => source.sourceKind === AiMetricsTranscriptSource.Enum.codex)
+          );
+
+          expect(O.isSome(codex)).toBe(true);
+          if (O.isNone(codex)) {
+            return;
+          }
+          expect(codex.value.candidateFileCount).toBe(2);
+          expect(codex.value.includedFileCount).toBe(1);
+          expect(codex.value.limitedByMaxFiles).toBe(false);
+          expect(result.discoveredFileCount).toBe(1);
+        })
+      ).pipe(Effect.provide(NodeServices.layer));
+    })
+  );
+
+  it.effect(
+    "uses caller-relative paths for Claude source role attribution",
+    Effect.fn(function* () {
+      const content = '{"sessionId":"claude-session","timestamp":"2026-05-05T11:00:00Z"}';
+      const primarySummary = yield* summarizeTranscriptText({
+        content,
+        hashSalt: "test-salt",
+        sourceKind: AiMetricsTranscriptSource.Enum.claude,
+        sourcePath: "/tmp/subagents/workspace/claude.jsonl",
+      });
+      const primary = yield* makeAiMetricsPrivacyCheckResult({
+        content,
+        hashSalt: "test-salt",
+        sourcePath: "/tmp/subagents/workspace/claude.jsonl",
+        summary: primarySummary,
+      });
+      const subagent = yield* makeAiMetricsPrivacyCheckResult({
+        content,
+        hashSalt: "test-salt",
+        relativePath: "subagents/claude.jsonl",
+        sourcePath: "/tmp/workspace/subagents/claude.jsonl",
+        summary: primarySummary,
+      });
+
+      expect(primary.sanitized.sourceRole).toBe("primary");
+      expect(subagent.sanitized.sourceRole).toBe("subagent");
     })
   );
 });

--- a/packages/tooling/tool/cli/src/commands/AIMetrics/index.ts
+++ b/packages/tooling/tool/cli/src/commands/AIMetrics/index.ts
@@ -1280,7 +1280,7 @@ const makeForwarderTimerProgram = Effect.fn("AIMetrics.makeForwarderTimerProgram
     rawArchiveKeySecretRef: yield* resolveRawArchiveKeySecretRef(rawArchiveKeySecretRef),
     target,
   });
-  const dataRootFlag = ` --data-root ${spec.storage.dataRoot}`;
+  const dataRootFlag = ` --data-root ${shellQuote(spec.storage.dataRoot)}`;
   const hashSaltSecretRefFlagText =
     resolvedHashSaltSecretRef === undefined ? "" : ` --hash-salt-secret-ref ${shellQuote(resolvedHashSaltSecretRef)}`;
   const rawArchiveKeySecretRefFlagText =
@@ -1288,7 +1288,7 @@ const makeForwarderTimerProgram = Effect.fn("AIMetrics.makeForwarderTimerProgram
       ? ""
       : ` --raw-archive-key-secret-ref ${shellQuote(resolvedRawArchiveKeySecretRef)}`;
   const otlpFlagText =
-    target === AiMetricsDeployTarget.Enum.dankserver ? ` --otlp --otlp-base-url ${endpoint.baseUrl}` : "";
+    target === AiMetricsDeployTarget.Enum.dankserver ? ` --otlp --otlp-base-url ${shellQuote(endpoint.baseUrl)}` : "";
   const plan = renderAiMetricsForwarderTimerPlan(
     new AiMetricsForwarderTimerInput({
       command: `bun run beep ai-metrics forwarder run --target ${target}${dataRootFlag}${hashSaltSecretRefFlagText}${rawArchiveKeySecretRefFlagText}${otlpFlagText} --json`,
@@ -2394,7 +2394,7 @@ const archiveCommand = Command.make(
     yield* Console.log("AI metrics archive commands:");
     yield* Console.log("- bun run beep ai-metrics archive drill");
     yield* Console.log(
-      "- bun run beep ai-metrics archive drill --target dankserver --data-root .beep/ai-metrics --hash-salt-secret-ref op://TBK/ai-metrics/hash-salt --raw-archive-key-secret-ref op://TBK/ai-metrics/raw-archive-key"
+      `- BEEP_AI_METRICS_RAW_ARCHIVE_KEY="$(op read 'op://TBK/ai-metrics/raw-archive-key')" bun run beep ai-metrics archive drill --target dankserver --data-root .beep/ai-metrics --hash-salt-secret-ref op://TBK/ai-metrics/hash-salt --raw-archive-key-secret-ref op://TBK/ai-metrics/raw-archive-key`
     );
   })
 ).pipe(

--- a/packages/tooling/tool/cli/src/commands/AIMetrics/index.ts
+++ b/packages/tooling/tool/cli/src/commands/AIMetrics/index.ts
@@ -73,6 +73,7 @@ import {
   renderAiMetricsLocalPhoenixCompose,
   runAiMetricsForwarder,
   runAiMetricsOtlpExport,
+  shellQuote,
   sourceDiscoveryToJson,
   summarizeTranscriptText,
   summaryToJson,
@@ -104,7 +105,6 @@ const $I = $RepoCliId.create("commands/AIMetrics");
 const encodeJson = S.encodeUnknownEffect(S.UnknownFromJsonString);
 const encodeInstallSpecJson = S.encodeUnknownEffect(S.fromJsonString(AiMetricsInstallSpec));
 const localCollectorDataRoot = ".beep/ai-metrics";
-const shellQuote = (value: string): string => `'${Str.replace(/'/gu, "'\\''")(value)}'`;
 
 /**
  * Error raised by the AI metrics CLI.


### PR DESCRIPTION
## Summary

Follow-up fixes for unresolved review threads on #121.

- Keeps config snapshots backward-compatible with pre-P6a `latest.json` artifacts and promotes `latest.json` via temp-file rename.
- Corrects timer/systemd behavior: start-limit keys live in `[Unit]`, failure runs still publish a JSON status artifact, and CLI-rendered timer commands quote `dataRoot` / OTLP URL values.
- Tightens source attribution and discovery: deterministic task IDs include `sourceRole`, Claude role detection uses caller-relative paths, Codex discovery streams attribution content until `session_meta`, and transient per-file discovery failures are skipped without misreporting max-file limiting.
- Updates the archive command help example to include the runtime raw archive key read.

## Validation

- `bun run --filter @beep/repo-ai-metrics check`
- `bun run --filter @beep/repo-ai-metrics test` (2 files, 27 tests)
- `bun run --filter @beep/repo-ai-metrics lint`
- `bun run --filter @beep/repo-ai-metrics docgen`
- `bun run --filter @beep/repo-cli check`
- `bun run --filter @beep/repo-cli lint`
- `bun run --filter @beep/repo-cli test` (24 files, 208 tests)
- `git diff --check`
- `bash scripts/run-github-checks.sh quality`

## Review Threads Addressed

Addresses the unresolved CodeRabbit threads on PR #121 for:

- legacy config snapshot decoding
- atomic latest pointer promotion
- deterministic task key source role
- timer failure status publishing
- systemd start-limit section placement
- Claude relative-path role attribution
- transient discovery read/stat failures
- Codex attribution content streaming
- timer command shell quoting
- archive drill example runtime key wiring

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kriegcloud/codesmith/beep-effect/pr/123"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->