### PR TITLE
docs: record jsdoc quality p5 evaluation

### DIFF
--- a/initiatives/jsdoc-quality-enforcement/PLAN.md
+++ b/initiatives/jsdoc-quality-enforcement/PLAN.md
@@ -27,7 +27,8 @@ V1 is implemented as a report-only quality workflow:
 | P2 | Complete | Synthesize cross-lane findings. | `research/synthesis-and-recommendations.md` |
 | P3 | Complete | Challenge the implementation direction. | `grill-with-docs` decision plan |
 | P4 | Complete | Implement report-only V1 quality workflow. | `beep docgen quality`, tests, guidance updates |
-| P5 | Pending | Evaluate enforcement readiness. | Repo-specific evals and threshold proposal |
+| P5 | Complete | Evaluate enforcement readiness. | `research/enforcement-readiness-eval.md`, compact summary artifact |
+| P6 | Pending | Harden before any enforcement. | Runtime bounds, re-export policy, type-only example policy, opt-in warning proposal |
 
 ## V1 Implementation Changes
 
@@ -44,10 +45,14 @@ V1 is implemented as a report-only quality workflow:
 
 ## Future Work
 
-- Build repo-specific eval fixtures before proposing any blocking threshold.
+- Bound package-local report runtime before proposing any blocking threshold.
+- Decide re-export/barrel documentation policy before gating namespace export
+  findings.
+- Decide type-only example usefulness policy before gating observable-result
+  findings on type exports.
 - Decide whether advisory packets should grow into guided Codex remediation
-  execution.
+  execution after packet sizing and prioritization are improved.
 - Revisit local/Qwen workers only behind an eval-only mode with measured
   precision and cost.
-- Consider package opt-in or changed-files-only blocking after V1 reports show
-  stable signal.
+- Consider package opt-in warning mode before changed-files-only blocking after
+  P6 hardening proves stable signal.

--- a/initiatives/jsdoc-quality-enforcement/README.md
+++ b/initiatives/jsdoc-quality-enforcement/README.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-V1 implemented
+V1 implemented; P5 enforcement-readiness eval complete
 
 ## Overview
 
@@ -28,6 +28,9 @@ The command is not a blocking gate.
 ## Operating Rules
 
 - Treat V1 quality findings as advisory report output only.
+- Do not add blocking enforcement until the P6 hardening items from
+  [research/enforcement-readiness-eval.md](./research/enforcement-readiness-eval.md)
+  are resolved.
 - Keep `@example` universal for exported symbols; do not invent exception
   categories in remediation work.
 - Place curated future evaluation reports in `research/`.

--- a/initiatives/jsdoc-quality-enforcement/history/outputs/jsdoc-quality-p5-summary.json
+++ b/initiatives/jsdoc-quality-enforcement/history/outputs/jsdoc-quality-p5-summary.json
@@ -1,0 +1,354 @@
+{
+  "schemaVersion": "1.0.0",
+  "generatedAt": "2026-05-09T06:58:45.455Z",
+  "source": "beep docgen quality",
+  "scope": "P5 architecture-stratified package sample",
+  "totals": {
+    "completedPackages": 9,
+    "failedPackages": 1,
+    "subjects": 1711,
+    "passing": 479,
+    "warnings": 704,
+    "failures": 528
+  },
+  "aggregateFindingCounts": {
+    "example-lacks-observable-result": 734,
+    "example-only-voids-result": 525,
+    "example-too-trivial": 82,
+    "missing-category": 1,
+    "missing-description": 175,
+    "missing-effects-for-effectful-symbol": 65,
+    "missing-example": 413,
+    "missing-since": 1
+  },
+  "samplePackages": [
+    {
+      "slug": "repo-cli",
+      "packageName": "@beep/repo-cli",
+      "packagePath": "packages/tooling/tool/cli",
+      "family": "tooling",
+      "status": "completed",
+      "durationMs": 75250,
+      "exitCode": 0,
+      "rubricVersion": "jsdoc-quality-v1",
+      "scorer": "deterministic-rubric-v1",
+      "summary": {
+        "packages": 1,
+        "subjects": 569,
+        "passing": 92,
+        "warnings": 130,
+        "failures": 347,
+        "remediationPackets": 0
+      },
+      "findingCounts": {
+        "example-lacks-observable-result": 47,
+        "example-only-voids-result": 15,
+        "example-too-trivial": 82,
+        "missing-category": 1,
+        "missing-description": 1,
+        "missing-effects-for-effectful-symbol": 38,
+        "missing-example": 347,
+        "missing-since": 1
+      }
+    },
+    {
+      "slug": "repo-docgen",
+      "packageName": "@beep/repo-docgen",
+      "packagePath": "packages/tooling/tool/docgen",
+      "family": "tooling",
+      "status": "completed",
+      "durationMs": 7248,
+      "exitCode": 0,
+      "rubricVersion": "jsdoc-quality-v1",
+      "scorer": "deterministic-rubric-v1",
+      "summary": {
+        "packages": 1,
+        "subjects": 73,
+        "passing": 7,
+        "warnings": 60,
+        "failures": 6,
+        "remediationPackets": 0
+      },
+      "findingCounts": {
+        "example-lacks-observable-result": 60,
+        "example-only-voids-result": 56,
+        "missing-description": 6,
+        "missing-effects-for-effectful-symbol": 11,
+        "missing-example": 6
+      }
+    },
+    {
+      "slug": "repo-utils",
+      "packageName": "@beep/repo-utils",
+      "packagePath": "packages/tooling/library/repo-utils",
+      "family": "tooling",
+      "status": "completed",
+      "durationMs": 124636,
+      "exitCode": 0,
+      "rubricVersion": "jsdoc-quality-v1",
+      "scorer": "deterministic-rubric-v1",
+      "summary": {
+        "packages": 1,
+        "subjects": 662,
+        "passing": 58,
+        "warnings": 441,
+        "failures": 163,
+        "remediationPackets": 0
+      },
+      "findingCounts": {
+        "example-lacks-observable-result": 556,
+        "example-only-voids-result": 442,
+        "missing-description": 157,
+        "missing-effects-for-effectful-symbol": 14,
+        "missing-example": 48
+      }
+    },
+    {
+      "slug": "schema",
+      "packageName": "@beep/schema",
+      "packagePath": "packages/foundation/modeling/schema",
+      "family": "foundation",
+      "status": "failed",
+      "durationMs": 384288,
+      "exitCode": 124,
+      "summary": null,
+      "findingCounts": {},
+      "notes": "No JSON report was produced before timeout."
+    },
+    {
+      "slug": "types",
+      "packageName": "@beep/types",
+      "packagePath": "packages/foundation/primitive/types",
+      "family": "foundation",
+      "status": "completed",
+      "durationMs": 3809,
+      "exitCode": 0,
+      "rubricVersion": "jsdoc-quality-v1",
+      "scorer": "deterministic-rubric-v1",
+      "summary": {
+        "packages": 1,
+        "subjects": 15,
+        "passing": 12,
+        "warnings": 3,
+        "failures": 0,
+        "remediationPackets": 0
+      },
+      "findingCounts": {
+        "example-lacks-observable-result": 3,
+        "example-only-voids-result": 3
+      }
+    },
+    {
+      "slug": "openai",
+      "packageName": "@beep/openai",
+      "packagePath": "packages/drivers/openai",
+      "family": "drivers",
+      "status": "completed",
+      "durationMs": 3212,
+      "exitCode": 0,
+      "rubricVersion": "jsdoc-quality-v1",
+      "scorer": "deterministic-rubric-v1",
+      "summary": {
+        "packages": 1,
+        "subjects": 2,
+        "passing": 1,
+        "warnings": 0,
+        "failures": 1,
+        "remediationPackets": 0
+      },
+      "findingCounts": {
+        "missing-description": 1,
+        "missing-example": 1
+      }
+    },
+    {
+      "slug": "shared-domain",
+      "packageName": "@beep/shared-domain",
+      "packagePath": "packages/shared/domain",
+      "family": "shared",
+      "status": "completed",
+      "durationMs": 8991,
+      "exitCode": 0,
+      "rubricVersion": "jsdoc-quality-v1",
+      "scorer": "deterministic-rubric-v1",
+      "summary": {
+        "packages": 1,
+        "subjects": 224,
+        "passing": 221,
+        "warnings": 3,
+        "failures": 0,
+        "remediationPackets": 0
+      },
+      "findingCounts": {
+        "example-lacks-observable-result": 1,
+        "missing-effects-for-effectful-symbol": 2
+      }
+    },
+    {
+      "slug": "fixture-domain",
+      "packageName": "@beep/fixture-lab-specimen-domain",
+      "packagePath": "packages/fixture-lab/specimen/domain",
+      "family": "fixture",
+      "status": "completed",
+      "durationMs": 5012,
+      "exitCode": 0,
+      "rubricVersion": "jsdoc-quality-v1",
+      "scorer": "deterministic-rubric-v1",
+      "summary": {
+        "packages": 1,
+        "subjects": 16,
+        "passing": 16,
+        "warnings": 0,
+        "failures": 0,
+        "remediationPackets": 0
+      },
+      "findingCounts": {}
+    },
+    {
+      "slug": "workspace-domain",
+      "packageName": "@beep/workspace-domain",
+      "packagePath": "packages/workspace/domain",
+      "family": "slice",
+      "status": "completed",
+      "durationMs": 5072,
+      "exitCode": 0,
+      "rubricVersion": "jsdoc-quality-v1",
+      "scorer": "deterministic-rubric-v1",
+      "summary": {
+        "packages": 1,
+        "subjects": 68,
+        "passing": 68,
+        "warnings": 0,
+        "failures": 0,
+        "remediationPackets": 0
+      },
+      "findingCounts": {}
+    },
+    {
+      "slug": "identity",
+      "packageName": "@beep/identity",
+      "packagePath": "packages/foundation/modeling/identity",
+      "family": "foundation",
+      "status": "completed",
+      "durationMs": 4534,
+      "exitCode": 0,
+      "replaces": "@beep/schema runtime failure",
+      "rubricVersion": "jsdoc-quality-v1",
+      "scorer": "deterministic-rubric-v1",
+      "summary": {
+        "packages": 1,
+        "subjects": 82,
+        "passing": 4,
+        "warnings": 67,
+        "failures": 11,
+        "remediationPackets": 0
+      },
+      "findingCounts": {
+        "example-lacks-observable-result": 67,
+        "example-only-voids-result": 9,
+        "missing-description": 10,
+        "missing-example": 11
+      }
+    }
+  ],
+  "codexPackets": [
+    {
+      "slug": "repo-cli-codex",
+      "packagePath": "packages/tooling/tool/cli",
+      "status": "completed",
+      "durationMs": 117338,
+      "exitCode": 0,
+      "packageName": "@beep/repo-cli",
+      "scorer": "codex-advisory-packet-v1",
+      "remediationPacketCount": 477,
+      "firstPacketTitles": [
+        "Improve JSDoc for AIDocsError",
+        "Improve JSDoc for AIDocKind",
+        "Improve JSDoc for AIDocKind"
+      ]
+    },
+    {
+      "slug": "openai-codex",
+      "packagePath": "packages/drivers/openai",
+      "status": "completed",
+      "durationMs": 2743,
+      "exitCode": 0,
+      "packageName": "@beep/openai",
+      "scorer": "codex-advisory-packet-v1",
+      "remediationPacketCount": 1,
+      "firstPacketTitles": ["Improve JSDoc for VERSION"]
+    },
+    {
+      "slug": "identity-codex",
+      "packagePath": "packages/foundation/modeling/identity",
+      "status": "completed",
+      "durationMs": 4180,
+      "exitCode": 0,
+      "packageName": "@beep/identity",
+      "scorer": "codex-advisory-packet-v1",
+      "remediationPacketCount": 78,
+      "firstPacketTitles": [
+        "Improve JSDoc for IdentityInterpolationError",
+        "Improve JSDoc for make",
+        "Improve JSDoc for IdentityComposer"
+      ]
+    }
+  ],
+  "triage": [
+    {
+      "packageName": "@beep/openai",
+      "symbol": "VERSION",
+      "sourceAnchor": "packages/drivers/openai/src/index.ts:12",
+      "findingCodes": ["missing-description", "missing-example"],
+      "classification": "true-positive",
+      "recommendation": "Keep as advisory finding; suitable for package opt-in after runtime and re-export policy issues are resolved."
+    },
+    {
+      "packageName": "@beep/repo-cli",
+      "symbol": "ciCommand",
+      "sourceAnchor": "packages/tooling/tool/cli/src/commands/Ci.ts:337",
+      "findingCodes": ["example-too-trivial"],
+      "classification": "true-positive",
+      "recommendation": "Keep heuristic; console.log of a symbol name is low-value documentation."
+    },
+    {
+      "packageName": "@beep/types",
+      "symbol": "Elem",
+      "sourceAnchor": "packages/foundation/primitive/types/src/TArray.types.ts:29",
+      "findingCodes": [
+        "example-only-voids-result",
+        "example-lacks-observable-result"
+      ],
+      "classification": "policy-gap",
+      "recommendation": "Define type-only example policy before gating; type-level examples can be useful even when they end with void or comments."
+    },
+    {
+      "packageName": "@beep/shared-domain",
+      "symbol": "fromString",
+      "sourceAnchor": "packages/shared/domain/src/values/LocalDate/LocalDate.behavior.ts:207",
+      "findingCodes": ["missing-effects-for-effectful-symbol"],
+      "classification": "true-positive",
+      "recommendation": "Good candidate for future changed-files warning because the example is meaningful but the Effect contract prose is missing."
+    },
+    {
+      "packageName": "@beep/repo-docgen",
+      "symbol": "export * as Checker",
+      "sourceAnchor": "packages/tooling/tool/docgen/src/index.ts:12",
+      "findingCodes": ["missing-description", "missing-example"],
+      "classification": "tooling-gap",
+      "recommendation": "Decide re-export/barrel policy before blocking; some namespace re-exports may need generated or inherited docs instead of hand-written examples."
+    },
+    {
+      "packageName": "@beep/schema",
+      "symbol": "<package report>",
+      "sourceAnchor": "packages/foundation/modeling/schema",
+      "findingCodes": ["runtime-timeout"],
+      "classification": "tooling-gap",
+      "recommendation": "Do not gate until package-local report runtime has bounded behavior for large schema-heavy packages."
+    }
+  ],
+  "recommendation": {
+    "posture": "keep-report-only",
+    "nextAction": "Plan a P6 follow-up that first fixes runtime bounds and re-export/type-only policy gaps, then considers package opt-in warnings before any blocking gate."
+  }
+}

--- a/initiatives/jsdoc-quality-enforcement/ops/manifest.json
+++ b/initiatives/jsdoc-quality-enforcement/ops/manifest.json
@@ -3,7 +3,7 @@
   "initiative": {
     "id": "jsdoc-quality-enforcement",
     "title": "JSDoc Quality Enforcement",
-    "status": "v1-implemented",
+    "status": "p5-evaluated",
     "created": "2026-05-08",
     "updated": "2026-05-09",
     "packetAnchorDocument": "SPEC.md"
@@ -35,8 +35,15 @@
       "title": "Synthesis And Recommendations",
       "status": "complete",
       "output": "research/synthesis-and-recommendations.md"
+    },
+    {
+      "id": "enforcement-readiness-eval",
+      "title": "Enforcement Readiness Evaluation",
+      "status": "complete",
+      "output": "research/enforcement-readiness-eval.md"
     }
   ],
+  "evaluationOutputs": ["history/outputs/jsdoc-quality-p5-summary.json"],
   "implementedSurfaces": [
     "packages/tooling/tool/cli/src/commands/Docgen/index.ts",
     "packages/tooling/tool/cli/src/commands/Docgen/internal/Quality.ts",
@@ -52,5 +59,5 @@
     "local model workers",
     "example exception categories"
   ],
-  "nextAction": "Collect repo-specific quality report examples and evaluate whether any advisory finding should become a future opt-in gate."
+  "nextAction": "Plan P6 hardening before enforcement: bound docgen quality runtime, decide re-export/barrel policy, decide type-only example policy, and only then consider package opt-in warnings."
 }

--- a/initiatives/jsdoc-quality-enforcement/research/enforcement-readiness-eval.md
+++ b/initiatives/jsdoc-quality-enforcement/research/enforcement-readiness-eval.md
@@ -1,0 +1,144 @@
+# Enforcement Readiness Evaluation
+
+## Question
+
+Can the V1 `beep docgen quality` advisory workflow support a future blocking or
+opt-in enforcement gate now, or does the repo need another hardening phase
+first?
+
+## Scope
+
+This evaluation sampled package-local `beep docgen quality` reports across the
+repo's architecture families:
+
+- tooling: `@beep/repo-cli`, `@beep/repo-docgen`, `@beep/repo-utils`
+- foundation: `@beep/schema`, `@beep/types`, and replacement
+  `@beep/identity`
+- drivers: `@beep/openai`
+- shared kernel: `@beep/shared-domain`
+- executable architecture fixture: `@beep/fixture-lab-specimen-domain`
+- product slice domain: `@beep/workspace-domain`
+
+The pass intentionally did not fix source JSDoc, change the quality rubric,
+add a gate, run model remediation, or evaluate local model workers.
+
+## Repo Evidence
+
+The initiative packet says V1 is report-only and that enforcement must wait for
+repo-specific evals. The binding architecture standard routes repo operations,
+policy packs, generators, and automation to `tooling`, so the V1 ownership in
+`@beep/repo-cli` remains doctrinally correct; this P5 pass does not require a
+new slice, shared-kernel package, foundation package, or driver.
+
+Full raw package reports were written to `/tmp/jsdoc-quality-p5/` during the
+run. The committed compact summary is
+[`../history/outputs/jsdoc-quality-p5-summary.json`](../history/outputs/jsdoc-quality-p5-summary.json).
+
+Completed deterministic package reports covered 1,711 subjects:
+
+| Package | Family | Runtime | Subjects | Pass | Warn | Fail |
+|---|---:|---:|---:|---:|---:|---:|
+| `@beep/repo-cli` | tooling | 75.250s | 569 | 92 | 130 | 347 |
+| `@beep/repo-docgen` | tooling | 7.248s | 73 | 7 | 60 | 6 |
+| `@beep/repo-utils` | tooling | 124.636s | 662 | 58 | 441 | 163 |
+| `@beep/schema` | foundation | 384.288s | n/a | n/a | n/a | n/a |
+| `@beep/types` | foundation | 3.809s | 15 | 12 | 3 | 0 |
+| `@beep/openai` | drivers | 3.212s | 2 | 1 | 0 | 1 |
+| `@beep/shared-domain` | shared | 8.991s | 224 | 221 | 3 | 0 |
+| `@beep/fixture-lab-specimen-domain` | fixture | 5.012s | 16 | 16 | 0 | 0 |
+| `@beep/workspace-domain` | slice | 5.072s | 68 | 68 | 0 | 0 |
+| `@beep/identity` | foundation replacement | 4.534s | 82 | 4 | 67 | 11 |
+
+`@beep/schema` did not produce a JSON report before the runtime ceiling. It was
+terminated and recorded as a runtime/tooling gap. `@beep/identity` was added as
+a same-family foundation/modeling replacement sample.
+
+Aggregate deterministic finding counts across completed package reports:
+
+| Finding code | Count |
+|---|---:|
+| `example-lacks-observable-result` | 734 |
+| `example-only-voids-result` | 525 |
+| `example-too-trivial` | 82 |
+| `missing-category` | 1 |
+| `missing-description` | 175 |
+| `missing-effects-for-effectful-symbol` | 65 |
+| `missing-example` | 413 |
+| `missing-since` | 1 |
+
+Selective `--score codex` packet runs completed without executing any model or
+making edits:
+
+| Package | Runtime | Packets |
+|---|---:|---:|
+| `@beep/repo-cli` | 117.338s | 477 |
+| `@beep/openai` | 2.743s | 1 |
+| `@beep/identity` | 4.180s | 78 |
+
+## External Evidence
+
+No new external evidence was needed for this pass. P5 evaluated the V1 workflow
+against repo-local reports, architecture doctrine, and the initiative decisions
+already captured in prior research.
+
+## Options
+
+1. Keep the workflow report-only until runtime and rubric gaps are hardened.
+2. Add package opt-in warnings for packages with clean runtime and low false
+   positive risk.
+3. Add changed-files blocking now for high-confidence finding codes only.
+4. Add repo-wide blocking now.
+
+## Tradeoffs And Risks
+
+The strongest signals are real and useful. Missing examples, missing
+descriptions, obviously trivial examples such as `console.log("ciCommand")`,
+and missing `@effects` prose on effectful symbols point to actual documentation
+quality gaps.
+
+The current signal is not gate-ready. Three gaps matter most:
+
+- Runtime is not bounded enough. `@beep/schema` failed to produce a package
+  report before the eval ceiling, while `@beep/repo-utils` and Codex packet
+  mode for `@beep/repo-cli` were both slow enough to be poor candidates for
+  casual changed-files enforcement.
+- Re-export/barrel findings need policy. Namespace re-exports in
+  `@beep/repo-docgen` and `@beep/repo-utils` are flagged as missing
+  descriptions and examples, but the durable policy might be inherited docs,
+  generated docs, or a narrower requirement rather than hand-written examples
+  on every barrel export.
+- Type-only examples need a separate usefulness rule. Several `@beep/types`
+  examples are useful type-level examples, but the current observable-result
+  heuristic treats `void` and comment-only type assertions as weak examples.
+
+Codex remediation packets are useful as bounded work queues, but their volume
+tracks every advisory finding. Packet generation should remain advisory until
+batch sizing and prioritization are improved.
+
+## Recommendation
+
+Keep P5 report-only and do not add a blocking gate yet.
+
+The next initiative step should be a P6 hardening branch, not an enforcement
+branch. P6 should:
+
+1. Bound package-local report runtime and investigate the `@beep/schema`
+   timeout before any gate is proposed.
+2. Decide and encode re-export/barrel documentation policy.
+3. Decide and encode type-only example policy so useful type examples are not
+   penalized only because they lack runtime output.
+4. Add a smaller gate candidate mode only after those issues are fixed, likely
+   package opt-in warnings before changed-files blocking.
+
+## Open Questions
+
+- Should namespace re-exports inherit documentation from their target module,
+  require their own concise barrel docs, or be excluded from `@example`
+  usefulness scoring?
+- What observable-result rule should apply to type-only exports where runtime
+  output is not the point of the example?
+- Why does `@beep/schema` exceed the eval ceiling, and is the cause subject
+  count, ts-morph enrichment, schema-heavy source parsing, or a specific
+  declaration?
+- Should Codex remediation packets be capped by package, finding tier, or
+  changed-file scope before they are used in routine workflows?


### PR DESCRIPTION
## Summary
- record the P5 enforcement-readiness evaluation for the JSDoc quality initiative
- preserve the compact package-sample summary artifact
- mark the next initiative action as P6 hardening before enforcement

## Verification
- jq empty initiatives/jsdoc-quality-enforcement/ops/manifest.json initiatives/jsdoc-quality-enforcement/history/outputs/jsdoc-quality-p5-summary.json
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kriegcloud/codesmith/beep-effect/pr/128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Completed JSDoc quality enforcement evaluation phase with published findings report.
  * Updated initiative roadmap defining next hardening requirements including runtime bounds and policy decisions.
  * Added enforcement readiness assessment documenting evaluation scope and findings analysis.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kriegcloud/beep-effect/pull/128)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->