### PR TITLE
feat: harden jsdoc quality reporting

### DIFF
--- a/.aiassistant/skills/jsdoc-annotation-specialist/SKILL.md
+++ b/.aiassistant/skills/jsdoc-annotation-specialist/SKILL.md
@@ -82,12 +82,19 @@ Tag order within the block:
 
 The report-only `beep docgen quality` command scores the whole JSDoc block, not
 just whether tags exist. Treat `@example` as universal for exported symbols; for
-error classes, type-only helpers, constants, schemas, and re-exports, choose a
-handling, narrowing, construction, or import example that fits the symbol.
+error classes, type-only helpers, constants, and schemas, choose a handling,
+narrowing, construction, or import example that fits the symbol.
 
-A useful example is fenced TypeScript and shows an observable result: an
-assertion, returned value, decoded value, Effect execution, or visible output.
-`const result = ...; void result` is a compile trick, not documentation.
+Re-export declarations are graph edges, not symbol-quality subjects. Document
+the exported symbol at its owning declaration instead of inventing a fake barrel
+example.
+
+A useful example is fenced TypeScript and shows an observable result:
+assertion, returned value, decoded value, Effect execution, visible output, or
+type-level evidence. For type-only exports, useful evidence includes named
+aliases, assignability or `satisfies` checks, `Equal`/`Expect`-style assertions,
+or comments that show inferred types. `const result = ...; void result` is a
+compile trick, not documentation.
 
 ## TSDoc Grammar Hard Rules
 
@@ -338,9 +345,10 @@ Run this checklist against every file before finishing:
 ### Whole-block quality
 
 5. Description explains purpose rather than restating the symbol name.
-6. `@example` shows meaningful input and an observable result.
-7. Error, type-only, schema, constant, and re-export symbols still have
-   examples suited to their shape.
+6. `@example` shows meaningful input and an observable result, or type-level
+   evidence for type-only exports.
+7. Error, type-only, schema, and constant symbols still have examples suited to
+   their shape; re-export declarations point at owning symbol docs.
 
 ### Conditional tag correctness
 

--- a/.claude/skills/jsdoc-annotation-specialist/SKILL.md
+++ b/.claude/skills/jsdoc-annotation-specialist/SKILL.md
@@ -82,12 +82,19 @@ Tag order within the block:
 
 The report-only `beep docgen quality` command scores the whole JSDoc block, not
 just whether tags exist. Treat `@example` as universal for exported symbols; for
-error classes, type-only helpers, constants, schemas, and re-exports, choose a
-handling, narrowing, construction, or import example that fits the symbol.
+error classes, type-only helpers, constants, and schemas, choose a handling,
+narrowing, construction, or import example that fits the symbol.
 
-A useful example is fenced TypeScript and shows an observable result: an
-assertion, returned value, decoded value, Effect execution, or visible output.
-`const result = ...; void result` is a compile trick, not documentation.
+Re-export declarations are graph edges, not symbol-quality subjects. Document
+the exported symbol at its owning declaration instead of inventing a fake barrel
+example.
+
+A useful example is fenced TypeScript and shows an observable result:
+assertion, returned value, decoded value, Effect execution, visible output, or
+type-level evidence. For type-only exports, useful evidence includes named
+aliases, assignability or `satisfies` checks, `Equal`/`Expect`-style assertions,
+or comments that show inferred types. `const result = ...; void result` is a
+compile trick, not documentation.
 
 ## TSDoc Grammar Hard Rules
 
@@ -338,9 +345,10 @@ Run this checklist against every file before finishing:
 ### Whole-block quality
 
 5. Description explains purpose rather than restating the symbol name.
-6. `@example` shows meaningful input and an observable result.
-7. Error, type-only, schema, constant, and re-export symbols still have
-   examples suited to their shape.
+6. `@example` shows meaningful input and an observable result, or type-level
+   evidence for type-only exports.
+7. Error, type-only, schema, and constant symbols still have examples suited to
+   their shape; re-export declarations point at owning symbol docs.
 
 ### Conditional tag correctness
 

--- a/.patterns/jsdoc-documentation.md
+++ b/.patterns/jsdoc-documentation.md
@@ -89,16 +89,23 @@ use the symbol without inventing intent.
 - The description says what problem the symbol solves, not just what its name
   already says.
 - `@example` is still universal for exported symbols. Error classes, type-only
-  helpers, schemas, constants, and re-exports need examples too; choose a
-  handling, narrowing, construction, or import example that fits the symbol.
+  helpers, schemas, and constants need examples too; choose a handling,
+  narrowing, construction, or import example that fits the symbol.
+- Re-export declarations are graph edges, not symbol-quality subjects. Document
+  the exported symbol at its owning declaration; do not add fake examples to a
+  barrel just to satisfy quality tooling.
 - Examples use fenced TypeScript and show an observable result, assertion,
-  decoded value, Effect execution, or returned value. `const result = ...;
-  void result` is a compile trick, not useful documentation.
+  decoded value, Effect execution, returned value, or type-level evidence. For
+  type-only exports, useful evidence includes named aliases, assignability or
+  `satisfies` checks, `Equal`/`Expect`-style assertions, or comments that show
+  inferred types. `const result = ...; void result` is a compile trick, not
+  useful documentation.
 - Conditional tags are added only when they supply information that is not
   visible in the signature.
 
 Use `bun run beep docgen quality -p <package> --json --score codex` for the
-report-only quality subject and remediation packet shape.
+report-only quality subject and capped remediation packet shape. Add
+`--packet-limit <count>` to widen or suppress Codex advisory packets.
 
 ### Conditional Tags (Present Only When They Add Information)
 
@@ -901,6 +908,8 @@ const program = Effect.gen(function* () {
 - [ ] At least one practical, compilable example
 - [ ] Examples compile with `bun run docgen`
 - [ ] Quality report is reviewable with `bun run beep docgen quality -p <package>`
+- [ ] Type-only examples use concrete type evidence instead of value-only noise
+- [ ] Re-export barrels document owning symbols rather than fake barrel examples
 - [ ] All imports use correct namespace aliases
 - [ ] No `any` types, type assertions, `declare`, or empty example bodies
 - [ ] `@category` (canonical kebab-case slug from standard list)

--- a/initiatives/jsdoc-quality-enforcement/PLAN.md
+++ b/initiatives/jsdoc-quality-enforcement/PLAN.md
@@ -28,7 +28,7 @@ V1 is implemented as a report-only quality workflow:
 | P3 | Complete | Challenge the implementation direction. | `grill-with-docs` decision plan |
 | P4 | Complete | Implement report-only V1 quality workflow. | `beep docgen quality`, tests, guidance updates |
 | P5 | Complete | Evaluate enforcement readiness. | `research/enforcement-readiness-eval.md`, compact summary artifact |
-| P6 | Pending | Harden before any enforcement. | Runtime bounds, re-export policy, type-only example policy, opt-in warning proposal |
+| P6 | Complete | Harden before any enforcement. | Schema v2 package status, bounded JSON/report runtime, re-export/type-only policy, capped packets |
 
 ## V1 Implementation Changes
 
@@ -43,16 +43,25 @@ V1 is implemented as a report-only quality workflow:
 - Updated JSDoc pattern and skill guidance to reject low-value examples such as
   result-silencing examples.
 
+## P6 Hardening Changes
+
+- Bumped quality reports to schema v2 with package status, duration, timeout,
+  error, and omitted-packet metadata.
+- Kept re-export declarations as export graph edges instead of
+  symbol-quality subjects.
+- Accepted type-level evidence as useful `@example` content for type-only
+  exports while still flagging value examples that only silence results.
+- Ranked and capped Codex advisory remediation packets at 25 per run by
+  default, with `--packet-limit` for explicit overrides.
+- Bounded large JSON report rendering so schema-heavy packages emit reports
+  instead of stalling in pretty-formatting.
+
 ## Future Work
 
-- Bound package-local report runtime before proposing any blocking threshold.
-- Decide re-export/barrel documentation policy before gating namespace export
-  findings.
-- Decide type-only example usefulness policy before gating observable-result
-  findings on type exports.
+- Run a post-P6 report sample before proposing any blocking threshold.
+- Consider package opt-in warning mode before changed-files-only blocking after
+  P6 hardening proves stable signal in routine use.
 - Decide whether advisory packets should grow into guided Codex remediation
-  execution after packet sizing and prioritization are improved.
+  execution after capped packet batches are reviewed in real remediation work.
 - Revisit local/Qwen workers only behind an eval-only mode with measured
   precision and cost.
-- Consider package opt-in warning mode before changed-files-only blocking after
-  P6 hardening proves stable signal.

--- a/initiatives/jsdoc-quality-enforcement/README.md
+++ b/initiatives/jsdoc-quality-enforcement/README.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-V1 implemented; P5 enforcement-readiness eval complete
+V1 implemented; P6 hardening complete; still report-only
 
 ## Overview
 
@@ -13,7 +13,9 @@ V1 adds a report-only `beep docgen quality` workflow owned by `@beep/repo-cli`.
 It extracts deterministic quality subjects with `@beep/repo-docgen` parsing and
 required-tag policy, enriches them with source-file ts-morph evidence and
 `@beep/repo-utils` content hashing, scores the whole JSDoc block with typed
-findings, and emits bounded advisory Codex remediation packets. Diagnostics and
+findings, and emits bounded advisory Codex remediation packets. P6 adds schema
+v2 package status metadata, faster schema-heavy reports, re-export edge policy,
+type-only example evidence, and capped packet output. Diagnostics and
 related-symbol fields are reserved for follow-up enrichment when unavailable.
 The command is not a blocking gate.
 
@@ -28,11 +30,9 @@ The command is not a blocking gate.
 ## Operating Rules
 
 - Treat V1 quality findings as advisory report output only.
-- Do not add blocking enforcement until the P6 hardening items from
-  [research/enforcement-readiness-eval.md](./research/enforcement-readiness-eval.md)
-  are resolved.
-- Keep `@example` universal for exported symbols; do not invent exception
-  categories in remediation work.
+- Do not add blocking enforcement until post-P6 reports prove stable signal.
+- Keep `@example` universal for owning exported symbols; re-export declarations
+  are graph edges, not exception categories.
 - Place curated future evaluation reports in `research/`.
 - Place raw agent outputs, transcripts, or generated evidence in
   `history/outputs/` only when they need to be preserved.

--- a/initiatives/jsdoc-quality-enforcement/SPEC.md
+++ b/initiatives/jsdoc-quality-enforcement/SPEC.md
@@ -77,6 +77,7 @@ V1 adds:
 - `beep docgen quality --all`
 - `beep docgen quality --json`
 - `beep docgen quality --score codex`
+- `beep docgen quality --score codex --packet-limit <count>`
 - `beep docgen quality -o <path>`
 
 Package-local runs without `--output` write `JSDOC_QUALITY.md` or
@@ -93,6 +94,11 @@ The consolidated report contains:
 - `scope`
 - `scorer`
 - `summary`
+- `packages[].status`
+- `packages[].durationMs`
+- `packages[].error`
+- `packages[].timedOut`
+- `packages[].omittedPacketCount`
 - `packages[].subjects[]`
 - `packages[].reviews[]`
 - `remediationPackets[]`

--- a/initiatives/jsdoc-quality-enforcement/ops/manifest.json
+++ b/initiatives/jsdoc-quality-enforcement/ops/manifest.json
@@ -3,7 +3,7 @@
   "initiative": {
     "id": "jsdoc-quality-enforcement",
     "title": "JSDoc Quality Enforcement",
-    "status": "p5-evaluated",
+    "status": "p6-hardened",
     "created": "2026-05-08",
     "updated": "2026-05-09",
     "packetAnchorDocument": "SPEC.md"
@@ -51,7 +51,8 @@
     ".patterns/jsdoc-documentation.md",
     ".claude/skills/jsdoc-annotation-specialist/SKILL.md",
     ".agents/skills/jsdoc-annotation-specialist/SKILL.md",
-    ".aiassistant/skills/jsdoc-annotation-specialist/SKILL.md"
+    ".aiassistant/skills/jsdoc-annotation-specialist/SKILL.md",
+    "packages/tooling/tool/cli/README.md"
   ],
   "v1NonGoals": [
     "blocking quality gates",
@@ -59,5 +60,5 @@
     "local model workers",
     "example exception categories"
   ],
-  "nextAction": "Plan P6 hardening before enforcement: bound docgen quality runtime, decide re-export/barrel policy, decide type-only example policy, and only then consider package opt-in warnings."
+  "nextAction": "Run post-P6 report samples and consider package opt-in warnings only after the hardened report signal proves stable."
 }

--- a/packages/tooling/tool/cli/README.md
+++ b/packages/tooling/tool/cli/README.md
@@ -40,12 +40,15 @@ Produce a report-only JSDoc quality review for exported symbols. The command
 does not block on advisory findings; use `--score codex` when you want bounded
 remediation packets for follow-up documentation work. Package-local runs write
 `JSDOC_QUALITY.md` or `JSDOC_QUALITY.json` by default; use `--output` for a
-scratch destination.
+scratch destination. Reports use schema v2 package status fields, so a
+time-bounded package can appear as `partial` without discarding the rest of the
+run. Codex packets are ranked and capped at 25 per run by default; use
+`--packet-limit` to widen the work queue or `--packet-limit 0` to suppress it.
 
 ```bash
 bun run beep docgen quality -p packages/shared/config -o /tmp/jsdoc-quality.md
 bun run beep docgen quality --changed-files --json
-bun run beep docgen quality --all --score codex -o /tmp/jsdoc-quality.json
+bun run beep docgen quality --all --score codex --packet-limit 25 -o /tmp/jsdoc-quality.json
 ```
 
 ### `files`

--- a/packages/tooling/tool/cli/src/commands/Docgen/index.ts
+++ b/packages/tooling/tool/cli/src/commands/Docgen/index.ts
@@ -74,7 +74,9 @@ const qualityScoreFlag = Flag.choiceWithValue("score", [
 );
 const packetLimitFlag = Flag.integer("packet-limit").pipe(
   Flag.withDefault(25),
-  Flag.withDescription("Maximum number of Codex advisory remediation packets to emit; use 0 to suppress packets")
+  Flag.withDescription(
+    "Maximum number of Codex advisory remediation packets to emit; use 0 to suppress packets; must be zero or greater"
+  )
 );
 const verboseFlag = Flag.boolean("verbose").pipe(
   Flag.withAlias("v"),
@@ -655,6 +657,12 @@ const docgenQualityCommand = Command.make(
       if (targets.length === 0) {
         yield* Console.log("docgen: no packages selected for quality analysis");
         return;
+      }
+
+      if (packetLimit < 0) {
+        return yield* new DomainError({
+          message: "--packet-limit must be zero or greater; use 0 to suppress packets",
+        });
       }
 
       const report = yield* analyzeDocgenQuality({

--- a/packages/tooling/tool/cli/src/commands/Docgen/index.ts
+++ b/packages/tooling/tool/cli/src/commands/Docgen/index.ts
@@ -72,6 +72,10 @@ const qualityScoreFlag = Flag.choiceWithValue("score", [
     "Advisory scoring mode: rubric for deterministic findings, none as a compatibility alias, codex for Codex-ready packets"
   )
 );
+const packetLimitFlag = Flag.integer("packet-limit").pipe(
+  Flag.withDefault(25),
+  Flag.withDescription("Maximum number of Codex advisory remediation packets to emit; use 0 to suppress packets")
+);
 const verboseFlag = Flag.boolean("verbose").pipe(
   Flag.withAlias("v"),
   Flag.withDescription("Include extra package detail")
@@ -636,8 +640,9 @@ const docgenQualityCommand = Command.make(
     output: outputFlag,
     json: jsonFlag,
     score: qualityScoreFlag,
+    packetLimit: packetLimitFlag,
   },
-  ({ package: packageSelector, all, changedFiles, output, json, score }) =>
+  ({ package: packageSelector, all, changedFiles, output, json, score, packetLimit }) =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
@@ -653,6 +658,7 @@ const docgenQualityCommand = Command.make(
       }
 
       const report = yield* analyzeDocgenQuality({
+        packetLimit,
         scope,
         scoreMode: score,
         targets,

--- a/packages/tooling/tool/cli/src/commands/Docgen/internal/Quality.ts
+++ b/packages/tooling/tool/cli/src/commands/Docgen/internal/Quality.ts
@@ -15,7 +15,7 @@ import { DomainError, findRepoRoot } from "@beep/repo-utils";
 import { ContentHashFromSourceText } from "@beep/repo-utils/TSMorph/index";
 import { LiteralKit } from "@beep/schema";
 import { thunkEmptyStr } from "@beep/utils";
-import { DateTime, Effect, FileSystem, flow, Match, Order, Path, pipe, Stream } from "effect";
+import { DateTime, Duration, Effect, FileSystem, flow, Match, Order, Path, pipe, Stream } from "effect";
 import * as A from "effect/Array";
 import * as O from "effect/Option";
 import * as P from "effect/Predicate";
@@ -37,8 +37,11 @@ import {
 
 const $I = $RepoCliId.create("commands/Docgen/internal/Quality");
 
-const QUALITY_SCHEMA_VERSION = 1 as const;
+const QUALITY_SCHEMA_VERSION = 2 as const;
 const QUALITY_RUBRIC_VERSION = "jsdoc-quality-v1" as const;
+const DEFAULT_PACKAGE_TIMEOUT = Duration.seconds(180);
+const DEFAULT_REMEDIATION_PACKET_LIMIT = 25;
+const JSON_FORMAT_MAX_LENGTH = 500_000;
 const QUALITY_REQUIRED_EXPORT_TAGS = ["@category", "@example", "@since"] as const;
 const QUALITY_REQUIRED_MODULE_TAGS = ["@since"] as const;
 const QUALITY_TS_GLOBS = ["**/*.ts", "**/*.tsx"] as const;
@@ -169,6 +172,14 @@ export const DocgenQualityTier = LiteralKit(["pass", "warn", "fail"]).annotate(
  * @since 0.0.0
  */
 export type DocgenQualityTier = typeof DocgenQualityTier.Type;
+
+const DocgenQualityPackageStatus = LiteralKit(["completed", "partial", "failed"]).annotate(
+  $I.annote("DocgenQualityPackageStatus", {
+    description: "Completion status for a package-local docgen quality analysis.",
+  })
+);
+
+type DocgenQualityPackageStatus = typeof DocgenQualityPackageStatus.Type;
 
 /**
  * Typed finding code emitted by the v1 quality rubric.
@@ -326,6 +337,11 @@ class DocgenQualityPackageReport extends S.Class<DocgenQualityPackageReport>($I`
   {
     packageName: S.String,
     packagePath: S.String,
+    status: DocgenQualityPackageStatus,
+    durationMs: S.Number,
+    error: S.NullOr(S.String),
+    timedOut: S.Boolean,
+    omittedPacketCount: S.Number,
     subjects: S.Array(DocgenQualitySubject),
     reviews: S.Array(DocgenQualityReview),
     summary: DocgenQualitySummary,
@@ -358,7 +374,7 @@ class DocgenQualityRemediationPacket extends S.Class<DocgenQualityRemediationPac
  * ```ts
  * import type { DocgenQualityReport } from "@beep/repo-cli/commands/Docgen/internal/Quality"
  *
- * const report: Pick<DocgenQualityReport, "schemaVersion"> = { schemaVersion: 1 }
+ * const report: Pick<DocgenQualityReport, "schemaVersion"> = { schemaVersion: 2 }
  * console.log(report.schemaVersion)
  * ```
  * @category models
@@ -396,6 +412,29 @@ const bySubjectIdentityAscending: Order.Order<DocgenQualitySubject> = Order.mapI
 
 const normalizeSlashes = (value: string): string => value.replace(/\\/g, "/");
 
+type QualityRuntimeBudget = {
+  readonly startedAtMs: number;
+  readonly timeoutMs: number;
+};
+
+const makeRuntimeBudget = (timeout: Duration.Duration): QualityRuntimeBudget => ({
+  startedAtMs: globalThis.performance.now(),
+  timeoutMs: Duration.toMillis(timeout),
+});
+
+const budgetDurationMs = (budget: QualityRuntimeBudget): number =>
+  Math.max(0, Math.round(globalThis.performance.now() - budget.startedAtMs));
+
+const budgetExceeded = (budget: QualityRuntimeBudget): boolean => budgetDurationMs(budget) >= budget.timeoutMs;
+
+const packageTimeoutMessage = (target: DocgenWorkspacePackage, budget: QualityRuntimeBudget): string =>
+  `Timed out after ${budget.timeoutMs}ms while analyzing ${target.relativePath}.`;
+
+const errorMessage = (error: unknown): string =>
+  P.isObject(error) && P.hasProperty(error, "message") && P.isString(error.message)
+    ? error.message
+    : "Unknown docgen quality analysis failure.";
+
 const firstLine = (value: string): string => {
   const [line] = value.split(/\r?\n/);
   return Str.trim(line ?? value);
@@ -407,6 +446,10 @@ const renderJson = Effect.fn("DocgenQuality.renderJson")(function* (value: unkno
   const encoded = yield* encodeJson(value).pipe(
     Effect.mapError((cause) => new DomainError({ message: "Failed to encode docgen quality JSON.", cause }))
   );
+  if (encoded.length > JSON_FORMAT_MAX_LENGTH) {
+    return `${encoded}\n`;
+  }
+
   const edits = jsonc.format(encoded, undefined, {
     tabSize: 2,
     insertSpaces: true,
@@ -726,9 +769,50 @@ type ExportedDeclarationCandidate = {
   readonly exportDeclarationText?: string;
 };
 
+type LocalDeclaration = {
+  readonly name: string;
+  readonly declaration: Node;
+};
+
+const collectLocalDeclarations = (sourceFile: SourceFile): ReadonlyArray<LocalDeclaration> => {
+  let declarations = A.empty<LocalDeclaration>();
+
+  for (const statement of sourceFile.getStatements()) {
+    if (Node.isVariableStatement(statement)) {
+      for (const declaration of statement.getDeclarations()) {
+        declarations = A.append(declarations, {
+          declaration,
+          name: declaration.getName(),
+        });
+      }
+      continue;
+    }
+
+    if (
+      Node.isFunctionDeclaration(statement) ||
+      Node.isClassDeclaration(statement) ||
+      Node.isInterfaceDeclaration(statement) ||
+      Node.isTypeAliasDeclaration(statement) ||
+      Node.isEnumDeclaration(statement) ||
+      Node.isModuleDeclaration(statement)
+    ) {
+      const name = statement.getName();
+
+      if (name !== undefined) {
+        declarations = A.append(declarations, {
+          declaration: statement,
+          name,
+        });
+      }
+    }
+  }
+
+  return declarations;
+};
+
 const collectExportedDeclarationCandidates = (sourceFile: SourceFile): ReadonlyArray<ExportedDeclarationCandidate> => {
   let candidates = A.empty<ExportedDeclarationCandidate>();
-  const exportedDeclarations = sourceFile.getExportedDeclarations();
+  const localDeclarations = collectLocalDeclarations(sourceFile);
 
   for (const exportDeclaration of sourceFile.getExportDeclarations()) {
     if (exportDeclaration.getModuleSpecifierValue() !== undefined) {
@@ -736,25 +820,22 @@ const collectExportedDeclarationCandidates = (sourceFile: SourceFile): ReadonlyA
     }
 
     const rawJsDoc = getLeadingJsDocCommentText(exportDeclaration);
-    if (Str.trim(rawJsDoc).length === 0) {
-      continue;
-    }
 
     for (const specifier of exportDeclaration.getNamedExports()) {
+      const localName = specifier.getName();
       const exportName = specifier.getAliasNode()?.getText() ?? specifier.getName();
-      const declarations =
-        exportedDeclarations.get(exportName) ?? exportedDeclarations.get(specifier.getName()) ?? A.empty();
+      const declarations = pipe(
+        localDeclarations,
+        A.filter((entry) => entry.name === localName),
+        A.map((entry) => entry.declaration)
+      );
 
       for (const declaration of declarations) {
-        if (declaration.getSourceFile() !== sourceFile) {
-          continue;
-        }
-
         candidates = A.append(candidates, {
           name: exportName,
           declaration,
           anchorNode: exportDeclaration,
-          rawJsDoc,
+          ...(Str.trim(rawJsDoc).length > 0 ? { rawJsDoc } : {}),
           exportDeclarationText: exportDeclaration.getText(),
         });
       }
@@ -789,19 +870,6 @@ const collectExportedDeclarationCandidates = (sourceFile: SourceFile): ReadonlyA
           declaration: statement,
         });
       }
-    }
-  }
-
-  for (const [name, declarations] of exportedDeclarations) {
-    for (const declaration of declarations) {
-      if (declaration.getSourceFile() !== sourceFile) {
-        continue;
-      }
-
-      candidates = A.append(candidates, {
-        name,
-        declaration,
-      });
     }
   }
 
@@ -993,67 +1061,7 @@ const collectModuleSubject = ({
   );
 };
 
-const collectReExportSubjects = ({
-  diagnostics,
-  filePath,
-  generatedDocSnippet,
-  packageName,
-  packagePath,
-  repoPath,
-  sourceFile,
-}: {
-  readonly diagnostics: ReadonlyArray<Diagnostic>;
-  readonly filePath: string;
-  readonly generatedDocSnippet: string | null;
-  readonly packageName: string;
-  readonly packagePath: string;
-  readonly repoPath: string;
-  readonly sourceFile: SourceFile;
-}): ReadonlyArray<DocgenQualitySubjectCandidate> => {
-  let subjects = A.empty<DocgenQualitySubjectCandidate>();
-
-  for (const declaration of sourceFile.getExportDeclarations()) {
-    if (declaration.getModuleSpecifierValue() === undefined) {
-      continue;
-    }
-
-    const rawJsDoc = getLeadingJsDocCommentText(declaration);
-    const line = nodeLine(declaration);
-    const name =
-      declaration.getNamedExports().length === 0
-        ? `export * from ${declaration.getModuleSpecifierValue()}`
-        : `export { ${A.join(
-            A.map(
-              declaration.getNamedExports(),
-              (specifier) => specifier.getAliasNode()?.getText() ?? specifier.getName()
-            ),
-            ", "
-          )} }`;
-
-    subjects = A.append(
-      subjects,
-      makeSubjectCandidate({
-        declarationKind: "re-export",
-        declarationSource: declaration.getText(),
-        diagnostics,
-        endLine: sourceFile.getLineAndColumnAtPos(declaration.getEnd()).line,
-        exportName: name,
-        filePath,
-        generatedDocSnippet,
-        hashSourceText: `${rawJsDoc}\n${declaration.getText()}`,
-        line,
-        packageName,
-        packagePath,
-        rawJsDoc,
-        relatedSymbols: A.empty(),
-        repoPath,
-        signature: signatureText(declaration),
-      })
-    );
-  }
-
-  return subjects;
-};
+const collectReExportSubjects = A.empty;
 
 const collectDirectExportSubjects = ({
   diagnostics,
@@ -1138,8 +1146,16 @@ const finalizeSubject = Effect.fn("DocgenQuality.finalizeSubject")(function* (
   });
 });
 
+type PackageSubjectCandidateResult = {
+  readonly candidates: ReadonlyArray<DocgenQualitySubjectCandidate>;
+  readonly error: string | null;
+  readonly status: DocgenQualityPackageStatus;
+  readonly timedOut: boolean;
+};
+
 const collectPackageSubjectCandidates = Effect.fn("DocgenQuality.collectPackageSubjectCandidates")(function* (
-  target: DocgenWorkspacePackage
+  target: DocgenWorkspacePackage,
+  budget: QualityRuntimeBudget
 ) {
   const path = yield* Path.Path;
   const config = target.hasDocgenConfig
@@ -1155,7 +1171,7 @@ const collectPackageSubjectCandidates = Effect.fn("DocgenQuality.collectPackageS
     QUALITY_TS_GLOBS,
     A.map((glob) => normalizeSlashes(path.join(target.absolutePath, srcDir, glob)))
   );
-  const candidates = yield* Effect.try({
+  return yield* Effect.try({
     try: () => {
       const project = new Project({
         skipAddingFilesFromTsConfig: true,
@@ -1165,6 +1181,15 @@ const collectPackageSubjectCandidates = Effect.fn("DocgenQuality.collectPackageS
       let subjects = A.empty<DocgenQualitySubjectCandidate>();
 
       for (const sourceFile of project.getSourceFiles()) {
+        if (budgetExceeded(budget)) {
+          return {
+            candidates: subjects,
+            error: packageTimeoutMessage(target, budget),
+            status: "partial" as const,
+            timedOut: true,
+          } satisfies PackageSubjectCandidateResult;
+        }
+
         if (!isInterestingSourceFile(target, sourceFile, srcDir, exclude, path)) {
           continue;
         }
@@ -1184,12 +1209,17 @@ const collectPackageSubjectCandidates = Effect.fn("DocgenQuality.collectPackageS
         subjects = [
           ...subjects,
           ...pipe(collectModuleSubject(payload), O.match({ onNone: A.empty, onSome: (subject) => [subject] })),
-          ...collectReExportSubjects(payload),
+          ...collectReExportSubjects(),
           ...collectDirectExportSubjects(payload),
         ];
       }
 
-      return subjects;
+      return {
+        candidates: subjects,
+        error: null,
+        status: "completed" as const,
+        timedOut: false,
+      } satisfies PackageSubjectCandidateResult;
     },
     catch: (cause) =>
       new DomainError({
@@ -1197,26 +1227,42 @@ const collectPackageSubjectCandidates = Effect.fn("DocgenQuality.collectPackageS
         cause,
       }),
   });
-
-  return yield* Effect.forEach(candidates, finalizeSubject);
 });
 
 const withGeneratedDocSnippets = Effect.fn("DocgenQuality.withGeneratedDocSnippets")(function* (
   target: DocgenWorkspacePackage,
   subjects: ReadonlyArray<DocgenQualitySubject>
 ) {
-  return yield* Effect.forEach(subjects, (subject) =>
-    generatedDocSnippetForFile(target, subject.filePath).pipe(
-      Effect.map((snippet) =>
-        snippet === subject.generatedDocSnippet
-          ? subject
-          : new DocgenQualitySubject({
-              ...subject,
-              generatedDocSnippet: snippet,
-            })
-      )
-    )
+  const snippets = yield* Effect.forEach(
+    pipe(
+      subjects,
+      A.map((subject) => subject.filePath),
+      A.dedupe,
+      A.sort(Order.String)
+    ),
+    (filePath) =>
+      generatedDocSnippetForFile(target, filePath).pipe(
+        Effect.map((snippet) => ({
+          filePath,
+          snippet,
+        }))
+      ),
+    { concurrency: 4 }
   );
+  return A.map(subjects, (subject) => {
+    const snippet = pipe(
+      snippets,
+      A.findFirst((candidate) => candidate.filePath === subject.filePath),
+      O.map((candidate) => candidate.snippet),
+      O.getOrElse(() => subject.generatedDocSnippet)
+    );
+    return snippet === subject.generatedDocSnippet
+      ? subject
+      : new DocgenQualitySubject({
+          ...subject,
+          generatedDocSnippet: snippet,
+        });
+  });
 });
 
 const exampleHasFencedCode = (example: string): boolean => /```(?:ts|tsx|typescript)?\s*[\s\S]*?```/i.test(example);
@@ -1238,6 +1284,8 @@ const exampleIsTooTrivial = (example: string): boolean => {
 
 const OBSERVABLE_EXAMPLE_RESULT_PATTERN =
   /expect\s*\(|assert|return\s+|(?:Console|console)\.|Effect\.run|S\.decode|Schema\.decode|Equal\.|\.pipe\(/;
+const TYPE_EVIDENCE_EXAMPLE_PATTERN =
+  /\btype\s+[A-Z_a-z]\w*\s*=|\binterface\s+[A-Z_a-z]\w*|\bsatisfies\b|\bExpect<|\bEqual\.|expectTypeOf\s*\(/;
 
 const exampleOnlyVoidsResult = (example: string): boolean => {
   const code = exampleCodeText(example);
@@ -1246,6 +1294,18 @@ const exampleOnlyVoidsResult = (example: string): boolean => {
 
 const exampleHasObservableResult = (example: string): boolean =>
   OBSERVABLE_EXAMPLE_RESULT_PATTERN.test(exampleCodeText(example));
+
+const exampleHasTypeEvidence = (example: string): boolean =>
+  TYPE_EVIDENCE_EXAMPLE_PATTERN.test(exampleCodeText(example));
+
+const isTypeOnlySubject = (subject: DocgenQualitySubject): boolean =>
+  subject.declarationKind === "type" || subject.declarationKind === "interface";
+
+const exampleOnlyVoidsSubjectResult = (subject: DocgenQualitySubject, example: string): boolean =>
+  isTypeOnlySubject(subject) && exampleHasTypeEvidence(example) ? false : exampleOnlyVoidsResult(example);
+
+const exampleHasSubjectEvidence = (subject: DocgenQualitySubject, example: string): boolean =>
+  exampleHasObservableResult(example) || (isTypeOnlySubject(subject) && exampleHasTypeEvidence(example));
 
 const addFinding = (
   findings: ReadonlyArray<DocgenQualityFinding>,
@@ -1354,7 +1414,7 @@ const scoreSubject = (subject: DocgenQualitySubject): DocgenQualityReview => {
       );
     }
 
-    if (exampleOnlyVoidsResult(example)) {
+    if (exampleOnlyVoidsSubjectResult(subject, example)) {
       findings = addFinding(
         findings,
         makeFinding({
@@ -1369,7 +1429,10 @@ const scoreSubject = (subject: DocgenQualitySubject): DocgenQualityReview => {
     }
   }
 
-  if (subject.parsedExamples.length > 0 && !A.some(subject.parsedExamples, exampleHasObservableResult)) {
+  if (
+    subject.parsedExamples.length > 0 &&
+    !A.some(subject.parsedExamples, (example) => exampleHasSubjectEvidence(subject, example))
+  ) {
     findings = addFinding(
       findings,
       makeFinding({
@@ -1439,6 +1502,32 @@ const summarizeReviews = (
     remediationPackets,
   });
 
+const emptyPackageReport = ({
+  durationMs,
+  error,
+  status,
+  target,
+  timedOut,
+}: {
+  readonly durationMs: number;
+  readonly error: string | null;
+  readonly status: DocgenQualityPackageStatus;
+  readonly target: DocgenWorkspacePackage;
+  readonly timedOut: boolean;
+}): DocgenQualityPackageReport =>
+  new DocgenQualityPackageReport({
+    packageName: target.name,
+    packagePath: target.relativePath,
+    status,
+    durationMs,
+    error,
+    timedOut,
+    omittedPacketCount: 0,
+    subjects: A.empty(),
+    reviews: A.empty(),
+    summary: summarizeReviews(1, 0, A.empty(), 0),
+  });
+
 const remediationPrompt = (subject: DocgenQualitySubject, review: DocgenQualityReview): string =>
   [
     "Improve the JSDoc block for this exported symbol without changing runtime behavior.",
@@ -1468,35 +1557,82 @@ const makeRemediationPacket = (
     verificationArgv: ["bun", "run", "beep", "docgen", "quality", "-p", subject.packagePath, "--json"],
   });
 
-const remediationPacketsForPackage = (pkg: DocgenQualityPackageReport): ReadonlyArray<DocgenQualityRemediationPacket> =>
+type RemediationPacketCandidate = {
+  readonly impact: number;
+  readonly isFail: boolean;
+  readonly packagePath: string;
+  readonly packet: DocgenQualityRemediationPacket;
+  readonly subjectId: string;
+};
+
+const packetCandidateOrder: Order.Order<RemediationPacketCandidate> = Order.combine(
+  Order.mapInput(Order.Number, (candidate) => (candidate.isFail ? 0 : 1)),
+  Order.combine(
+    Order.flip(Order.mapInput(Order.Number, (candidate) => candidate.impact)),
+    Order.combine(
+      Order.mapInput(Order.String, (candidate) => candidate.packagePath),
+      Order.mapInput(Order.String, (candidate) => candidate.subjectId)
+    )
+  )
+);
+
+const remediationPacketCandidatesForPackage = (
+  pkg: DocgenQualityPackageReport
+): ReadonlyArray<RemediationPacketCandidate> =>
   pipe(
     pkg.reviews,
     A.filter((review) => review.tier !== "pass"),
     A.flatMap((review) => {
       const subject = A.findFirst(pkg.subjects, (candidate) => candidate.stableIdentity === review.subjectId);
       return O.isSome(subject)
-        ? [makeRemediationPacket(subject.value, review)]
-        : A.empty<DocgenQualityRemediationPacket>();
+        ? [
+            {
+              impact: A.reduce(review.findings, 0, (total, finding) => total + finding.scoreImpact),
+              isFail: review.tier === "fail",
+              packagePath: pkg.packagePath,
+              packet: makeRemediationPacket(subject.value, review),
+              subjectId: review.subjectId,
+            },
+          ]
+        : A.empty<RemediationPacketCandidate>();
     })
   );
 
+const countCandidatesForPackage = (
+  candidates: ReadonlyArray<RemediationPacketCandidate>,
+  packagePath: string
+): number => A.filter(candidates, (candidate) => candidate.packagePath === packagePath).length;
+
 const withRemediationPacketCount = (
   pkg: DocgenQualityPackageReport,
-  remediationPackets: number
+  remediationPackets: number,
+  omittedPacketCount: number
 ): DocgenQualityPackageReport =>
   new DocgenQualityPackageReport({
     ...pkg,
+    omittedPacketCount,
     summary: summarizeReviews(1, pkg.subjects.length, pkg.reviews, remediationPackets),
   });
 
 const packageReport = (
   target: DocgenWorkspacePackage,
-  subjects: ReadonlyArray<DocgenQualitySubject>
+  subjects: ReadonlyArray<DocgenQualitySubject>,
+  options: {
+    readonly durationMs: number;
+    readonly error: string | null;
+    readonly status: DocgenQualityPackageStatus;
+    readonly timedOut: boolean;
+  }
 ): DocgenQualityPackageReport => {
   const reviews = A.map(subjects, scoreSubject);
   return new DocgenQualityPackageReport({
     packageName: target.name,
     packagePath: target.relativePath,
+    status: options.status,
+    durationMs: options.durationMs,
+    error: options.error,
+    timedOut: options.timedOut,
+    omittedPacketCount: 0,
     subjects,
     reviews,
     summary: summarizeReviews(1, subjects.length, reviews, 0),
@@ -1531,18 +1667,45 @@ const packageReport = (
  * @since 0.0.0
  */
 export const analyzePackageQuality = Effect.fn("DocgenQuality.analyzePackageQuality")(function* (
-  target: DocgenWorkspacePackage
+  target: DocgenWorkspacePackage,
+  options?: {
+    readonly packageTimeout?: Duration.Duration;
+  }
 ) {
-  const candidates = yield* collectPackageSubjectCandidates(target);
-  const subjects = yield* withGeneratedDocSnippets(
-    target,
-    pipe(
-      candidates,
-      A.dedupeWith((left, right) => left.stableIdentity === right.stableIdentity),
-      A.sort(bySubjectIdentityAscending)
+  const budget = makeRuntimeBudget(options?.packageTimeout ?? DEFAULT_PACKAGE_TIMEOUT);
+  return yield* Effect.gen(function* () {
+    const candidateResult = yield* collectPackageSubjectCandidates(target, budget);
+    const finalizedSubjects = yield* Effect.forEach(candidateResult.candidates, finalizeSubject);
+    const subjects = yield* withGeneratedDocSnippets(
+      target,
+      pipe(
+        finalizedSubjects,
+        A.dedupeWith((left, right) => left.stableIdentity === right.stableIdentity),
+        A.sort(bySubjectIdentityAscending)
+      )
+    );
+    const timedOut = candidateResult.timedOut || budgetExceeded(budget);
+    const status: DocgenQualityPackageStatus = timedOut ? "partial" : candidateResult.status;
+    const error = timedOut ? (candidateResult.error ?? packageTimeoutMessage(target, budget)) : candidateResult.error;
+    return packageReport(target, subjects, {
+      durationMs: budgetDurationMs(budget),
+      error,
+      status,
+      timedOut,
+    });
+  }).pipe(
+    Effect.catch((error) =>
+      Effect.succeed(
+        emptyPackageReport({
+          durationMs: budgetDurationMs(budget),
+          error: errorMessage(error),
+          status: "failed",
+          target,
+          timedOut: false,
+        })
+      )
     )
   );
-  return packageReport(target, subjects);
 });
 
 /**
@@ -1571,20 +1734,37 @@ export const analyzePackageQuality = Effect.fn("DocgenQuality.analyzePackageQual
  * @since 0.0.0
  */
 export const analyzeDocgenQuality = Effect.fn("DocgenQuality.analyzeDocgenQuality")(function* ({
+  packageTimeout,
+  packetLimit,
   scope,
   scoreMode,
   targets,
 }: {
+  readonly packageTimeout?: Duration.Duration;
+  readonly packetLimit?: number;
   readonly scope: DocgenQualityScopeMode;
   readonly scoreMode: DocgenQualityScoreMode;
   readonly targets: ReadonlyArray<DocgenWorkspacePackage>;
 }) {
-  const analyzedPackages = yield* Effect.forEach(targets, analyzePackageQuality, { concurrency: 2 });
-  const packagePackets = A.map(analyzedPackages, (pkg) => ({
-    packets: scoreMode === "codex" ? remediationPacketsForPackage(pkg) : A.empty<DocgenQualityRemediationPacket>(),
-    pkg,
-  }));
-  const packages = A.map(packagePackets, ({ packets, pkg }) => withRemediationPacketCount(pkg, packets.length));
+  const packageQualityOptions = packageTimeout === undefined ? {} : { packageTimeout };
+  const analyzedPackages = yield* Effect.forEach(
+    targets,
+    (target) => analyzePackageQuality(target, packageQualityOptions),
+    {
+      concurrency: 2,
+    }
+  );
+  const packetCap = Math.max(0, packetLimit ?? DEFAULT_REMEDIATION_PACKET_LIMIT);
+  const packetCandidates =
+    scoreMode === "codex"
+      ? pipe(analyzedPackages, A.flatMap(remediationPacketCandidatesForPackage), A.sort(packetCandidateOrder))
+      : A.empty<RemediationPacketCandidate>();
+  const selectedCandidates = A.take(packetCandidates, packetCap);
+  const packages = A.map(analyzedPackages, (pkg) => {
+    const selectedCount = countCandidatesForPackage(selectedCandidates, pkg.packagePath);
+    const candidateCount = countCandidatesForPackage(packetCandidates, pkg.packagePath);
+    return withRemediationPacketCount(pkg, selectedCount, Math.max(0, candidateCount - selectedCount));
+  });
   const reviews = pipe(
     packages,
     A.flatMap((pkg) => pkg.reviews)
@@ -1593,10 +1773,7 @@ export const analyzeDocgenQuality = Effect.fn("DocgenQuality.analyzeDocgenQualit
     packages,
     A.flatMap((pkg) => pkg.subjects)
   );
-  const remediationPackets = pipe(
-    packagePackets,
-    A.flatMap(({ packets }) => packets)
-  );
+  const remediationPackets = A.map(selectedCandidates, (candidate) => candidate.packet);
 
   return new DocgenQualityReport({
     schemaVersion: QUALITY_SCHEMA_VERSION,
@@ -1703,7 +1880,19 @@ export const generateQualityReport = (report: DocgenQualityReport): string => {
   ];
 
   for (const pkg of report.packages) {
-    lines.push(`## ${pkg.packageName}`, "", `Path: \`${pkg.packagePath}\``, "");
+    lines.push(
+      `## ${pkg.packageName}`,
+      "",
+      `Path: \`${pkg.packagePath}\``,
+      `Status: \`${pkg.status}\``,
+      `Duration: ${pkg.durationMs}ms`,
+      `Omitted packets: ${pkg.omittedPacketCount}`,
+      ""
+    );
+
+    if (pkg.error !== null) {
+      lines.push(`> ${pkg.error}`, "");
+    }
 
     if (pkg.subjects.length === 0) {
       lines.push("No exported-symbol JSDoc subjects found.", "");

--- a/packages/tooling/tool/cli/src/commands/Docgen/internal/Quality.ts
+++ b/packages/tooling/tool/cli/src/commands/Docgen/internal/Quality.ts
@@ -24,7 +24,7 @@ import * as S from "effect/Schema";
 import * as Str from "effect/String";
 import { ChildProcess } from "effect/unstable/process";
 import * as jsonc from "jsonc-parser";
-import { type Diagnostic, type ExportDeclaration, type JSDoc, Node, Project, type SourceFile } from "ts-morph";
+import { type Diagnostic, type JSDoc, Node, Project, type SourceFile } from "ts-morph";
 import { normalizeJSDocCategory } from "../../Shared/JSDocCategories.js";
 import {
   assertNoOrphanDocgenConfigPaths,
@@ -521,9 +521,7 @@ const selectPackagesForFiles = (
 ): ReadonlyArray<DocgenWorkspacePackage> =>
   pipe(
     packages,
-    A.filter((pkg) =>
-      A.some(files, (filePath) => filePath === pkg.relativePath || Str.startsWith(`${pkg.relativePath}/`)(filePath))
-    ),
+    A.filter((pkg) => A.some(files, (filePath) => Str.startsWith(`${pkg.relativePath}/`)(filePath))),
     A.sort(byPackagePathAscending)
   );
 
@@ -697,7 +695,7 @@ const getLastJsDocText = (node: Node): string =>
     O.getOrElse(thunkEmptyStr)
   );
 
-const getLeadingJsDocCommentText = (node: ExportDeclaration): string =>
+const getLeadingJsDocCommentText = (node: Node): string =>
   pipe(
     node.getLeadingCommentRanges(),
     A.filter((range) => Str.startsWith("/**")(range.getText())),
@@ -814,6 +812,32 @@ const collectExportedDeclarationCandidates = (sourceFile: SourceFile): ReadonlyA
   let candidates = A.empty<ExportedDeclarationCandidate>();
   const localDeclarations = collectLocalDeclarations(sourceFile);
 
+  for (const exportAssignment of sourceFile.getExportAssignments()) {
+    if (exportAssignment.isExportEquals()) {
+      continue;
+    }
+
+    const rawJsDoc = getLeadingJsDocCommentText(exportAssignment);
+    const expression = exportAssignment.getExpression();
+    const declarations = Node.isIdentifier(expression)
+      ? pipe(
+          localDeclarations,
+          A.filter((entry) => entry.name === expression.getText()),
+          A.map((entry) => entry.declaration)
+        )
+      : [expression];
+
+    for (const declaration of declarations) {
+      candidates = A.append(candidates, {
+        name: "default",
+        declaration,
+        anchorNode: exportAssignment,
+        ...(Str.trim(rawJsDoc).length > 0 ? { rawJsDoc } : {}),
+        exportDeclarationText: exportAssignment.getText(),
+      });
+    }
+  }
+
   for (const exportDeclaration of sourceFile.getExportDeclarations()) {
     if (exportDeclaration.getModuleSpecifierValue() !== undefined) {
       continue;
@@ -862,7 +886,7 @@ const collectExportedDeclarationCandidates = (sourceFile: SourceFile): ReadonlyA
         Node.isModuleDeclaration(statement)) &&
       statement.isExported()
     ) {
-      const name = statement.getName();
+      const name = statement.isDefaultExport() ? "default" : statement.getName();
 
       if (name !== undefined) {
         candidates = A.append(candidates, {
@@ -1061,6 +1085,8 @@ const collectModuleSubject = ({
   );
 };
 
+// Re-export declarations are permanent export graph edges, not owner
+// declarations for quality scoring. The owning declaration remains the subject.
 const collectReExportSubjects = A.empty;
 
 const collectDirectExportSubjects = ({

--- a/packages/tooling/tool/cli/test/docgen.test.ts
+++ b/packages/tooling/tool/cli/test/docgen.test.ts
@@ -953,6 +953,125 @@ export type Elem<T> = T extends readonly (infer U)[] ? U : never;
     );
   });
 
+  it("preserves default-export subjects in quality analysis", async () => {
+    await Effect.runPromise(
+      withTempRepo(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const tmpDir = process.cwd();
+          yield* fs.writeFileString(
+            path.join(tmpDir, "package.json"),
+            encodeJson({
+              name: "@beep/test-root",
+              private: true,
+              workspaces: ["packages/foundation/*/*"],
+            })
+          );
+
+          const packageDir = path.join(tmpDir, "packages", "foundation", "modeling", "schema");
+          yield* fs.makeDirectory(path.join(packageDir, "src"), { recursive: true });
+          yield* fs.writeFileString(
+            path.join(packageDir, "package.json"),
+            encodeJson({
+              name: "@beep/schema",
+              version: "0.0.0",
+            })
+          );
+          yield* fs.writeFileString(path.join(packageDir, "docgen.json"), encodeJson({ srcDir: "src" }));
+          yield* fs.writeFileString(
+            path.join(packageDir, "src", "DefaultFunction.ts"),
+            `/**
+ * Normalizes a default-exported function value.
+ *
+ * @example
+ * \`\`\`ts
+ * import normalizeDefault from "@beep/schema/DefaultFunction"
+ *
+ * console.log(normalizeDefault(" hello "))
+ * \`\`\`
+ * @category parsing
+ * @since 0.0.0
+ */
+export default function (value: string): string {
+  return value.trim();
+}
+`
+          );
+          yield* fs.writeFileString(
+            path.join(packageDir, "src", "DefaultClass.ts"),
+            `/**
+ * Default-exported value holder fixture.
+ *
+ * @example
+ * \`\`\`ts
+ * import DefaultValueHolder from "@beep/schema/DefaultClass"
+ *
+ * console.log(new DefaultValueHolder().value)
+ * \`\`\`
+ * @category models
+ * @since 0.0.0
+ */
+export default class {
+  readonly value = "class-default";
+}
+`
+          );
+          yield* fs.writeFileString(
+            path.join(packageDir, "src", "AssignedDefault.ts"),
+            `/**
+ * Trims a value before exporting it as the module default.
+ *
+ * @example
+ * \`\`\`ts
+ * import trimDefault from "@beep/schema/AssignedDefault"
+ *
+ * console.log(trimDefault(" hello "))
+ * \`\`\`
+ * @category parsing
+ * @since 0.0.0
+ */
+const trimDefault = (value: string): string => value.trim();
+
+export default trimDefault;
+`
+          );
+
+          const packages = yield* discoverDocgenWorkspacePackages(tmpDir);
+          const target = packages.find((pkg) => pkg.name === "@beep/schema");
+
+          expect(target).toBeDefined();
+
+          const report = yield* analyzePackageQuality(target!);
+          const defaultSubjects = pipe(
+            report.subjects,
+            A.filter((subject) => subject.exportName === "default")
+          );
+
+          expect(defaultSubjects).toHaveLength(3);
+          expect(
+            pipe(
+              defaultSubjects,
+              A.map((subject) => subject.declarationKind)
+            )
+          ).toEqual(expect.arrayContaining(["class", "const", "function"]));
+          expect(
+            pipe(
+              defaultSubjects,
+              A.map((subject) => subject.repoPath)
+            )
+          ).toEqual(
+            expect.arrayContaining([
+              "packages/foundation/modeling/schema/src/AssignedDefault.ts",
+              "packages/foundation/modeling/schema/src/DefaultClass.ts",
+              "packages/foundation/modeling/schema/src/DefaultFunction.ts",
+            ])
+          );
+        })
+      )
+    );
+  });
+
   it("treats module re-exports as graph edges instead of quality subjects", async () => {
     await Effect.runPromise(
       withTempRepo(
@@ -1402,6 +1521,133 @@ export const value${index} = ${index};
           expect(limitedReport.packages[0]?.omittedPacketCount).toBe(28);
           expect(suppressedReport.remediationPackets).toHaveLength(0);
           expect(suppressedReport.packages[0]?.omittedPacketCount).toBe(30);
+        })
+      )
+    );
+  });
+
+  it("wires --packet-limit through the quality CLI", { timeout: DOCGEN_COMMAND_TEST_TIMEOUT }, async () => {
+    await Effect.runPromise(
+      withTempRepoCommand(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const tmpDir = process.cwd();
+          yield* fs.writeFileString(
+            path.join(tmpDir, "package.json"),
+            encodeJson({
+              name: "@beep/test-root",
+              private: true,
+              workspaces: ["packages/foundation/*/*"],
+            })
+          );
+
+          const packageDir = path.join(tmpDir, "packages", "foundation", "modeling", "schema");
+          const outputPath = path.join(tmpDir, "quality.json");
+          yield* fs.makeDirectory(path.join(packageDir, "src"), { recursive: true });
+          yield* fs.writeFileString(
+            path.join(packageDir, "package.json"),
+            encodeJson({
+              name: "@beep/schema",
+              version: "0.0.0",
+            })
+          );
+          yield* fs.writeFileString(path.join(packageDir, "docgen.json"), encodeJson({ srcDir: "src" }));
+          yield* fs.writeFileString(
+            path.join(packageDir, "src", "index.ts"),
+            A.join(
+              A.map(
+                A.range(1, 5),
+                (index) => `/**
+ * Missing example CLI fixture ${index}.
+ *
+ * @category parsing
+ * @since 0.0.0
+ */
+export const cliValue${index} = ${index};
+`
+              ),
+              "\n"
+            )
+          );
+
+          yield* runDocgenCommand([
+            "quality",
+            "-p",
+            "packages/foundation/modeling/schema",
+            "--json",
+            "--score",
+            "codex",
+            "--packet-limit",
+            "2",
+            "--output",
+            outputPath,
+          ]);
+
+          const decoded = decodeUnknownJson(yield* fs.readFileString(outputPath)) as {
+            readonly packages?: ReadonlyArray<{
+              readonly omittedPacketCount?: unknown;
+              readonly summary?: { readonly remediationPackets?: unknown };
+            }>;
+            readonly remediationPackets?: ReadonlyArray<unknown>;
+          };
+
+          expect(decoded.remediationPackets).toHaveLength(2);
+          expect(decoded.packages?.[0]?.summary?.remediationPackets).toBe(2);
+          expect(decoded.packages?.[0]?.omittedPacketCount).toBe(3);
+        })
+      )
+    );
+  });
+
+  it("rejects negative --packet-limit values", { timeout: DOCGEN_COMMAND_TEST_TIMEOUT }, async () => {
+    await Effect.runPromise(
+      withTempRepoCommand(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const tmpDir = process.cwd();
+          yield* fs.writeFileString(
+            path.join(tmpDir, "package.json"),
+            encodeJson({
+              name: "@beep/test-root",
+              private: true,
+              workspaces: ["packages/foundation/*/*"],
+            })
+          );
+
+          const packageDir = path.join(tmpDir, "packages", "foundation", "modeling", "schema");
+          yield* fs.makeDirectory(path.join(packageDir, "src"), { recursive: true });
+          yield* fs.writeFileString(
+            path.join(packageDir, "package.json"),
+            encodeJson({
+              name: "@beep/schema",
+              version: "0.0.0",
+            })
+          );
+          yield* fs.writeFileString(path.join(packageDir, "docgen.json"), encodeJson({ srcDir: "src" }));
+          yield* fs.writeFileString(
+            path.join(packageDir, "src", "index.ts"),
+            `/**
+ * Parses a value into the normalized schema fixture.
+ *
+ * @example
+ * \`\`\`ts
+ * import { parseValue } from "@beep/schema"
+ *
+ * console.log(parseValue(" hello "))
+ * \`\`\`
+ * @category parsing
+ * @since 0.0.0
+ */
+export const parseValue = (value: string): string => value.trim();
+`
+          );
+
+          yield* runDocgenCommand(["quality", "-p", "packages/foundation/modeling/schema", "--packet-limit=-1"]);
+
+          expect((yield* TestConsole.errorLines).join("\n")).toContain("--packet-limit must be zero or greater");
+          expect(process.exitCode).toBe(1);
         })
       )
     );

--- a/packages/tooling/tool/cli/test/docgen.test.ts
+++ b/packages/tooling/tool/cli/test/docgen.test.ts
@@ -21,7 +21,8 @@ import { FsUtilsLive, TSMorphServiceLive } from "@beep/repo-utils";
 import { NodeChildProcessSpawner, NodeServices } from "@effect/platform-node";
 import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
 import * as NodePath from "@effect/platform-node/NodePath";
-import { Effect, Exit, FileSystem, Layer, Path } from "effect";
+import { Duration, Effect, Exit, FileSystem, Layer, Path, pipe } from "effect";
+import * as A from "effect/Array";
 import * as S from "effect/Schema";
 import * as TestConsole from "effect/testing/TestConsole";
 import { Command } from "effect/unstable/cli";
@@ -885,6 +886,207 @@ export const formatValue = (value: string): string => \`value: \${value}\`;
     );
   });
 
+  it("accepts type-level evidence as a useful type-only example", async () => {
+    await Effect.runPromise(
+      withTempRepo(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const tmpDir = process.cwd();
+          yield* fs.writeFileString(
+            path.join(tmpDir, "package.json"),
+            encodeJson({
+              name: "@beep/test-root",
+              private: true,
+              workspaces: ["packages/foundation/*/*"],
+            })
+          );
+
+          const packageDir = path.join(tmpDir, "packages", "foundation", "modeling", "schema");
+          yield* fs.makeDirectory(path.join(packageDir, "src"), { recursive: true });
+          yield* fs.writeFileString(
+            path.join(packageDir, "package.json"),
+            encodeJson({
+              name: "@beep/schema",
+              version: "0.0.0",
+            })
+          );
+          yield* fs.writeFileString(path.join(packageDir, "docgen.json"), encodeJson({ srcDir: "src" }));
+          yield* fs.writeFileString(
+            path.join(packageDir, "src", "index.ts"),
+            `/**
+ * Extracts the element type from an array or tuple.
+ *
+ * @example
+ * \`\`\`ts
+ * import type { Elem } from "@beep/schema"
+ *
+ * type TupleElement = Elem<readonly [1, 2, 3]>
+ * // 1 | 2 | 3
+ *
+ * declare const element: TupleElement
+ * void element
+ * \`\`\`
+ * @category type-level
+ * @since 0.0.0
+ */
+export type Elem<T> = T extends readonly (infer U)[] ? U : never;
+`
+          );
+
+          const packages = yield* discoverDocgenWorkspacePackages(tmpDir);
+          const target = packages.find((pkg) => pkg.name === "@beep/schema");
+
+          expect(target).toBeDefined();
+
+          const report = yield* analyzePackageQuality(target!);
+          const subject = report.subjects.find((entry) => entry.exportName === "Elem");
+          const review = report.reviews.find((entry) => entry.subjectId === subject?.stableIdentity);
+          const findingCodes = review?.findings.map((finding) => finding.code) ?? [];
+
+          expect(subject?.declarationKind).toBe("type");
+          expect(findingCodes).not.toContain("example-only-voids-result");
+          expect(findingCodes).not.toContain("example-lacks-observable-result");
+          expect(review?.tier).toBe("pass");
+        })
+      )
+    );
+  });
+
+  it("treats module re-exports as graph edges instead of quality subjects", async () => {
+    await Effect.runPromise(
+      withTempRepo(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const tmpDir = process.cwd();
+          yield* fs.writeFileString(
+            path.join(tmpDir, "package.json"),
+            encodeJson({
+              name: "@beep/test-root",
+              private: true,
+              workspaces: ["packages/foundation/*/*"],
+            })
+          );
+
+          const packageDir = path.join(tmpDir, "packages", "foundation", "modeling", "schema");
+          yield* fs.makeDirectory(path.join(packageDir, "src"), { recursive: true });
+          yield* fs.writeFileString(
+            path.join(packageDir, "package.json"),
+            encodeJson({
+              name: "@beep/schema",
+              version: "0.0.0",
+            })
+          );
+          yield* fs.writeFileString(path.join(packageDir, "docgen.json"), encodeJson({ srcDir: "src" }));
+          yield* fs.writeFileString(
+            path.join(packageDir, "src", "Value.ts"),
+            `/**
+ * Parses a value into the normalized schema fixture.
+ *
+ * @example
+ * \`\`\`ts
+ * import { parseValue } from "@beep/schema/Value"
+ * const result = parseValue(" hello ")
+ * console.log(result)
+ * \`\`\`
+ * @category parsing
+ * @since 0.0.0
+ */
+export const parseValue = (value: string): string => value.trim();
+`
+          );
+          yield* fs.writeFileString(
+            path.join(packageDir, "src", "index.ts"),
+            `/**
+ * @since 0.0.0
+ * @category parsing
+ */
+export * as Value from "./Value.ts";
+`
+          );
+
+          const packages = yield* discoverDocgenWorkspacePackages(tmpDir);
+          const target = packages.find((pkg) => pkg.name === "@beep/schema");
+
+          expect(target).toBeDefined();
+
+          const report = yield* analyzePackageQuality(target!);
+          const exportNames = report.subjects.map((subject) => subject.exportName);
+          const findingCodes = pipe(
+            report.reviews,
+            A.flatMap((review) => A.map(review.findings, (finding) => finding.code))
+          );
+
+          expect(exportNames).toEqual(["parseValue"]);
+          expect(exportNames).not.toContain("export * as Value");
+          expect(findingCodes).not.toContain("missing-example");
+          expect(findingCodes).not.toContain("missing-description");
+        })
+      )
+    );
+  });
+
+  it("emits schema v2 partial package reports when the package budget is exhausted", async () => {
+    await Effect.runPromise(
+      withTempRepo(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const tmpDir = process.cwd();
+          yield* fs.writeFileString(
+            path.join(tmpDir, "package.json"),
+            encodeJson({
+              name: "@beep/test-root",
+              private: true,
+              workspaces: ["packages/foundation/*/*"],
+            })
+          );
+
+          const packageDir = path.join(tmpDir, "packages", "foundation", "modeling", "schema");
+          yield* fs.makeDirectory(path.join(packageDir, "src"), { recursive: true });
+          yield* fs.writeFileString(
+            path.join(packageDir, "package.json"),
+            encodeJson({
+              name: "@beep/schema",
+              version: "0.0.0",
+            })
+          );
+          yield* fs.writeFileString(path.join(packageDir, "docgen.json"), encodeJson({ srcDir: "src" }));
+          yield* fs.writeFileString(path.join(packageDir, "src", "index.ts"), `export const parseValue = "skip";\n`);
+
+          const packages = yield* discoverDocgenWorkspacePackages(tmpDir);
+          const target = packages.find((pkg) => pkg.name === "@beep/schema");
+
+          expect(target).toBeDefined();
+
+          const report = yield* analyzeDocgenQuality({
+            packageTimeout: Duration.millis(0),
+            scope: "package",
+            scoreMode: "rubric",
+            targets: [target!],
+          });
+          const json = yield* generateQualityJson(report);
+          const decoded = decodeUnknownJson(json) as {
+            readonly schemaVersion?: unknown;
+            readonly packages?: ReadonlyArray<{
+              readonly durationMs?: unknown;
+              readonly error?: unknown;
+              readonly status?: unknown;
+              readonly timedOut?: unknown;
+            }>;
+          };
+
+          expect(decoded.schemaVersion).toBe(2);
+          expect(decoded.packages?.[0]?.status).toBe("partial");
+          expect(decoded.packages?.[0]?.timedOut).toBe(true);
+          expect(decoded.packages?.[0]?.durationMs).toEqual(expect.any(Number));
+          expect(decoded.packages?.[0]?.error).toContain("Timed out");
+        })
+      )
+    );
+  });
+
   it("honors docgen exclude globs during quality subject collection", async () => {
     await Effect.runPromise(
       withTempRepo(
@@ -1120,7 +1322,86 @@ export const parseValue = (value: string): string => value.trim();
           expect(markdown).toContain("# JSDoc Quality Report");
           expect(markdown).toContain("## @beep/schema");
           expect(markdown).toContain("Improve the JSDoc block for this exported symbol");
-          expect(decoded.schemaVersion).toBe(1);
+          expect(decoded.schemaVersion).toBe(2);
+        })
+      )
+    );
+  });
+
+  it("caps and ranks Codex remediation packets for broad quality reports", async () => {
+    await Effect.runPromise(
+      withTempRepo(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const tmpDir = process.cwd();
+          yield* fs.writeFileString(
+            path.join(tmpDir, "package.json"),
+            encodeJson({
+              name: "@beep/test-root",
+              private: true,
+              workspaces: ["packages/foundation/*/*"],
+            })
+          );
+
+          const packageDir = path.join(tmpDir, "packages", "foundation", "modeling", "schema");
+          yield* fs.makeDirectory(path.join(packageDir, "src"), { recursive: true });
+          yield* fs.writeFileString(
+            path.join(packageDir, "package.json"),
+            encodeJson({
+              name: "@beep/schema",
+              version: "0.0.0",
+            })
+          );
+          yield* fs.writeFileString(path.join(packageDir, "docgen.json"), encodeJson({ srcDir: "src" }));
+          yield* fs.writeFileString(
+            path.join(packageDir, "src", "index.ts"),
+            A.join(
+              A.map(
+                A.range(1, 30),
+                (index) => `/**
+ * Missing example fixture ${index}.
+ *
+ * @category parsing
+ * @since 0.0.0
+ */
+export const value${index} = ${index};
+`
+              ),
+              "\n"
+            )
+          );
+
+          const packages = yield* discoverDocgenWorkspacePackages(tmpDir);
+          const target = packages.find((pkg) => pkg.name === "@beep/schema");
+
+          expect(target).toBeDefined();
+
+          const defaultReport = yield* analyzeDocgenQuality({
+            scope: "package",
+            scoreMode: "codex",
+            targets: [target!],
+          });
+          const limitedReport = yield* analyzeDocgenQuality({
+            packetLimit: 2,
+            scope: "package",
+            scoreMode: "codex",
+            targets: [target!],
+          });
+          const suppressedReport = yield* analyzeDocgenQuality({
+            packetLimit: 0,
+            scope: "package",
+            scoreMode: "codex",
+            targets: [target!],
+          });
+
+          expect(defaultReport.remediationPackets).toHaveLength(25);
+          expect(defaultReport.packages[0]?.omittedPacketCount).toBe(5);
+          expect(limitedReport.remediationPackets).toHaveLength(2);
+          expect(limitedReport.packages[0]?.summary.remediationPackets).toBe(2);
+          expect(limitedReport.packages[0]?.omittedPacketCount).toBe(28);
+          expect(suppressedReport.remediationPackets).toHaveLength(0);
+          expect(suppressedReport.packages[0]?.omittedPacketCount).toBe(30);
         })
       )
     );
@@ -1351,7 +1632,7 @@ export const parseValue = (value: string): string => value.trim();
           };
           const logText = (yield* TestConsole.logLines).join("\n");
 
-          expect(decoded.schemaVersion).toBe(1);
+          expect(decoded.schemaVersion).toBe(2);
           expect(decoded.scorer).toBe("codex-advisory-packet-v1");
           expect(decoded.remediationPackets?.[0]?.prompt).toContain("Keep @example mandatory");
           expect(logText).toContain("docgen: wrote");

--- a/standards/jsdoc-documentation.inventory.md
+++ b/standards/jsdoc-documentation.inventory.md
@@ -1,6 +1,6 @@
 # JSDoc Documentation Compliance Inventory
 
-Generated: 2026-05-09T03:07:26.659Z
+Generated: 2026-05-09T08:26:36.147Z
 
 ## Scope
 
@@ -14,8 +14,8 @@ The package universe is the current `bun run topo-sort` output. This inventory c
 | cleanPackages | 24 |
 | packagesWithoutPublicSrcSurface | 1 |
 | packagesNeedingRemediation | 30 |
-| publicModules | 835 |
-| publicExports | 5825 |
+| publicModules | 837 |
+| publicExports | 5852 |
 | openModules | 123 |
 | openExports | 2457 |
 | missingExportExamples | 2251 |
@@ -55,7 +55,7 @@ The package universe is the current `bun run topo-sort` output. This inventory c
 | 12 | `@beep/fixture-lab-specimen-domain` | `packages/fixture-lab/specimen/domain` | needs-remediation | 6 | 10 | 0 | 2 |
 | 13 | `@beep/test-utils` | `packages/tooling/test-kit/test-utils` | needs-remediation | 2 | 21 | 0 | 6 |
 | 14 | `@beep/repo-docgen` | `packages/tooling/tool/docgen` | needs-remediation | 8 | 66 | 0 | 21 |
-| 15 | `@beep/repo-ai-metrics` | `packages/tooling/library/ai-metrics` | clean | 13 | 156 | 0 | 0 |
+| 15 | `@beep/repo-ai-metrics` | `packages/tooling/library/ai-metrics` | clean | 14 | 168 | 0 | 0 |
 | 16 | `@beep/ffmpeg` | `packages/drivers/ffmpeg` | needs-remediation | 4 | 38 | 0 | 6 |
 | 17 | `@beep/observability` | `packages/foundation/capability/observability` | needs-remediation | 23 | 134 | 3 | 30 |
 | 18 | `@beep/repo-configs` | `packages/tooling/policy-pack/repo-configs` | needs-remediation | 24 | 130 | 0 | 5 |
@@ -68,12 +68,12 @@ The package universe is the current `bun run topo-sort` output. This inventory c
 | 25 | `@beep/agent-capability-use-cases` | `packages/agent-capability/use-cases` | needs-remediation | 13 | 47 | 0 | 11 |
 | 26 | `@beep/agent-capability-domain` | `packages/agent-capability/domain` | clean | 7 | 12 | 0 | 0 |
 | 27 | `@beep/workspace-domain` | `packages/workspace/domain` | clean | 21 | 40 | 0 | 0 |
-| 28 | `@beep/epistemic-domain` | `packages/epistemic/domain` | clean | 13 | 22 | 0 | 0 |
+| 28 | `@beep/epistemic-domain` | `packages/epistemic/domain` | clean | 13 | 21 | 0 | 0 |
 | 29 | `@beep/wealth-management-domain` | `packages/wealth-management/domain` | clean | 14 | 25 | 0 | 0 |
 | 30 | `@beep/root` | `.` | no-public-src-surface | 0 | 0 | 0 | 0 |
 | 31 | `@beep/fixture-lab-specimen-tables` | `packages/fixture-lab/specimen/tables` | clean | 6 | 12 | 0 | 0 |
 | 32 | `@beep/db-admin` | `packages/_internal/db-admin` | clean | 1 | 1 | 0 | 0 |
-| 33 | `@beep/repo-cli` | `packages/tooling/tool/cli` | needs-remediation | 69 | 482 | 0 | 349 |
+| 33 | `@beep/repo-cli` | `packages/tooling/tool/cli` | needs-remediation | 70 | 498 | 0 | 349 |
 | 34 | `@beep/shared-server` | `packages/shared/server` | clean | 1 | 1 | 0 | 0 |
 | 35 | `@beep/shared-config` | `packages/shared/config` | clean | 1 | 1 | 0 | 0 |
 | 36 | `@beep/sandbox` | `packages/foundation/capability/sandbox` | needs-remediation | 29 | 290 | 0 | 248 |
@@ -281,7 +281,7 @@ Export findings:
 - `src/EntitySchema.ts:749` `AssignedPersisted` (type) - missing @example
 - `src/EntitySchema.ts:766` `assignEntityParts` (const) - missing @example
 - `src/EntitySchema.ts:788` `ClassFactory` (type) - missing @example
-- `src/EntitySchema.ts:1600` `ClassFactory` (const) - missing @example
+- `src/EntitySchema.ts:1614` `ClassFactory` (const) - missing @example
 - `src/EntitySchema.ts:842` `persist` (const) - missing @example
 - `src/EntitySchema.ts:860` `DateTimeFromMillis` (const) - missing @example
 - `src/EntitySchema.ts:868` `int` (const) - missing @example
@@ -295,7 +295,7 @@ Export findings:
 - `src/EntitySchema.ts:1123` `selectedRowFieldShape` (const) - missing @example
 - `src/EntitySchema.ts:1143` `isEncodedNullable` (const) - missing @example
 - `src/EntitySchema.ts:1151` `isEncodedOptional` (const) - missing @example
-- `src/EntitySchema.ts:1621` `getDefinition` (const) - missing @example
+- `src/EntitySchema.ts:1635` `getDefinition` (const) - missing @example
 - `src/FileExtension.ts:121` `ApplicationFileExtension` (type) - 1 unsafe example violation(s)
 - `src/FileExtension.ts:160` `VideoFileExtension` (type) - 1 unsafe example violation(s)
 - `src/FileExtension.ts:199` `TextFileExtension` (type) - 1 unsafe example violation(s)
@@ -417,27 +417,27 @@ Export findings:
 - `src/LiteralKit.ts:644` `LiteralKit` (interface) - missing summary; missing @example, @category
 - `src/LiteralKit.ts:36` `LiteralToKey` (type) - missing @example
 - `src/LocalDate.ts:129` `isLocalDate` (const) - missing @example
-- `src/LocalDate.ts:212` `fromString` (const) - missing @example
-- `src/LocalDate.ts:235` `fromDate` (const) - missing @example
-- `src/LocalDate.ts:249` `today` (const) - missing @example
-- `src/LocalDate.ts:257` `todayEffect` (const) - missing @example
-- `src/LocalDate.ts:268` `fromDateTime` (const) - missing @example
-- `src/LocalDate.ts:283` `Order` (const) - missing @example
-- `src/LocalDate.ts:302` `isBefore` (const) - missing @example
-- `src/LocalDate.ts:313` `isAfter` (const) - missing @example
-- `src/LocalDate.ts:324` `equals` (const) - missing @example
-- `src/LocalDate.ts:339` `addDays` (const) - missing @example
-- `src/LocalDate.ts:354` `addMonths` (const) - missing @example
-- `src/LocalDate.ts:369` `addYears` (const) - missing @example
-- `src/LocalDate.ts:384` `diffInDays` (const) - missing @example
-- `src/LocalDate.ts:400` `startOfMonth` (const) - missing @example
-- `src/LocalDate.ts:414` `endOfMonth` (const) - missing @example
-- `src/LocalDate.ts:428` `startOfYear` (const) - missing @example
-- `src/LocalDate.ts:442` `endOfYear` (const) - missing @example
-- `src/LocalDate.ts:456` `isLeapYear` (const) - missing @example
-- `src/LocalDate.ts:466` `daysInMonth` (const) - missing @example
-- `src/LocalDate.ts:513` `LocalDateFromString` (type) - missing @example
-- `src/LocalDate.ts:521` `LocalDateFromString` (namespace) - missing @example
+- `src/LocalDate.ts:213` `fromString` (const) - missing @example
+- `src/LocalDate.ts:236` `fromDate` (const) - missing @example
+- `src/LocalDate.ts:250` `today` (const) - missing @example
+- `src/LocalDate.ts:258` `todayEffect` (const) - missing @example
+- `src/LocalDate.ts:269` `fromDateTime` (const) - missing @example
+- `src/LocalDate.ts:284` `Order` (const) - missing @example
+- `src/LocalDate.ts:303` `isBefore` (const) - missing @example
+- `src/LocalDate.ts:314` `isAfter` (const) - missing @example
+- `src/LocalDate.ts:325` `equals` (const) - missing @example
+- `src/LocalDate.ts:340` `addDays` (const) - missing @example
+- `src/LocalDate.ts:355` `addMonths` (const) - missing @example
+- `src/LocalDate.ts:370` `addYears` (const) - missing @example
+- `src/LocalDate.ts:385` `diffInDays` (const) - missing @example
+- `src/LocalDate.ts:401` `startOfMonth` (const) - missing @example
+- `src/LocalDate.ts:415` `endOfMonth` (const) - missing @example
+- `src/LocalDate.ts:429` `startOfYear` (const) - missing @example
+- `src/LocalDate.ts:443` `endOfYear` (const) - missing @example
+- `src/LocalDate.ts:457` `isLeapYear` (const) - missing @example
+- `src/LocalDate.ts:467` `daysInMonth` (const) - missing @example
+- `src/LocalDate.ts:514` `LocalDateFromString` (type) - missing @example
+- `src/LocalDate.ts:522` `LocalDateFromString` (namespace) - missing @example
 - `src/Logs.ts:43` `LogLevel` (type) - missing @example
 - `src/Logs.ts:74` `LogSeverity` (type) - missing @example
 - `src/MappedLiteralKit.ts:331` `MappedLiteralKit` (function) - 1 unsafe example violation(s)
@@ -2450,7 +2450,7 @@ Export findings:
 - `src/commands/CreatePackage/TsMorphIntegrationService.ts:234` `TsMorphIntegrationService` (class) - missing @example
 - `src/commands/CreatePackage/TsMorphIntegrationService.ts:258` `createTsMorphIntegrationService` (const) - missing @example
 - `src/commands/CreatePackage/index.ts:16` `createPackageCommand` (const) - missing @example
-- `src/commands/Docgen/index.ts:618` `docgenCommand` (const) - missing @example
+- `src/commands/Docgen/index.ts:720` `docgenCommand` (const) - missing @example
 - `src/commands/Docgen/internal/Operations.ts:86` `DocgenPackageStatus` (const) - missing @example
 - `src/commands/Docgen/internal/Operations.ts:101` `DocgenPackageStatus` (type) - missing @example
 - `src/commands/Docgen/internal/Operations.ts:115` `DocgenConfigDocument` (class) - missing @example
@@ -3177,7 +3177,7 @@ Export findings:
 - `src/services/canonicalization.ts:47` `CanonicalizationAlgorithm` (const) - 1 schema annotation/type-alias gap(s)
 - `src/services/jsonld-context.ts:43` `JsonLdContextErrorReason` (const) - 1 schema annotation/type-alias gap(s)
 - `src/services/jsonld-document.ts:45` `JsonLdDocumentErrorReason` (const) - 1 schema annotation/type-alias gap(s)
-- `src/services/jsonld-stream-parse.ts:229` `JsonLdStreamParseErrorReason` (const) - 1 schema annotation/type-alias gap(s)
+- `src/services/jsonld-stream-parse.ts:230` `JsonLdStreamParseErrorReason` (const) - 1 schema annotation/type-alias gap(s)
 - `src/services/jsonld-stream-serialize.ts:107` `JsonLdStreamSerializeErrorReason` (const) - 1 schema annotation/type-alias gap(s)
 - `src/services/provenance.ts:64` `ProvenanceExportProfile` (const) - 1 schema annotation/type-alias gap(s)
 - `src/services/shacl-validation.ts:46` `ShaclSeverity` (const) - 1 schema annotation/type-alias gap(s)

--- a/standards/jsdoc-documentation.inventory.md
+++ b/standards/jsdoc-documentation.inventory.md
@@ -1,6 +1,6 @@
 # JSDoc Documentation Compliance Inventory
 
-Generated: 2026-05-09T08:26:36.147Z
+Generated: 2026-05-09T09:28:12.290Z
 
 ## Scope
 
@@ -2450,7 +2450,7 @@ Export findings:
 - `src/commands/CreatePackage/TsMorphIntegrationService.ts:234` `TsMorphIntegrationService` (class) - missing @example
 - `src/commands/CreatePackage/TsMorphIntegrationService.ts:258` `createTsMorphIntegrationService` (const) - missing @example
 - `src/commands/CreatePackage/index.ts:16` `createPackageCommand` (const) - missing @example
-- `src/commands/Docgen/index.ts:720` `docgenCommand` (const) - missing @example
+- `src/commands/Docgen/index.ts:728` `docgenCommand` (const) - missing @example
 - `src/commands/Docgen/internal/Operations.ts:86` `DocgenPackageStatus` (const) - missing @example
 - `src/commands/Docgen/internal/Operations.ts:101` `DocgenPackageStatus` (type) - missing @example
 - `src/commands/Docgen/internal/Operations.ts:115` `DocgenConfigDocument` (class) - missing @example


### PR DESCRIPTION
## Summary
- hardens docgen quality reports with schema v2 package status, duration, timeout/error fields, and omitted packet counts
- treats re-export declarations as graph edges and accepts type-level evidence for type/interface examples
- caps Codex remediation packets with --packet-limit and refreshes initiative/guidance surfaces plus the JSDoc inventory artifacts

## Validation
- bun run --filter @beep/repo-cli check
- bun run --filter @beep/repo-cli test -- docgen
- bun run --filter @beep/repo-cli lint
- bun run --filter @beep/repo-cli test
- bun run beep docgen quality -p packages/foundation/modeling/schema --json --output /tmp/jsdoc-quality-schema.json
- bun run beep docgen quality -p packages/tooling/tool/cli --json --score codex --output /tmp/jsdoc-quality-cli.json
- bun run check
- bun run lint
- bun run jsdoc:inventory
- bun run docgen:affected
- git diff --check
- jq empty initiatives/jsdoc-quality-enforcement/ops/manifest.json standards/jsdoc-documentation.inventory.jsonc

## Notes
- PR #128/P5 is already merged; this branch is rebased onto current origin/main.
- Direct markdownlint/biome/cspell runs against the generated inventory files are not repo gates; those generated files are ignored by the root lint configuration.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kriegcloud/codesmith/beep-effect/pr/130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--packet-limit` flag to `docgen quality` command for controlling remediation packet output.

* **Documentation**
  * Clarified JSDoc `@example` requirements for constants, helpers, and schemas.
  * Expanded guidance on acceptable type-level evidence for type-only exports.

* **Progress**
  * JSDoc Quality Enforcement advanced to P6 hardening phase; report schema updated with enhanced package metadata.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kriegcloud/beep-effect/pull/130)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->