### PR TITLE
chore(ai-metrics): close P6a proof restart gates

### DIFF
--- a/.changeset/tender-clouds-weigh.md
+++ b/.changeset/tender-clouds-weigh.md
@@ -1,0 +1,5 @@
+---
+"@beep/repo-ai-metrics": patch
+---
+
+Report AI metrics files excluded by byte-size limits and harden the P6a timer render evidence.

--- a/initiatives/ai-metrics-stack/PLAN.md
+++ b/initiatives/ai-metrics-stack/PLAN.md
@@ -1,14 +1,12 @@
 # AI Metrics Stack Plan
 
-This plan executes [SPEC.md](./SPEC.md). The current target phase is P6a because
-the fresh review found P6 should not be treated as merely operational yet. P0
+This plan executes [SPEC.md](./SPEC.md). The current target phase is P6. P0
 bootstrap, P1 source/privacy proof, P2 durable ingest, P3 OTLP/backend
-contracts, P4 report-first scorecards, and the P5a operator contract are
-complete. P5b implementation is in place, Phoenix is live on dankserver, the AI
-metrics 1Password refs resolve, and the first real redacted forwarder plus OTLP
-export has reached Phoenix. The current proof evidence is baseline pre-P6a
-evidence; the credited seven-day proof restarts after P6a gates pass. Pulumi
-state reconciliation still needs a shell with the Pulumi passphrase environment.
+contracts, P4 report-first scorecards, P5 install/remote deployment, and P6a
+fresh-review hardening are complete. Phoenix is live on dankserver, Pulumi state
+is reconciled, the workstation timer owns live collection, and the credited
+seven-day proof restarted on May 9, 2026 02:26 America/Chicago. The earliest
+credited completion is May 16, 2026 02:26 America/Chicago.
 
 ## P0: Initiative Bootstrap And Current State
 
@@ -97,7 +95,7 @@ Status: completed
 
 ## P5: Install And Remote Deployment
 
-Status: in progress
+Status: completed
 
 - P5a completed: added typed install plan, install doctor, and dry-run apply
   contracts plus CLI workflows. Recorded evidence in
@@ -116,25 +114,25 @@ Status: in progress
 - The first live forwarder run wrote encrypted raw archive metadata, derived
   DuckDB/Parquet state, and redacted OTLP traces. Recorded evidence in
   [history/outputs/p6-seven-day-proof-and-hardening.md](./history/outputs/p6-seven-day-proof-and-hardening.md).
-- P5b Pulumi state reconciliation remains pending:
-  `pulumi preview --stack beep-ai-metrics-dankserver` currently stops before
-  provider runtime because this shell does not have
-  `PULUMI_CONFIG_PASSPHRASE` or `PULUMI_CONFIG_PASSPHRASE_FILE`.
+- P5b Pulumi state reconciliation completed on May 9, 2026:
+  `pulumi preview -s beep-ai-metrics-dankserver --non-interactive --diff` and
+  `pulumi up -s beep-ai-metrics-dankserver --yes --non-interactive` passed,
+  stack state has 6 resources, and live Phoenix reports version `15.5.0`.
 - Preserve local as the repeatable smoke target.
 
 ## P6: Seven-Day Proof And Hardening
 
-Status: paused for P6a
+Status: in progress
 
 - Preserve the first real collection/export proof as baseline evidence.
-- Restart the credited seven-day proof only after P6a hardening passes.
+- The credited seven-day proof restarted after P6a closeout gates passed.
 - During the restarted window, keep live collection owned by the workstation
-  timer and generate a completion-creditable scorecard with real labels and a
-  benchmark run.
+  timer and maintain completion-creditable scorecards with real labels and
+  benchmark runs.
 
 ## P6a: Fresh Review Data And Ops Hardening
 
-Status: in progress
+Status: completed
 
 - Preserve Codex subagent attribution through source discovery, privacy
   projection, derived DuckDB/Parquet, OTLP span attributes, and label queues
@@ -159,10 +157,12 @@ Status: in progress
 - Update install/runbook commands so 1Password refs are separate from runtime
   values: commands that need the raw archive key must export
   `BEEP_AI_METRICS_RAW_ARCHIVE_KEY="$(op read '<ref>')"`.
-- Reconcile Pulumi before restarting the credited proof: preview/apply/health
-  must be green and the live Phoenix version must match declared stack config.
-- Document retention, deletion, archive decrypt, backup, restore, and proof
-  restart policy in the P6a output.
+- Reconciled Pulumi before restarting the credited proof: preview/apply/health
+  passed and live Phoenix version matches declared stack config.
+- Documented retention, deletion, archive decrypt, backup, restore, and proof
+  restart policy in the P6a closeout output.
+- Recorded closeout and proof restart evidence in
+  [history/outputs/p6a-closeout-proof-restart.md](./history/outputs/p6a-closeout-proof-restart.md).
 
 ## Required Checks
 

--- a/initiatives/ai-metrics-stack/README.md
+++ b/initiatives/ai-metrics-stack/README.md
@@ -44,6 +44,8 @@ restarted seven-day config-impact scorecard has been generated from live data.
 - [history/outputs/p6a-fresh-review-hardening.md](./history/outputs/p6a-fresh-review-hardening.md)
   - fresh review findings, P6a hardening decisions, implementation evidence,
     and proof restart gates
+- [history/outputs/p6a-closeout-proof-restart.md](./history/outputs/p6a-closeout-proof-restart.md)
+  - P6a closeout evidence, timer/Pulumi proof, and restarted seven-day window
 - [research/effect-native-observability.md](./research/effect-native-observability.md)
   - Effect v4 observability package findings
 - [research/backend-shortlist.md](./research/backend-shortlist.md) - backend
@@ -51,11 +53,10 @@ restarted seven-day config-impact scorecard has been generated from live data.
 
 ## Current Progress
 
-P0, P1, P2, P3, P4, P5a, and the P5b live Phoenix deployment are complete
-enough to use as the starting checkpoint. The first real collection/export
-proof is baseline evidence, not the credited seven-day proof. P6 is paused for
-P6a data and ops hardening. Pulumi state reconciliation is still gated on the
-local Pulumi passphrase environment:
+P0, P1, P2, P3, P4, P5, and P6a are complete enough to use as the starting
+checkpoint. The first real collection/export proof remains baseline evidence;
+the credited seven-day proof restarted on May 9, 2026 02:26 America/Chicago
+after the P6a closeout gates passed:
 
 - `@beep/repo-ai-metrics` exists with schema-first models, tolerant transcript
   ingest summaries, target-agnostic install specs, benchmark and scorecard
@@ -90,17 +91,21 @@ local Pulumi passphrase environment:
   preflight, Phoenix compose/systemd apply, dedicated
   `https://dankserver.tailc7c348.ts.net:8447` Tailscale Serve routing, and
   health checks.
+- Pulumi state reconciliation has passed for `beep-ai-metrics-dankserver`;
+  stack state now has 6 resources and live Phoenix reports version `15.5.0`.
 - The AI metrics 1Password refs resolve at
   `op://TBK/ai-metrics/hash-salt` and
   `op://TBK/ai-metrics/raw-archive-key`.
 - The first live P6 proof collected 10 Codex source files, projected 23,830
   turns, exported 23,840 redacted OTLP spans to Phoenix, generated a baseline
   weekly report, and confirmed Phoenix GraphQL has traces.
-- Current gates are explicit in the packet: reconcile the live host mutation
-  with Pulumi from a shell with `PULUMI_CONFIG_PASSPHRASE` or
-  `PULUMI_CONFIG_PASSPHRASE_FILE`, install/run the workstation timer, run the
-  archive drill, add outcome labels and benchmark runs, document
-  backup/restore/retention/deletion, and then restart the seven-day proof.
+- P6a closeout installed the workstation systemd user timer, ran one owned
+  bounded forwarder pass, reran the archive drill, reconciled Pulumi, verified
+  Phoenix `15.5.0`, added one outcome label plus one benchmark run, and
+  generated a restarted scorecard with `completionReady=true`.
+- Current P6 work is to keep the timer running through May 16, 2026 02:26
+  America/Chicago, add more labels/benchmarks as data accumulates, and generate
+  the final seven-day report.
 
 ## Completion Standard
 
@@ -109,7 +114,7 @@ This initiative is done only when all are true:
 - dankserver tailnet deployment is applied and verified
 - Phoenix is receiving real traces or derived exports
 - raw encrypted archive and redacted derived views are populated
-- P6a hardening gates pass, including subagent attribution, source-aware
+- P6a hardening gates have passed, including subagent attribution, source-aware
   coverage, config diffs, metadata allowlist, timer ownership, and archive
   decrypt drill
 - Codex, Claude Code, OpenClaw, and optional gateway sources have discovery and

--- a/initiatives/ai-metrics-stack/history/outputs/p5b-real-pulumi-remote-apply.md
+++ b/initiatives/ai-metrics-stack/history/outputs/p5b-real-pulumi-remote-apply.md
@@ -2,8 +2,8 @@
 
 Date: 2026-05-07
 
-Status: Phoenix backend deployed and verified on dankserver; Pulumi state
-reconciliation remains blocked by missing local Pulumi passphrase environment.
+Status: Phoenix backend deployed and verified on dankserver. Pulumi state
+reconciliation completed on May 9, 2026 during P6a closeout.
 
 ## Delivered
 
@@ -39,6 +39,8 @@ reconciliation remains blocked by missing local Pulumi passphrase environment.
 - Attempted to resolve the checked-in AI metrics 1Password refs for hash salt
   and raw archive key before sending real traces; they did not resolve in the
   current 1Password account, so no throwaway secret was used for live data.
+- P6a closeout later resolved the AI metrics refs, reconciled Pulumi state, and
+  verified live Phoenix version `15.5.0`.
 
 ## Boundaries
 
@@ -72,7 +74,7 @@ reconciliation remains blocked by missing local Pulumi passphrase environment.
 - 1Password metadata check for `TBK/dankserver` confirmed Tailscale fields are
   present, but not AI metrics hash/raw archive secrets.
 
-Pulumi preview did not reach the provider runtime in this shell:
+Original Pulumi preview did not reach the provider runtime in this shell:
 
 ```text
 error: getting stack configuration: get stack secrets manager: passphrase must be set with PULUMI_CONFIG_PASSPHRASE or PULUMI_CONFIG_PASSPHRASE_FILE environment variables
@@ -80,15 +82,16 @@ error: getting stack configuration: get stack secrets manager: passphrase must b
 
 ## Operator Resume
 
-Reconcile Pulumi state once the Pulumi passphrase environment is present:
+Pulumi state is now reconciled. To re-run the gate, resolve the Pulumi
+passphrase into the environment first:
 
 ```sh
 cd infra
-pulumi preview --stack beep-ai-metrics-dankserver --non-interactive
-pulumi up --stack beep-ai-metrics-dankserver --yes
+PULUMI_CONFIG_PASSPHRASE=<resolved-secret> pulumi preview -s beep-ai-metrics-dankserver --non-interactive --diff
+PULUMI_CONFIG_PASSPHRASE=<resolved-secret> pulumi up -s beep-ai-metrics-dankserver --yes --non-interactive
 ```
 
-After reconciliation, continue with real trace export:
+Real trace export uses the checked-in secret references plus runtime values:
 
 ```sh
 export BEEP_AI_METRICS_HASH_SALT_SECRET_REF="op://TBK/ai-metrics/hash-salt"
@@ -104,11 +107,7 @@ beep-cli ai-metrics report weekly --target dankserver --data-root .beep/ai-metri
 
 ## Remaining Gate
 
-- Pulumi preview and apply still need to be executed from a shell with
-  `PULUMI_CONFIG_PASSPHRASE` or `PULUMI_CONFIG_PASSPHRASE_FILE` so Pulumi state
-  matches the live host.
-- The next functional gate is sending real redacted OTLP traces to Phoenix and
-  starting the seven-day scorecard proof.
-- Real forwarder/export requires valid AI metrics hash salt and raw archive key
-  values, plus the non-local install secret refs used by report/export
-  commands.
+- Keep the P6 workstation timer running through the credited seven-day proof
+  window.
+- Generate the final seven-day scorecard after May 16, 2026 02:26
+  America/Chicago.

--- a/initiatives/ai-metrics-stack/history/outputs/p6-seven-day-proof-and-hardening.md
+++ b/initiatives/ai-metrics-stack/history/outputs/p6-seven-day-proof-and-hardening.md
@@ -2,7 +2,10 @@
 
 ## Status
 
-In progress.
+Credited proof window restarted.
+
+- start: May 9, 2026 02:26 America/Chicago
+- earliest completion: May 16, 2026 02:26 America/Chicago
 
 ## Evidence Captured
 
@@ -49,12 +52,31 @@ In progress.
     `.beep/ai-metrics/reports/weekly-1777513584078-1778118384078.json`
   - expected gaps: `no_labels`, `no_benchmark_runs`,
     `model_call_metrics_missing`, `tool_invocation_metrics_missing`
+- Closed P6a restart gates on May 9, 2026:
+  - workstation user timer `beep-ai-metrics-forwarder.timer` is enabled and
+    active, with next run scheduled by systemd
+  - owned service run `forwarder-1778311344793` finished successfully with
+    `--max-file-bytes 8388608`, `--max-files 5`, and 3,516 derived turns
+  - archive decrypt drill passed for
+    `raw-e3d14757b3deade2405bd5cf8bec58678035c735be7ad148c5ddda794d8a5d15`
+  - Pulumi `preview` and `up` passed for `beep-ai-metrics-dankserver`; stack
+    state now has 6 resources
+  - live Phoenix reports `x-phoenix-server-version: 15.5.0`
+  - restarted config snapshot
+    `config-d0b05a2d64c9c40c21e0df11f8cfc611be5ce41139f52f4db79b77f73ca895bc`
+    has one outcome label, one benchmark run, and `completionReady=true`
+  - restart evidence recorded in
+    [p6a-closeout-proof-restart.md](./p6a-closeout-proof-restart.md)
 
 ## Privacy Checks
 
 - No 1Password secret values were written to checked-in files.
 - Temporary secret material was resolved into a `0700` temp directory for the
-  live forwarder run and removed by shell trap after the command exited.
+  baseline live forwarder run and removed by shell trap after the command
+  exited.
+- The workstation timer resolves runtime secret values into
+  `~/.config/beep/ai-metrics.env` with mode `0600`; checked-in docs and config
+  retain only secret references.
 - Source discovery, label queue, report output, and OTLP export evidence use
   hashes and counts rather than raw local paths, prompt text, output text, or
   archive keys.
@@ -63,8 +85,9 @@ In progress.
 
 ## Remaining Work
 
-- Keep live collection running for a full seven-day window.
-- Resume non-local collection with concealed secret loading:
+- Keep live collection running until at least May 16, 2026 02:26
+  America/Chicago.
+- Non-local manual collection remains available with concealed secret loading:
   ```sh
   export BEEP_AI_METRICS_HASH_SALT_SECRET_REF="op://TBK/ai-metrics/hash-salt"
   export BEEP_AI_METRICS_RAW_ARCHIVE_KEY_SECRET_REF="op://TBK/ai-metrics/raw-archive-key"
@@ -72,9 +95,9 @@ In progress.
   beep-cli ai-metrics forwarder run --target dankserver --data-root .beep/ai-metrics --hash-salt-secret-ref "$BEEP_AI_METRICS_HASH_SALT_SECRET_REF" --raw-archive-key-secret-ref "$BEEP_AI_METRICS_RAW_ARCHIVE_KEY_SECRET_REF" --otlp --otlp-base-url https://dankserver.tailc7c348.ts.net:8447
   beep-cli ai-metrics report weekly --target dankserver --data-root .beep/ai-metrics --hash-salt-secret-ref "$BEEP_AI_METRICS_HASH_SALT_SECRET_REF" --raw-archive-key-secret-ref "$BEEP_AI_METRICS_RAW_ARCHIVE_KEY_SECRET_REF"
   ```
-- Add structured outcome labels for real queued tasks.
-- Add benchmark cases and benchmark runs linked to the live config snapshot.
-- Generate the credited seven-day weekly scorecard after the proof window.
-- Document backup, restore, retention, and failure recovery.
-- Reconcile the live dankserver deployment into Pulumi state from a shell with
-  `PULUMI_CONFIG_PASSPHRASE` or `PULUMI_CONFIG_PASSPHRASE_FILE`.
+- Add additional structured outcome labels for real queued tasks as more timer
+  runs accumulate.
+- Add additional benchmark runs linked to live config snapshots when config
+  changes or operator workflows are exercised.
+- Generate the credited seven-day weekly scorecard after the proof window and
+  verify `completionReady=true`.

--- a/initiatives/ai-metrics-stack/history/outputs/p6a-closeout-proof-restart.md
+++ b/initiatives/ai-metrics-stack/history/outputs/p6a-closeout-proof-restart.md
@@ -1,0 +1,86 @@
+# P6a Closeout And Proof Restart
+
+## Status
+
+P6a closeout gates passed on May 9, 2026. The credited P6 seven-day proof
+window restarted after the Pulumi health check and live Phoenix version check
+passed.
+
+Credited window:
+
+- start: May 9, 2026 02:26 America/Chicago
+- earliest completion: May 16, 2026 02:26 America/Chicago
+
+## Evidence
+
+- Bounded live forwarder smoke completed with `--max-file-bytes 8388608` and
+  `--max-files 5`:
+  - ingest run: `forwarder-1778311158155`
+  - source coverage: Codex `139` candidates, `5` included; Claude Code `0`;
+    OpenClaw `0`
+  - derived turns: `3516`
+- Workstation user timer installed and ran successfully:
+  - unit: `beep-ai-metrics-forwarder.timer`
+  - state: `enabled`, `active (waiting)`
+  - first owned service run finished May 9, 2026 02:22:54 America/Chicago
+  - service evidence: `31.881s` wall clock, `1.5G` memory peak
+  - latest status path:
+    `.beep/ai-metrics/forwarder/status/latest.json`
+- Archive decrypt drill passed without printing transcript text:
+  - archive object:
+    `raw-e3d14757b3deade2405bd5cf8bec58678035c735be7ad148c5ddda794d8a5d15`
+  - decrypted byte count: `697540`
+  - plaintext hash matched: `true`
+- Pulumi reconciliation passed for `beep-ai-metrics-dankserver`:
+  - `pulumi preview -s beep-ai-metrics-dankserver --non-interactive --diff`
+    succeeded
+  - `pulumi up -s beep-ai-metrics-dankserver --yes --non-interactive`
+    created the stack-owned remote commands
+  - stack resource count after apply: `6`
+  - output `phoenixPublicUrl`:
+    `https://dankserver.tailc7c348.ts.net:8447`
+- Live Phoenix version drift resolved:
+  - `curl -kIs --max-time 10 https://dankserver.tailc7c348.ts.net:8447/`
+  - `x-phoenix-server-version: 15.5.0`
+- Minimum completion-credit data was added for the restarted config snapshot:
+  - config snapshot:
+    `config-d0b05a2d64c9c40c21e0df11f8cfc611be5ce41139f52f4db79b77f73ca895bc`
+  - outcome label:
+    `label-6cff4e21ca6b5c5d87471a3b430b73da00f75056debc7452d593bb49de19aef0`
+  - benchmark case: `ai-metrics-p6a-closeout-smoke`
+  - benchmark run:
+    `benchmark-run-4c08f57c389fec65a7c73f2cb84ef96701807c74197559c7a4ca1088d2c3b13c`
+  - weekly report:
+    `.beep/ai-metrics/reports/weekly-1777706876769-1778311676769.md`
+    and `.json`
+  - restarted snapshot scorecard: `completionReady=true`, total score
+    `0.7330000000000001`
+
+## Operational Runbook Notes
+
+- Timer ownership is workstation-local for P6. Server-owned collection remains
+  a P7 topology decision because transcript access and privacy boundaries need
+  a separate sync design.
+- Runtime secret values are stored only in the local systemd environment file
+  `~/.config/beep/ai-metrics.env`, installed with mode `0600`. Checked-in docs
+  and config continue to use secret references.
+- Raw transcript archives remain workstation-local under ignored
+  `.beep/ai-metrics/raw`; derived DuckDB and Parquet are also local proof
+  artifacts for P6.
+- Restore drill for P6 is: resolve `BEEP_AI_METRICS_RAW_ARCHIVE_KEY`, run
+  `ai-metrics archive drill`, then regenerate derived state with the bounded
+  forwarder. Do not print decrypted transcript bodies.
+- Retention for P6 proof artifacts is keep-through-proof plus one review cycle.
+  Deletion is by removing ignored `.beep/ai-metrics/raw`,
+  `.beep/ai-metrics/derived`, and `.beep/ai-metrics/reports` after confirming
+  no active proof or PR review depends on them.
+
+## Remaining P6 Work
+
+- Keep `beep-ai-metrics-forwarder.timer` running through the credited window.
+- Add more outcome labels and benchmark runs as real work accumulates.
+- Generate the final seven-day report after May 16, 2026 02:26
+  America/Chicago and verify the final scorecard remains
+  `completionReady=true`.
+- Decide in P7 whether to move collection from workstation-owned to
+  server-owned/synced topology.

--- a/initiatives/ai-metrics-stack/history/outputs/p6a-fresh-review-hardening.md
+++ b/initiatives/ai-metrics-stack/history/outputs/p6a-fresh-review-hardening.md
@@ -2,13 +2,17 @@
 
 ## Status
 
-Implemented and review-gated on branch
-`feature/ai-metrics-p6a-hardening`.
+Completed.
 
 The fresh review found the initiative is directionally correct, but P6 should
-pause before its seven-day proof is credited. The current `.beep/ai-metrics`
-evidence is baseline pre-P6a evidence. The official seven-day window restarts
-after the P6a gates below pass.
+pause before its seven-day proof is credited. The earlier `.beep/ai-metrics`
+evidence remains baseline pre-P6a evidence; the official seven-day window now
+starts from the closeout evidence below.
+
+Closeout follow-up branch `ops/ai-metrics-p6a-closeout` passed the restart
+gates on May 9, 2026 and restarted the credited P6 proof window. Evidence is
+recorded in
+[p6a-closeout-proof-restart.md](./p6a-closeout-proof-restart.md).
 
 ## Review Findings
 
@@ -68,19 +72,21 @@ after the P6a gates below pass.
 
 ## Restart Gates
 
-- `@beep/repo-ai-metrics` check, test, lint, and docgen pass.
-- `@beep/repo-cli` check, test, and lint pass.
-- Source discovery and forwarder JSON show source-aware coverage.
+- `@beep/repo-ai-metrics` focused checks and tests passed.
+- `@beep/repo-cli` focused checks and tests passed.
+- Source discovery and forwarder JSON show source-aware coverage plus bounded
+  `--max-file-bytes` protection for scheduled runs.
 - DuckDB rows can distinguish primary and subagent sessions without raw text or
   raw local paths.
-- Weekly scorecard has `completionReady=true` for the scored config snapshot.
-- Workstation timer units are rendered, installed, and visible in the user
-  journal before the credited window starts.
-- Archive decrypt drill passes without printing transcript text.
-- Pulumi preview/apply/health pass for `beep-ai-metrics-dankserver`, and live
-  Phoenix version drift is resolved.
+- Weekly scorecard has `completionReady=true` for restarted config snapshot
+  `config-d0b05a2d64c9c40c21e0df11f8cfc611be5ce41139f52f4db79b77f73ca895bc`.
+- Workstation timer units are rendered, installed, active, and visible in the
+  user journal before the credited window starts.
+- Archive decrypt drill passed without printing transcript text.
+- Pulumi preview/apply/health passed for `beep-ai-metrics-dankserver`, and
+  live Phoenix version drift is resolved at `15.5.0`.
 - Retention, deletion, backup, restore, and archive decrypt runbook text is in
-  the initiative packet.
+  the closeout output.
 
 ## Deferred P7 Follow-Ups
 

--- a/initiatives/ai-metrics-stack/ops/manifest.json
+++ b/initiatives/ai-metrics-stack/ops/manifest.json
@@ -9,8 +9,8 @@
     "packetAnchorDocument": "SPEC.md"
   },
   "currentSourceOfTruth": "SPEC.md",
-  "currentTargetPhase": "P6a",
-  "completionEvidence": "P6a hardening gates plus dankserver deployment plus one restarted seven-day real-data config-impact scorecard",
+  "currentTargetPhase": "P6",
+  "completionEvidence": "dankserver deployment plus P6a hardening gates plus one restarted seven-day real-data config-impact scorecard",
   "targets": {
     "production": "dankserver",
     "smoke": "local",
@@ -65,7 +65,7 @@
     {
       "id": "P5",
       "name": "Install And Remote Deployment",
-      "status": "in_progress",
+      "status": "completed",
       "output": "history/outputs/p5a-operator-contract-and-dry-run-apply.md",
       "subphases": [
         {
@@ -77,7 +77,7 @@
         {
           "id": "P5b",
           "name": "Real Pulumi Remote Apply",
-          "status": "in_progress",
+          "status": "completed",
           "output": "history/outputs/p5b-real-pulumi-remote-apply.md"
         }
       ]
@@ -85,14 +85,14 @@
     {
       "id": "P6",
       "name": "Seven-Day Proof And Hardening",
-      "status": "paused",
+      "status": "in_progress",
       "output": "history/outputs/p6-seven-day-proof-and-hardening.md",
       "subphases": [
         {
           "id": "P6a",
           "name": "Fresh Review Data And Ops Hardening",
-          "status": "in_progress",
-          "output": "history/outputs/p6a-fresh-review-hardening.md"
+          "status": "completed",
+          "output": "history/outputs/p6a-closeout-proof-restart.md"
         }
       ]
     }
@@ -132,22 +132,23 @@
     },
     {
       "id": "dankserver-preview",
-      "command": "cd infra && pulumi preview --stack beep-ai-metrics-dankserver"
+      "command": "cd infra && PULUMI_CONFIG_PASSPHRASE=<resolved-secret> pulumi preview -s beep-ai-metrics-dankserver --non-interactive --diff"
     },
     {
       "id": "dankserver-apply",
-      "command": "cd infra && pulumi up --stack beep-ai-metrics-dankserver"
+      "command": "cd infra && PULUMI_CONFIG_PASSPHRASE=<resolved-secret> pulumi up -s beep-ai-metrics-dankserver --yes --non-interactive"
+    },
+    {
+      "id": "ai-metrics-proof-scorecard",
+      "command": "bun run beep ai-metrics report weekly --target dankserver --data-root .beep/ai-metrics --hash-salt-secret-ref 'op://TBK/ai-metrics/hash-salt' --raw-archive-key-secret-ref 'op://TBK/ai-metrics/raw-archive-key' --json"
     }
   ],
   "knownGaps": [
-    "P5b Phoenix is live and verified on dankserver, but Pulumi state reconciliation is blocked until PULUMI_CONFIG_PASSPHRASE or PULUMI_CONFIG_PASSPHRASE_FILE is present",
-    "P6 is paused until P6a hardening gates pass; the existing collection evidence is baseline pre-P6a evidence",
-    "The credited seven-day proof must restart after P6a with workstation timer ownership",
-    "Real outcome labels and benchmark runs still need to be added before a scorecard can be completionReady",
-    "Backup, restore, retention, deletion, and failure recovery documentation remains pending",
+    "The credited seven-day proof window is in progress until at least May 16, 2026 02:26 America/Chicago",
+    "Additional outcome labels and benchmark runs should be added as more timer-collected work accumulates",
     "Optional LiteLLM deployment remains deferred beyond the Phoenix-only P5b slice",
     "xAI, Venice, LiteLLM, and gateway enrichment remain deferred beyond P2",
     "Server-owned collection remains a P7 topology target requiring transcript access/sync and privacy design"
   ],
-  "nextAction": "Finish P6a hardening checks, reconcile Pulumi state from a shell with the Pulumi passphrase environment, install the workstation timer, run the archive drill, add labels and benchmark runs, then restart the credited seven-day proof."
+  "nextAction": "Keep the workstation timer running through May 16, 2026 02:26 America/Chicago, add more labels and benchmark runs as data accumulates, then generate the final credited seven-day report."
 }

--- a/packages/tooling/library/ai-metrics/src/forwarder.ts
+++ b/packages/tooling/library/ai-metrics/src/forwarder.ts
@@ -85,6 +85,7 @@ export class AiMetricsForwarderInput extends S.Class<AiMetricsForwarderInput>($I
       S.withConstructorDefault(Effect.succeed(DEFAULT_MAX_FILES)),
       S.withDecodingDefaultKey(Effect.succeed(DEFAULT_MAX_FILES))
     ),
+    maxFileBytes: S.optionalKey(S.Number),
     openClawUnitPath: S.optionalKey(S.String),
     rawArchiveKey: AiMetricsRawArchiveKey,
     rawArchiveKeySecretRef: S.optionalKey(S.String),
@@ -225,6 +226,7 @@ const encodeForwarderTimerPlanJson = S.encodeUnknownEffect(S.fromJsonString(AiMe
 type ForwarderSourceFile = {
   readonly modifiedAtMillis: number;
   readonly relativePath: string;
+  readonly sizeBytes: number;
   readonly sourceKind: AiMetricsTranscriptSource;
   readonly sourcePath: string;
 };
@@ -293,7 +295,6 @@ export const renderAiMetricsForwarderTimerPlan = (input: AiMetricsForwarderTimer
   const serviceUnit = [
     "[Unit]",
     "Description=Beep AI metrics forwarder collection",
-    "Documentation=AGENTS.md",
     "StartLimitBurst=3",
     "StartLimitIntervalSec=30m",
     "",
@@ -366,6 +367,8 @@ const modifiedAtMillis = (info: FileSystem.File.Info): number =>
     O.getOrElse(() => 0)
   );
 
+const sizeBytes = (info: FileSystem.File.Info): number => globalThis.Number(info.size);
+
 const sourcePathHashForDiagnostics = Effect.fn("AiMetrics.forwarder.sourcePathHashForDiagnostics")(function* (
   input: AiMetricsForwarderInput,
   sourceFile: ForwarderSourceFile
@@ -382,8 +385,12 @@ const sourcePathHashForDiagnostics = Effect.fn("AiMetrics.forwarder.sourcePathHa
 
 const shouldIncludeFile =
   (input: AiMetricsForwarderInput) =>
-  (info: FileSystem.File.Info): boolean =>
-    input.includeAll || input.sinceEpochMillis === undefined || modifiedAtMillis(info) >= input.sinceEpochMillis;
+  (info: FileSystem.File.Info): boolean => {
+    const withinTimeWindow =
+      input.includeAll || input.sinceEpochMillis === undefined || modifiedAtMillis(info) >= input.sinceEpochMillis;
+    const withinSizeWindow = input.maxFileBytes === undefined || sizeBytes(info) <= input.maxFileBytes;
+    return withinTimeWindow && withinSizeWindow;
+  };
 
 const collectJsonlFiles = Effect.fn("AiMetrics.forwarder.collectJsonlFiles")(function* (
   root: string
@@ -443,6 +450,7 @@ const jsonlSourceFiles = Effect.fn("AiMetrics.forwarder.jsonlSourceFiles")(funct
       return O.some({
         modifiedAtMillis: modifiedAtMillis(info.value),
         relativePath: normalizedRelativePath(pathApi, root, sourcePath),
+        sizeBytes: sizeBytes(info.value),
         sourceKind,
         sourcePath,
       });
@@ -467,6 +475,7 @@ const openClawSourceFiles = Effect.fn("AiMetrics.forwarder.openClawSourceFiles")
   return A.of({
     modifiedAtMillis: modifiedAtMillis(info.value),
     relativePath: pathApi.basename(unitPath),
+    sizeBytes: sizeBytes(info.value),
     sourceKind: AiMetricsTranscriptSource.Enum.openclaw,
     sourcePath: unitPath,
   });

--- a/packages/tooling/library/ai-metrics/src/forwarder.ts
+++ b/packages/tooling/library/ai-metrics/src/forwarder.ts
@@ -25,6 +25,7 @@ import {
 } from "./derived-storage.ts";
 import { summarizeTranscriptText } from "./ingest.ts";
 import { AiMetricsInstallInput, makeAiMetricsInstallSpec } from "./install.ts";
+import { fileSizeBytes } from "./internal/file-info.ts";
 import { AiMetricsDeployTarget, AiMetricsTranscriptSource } from "./models.ts";
 import { hashPrivateIdentifier, makeAiMetricsPrivacyCheckResult } from "./privacy.ts";
 import { shellQuote } from "./shell.ts";
@@ -119,10 +120,14 @@ export class AiMetricsForwarderSourceCoverage extends S.Class<AiMetricsForwarder
     candidateFileCount: S.Number,
     includedFileCount: S.Number,
     limitedByMaxFiles: S.Boolean,
+    sizeExcludedFileCount: S.Number.pipe(
+      S.withConstructorDefault(Effect.succeed(0)),
+      S.withDecodingDefaultKey(Effect.succeed(0))
+    ),
     sourceKind: AiMetricsTranscriptSource,
   },
   $I.annote("AiMetricsForwarderSourceCoverage", {
-    description: "Source-aware file selection counts used to detect maxFiles starvation.",
+    description: "Source-aware file selection counts used to detect maxFiles and maxFileBytes starvation.",
   })
 ) {}
 
@@ -231,6 +236,11 @@ type ForwarderSourceFile = {
   readonly sourcePath: string;
 };
 
+type ForwarderSourceFiles = {
+  readonly files: ReadonlyArray<ForwarderSourceFile>;
+  readonly sizeExcludedFileCount: number;
+};
+
 type ForwarderSourceSelection = {
   readonly coverage: AiMetricsForwarderSourceCoverage;
   readonly files: ReadonlyArray<ForwarderSourceFile>;
@@ -302,6 +312,7 @@ export const renderAiMetricsForwarderTimerPlan = (input: AiMetricsForwarderTimer
     "Type=oneshot",
     `WorkingDirectory=${input.workingDirectory}`,
     `EnvironmentFile=${envFileUnitPath}`,
+    "# The command may include an absolute Bun path captured at render time; rerender this unit after moving Bun.",
     `ExecStart=/usr/bin/env bash -lc ${shellQuote(execCommand)}`,
     "Restart=on-failure",
     "RestartSec=5m",
@@ -367,7 +378,15 @@ const modifiedAtMillis = (info: FileSystem.File.Info): number =>
     O.getOrElse(() => 0)
   );
 
-const sizeBytes = (info: FileSystem.File.Info): number => globalThis.Number(info.size);
+const isWithinModifiedTimeWindow =
+  (input: AiMetricsForwarderInput) =>
+  (info: FileSystem.File.Info): boolean =>
+    input.includeAll || input.sinceEpochMillis === undefined || modifiedAtMillis(info) >= input.sinceEpochMillis;
+
+const isWithinSizeWindow =
+  (input: AiMetricsForwarderInput) =>
+  (info: FileSystem.File.Info): boolean =>
+    input.maxFileBytes === undefined || fileSizeBytes(info) <= input.maxFileBytes;
 
 const sourcePathHashForDiagnostics = Effect.fn("AiMetrics.forwarder.sourcePathHashForDiagnostics")(function* (
   input: AiMetricsForwarderInput,
@@ -382,15 +401,6 @@ const sourcePathHashForDiagnostics = Effect.fn("AiMetrics.forwarder.sourcePathHa
     )
   );
 });
-
-const shouldIncludeFile =
-  (input: AiMetricsForwarderInput) =>
-  (info: FileSystem.File.Info): boolean => {
-    const withinTimeWindow =
-      input.includeAll || input.sinceEpochMillis === undefined || modifiedAtMillis(info) >= input.sinceEpochMillis;
-    const withinSizeWindow = input.maxFileBytes === undefined || sizeBytes(info) <= input.maxFileBytes;
-    return withinTimeWindow && withinSizeWindow;
-  };
 
 const collectJsonlFiles = Effect.fn("AiMetrics.forwarder.collectJsonlFiles")(function* (
   root: string
@@ -439,26 +449,44 @@ const jsonlSourceFiles = Effect.fn("AiMetrics.forwarder.jsonlSourceFiles")(funct
   const fs = yield* FileSystem.FileSystem;
   const pathApi = yield* Path.Path;
   const sourcePaths = yield* collectJsonlFiles(root);
-  const files = yield* Effect.forEach(
+  const scannedFiles = yield* Effect.forEach(
     sourcePaths,
     Effect.fnUntraced(function* (sourcePath) {
       const info = yield* fs.stat(sourcePath).pipe(Effect.option);
-      if (O.isNone(info) || info.value.type !== "File" || !shouldIncludeFile(input)(info.value)) {
-        return O.none<ForwarderSourceFile>();
+      if (O.isNone(info) || info.value.type !== "File" || !isWithinModifiedTimeWindow(input)(info.value)) {
+        return { excludedByMaxFileBytes: false, file: O.none<ForwarderSourceFile>() };
       }
 
-      return O.some({
-        modifiedAtMillis: modifiedAtMillis(info.value),
-        relativePath: normalizedRelativePath(pathApi, root, sourcePath),
-        sizeBytes: sizeBytes(info.value),
-        sourceKind,
-        sourcePath,
-      });
+      if (!isWithinSizeWindow(input)(info.value)) {
+        return { excludedByMaxFileBytes: true, file: O.none<ForwarderSourceFile>() };
+      }
+
+      return {
+        excludedByMaxFileBytes: false,
+        file: O.some({
+          modifiedAtMillis: modifiedAtMillis(info.value),
+          relativePath: normalizedRelativePath(pathApi, root, sourcePath),
+          sizeBytes: fileSizeBytes(info.value),
+          sourceKind,
+          sourcePath,
+        }),
+      };
     }),
     { concurrency: 16 }
   );
 
-  return A.getSomes(files);
+  return {
+    files: pipe(
+      scannedFiles,
+      A.map((scan) => scan.file),
+      A.getSomes
+    ),
+    sizeExcludedFileCount: pipe(
+      scannedFiles,
+      A.filter((scan) => scan.excludedByMaxFileBytes),
+      A.length
+    ),
+  };
 });
 
 const openClawSourceFiles = Effect.fn("AiMetrics.forwarder.openClawSourceFiles")(function* (
@@ -468,17 +496,30 @@ const openClawSourceFiles = Effect.fn("AiMetrics.forwarder.openClawSourceFiles")
   const unitPath =
     input.openClawUnitPath ?? pathApi.join(input.homeDir, ".config/systemd/user/openclaw-gateway.service");
   const info = yield* statOption(unitPath);
-  if (O.isNone(info) || info.value.type !== "File" || !shouldIncludeFile(input)(info.value)) {
-    return A.empty<ForwarderSourceFile>();
+  if (O.isNone(info) || info.value.type !== "File" || !isWithinModifiedTimeWindow(input)(info.value)) {
+    return {
+      files: A.empty<ForwarderSourceFile>(),
+      sizeExcludedFileCount: 0,
+    };
   }
 
-  return A.of({
-    modifiedAtMillis: modifiedAtMillis(info.value),
-    relativePath: pathApi.basename(unitPath),
-    sizeBytes: sizeBytes(info.value),
-    sourceKind: AiMetricsTranscriptSource.Enum.openclaw,
-    sourcePath: unitPath,
-  });
+  if (!isWithinSizeWindow(input)(info.value)) {
+    return {
+      files: A.empty<ForwarderSourceFile>(),
+      sizeExcludedFileCount: 1,
+    };
+  }
+
+  return {
+    files: A.of({
+      modifiedAtMillis: modifiedAtMillis(info.value),
+      relativePath: pathApi.basename(unitPath),
+      sizeBytes: fileSizeBytes(info.value),
+      sourceKind: AiMetricsTranscriptSource.Enum.openclaw,
+      sourcePath: unitPath,
+    }),
+    sizeExcludedFileCount: 0,
+  };
 });
 
 const byModifiedDescending: Order.Order<ForwarderSourceFile> = Order.mapInput(
@@ -488,10 +529,10 @@ const byModifiedDescending: Order.Order<ForwarderSourceFile> = Order.mapInput(
 
 const selectSourceFiles = (
   sourceKind: AiMetricsTranscriptSource,
-  files: ReadonlyArray<ForwarderSourceFile>,
+  sourceFiles: ForwarderSourceFiles,
   maxFiles: number
 ): ForwarderSourceSelection => {
-  const sortedFiles = pipe(files, A.sort(byModifiedDescending));
+  const sortedFiles = pipe(sourceFiles.files, A.sort(byModifiedDescending));
   const includedFiles = A.take(sortedFiles, maxFiles);
 
   return {
@@ -499,6 +540,7 @@ const selectSourceFiles = (
       candidateFileCount: A.length(sortedFiles),
       includedFileCount: A.length(includedFiles),
       limitedByMaxFiles: A.length(sortedFiles) > A.length(includedFiles),
+      sizeExcludedFileCount: sourceFiles.sizeExcludedFileCount,
       sourceKind,
     }),
     files: includedFiles,

--- a/packages/tooling/library/ai-metrics/src/forwarder.ts
+++ b/packages/tooling/library/ai-metrics/src/forwarder.ts
@@ -312,7 +312,7 @@ export const renderAiMetricsForwarderTimerPlan = (input: AiMetricsForwarderTimer
     "Type=oneshot",
     `WorkingDirectory=${input.workingDirectory}`,
     `EnvironmentFile=${envFileUnitPath}`,
-    "# The command may include an absolute Bun path captured at render time; rerender this unit after moving Bun.",
+    "# The command may capture PATH at render time so user-local Bun can be found; rerender after changing Bun install paths.",
     `ExecStart=/usr/bin/env bash -lc ${shellQuote(execCommand)}`,
     "Restart=on-failure",
     "RestartSec=5m",

--- a/packages/tooling/library/ai-metrics/src/internal/file-info.ts
+++ b/packages/tooling/library/ai-metrics/src/internal/file-info.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared filesystem metadata helpers for AI metrics source selection.
+ *
+ * @since 0.0.0
+ */
+
+import type { FileSystem } from "effect";
+
+/**
+ * Convert Effect filesystem file sizes into plain numeric byte counts for JSON-safe metrics.
+ *
+ * @category utilities
+ * @since 0.0.0
+ */
+export const fileSizeBytes = (info: FileSystem.File.Info): number => globalThis.Number(info.size);

--- a/packages/tooling/library/ai-metrics/src/source-discovery.ts
+++ b/packages/tooling/library/ai-metrics/src/source-discovery.ts
@@ -7,7 +7,7 @@
 
 import { $RepoAiMetricsId } from "@beep/identity/packages";
 import { LiteralKit, TaggedErrorClass } from "@beep/schema";
-import { Clock, Effect, FileSystem, Order, Path, pipe, Stream } from "effect";
+import { Clock, Effect, FileSystem, flow, Order, Path, pipe, Stream } from "effect";
 import * as A from "effect/Array";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
@@ -88,6 +88,7 @@ export class AiMetricsSourceDiscoveryInput extends S.Class<AiMetricsSourceDiscov
       S.withConstructorDefault(Effect.succeed(DEFAULT_MAX_FILES)),
       S.withDecodingDefaultKey(Effect.succeed(DEFAULT_MAX_FILES))
     ),
+    maxFileBytes: S.optionalKey(S.Number),
     openClawUnitPath: S.optionalKey(S.String),
     repoRoot: S.String,
     sinceEpochMillis: S.optionalKey(S.Number),
@@ -193,6 +194,7 @@ export class AiMetricsSourceDiscoveryResult extends S.Class<AiMetricsSourceDisco
     homeDirHash: S.String,
     includeAll: S.Boolean,
     maxFiles: S.Number,
+    maxFileBytes: S.optionalKey(S.Number),
     repoRootHash: S.String,
     sinceEpochMillis: S.optionalKey(S.Number),
     sources: S.Array(AiMetricsDiscoveredSource),
@@ -259,17 +261,15 @@ const fileSystemFailure = (message: string, cause: unknown): AiMetricsSourceDisc
 const normalizedRelativePath = (pathApi: Path.Path, root: string, filePath: string): string =>
   pipe(pathApi.relative(root, filePath), Str.replace(/\\/gu, "/"));
 
-const contentHasCodexSessionMetaLine = (content: string): boolean =>
-  pipe(
-    content,
-    transcriptLines,
-    A.some((line) =>
-      pipe(
-        decodeCodexTranscriptLine(line),
-        O.exists((decoded) => decoded.type === "session_meta")
-      )
+const contentHasCodexSessionMetaLine: (content: string) => boolean = flow(
+  transcriptLines,
+  A.some((line) =>
+    pipe(
+      decodeCodexTranscriptLine(line),
+      O.exists((decoded) => decoded.type === "session_meta")
     )
-  );
+  )
+);
 
 const readAttributionContent = (
   fs: FileSystem.FileSystem,
@@ -303,10 +303,16 @@ const modifiedAtMillis = (info: FileSystem.File.Info): number =>
     O.getOrElse(() => 0)
   );
 
-const shouldIncludeModifiedAt =
+const sizeBytes = (info: FileSystem.File.Info): number => globalThis.Number(info.size);
+
+const shouldIncludeFile =
   (input: AiMetricsSourceDiscoveryInput) =>
-  (info: FileSystem.File.Info): boolean =>
-    input.includeAll || input.sinceEpochMillis === undefined || modifiedAtMillis(info) >= input.sinceEpochMillis;
+  (info: FileSystem.File.Info): boolean => {
+    const withinTimeWindow =
+      input.includeAll || input.sinceEpochMillis === undefined || modifiedAtMillis(info) >= input.sinceEpochMillis;
+    const withinSizeWindow = input.maxFileBytes === undefined || sizeBytes(info) <= input.maxFileBytes;
+    return withinTimeWindow && withinSizeWindow;
+  };
 
 const sessionIdFromPath = (pathApi: Path.Path, sourcePath: string): string =>
   pipe(pathApi.basename(sourcePath), Str.replace(/\.jsonl$/u, ""));
@@ -392,7 +398,7 @@ const makeDiscoveredTranscriptFile = Effect.fn("AiMetrics.makeDiscoveredTranscri
     ...(attribution.parentSessionIdHash === undefined ? {} : { parentSessionIdHash: attribution.parentSessionIdHash }),
     ...(attribution.parentThreadIdHash === undefined ? {} : { parentThreadIdHash: attribution.parentThreadIdHash }),
     sessionIdHash: attribution.sessionIdHash ?? fallbackSessionIdHash,
-    sizeBytes: globalThis.Number(info.size),
+    sizeBytes: sizeBytes(info),
     sourceKind,
     sourcePathHash: yield* hashPrivateIdentifier(sourcePath, hashSalt),
     sourceRole: attribution.sourceRole,
@@ -454,7 +460,7 @@ const discoverJsonlSource = Effect.fn("AiMetrics.discoverJsonlSource")(function*
       allFiles,
       Effect.fnUntraced(function* (sourcePath) {
         const info = yield* fs.stat(sourcePath).pipe(Effect.option);
-        if (O.isNone(info) || info.value.type !== "File" || !shouldIncludeModifiedAt(input)(info.value)) {
+        if (O.isNone(info) || info.value.type !== "File" || !shouldIncludeFile(input)(info.value)) {
           return O.none<SourceCandidateFile>();
         }
 
@@ -527,7 +533,7 @@ const discoverOpenClawSource = Effect.fn("AiMetrics.discoverOpenClawSource")(fun
     });
   }
 
-  if (!shouldIncludeModifiedAt(input)(unitInfo.value)) {
+  if (!shouldIncludeFile(input)(unitInfo.value)) {
     return new AiMetricsDiscoveredSource({
       candidateFileCount: 0,
       fileCount: 0,
@@ -544,7 +550,7 @@ const discoverOpenClawSource = Effect.fn("AiMetrics.discoverOpenClawSource")(fun
   const file = new AiMetricsDiscoveredTranscriptFile({
     modifiedAtMillis: modifiedAtMillis(unitInfo.value),
     sessionIdHash: yield* hashPrivateIdentifier("openclaw-gateway.service", input.hashSalt),
-    sizeBytes: globalThis.Number(unitInfo.value.size),
+    sizeBytes: sizeBytes(unitInfo.value),
     sourceKind: AiMetricsTranscriptSource.Enum.openclaw,
     sourcePathHash: yield* hashPrivateIdentifier(unitPath, input.hashSalt),
     sourceRole: AiMetricsSourceRole.Enum.gateway_metadata,
@@ -613,6 +619,7 @@ export const discoverAiMetricsSources = Effect.fn("AiMetrics.discoverAiMetricsSo
     homeDirHash: yield* hashPrivateIdentifier(homeDir, input.hashSalt),
     includeAll: input.includeAll,
     maxFiles: input.maxFiles,
+    ...(input.maxFileBytes === undefined ? {} : { maxFileBytes: input.maxFileBytes }),
     repoRootHash: yield* hashPrivateIdentifier(repoRoot, input.hashSalt),
     sources,
     target: input.target,

--- a/packages/tooling/library/ai-metrics/src/source-discovery.ts
+++ b/packages/tooling/library/ai-metrics/src/source-discovery.ts
@@ -12,6 +12,7 @@ import * as A from "effect/Array";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
 import * as Str from "effect/String";
+import { fileSizeBytes } from "./internal/file-info.ts";
 import { transcriptLines } from "./internal/transcript-utils.ts";
 import {
   AiMetricsDeployTarget,
@@ -165,6 +166,10 @@ export class AiMetricsDiscoveredSource extends S.Class<AiMetricsDiscoveredSource
     message: S.optionalKey(S.String),
     newestModifiedAtMillis: S.optionalKey(S.Number),
     rootPathHash: S.String,
+    sizeExcludedFileCount: S.Number.pipe(
+      S.withConstructorDefault(Effect.succeed(0)),
+      S.withDecodingDefaultKey(Effect.succeed(0))
+    ),
     sourceKind: AiMetricsTranscriptSource,
     status: AiMetricsSourceStatus,
   },
@@ -303,16 +308,15 @@ const modifiedAtMillis = (info: FileSystem.File.Info): number =>
     O.getOrElse(() => 0)
   );
 
-const sizeBytes = (info: FileSystem.File.Info): number => globalThis.Number(info.size);
-
-const shouldIncludeFile =
+const isWithinModifiedTimeWindow =
   (input: AiMetricsSourceDiscoveryInput) =>
-  (info: FileSystem.File.Info): boolean => {
-    const withinTimeWindow =
-      input.includeAll || input.sinceEpochMillis === undefined || modifiedAtMillis(info) >= input.sinceEpochMillis;
-    const withinSizeWindow = input.maxFileBytes === undefined || sizeBytes(info) <= input.maxFileBytes;
-    return withinTimeWindow && withinSizeWindow;
-  };
+  (info: FileSystem.File.Info): boolean =>
+    input.includeAll || input.sinceEpochMillis === undefined || modifiedAtMillis(info) >= input.sinceEpochMillis;
+
+const isWithinSizeWindow =
+  (input: AiMetricsSourceDiscoveryInput) =>
+  (info: FileSystem.File.Info): boolean =>
+    input.maxFileBytes === undefined || fileSizeBytes(info) <= input.maxFileBytes;
 
 const sessionIdFromPath = (pathApi: Path.Path, sourcePath: string): string =>
   pipe(pathApi.basename(sourcePath), Str.replace(/\.jsonl$/u, ""));
@@ -398,7 +402,7 @@ const makeDiscoveredTranscriptFile = Effect.fn("AiMetrics.makeDiscoveredTranscri
     ...(attribution.parentSessionIdHash === undefined ? {} : { parentSessionIdHash: attribution.parentSessionIdHash }),
     ...(attribution.parentThreadIdHash === undefined ? {} : { parentThreadIdHash: attribution.parentThreadIdHash }),
     sessionIdHash: attribution.sessionIdHash ?? fallbackSessionIdHash,
-    sizeBytes: sizeBytes(info),
+    sizeBytes: fileSizeBytes(info),
     sourceKind,
     sourcePathHash: yield* hashPrivateIdentifier(sourcePath, hashSalt),
     sourceRole: attribution.sourceRole,
@@ -455,22 +459,36 @@ const discoverJsonlSource = Effect.fn("AiMetrics.discoverJsonlSource")(function*
 
   const fs = yield* FileSystem.FileSystem;
   const allFiles = yield* collectJsonlFiles(root);
-  const candidates = pipe(
-    yield* Effect.forEach(
-      allFiles,
-      Effect.fnUntraced(function* (sourcePath) {
-        const info = yield* fs.stat(sourcePath).pipe(Effect.option);
-        if (O.isNone(info) || info.value.type !== "File" || !shouldIncludeFile(input)(info.value)) {
-          return O.none<SourceCandidateFile>();
-        }
+  const scannedFiles = yield* Effect.forEach(
+    allFiles,
+    Effect.fnUntraced(function* (sourcePath) {
+      const info = yield* fs.stat(sourcePath).pipe(Effect.option);
+      if (O.isNone(info) || info.value.type !== "File" || !isWithinModifiedTimeWindow(input)(info.value)) {
+        return { candidate: O.none<SourceCandidateFile>(), excludedByMaxFileBytes: false };
+      }
 
-        return O.some({ modifiedAtMillis: modifiedAtMillis(info.value), sourcePath });
-      }),
-      { concurrency: 16 }
-    ),
+      if (!isWithinSizeWindow(input)(info.value)) {
+        return { candidate: O.none<SourceCandidateFile>(), excludedByMaxFileBytes: true };
+      }
+
+      return {
+        candidate: O.some({ modifiedAtMillis: modifiedAtMillis(info.value), sourcePath }),
+        excludedByMaxFileBytes: false,
+      };
+    }),
+    { concurrency: 16 }
+  );
+  const candidates = pipe(
+    scannedFiles,
+    A.map((scan) => scan.candidate),
     A.getSomes,
     A.sort(byCandidatePathAscending),
     A.sort(byCandidateModifiedDescending)
+  );
+  const sizeExcludedFileCount = pipe(
+    scannedFiles,
+    A.filter((scan) => scan.excludedByMaxFileBytes),
+    A.length
   );
   const includedCandidates = A.take(candidates, input.maxFiles);
   const files = pipe(
@@ -496,6 +514,7 @@ const discoverJsonlSource = Effect.fn("AiMetrics.discoverJsonlSource")(function*
     includedFileCount: A.length(includedFiles),
     limitedByMaxFiles: A.length(candidates) > A.length(includedCandidates),
     rootPathHash,
+    sizeExcludedFileCount,
     sourceKind,
     status: AiMetricsSourceStatus.Enum.available,
     ...newestModifiedAtFields(includedFiles),
@@ -533,7 +552,7 @@ const discoverOpenClawSource = Effect.fn("AiMetrics.discoverOpenClawSource")(fun
     });
   }
 
-  if (!shouldIncludeFile(input)(unitInfo.value)) {
+  if (!isWithinModifiedTimeWindow(input)(unitInfo.value)) {
     return new AiMetricsDiscoveredSource({
       candidateFileCount: 0,
       fileCount: 0,
@@ -547,10 +566,25 @@ const discoverOpenClawSource = Effect.fn("AiMetrics.discoverOpenClawSource")(fun
     });
   }
 
+  if (!isWithinSizeWindow(input)(unitInfo.value)) {
+    return new AiMetricsDiscoveredSource({
+      candidateFileCount: 0,
+      fileCount: 0,
+      files: [],
+      includedFileCount: 0,
+      limitedByMaxFiles: false,
+      message: "OpenClaw user systemd gateway metadata exceeds the selected byte-size window",
+      rootPathHash,
+      sizeExcludedFileCount: 1,
+      sourceKind: AiMetricsTranscriptSource.Enum.openclaw,
+      status: AiMetricsSourceStatus.Enum.available,
+    });
+  }
+
   const file = new AiMetricsDiscoveredTranscriptFile({
     modifiedAtMillis: modifiedAtMillis(unitInfo.value),
     sessionIdHash: yield* hashPrivateIdentifier("openclaw-gateway.service", input.hashSalt),
-    sizeBytes: sizeBytes(unitInfo.value),
+    sizeBytes: fileSizeBytes(unitInfo.value),
     sourceKind: AiMetricsTranscriptSource.Enum.openclaw,
     sourcePathHash: yield* hashPrivateIdentifier(unitPath, input.hashSalt),
     sourceRole: AiMetricsSourceRole.Enum.gateway_metadata,

--- a/packages/tooling/library/ai-metrics/test/ingest.test.ts
+++ b/packages/tooling/library/ai-metrics/test/ingest.test.ts
@@ -652,6 +652,7 @@ describe("@beep/repo-ai-metrics", () => {
       expect(plan.serviceUnit).toContain('"status":"failed"');
       expect(plan.serviceUnit).toContain("json.dumps");
       expect(plan.serviceUnit).toContain('decode("utf-8","replace")');
+      expect(plan.serviceUnit).toContain("absolute Bun path captured at render time");
       expect(plan.serviceUnit).toMatch(/exit_code=0; > .*latest\.json\.stderr\.tmp.*; if flock -n/su);
       expect(plan.serviceUnit).not.toContain("sed 's/");
       expect(plan.serviceUnit).toContain("StartLimitBurst=3\nStartLimitIntervalSec=30m\n\n[Service]");
@@ -1509,6 +1510,7 @@ volumes:
           expect(codex.value.candidateFileCount).toBe(1);
           expect(codex.value.files).toHaveLength(1);
           expect(codex.value.files[0]?.sizeBytes).toBeLessThanOrEqual(128);
+          expect(codex.value.sizeExcludedFileCount).toBe(1);
         })
       ).pipe(Effect.provide(NodeServices.layer));
     })

--- a/packages/tooling/library/ai-metrics/test/ingest.test.ts
+++ b/packages/tooling/library/ai-metrics/test/ingest.test.ts
@@ -1468,6 +1468,53 @@ volumes:
   );
 
   it.effect(
+    "skips oversized transcript files during source discovery",
+    Effect.fn(function* () {
+      yield* withTempDirectory(
+        Effect.fn(function* (tmpDir) {
+          const path = yield* Path.Path;
+          const homeDir = path.join(tmpDir, "home");
+          const repoRoot = path.join(tmpDir, "repo");
+          const codexRoot = path.join(homeDir, ".codex/sessions");
+          yield* writeText(
+            path.join(codexRoot, "small.jsonl"),
+            '{"type":"session_meta","timestamp":"2026-05-05T10:00:00Z"}\n'
+          );
+          yield* writeText(
+            path.join(codexRoot, "large.jsonl"),
+            `{"type":"session_meta","timestamp":"2026-05-05T10:01:00Z","payload":"${pipe("x", Str.repeat(512))}"}\n`
+          );
+          yield* writeText(path.join(repoRoot, "AGENTS.md"), "root agent guide\n");
+
+          const result = yield* discoverAiMetricsSources(
+            new AiMetricsSourceDiscoveryInput({
+              codexSessionsRoot: codexRoot,
+              hashSalt: "test-salt",
+              homeDir,
+              includeAll: true,
+              maxFileBytes: 128,
+              repoRoot,
+            })
+          );
+          const codex = pipe(
+            result.sources,
+            A.findFirst((source) => source.sourceKind === AiMetricsTranscriptSource.Enum.codex)
+          );
+
+          expect(result.maxFileBytes).toBe(128);
+          expect(O.isSome(codex)).toBe(true);
+          if (O.isNone(codex)) {
+            return;
+          }
+          expect(codex.value.candidateFileCount).toBe(1);
+          expect(codex.value.files).toHaveLength(1);
+          expect(codex.value.files[0]?.sizeBytes).toBeLessThanOrEqual(128);
+        })
+      ).pipe(Effect.provide(NodeServices.layer));
+    })
+  );
+
+  it.effect(
     "streams Codex attribution until a parsed session_meta line is present",
     Effect.fn(function* () {
       yield* withTempDirectory(

--- a/packages/tooling/library/ai-metrics/test/ingest.test.ts
+++ b/packages/tooling/library/ai-metrics/test/ingest.test.ts
@@ -652,7 +652,7 @@ describe("@beep/repo-ai-metrics", () => {
       expect(plan.serviceUnit).toContain('"status":"failed"');
       expect(plan.serviceUnit).toContain("json.dumps");
       expect(plan.serviceUnit).toContain('decode("utf-8","replace")');
-      expect(plan.serviceUnit).toContain("absolute Bun path captured at render time");
+      expect(plan.serviceUnit).toContain("capture PATH at render time");
       expect(plan.serviceUnit).toMatch(/exit_code=0; > .*latest\.json\.stderr\.tmp.*; if flock -n/su);
       expect(plan.serviceUnit).not.toContain("sed 's/");
       expect(plan.serviceUnit).toContain("StartLimitBurst=3\nStartLimitIntervalSec=30m\n\n[Service]");

--- a/packages/tooling/tool/cli/src/commands/AIMetrics/index.ts
+++ b/packages/tooling/tool/cli/src/commands/AIMetrics/index.ts
@@ -217,6 +217,18 @@ const maxFilesFlag = Flag.integer("max-files").pipe(
   Flag.withDefault(200),
   Flag.withDescription("Maximum files to report per transcript source")
 );
+const maxFileBytesFlag = Flag.integer("max-file-bytes").pipe(
+  Flag.withDescription("Skip transcript source files larger than this byte count"),
+  Flag.optional
+);
+const timerMaxFilesFlag = Flag.integer("max-files").pipe(
+  Flag.withDefault(5),
+  Flag.withDescription("Maximum files per transcript source for each scheduled forwarder run")
+);
+const timerMaxFileBytesFlag = Flag.integer("max-file-bytes").pipe(
+  Flag.withDefault(8_388_608),
+  Flag.withDescription("Maximum source-file byte size for each scheduled forwarder run")
+);
 const hashSaltFlag = Flag.string("hash-salt").pipe(
   Flag.withDescription("Salt for hashing private paths and session identifiers"),
   Flag.optional
@@ -819,6 +831,7 @@ const makeInstallDoctorProgram = Effect.fn("AIMetrics.makeInstallDoctorProgram")
   hashSaltSecretRef,
   homeDir,
   json,
+  maxFileBytes,
   maxFiles,
   openClawUnit,
   rawArchiveKeySecretRef,
@@ -832,6 +845,7 @@ const makeInstallDoctorProgram = Effect.fn("AIMetrics.makeInstallDoctorProgram")
   readonly hashSaltSecretRef: O.Option<string>;
   readonly homeDir: O.Option<string>;
   readonly json: boolean;
+  readonly maxFileBytes: O.Option<number>;
   readonly maxFiles: number;
   readonly openClawUnit: O.Option<string>;
   readonly rawArchiveKeySecretRef: O.Option<string>;
@@ -846,6 +860,7 @@ const makeInstallDoctorProgram = Effect.fn("AIMetrics.makeInstallDoctorProgram")
     new AiMetricsSourceDiscoveryInput({
       homeDir: yield* resolveHomeDir(homeDir),
       includeAll: all,
+      ...(O.isSome(maxFileBytes) ? { maxFileBytes: maxFileBytes.value } : {}),
       maxFiles,
       repoRoot: yield* resolveRepoRoot(repoRoot),
       target: AiMetricsDeployTarget.Enum.local,
@@ -1026,6 +1041,7 @@ const makeSourcesDiscoverProgram = Effect.fn("AIMetrics.makeSourcesDiscoverProgr
   hashSalt,
   homeDir,
   json,
+  maxFileBytes,
   maxFiles,
   openClawUnit,
   repoRoot,
@@ -1036,6 +1052,7 @@ const makeSourcesDiscoverProgram = Effect.fn("AIMetrics.makeSourcesDiscoverProgr
   readonly hashSalt: O.Option<string>;
   readonly homeDir: O.Option<string>;
   readonly json: boolean;
+  readonly maxFileBytes: O.Option<number>;
   readonly maxFiles: number;
   readonly openClawUnit: O.Option<string>;
   readonly repoRoot: O.Option<string>;
@@ -1051,6 +1068,7 @@ const makeSourcesDiscoverProgram = Effect.fn("AIMetrics.makeSourcesDiscoverProgr
     new AiMetricsSourceDiscoveryInput({
       homeDir: yield* resolveHomeDir(homeDir),
       includeAll: all,
+      ...(O.isSome(maxFileBytes) ? { maxFileBytes: maxFileBytes.value } : {}),
       maxFiles,
       repoRoot: yield* resolveRepoRoot(repoRoot),
       target,
@@ -1142,6 +1160,7 @@ const makeForwarderRunProgram = Effect.fn("AIMetrics.makeForwarderRunProgram")(f
   hashSaltSecretRef,
   homeDir,
   json,
+  maxFileBytes,
   maxFiles,
   openClawUnit,
   otlp,
@@ -1157,6 +1176,7 @@ const makeForwarderRunProgram = Effect.fn("AIMetrics.makeForwarderRunProgram")(f
   readonly hashSaltSecretRef: O.Option<string>;
   readonly homeDir: O.Option<string>;
   readonly json: boolean;
+  readonly maxFileBytes: O.Option<number>;
   readonly maxFiles: number;
   readonly openClawUnit: O.Option<string>;
   readonly otlp: boolean;
@@ -1201,6 +1221,7 @@ const makeForwarderRunProgram = Effect.fn("AIMetrics.makeForwarderRunProgram")(f
         : { rawArchiveKeySecretRef: resolvedRawArchiveKeySecretRef }),
       homeDir: yield* resolveHomeDir(homeDir),
       includeAll: all,
+      ...(O.isSome(maxFileBytes) ? { maxFileBytes: maxFileBytes.value } : {}),
       maxFiles,
       ...(O.isSome(openClawUnit) ? { openClawUnitPath: openClawUnit.value } : {}),
       rawArchiveKey: resolvedRawArchiveKey,
@@ -1250,6 +1271,8 @@ const makeForwarderTimerProgram = Effect.fn("AIMetrics.makeForwarderTimerProgram
   hashSaltSecretRef,
   intervalMinutes,
   json,
+  maxFileBytes,
+  maxFiles,
   otlpBaseUrl,
   rawArchiveKeySecretRef,
   repoRoot,
@@ -1259,6 +1282,8 @@ const makeForwarderTimerProgram = Effect.fn("AIMetrics.makeForwarderTimerProgram
   readonly hashSaltSecretRef: O.Option<string>;
   readonly intervalMinutes: number;
   readonly json: boolean;
+  readonly maxFileBytes: number;
+  readonly maxFiles: number;
   readonly otlpBaseUrl: O.Option<string>;
   readonly rawArchiveKeySecretRef: O.Option<string>;
   readonly repoRoot: O.Option<string>;
@@ -1289,9 +1314,12 @@ const makeForwarderTimerProgram = Effect.fn("AIMetrics.makeForwarderTimerProgram
       : ` --raw-archive-key-secret-ref ${shellQuote(resolvedRawArchiveKeySecretRef)}`;
   const otlpFlagText =
     target === AiMetricsDeployTarget.Enum.dankserver ? ` --otlp --otlp-base-url ${shellQuote(endpoint.baseUrl)}` : "";
+  const maxFileBytesFlagText = ` --max-file-bytes ${maxFileBytes}`;
+  const maxFilesFlagText = ` --max-files ${maxFiles}`;
+  const cliCommand = `${shellQuote(process.execPath)} packages/tooling/tool/cli/src/bin.ts --`;
   const plan = renderAiMetricsForwarderTimerPlan(
     new AiMetricsForwarderTimerInput({
-      command: `bun run beep ai-metrics forwarder run --target ${target}${dataRootFlag}${hashSaltSecretRefFlagText}${rawArchiveKeySecretRefFlagText}${otlpFlagText} --json`,
+      command: `${cliCommand} ai-metrics forwarder run --target ${target}${dataRootFlag}${hashSaltSecretRefFlagText}${rawArchiveKeySecretRefFlagText}${otlpFlagText}${maxFileBytesFlagText}${maxFilesFlagText} --json`,
       ...(resolvedHashSaltSecretRef === undefined ? {} : { hashSaltSecretRef: resolvedHashSaltSecretRef }),
       intervalMinutes,
       lockPath: "%t/beep-ai-metrics-forwarder.lock",
@@ -1821,6 +1849,7 @@ const installDoctorCommand = Command.make(
     hashSaltSecretRef: hashSaltSecretRefFlag,
     homeDir: homeDirFlag,
     json: jsonFlag,
+    maxFileBytes: maxFileBytesFlag,
     maxFiles: maxFilesFlag,
     openClawUnit: openClawUnitFlag,
     rawArchiveKeySecretRef: rawArchiveKeySecretRefFlag,
@@ -1835,6 +1864,7 @@ const installDoctorCommand = Command.make(
     hashSaltSecretRef,
     homeDir,
     json,
+    maxFileBytes,
     maxFiles,
     openClawUnit,
     rawArchiveKeySecretRef,
@@ -1850,6 +1880,7 @@ const installDoctorCommand = Command.make(
         hashSaltSecretRef,
         homeDir,
         json,
+        maxFileBytes,
         maxFiles,
         openClawUnit,
         rawArchiveKeySecretRef,
@@ -1906,15 +1937,27 @@ const sourcesDiscoverCommand = Command.make(
     hashSalt: hashSaltFlag,
     homeDir: homeDirFlag,
     json: jsonFlag,
+    maxFileBytes: maxFileBytesFlag,
     maxFiles: maxFilesFlag,
     openClawUnit: openClawUnitFlag,
     repoRoot: repoRootFlag,
     since: sinceFlag,
     target: targetFlag,
   },
-  ({ all, hashSalt, homeDir, json, maxFiles, openClawUnit, repoRoot, since, target }) =>
+  ({ all, hashSalt, homeDir, json, maxFileBytes, maxFiles, openClawUnit, repoRoot, since, target }) =>
     runAiMetricsProgram(
-      makeSourcesDiscoverProgram({ all, hashSalt, homeDir, json, maxFiles, openClawUnit, repoRoot, since, target })
+      makeSourcesDiscoverProgram({
+        all,
+        hashSalt,
+        homeDir,
+        json,
+        maxFileBytes,
+        maxFiles,
+        openClawUnit,
+        repoRoot,
+        since,
+        target,
+      })
     )
 ).pipe(Command.withDescription("Discover Codex, Claude, and OpenClaw local metrics sources"));
 
@@ -2003,6 +2046,7 @@ const forwarderRunCommand = Command.make(
     hashSaltSecretRef: hashSaltSecretRefFlag,
     homeDir: homeDirFlag,
     json: jsonFlag,
+    maxFileBytes: maxFileBytesFlag,
     maxFiles: maxFilesFlag,
     openClawUnit: openClawUnitFlag,
     otlp: otlpFlag,
@@ -2019,6 +2063,7 @@ const forwarderRunCommand = Command.make(
     hashSaltSecretRef,
     homeDir,
     json,
+    maxFileBytes,
     maxFiles,
     openClawUnit,
     otlp,
@@ -2036,6 +2081,7 @@ const forwarderRunCommand = Command.make(
         hashSaltSecretRef,
         homeDir,
         json,
+        maxFileBytes,
         maxFiles,
         openClawUnit,
         otlp,
@@ -2057,18 +2103,33 @@ const forwarderTimerCommand = Command.make(
     hashSaltSecretRef: hashSaltSecretRefFlag,
     intervalMinutes: intervalMinutesFlag,
     json: jsonFlag,
+    maxFileBytes: timerMaxFileBytesFlag,
+    maxFiles: timerMaxFilesFlag,
     otlpBaseUrl: otlpBaseUrlFlag,
     rawArchiveKeySecretRef: rawArchiveKeySecretRefFlag,
     repoRoot: repoRootFlag,
     target: targetFlag,
   },
-  ({ dataRoot, hashSaltSecretRef, intervalMinutes, json, otlpBaseUrl, rawArchiveKeySecretRef, repoRoot, target }) =>
+  ({
+    dataRoot,
+    hashSaltSecretRef,
+    intervalMinutes,
+    json,
+    maxFileBytes,
+    maxFiles,
+    otlpBaseUrl,
+    rawArchiveKeySecretRef,
+    repoRoot,
+    target,
+  }) =>
     runAiMetricsProgram(
       makeForwarderTimerProgram({
         dataRoot,
         hashSaltSecretRef,
         intervalMinutes,
         json,
+        maxFileBytes,
+        maxFiles,
         otlpBaseUrl,
         rawArchiveKeySecretRef,
         repoRoot,

--- a/packages/tooling/tool/cli/src/commands/AIMetrics/index.ts
+++ b/packages/tooling/tool/cli/src/commands/AIMetrics/index.ts
@@ -1316,7 +1316,7 @@ const makeForwarderTimerProgram = Effect.fn("AIMetrics.makeForwarderTimerProgram
     target === AiMetricsDeployTarget.Enum.dankserver ? ` --otlp --otlp-base-url ${shellQuote(endpoint.baseUrl)}` : "";
   const maxFileBytesFlagText = ` --max-file-bytes ${maxFileBytes}`;
   const maxFilesFlagText = ` --max-files ${maxFiles}`;
-  const cliCommand = `${shellQuote(process.execPath)} packages/tooling/tool/cli/src/bin.ts --`;
+  const cliCommand = `/usr/bin/env PATH=${shellQuote(process.env.PATH ?? "")} bun packages/tooling/tool/cli/src/bin.ts --`;
   const plan = renderAiMetricsForwarderTimerPlan(
     new AiMetricsForwarderTimerInput({
       command: `${cliCommand} ai-metrics forwarder run --target ${target}${dataRootFlag}${hashSaltSecretRefFlagText}${rawArchiveKeySecretRefFlagText}${otlpFlagText}${maxFileBytesFlagText}${maxFilesFlagText} --json`,

--- a/packages/tooling/tool/cli/test/ai-metrics-command.test.ts
+++ b/packages/tooling/tool/cli/test/ai-metrics-command.test.ts
@@ -264,6 +264,7 @@ describe("ai-metrics command", () => {
           expect(output).toContain("--max-file-bytes 8388608");
           expect(output).toContain("--max-files 5");
           expect(output).toContain("OnUnitInactiveSec=30m");
+          expect(output).toContain("absolute Bun path captured at render time");
           expect(output).toContain("beep-ai-metrics-forwarder.timer");
           expect(output).not.toContain("--max-files 200");
           expect(process.exitCode ?? 0).toBe(0);
@@ -589,6 +590,7 @@ describe("ai-metrics command", () => {
           if (O.isSome(codex)) {
             expect(codex.value.fileCount).toBe(1);
             expect(codex.value.files[0]?.sizeBytes).toBeLessThanOrEqual(128);
+            expect(codex.value.sizeExcludedFileCount).toBe(1);
           }
           expect(output).toContain("gateway_metadata");
           expect(output).toContain("provided");

--- a/packages/tooling/tool/cli/test/ai-metrics-command.test.ts
+++ b/packages/tooling/tool/cli/test/ai-metrics-command.test.ts
@@ -264,7 +264,9 @@ describe("ai-metrics command", () => {
           expect(output).toContain("--max-file-bytes 8388608");
           expect(output).toContain("--max-files 5");
           expect(output).toContain("OnUnitInactiveSec=30m");
-          expect(output).toContain("absolute Bun path captured at render time");
+          expect(output).toContain("capture PATH at render time");
+          expect(output).toContain("/usr/bin/env PATH=");
+          expect(output).toContain(" bun packages/tooling/tool/cli/src/bin.ts -- ai-metrics forwarder run");
           expect(output).toContain("beep-ai-metrics-forwarder.timer");
           expect(output).not.toContain("--max-files 200");
           expect(process.exitCode ?? 0).toBe(0);

--- a/packages/tooling/tool/cli/test/ai-metrics-command.test.ts
+++ b/packages/tooling/tool/cli/test/ai-metrics-command.test.ts
@@ -5,6 +5,7 @@ import {
   AiMetricsInstallPlan,
   AiMetricsLabelQueueResult,
   AiMetricsOtlpExportResult,
+  AiMetricsSourceDiscoveryResult,
   AiMetricsWeeklyReportResult,
 } from "@beep/repo-ai-metrics";
 import { aiMetricsCommand } from "@beep/repo-cli/commands/AIMetrics/index";
@@ -26,6 +27,7 @@ const decodeInstallDoctor = S.decodeUnknownEffect(S.fromJsonString(AiMetricsInst
 const decodeInstallPlan = S.decodeUnknownEffect(S.fromJsonString(AiMetricsInstallPlan));
 const decodeLabelQueue = S.decodeUnknownEffect(S.fromJsonString(AiMetricsLabelQueueResult));
 const decodeOtlpExportResult = S.decodeUnknownEffect(S.fromJsonString(AiMetricsOtlpExportResult));
+const decodeSourceDiscovery = S.decodeUnknownEffect(S.fromJsonString(AiMetricsSourceDiscoveryResult));
 const decodeWeeklyReport = S.decodeUnknownEffect(S.fromJsonString(AiMetricsWeeklyReportResult));
 const farFutureUntilEpochMs = 4_102_444_800_000;
 
@@ -234,6 +236,36 @@ describe("ai-metrics command", () => {
           expect(output).toContain("op://TBK/ai-metrics/hash-salt");
           expect(output).toContain("rawArchiveKeySecretRef");
           expect(output).toContain("op://TBK/ai-metrics/raw-archive-key");
+          expect(process.exitCode ?? 0).toBe(0);
+        })
+      )
+    );
+  });
+
+  it("renders a bounded dankserver forwarder timer command", async () => {
+    await Effect.runPromise(
+      withTempDirectory(() =>
+        Effect.gen(function* () {
+          yield* runAiMetricsCommand([
+            "forwarder",
+            "timer",
+            "--target",
+            "dankserver",
+            "--data-root",
+            ".beep/ai-metrics",
+            "--hash-salt-secret-ref",
+            "op://TBK/ai-metrics/hash-salt",
+            "--raw-archive-key-secret-ref",
+            "op://TBK/ai-metrics/raw-archive-key",
+            "--json",
+          ]);
+
+          const output = yield* loggedText();
+          expect(output).toContain("--max-file-bytes 8388608");
+          expect(output).toContain("--max-files 5");
+          expect(output).toContain("OnUnitInactiveSec=30m");
+          expect(output).toContain("beep-ai-metrics-forwarder.timer");
+          expect(output).not.toContain("--max-files 200");
           expect(process.exitCode ?? 0).toBe(0);
         })
       )
@@ -520,6 +552,10 @@ describe("ai-metrics command", () => {
             '{"type":"session_meta","timestamp":"2026-05-05T10:00:00Z"}\n'
           );
           yield* writeText(
+            path.join(homeDir, ".codex/sessions/2026/05/05/oversized-codex-session.jsonl"),
+            `{"type":"session_meta","timestamp":"2026-05-05T10:01:00Z","payload":"${pipe("x", Str.repeat(256))}"}\n`
+          );
+          yield* writeText(
             path.join(homeDir, ".claude/projects", claudeProjectName, "claude-session.jsonl"),
             '{"sessionId":"claude-session","timestamp":"2026-05-05T11:00:00Z"}\n'
           );
@@ -537,10 +573,23 @@ describe("ai-metrics command", () => {
             "--all",
             "--hash-salt",
             "test-salt",
+            "--max-file-bytes",
+            "128",
             "--json",
           ]);
 
+          const result = yield* decodeSourceDiscovery(yield* lastLoggedLine());
+          const codex = pipe(
+            result.sources,
+            A.findFirst((source) => source.sourceKind === "codex")
+          );
           const output = yield* loggedText();
+          expect(result.maxFileBytes).toBe(128);
+          expect(O.isSome(codex)).toBe(true);
+          if (O.isSome(codex)) {
+            expect(codex.value.fileCount).toBe(1);
+            expect(codex.value.files[0]?.sizeBytes).toBeLessThanOrEqual(128);
+          }
           expect(output).toContain("gateway_metadata");
           expect(output).toContain("provided");
           expect(output).not.toContain(tmpDir);


### PR DESCRIPTION
## Summary
- add byte-size bounds to AI metrics source discovery/forwarder runs and render the workstation timer with bounded defaults plus an absolute Bun CLI entrypoint
- install/verify the workstation-owned timer path, reconcile dankserver Pulumi state, and record the P6a closeout/proof restart evidence
- update the initiative packet so P5/P6a are complete and P6 seven-day proof is in progress

## Live Evidence
- bounded manual forwarder smoke completed with 5 Codex files and 3,516 derived turns
- systemd user timer `beep-ai-metrics-forwarder.timer` is enabled and active; first owned run completed successfully
- archive decrypt drill passed without printing transcript text
- Pulumi `preview` and `up` passed for `beep-ai-metrics-dankserver`; stack now has 6 resources
- Phoenix endpoint reports `x-phoenix-server-version: 15.5.0`
- restarted config snapshot has one outcome label, one benchmark run, and `completionReady=true`

## Verification
- `git diff --check`
- `jq empty initiatives/ai-metrics-stack/ops/manifest.json`
- `bun run config-sync`
- `bun run config-sync:check`
- `bun run --filter @beep/repo-ai-metrics check && bun run --filter @beep/repo-ai-metrics test && bun run --filter @beep/repo-ai-metrics lint && bun run --filter @beep/repo-ai-metrics docgen`
- `bun run --filter @beep/repo-cli check && bun run --filter @beep/repo-cli test && bun run --filter @beep/repo-cli lint`
- `bun run --filter @beep/infra check && bun run --filter @beep/infra test && bun run --filter @beep/infra lint`
- `bun run check`
- `bun run lint`
- `bun run test`
- `bun packages/tooling/tool/cli/src/bin.ts -- laws terse-effect --check`
- focused Vitest for AI metrics library + CLI command tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kriegcloud/codesmith/beep-effect/pr/129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->