### PR TITLE
[codex] Record AI metrics pre-May-16 readiness

### DIFF
--- a/initiatives/ai-metrics-stack/PLAN.md
+++ b/initiatives/ai-metrics-stack/PLAN.md
@@ -4,9 +4,10 @@ This plan executes [SPEC.md](./SPEC.md). The current target phase is P6. P0
 bootstrap, P1 source/privacy proof, P2 durable ingest, P3 OTLP/backend
 contracts, P4 report-first scorecards, P5 install/remote deployment, and P6a
 fresh-review hardening are complete. Phoenix is live on dankserver, Pulumi state
-is reconciled, the workstation timer owns live collection, and the credited
-seven-day proof restarted on May 9, 2026 02:26 America/Chicago. The earliest
-credited completion is May 16, 2026 02:26 America/Chicago.
+is reconciled, the workstation timer owns live collection from an isolated
+pinned proof worktree, and the credited seven-day proof restarted on May 9,
+2026 02:26 America/Chicago. The earliest credited completion is May 16, 2026
+02:26 America/Chicago.
 
 ## P0: Initiative Bootstrap And Current State
 
@@ -129,6 +130,19 @@ Status: in progress
 - During the restarted window, keep live collection owned by the workstation
   timer and maintain completion-creditable scorecards with real labels and
   benchmark runs.
+- Isolate the runner from normal repo work by running the workstation timer from
+  the locked sibling worktree
+  `/home/elpresidank/YeeBois/projects/beep-effect-worktrees/ai-metrics-p6-proof`,
+  pinned at `63c419721c735bfb860ccfa9bf1b31efbb23e33c`, while keeping the
+  proof data root at
+  `/home/elpresidank/YeeBois/projects/beep-effect/.beep/ai-metrics`.
+- Use the daily runbook in
+  [history/outputs/p6-proof-runner-isolation-and-runbook.md](./history/outputs/p6-proof-runner-isolation-and-runbook.md).
+- Track pre-closeout readiness evidence in
+  [history/outputs/p6-pre-may16-readiness-ledger.md](./history/outputs/p6-pre-may16-readiness-ledger.md).
+- Additional labels require explicit human outcome judgment. Benchmark runs may
+  be recorded for real operator workflows with deploy-safe prompt hashes and
+  redacted notes.
 
 ## P6a: Fresh Review Data And Ops Hardening
 
@@ -164,6 +178,22 @@ Status: completed
 - Recorded closeout and proof restart evidence in
   [history/outputs/p6a-closeout-proof-restart.md](./history/outputs/p6a-closeout-proof-restart.md).
 
+## P7: Topology-First Productionization
+
+Status: planned
+
+- Start only after the P6 proof is credited or explicitly abandoned.
+- Decide server-owned, workstation-owned, synced, or hybrid collection topology
+  before implementing provider/gateway enrichment.
+- Promote retention, restore, deletion, and compaction from P6 runbook notes
+  into executable operator workflows.
+- Add real model-call, tool-invocation, token, cost, and latency metrics only
+  from sources with a proven privacy and attribution contract.
+- Keep Phoenix as the default UI; add Langfuse, Opik, PostHog, or other
+  backend-specific drivers only when a real backend API need appears.
+- Planning packet:
+  [history/outputs/p7-topology-first-production-plan.md](./history/outputs/p7-topology-first-production-plan.md).
+
 ## Required Checks
 
 - `bun run check`
@@ -173,4 +203,7 @@ Status: completed
 - `@beep/infra`: `check`, `test`, `lint`
 - CLI smoke for source discovery, ingest, install plan/doctor, forwarder timer
   rendering, archive drill, labels, benchmarks, and report generation
+- Proof-runner timer verification: locked proof worktree, service
+  `WorkingDirectory`, absolute proof data root, latest status JSON, and Phoenix
+  health
 - Pulumi preview and apply for the dankserver target

--- a/initiatives/ai-metrics-stack/README.md
+++ b/initiatives/ai-metrics-stack/README.md
@@ -46,6 +46,14 @@ restarted seven-day config-impact scorecard has been generated from live data.
     and proof restart gates
 - [history/outputs/p6a-closeout-proof-restart.md](./history/outputs/p6a-closeout-proof-restart.md)
   - P6a closeout evidence, timer/Pulumi proof, and restarted seven-day window
+- [history/outputs/p6-proof-runner-isolation-and-runbook.md](./history/outputs/p6-proof-runner-isolation-and-runbook.md)
+  - isolated proof runner evidence, daily P6 health checklist, and final
+    closeout template
+- [history/outputs/p6-pre-may16-readiness-ledger.md](./history/outputs/p6-pre-may16-readiness-ledger.md)
+  - pre-closeout readiness evidence, label candidates, benchmark/report state,
+    and the remaining completion gate before May 16
+- [history/outputs/p7-topology-first-production-plan.md](./history/outputs/p7-topology-first-production-plan.md)
+  - planned P7 topology-first production packet
 - [research/effect-native-observability.md](./research/effect-native-observability.md)
   - Effect v4 observability package findings
 - [research/backend-shortlist.md](./research/backend-shortlist.md) - backend
@@ -103,9 +111,19 @@ after the P6a closeout gates passed:
   bounded forwarder pass, reran the archive drill, reconciled Pulumi, verified
   Phoenix `15.5.0`, added one outcome label plus one benchmark run, and
   generated a restarted scorecard with `completionReady=true`.
+- P6 isolation now runs the workstation timer from locked detached worktree
+  `/home/elpresidank/YeeBois/projects/beep-effect-worktrees/ai-metrics-p6-proof`
+  pinned at `63c419721c735bfb860ccfa9bf1b31efbb23e33c`, while preserving the
+  original proof data root under the main checkout.
+- Source discovery remains Codex-only in the recent proof window; `--all`
+  discovery confirms Claude Code and OpenClaw sources exist outside the active
+  proof window and are deferred to P7 topology decisions.
 - Current P6 work is to keep the timer running through May 16, 2026 02:26
-  America/Chicago, add more labels/benchmarks as data accumulates, and generate
-  the final seven-day report.
+  America/Chicago, add human-approved labels and real benchmark runs as data
+  accumulates, and generate the final seven-day report.
+- The May 9 readiness pass recorded another successful scheduled timer run and
+  a second isolation benchmark run for the isolated-runner config. That config
+  remains blocked only by the explicit human-label gate plus elapsed proof time.
 
 ## Completion Standard
 

--- a/initiatives/ai-metrics-stack/SPEC.md
+++ b/initiatives/ai-metrics-stack/SPEC.md
@@ -85,6 +85,8 @@ output.
 - Labeling workflow: CLI review queue.
 - Completion evidence: P6a hardening gates, deployed stack, and one restarted
   seven-day real-data scorecard.
+- P7 topology posture: decide collection ownership, sync, retention, deletion,
+  and restore before adding provider/gateway enrichment or new dashboards.
 
 ## Data Products
 
@@ -149,6 +151,10 @@ deployment mechanism.
 P6a live collection is workstation-owned because Codex and Claude raw sources
 live on the workstation. The credited proof window must use a local scheduled
 runner with a lock, retry/backoff, status artifact, and journal evidence.
+During the credited P6 window, that scheduled runner may execute from a locked,
+pinned sibling worktree as long as the proof data root, timer budgets, privacy
+contract, and source window remain stable and the isolation evidence is
+recorded.
 Server-owned collection is a P7 topology target and requires a separate
 transcript access/sync and privacy design.
 

--- a/initiatives/ai-metrics-stack/history/outputs/p6-pre-may16-readiness-ledger.md
+++ b/initiatives/ai-metrics-stack/history/outputs/p6-pre-may16-readiness-ledger.md
@@ -1,0 +1,173 @@
+# P6 Pre-May-16 Readiness Ledger
+
+## Status
+
+Started on May 9, 2026 while the credited seven-day proof window is still
+running.
+
+This ledger records work that can safely move P6 closer to closeout before May
+16, 2026 02:26 America/Chicago. It deliberately does not change the forwarder
+implementation, timer cadence, `max-files` budget, source window, proof data
+root, hash salt, archive key, or pinned proof worktree.
+
+## Guardrails
+
+- Do not mark P6 complete before May 16, 2026 02:26 America/Chicago.
+- Do not restart the credited proof clock unless the proof runner, source
+  window, privacy contract, timer cadence, or data root changes.
+- Do not write outcome labels without explicit human judgment.
+- Do not print raw transcript bodies, prompt text, output text, or secret
+  values while collecting evidence.
+
+## May 9, 2026 Readiness Check
+
+Collected at approximately May 9, 2026 04:22-04:24 America/Chicago.
+
+### Timer And Proof Runner
+
+- Main checkout branch:
+  `codex/ai-metrics-pre-may16-readiness`
+- Proof runner worktree:
+  `/home/elpresidank/YeeBois/projects/beep-effect-worktrees/ai-metrics-p6-proof`
+- Proof runner state: detached and locked with reason
+  `AI metrics P6 proof runner pinned through 2026-05-16`
+- Proof runner commit:
+  `63c419721c735bfb860ccfa9bf1b31efbb23e33c`
+- Installed service working directory:
+  `/home/elpresidank/YeeBois/projects/beep-effect-worktrees/ai-metrics-p6-proof`
+- Installed service data root:
+  `/home/elpresidank/YeeBois/projects/beep-effect/.beep/ai-metrics`
+- Timer state: `enabled`, `active`
+- Scheduled service run:
+  - start: May 9, 2026 04:22:15 America/Chicago
+  - exit: May 9, 2026 04:23:00 America/Chicago
+  - state: `inactive`
+  - result: `success`
+  - exit status: `0`
+
+### Latest Forwarder Status
+
+- Ingest run:
+  `forwarder-1778318537681`
+- Config snapshot:
+  `config-6c5738fd0e1932ced6043ab52c7df04e52278b1024470769243b724c265f7d52`
+- Source files: `5`
+- Derived turns: `3516`
+- Source coverage:
+  - Codex: `131` candidates, `5` included, `limitedByMaxFiles=true`,
+    `10` size-excluded
+  - Claude Code: `0` candidates, `0` included
+  - OpenClaw: `0` candidates, `0` included
+- Parquet export:
+  `/home/elpresidank/YeeBois/projects/beep-effect/.beep/ai-metrics/derived/parquet/forwarder-1778318537681`
+
+### Phoenix Health
+
+- Endpoint: `https://dankserver.tailc7c348.ts.net:8447/`
+- HTTP status: `200`
+- Phoenix version header: `15.5.0`
+
+### Source Discovery
+
+Recent source discovery with `--max-files 50`:
+
+| sourceKind | candidates | included | limitedByMaxFiles |
+| --- | ---: | ---: | --- |
+| `codex` | 141 | 50 | yes |
+| `claude` | 0 | 0 | no |
+| `openclaw` | 0 | 0 | no |
+
+All-time source discovery with `--all --max-files 50`:
+
+| sourceKind | candidates | included | limitedByMaxFiles |
+| --- | ---: | ---: | --- |
+| `codex` | 3151 | 50 | yes |
+| `claude` | 396 | 50 | yes |
+| `openclaw` | 1 | 1 | no |
+
+The active proof remains Codex-only in the recent source window. Claude Code
+and OpenClaw remain proven as adapter-visible all-time sources outside the
+credited proof window.
+
+### Labels
+
+No labels were written during this readiness pass. The isolated-runner config
+still needs at least one explicit human-approved outcome label before it can be
+completion-ready.
+
+Deploy-safe queued candidates for the isolated-runner config:
+
+| agentTaskId | sourceKind | turnCount |
+| --- | --- | ---: |
+| `agent-task-c886e04027aa404a83038636272c53be5e7e157681749b3efb96c10a6202ca25` | `codex` | 506 |
+| `agent-task-00ad860fd2e6e82770cd44cf8a76ee02b740dc38baf167f9a70b47313183b240` | `codex` | 1238 |
+| `agent-task-75df913a8e64fe66e82381aa87ce98ea1864502c2640cba19dd2928a98682fc6` | `codex` | 410 |
+| `agent-task-96b706f6e08bfffb44f60ede423e0a9b8bbd467bde6893a86505fc0f12768cd7` | `codex` | 494 |
+| `agent-task-7185336c2117c8e71aa4814fac05bc7785a6c85c5775292175e36c212bd6d980` | `codex` | 4384 |
+
+When the operator gives a judgment, use the CLI shape below and keep the note
+redacted:
+
+```sh
+bun run beep ai-metrics label add \
+  --target local \
+  --task '<agent-task-id>' \
+  --passed true \
+  --quality-gate passed \
+  --rating 5 \
+  --interventions 0 \
+  --follow-up-fix false \
+  --note '<redacted human judgment note>' \
+  --json
+```
+
+The exact `passed`, `quality-gate`, `rating`, `interventions`, and
+`follow-up-fix` values must come from human review of the work outcome.
+
+### Benchmarks
+
+Recorded one additional benchmark run against the isolated-runner config after
+the fresh scheduled timer health smoke:
+
+- Benchmark run:
+  `benchmark-run-b5aa29ef19fcf32c96f4db264895f25ee96980e662452f862eef149fe61ded9a`
+- Benchmark case:
+  `ai-metrics-p6-proof-runner-isolation`
+- Config snapshot:
+  `config-6c5738fd0e1932ced6043ab52c7df04e52278b1024470769243b724c265f7d52`
+- Passed: `true`
+- Quality gate: `passed`
+- Elapsed: `45000` milliseconds
+- Redacted note:
+  `2026-05-09 04:22 CDT scheduled timer health smoke: forwarder-1778318537681, Phoenix 15.5.0, proof worktree unchanged`
+
+`ai-metrics benchmark compare --json` still reports the outcome-heavy score
+model as `ready-for-derived-runs`.
+
+### Intermediate Report
+
+Generated an intermediate local weekly report after the extra benchmark run:
+
+- Markdown:
+  `.beep/ai-metrics/reports/weekly-1777713840128-1778318640128.md`
+- JSON:
+  `.beep/ai-metrics/reports/weekly-1777713840128-1778318640128.json`
+
+Scorecard summary:
+
+| configSnapshotId | tasks | labels | benchmarks | completionReady | gaps |
+| --- | ---: | ---: | ---: | --- | --- |
+| `config-6c5738fd0e1932ced6043ab52c7df04e52278b1024470769243b724c265f7d52` | 5 | 0 | 2 | no | `no_labels`, unavailable model/tool/cost metrics |
+| `config-d0b05a2d64c9c40c21e0df11f8cfc611be5ce41139f52f4db79b77f73ca895bc` | 5 | 1 | 1 | yes | unavailable model/tool/cost metrics |
+| `config-910eecbb488885f42c4caea393b4dd4512bee62869a1f0df7c9a27d42839ebf1` | 10 | 0 | 0 | no | `no_labels`, `no_benchmark_runs`, unavailable model/tool/cost metrics |
+
+## Remaining Pre-May-16 Work
+
+- Add at least one human-approved label for
+  `config-6c5738fd0e1932ced6043ab52c7df04e52278b1024470769243b724c265f7d52`.
+- Regenerate the intermediate weekly report and confirm that the same config
+  snapshot flips to `completionReady=true`.
+- Continue daily timer/Phoenix/source/report health checks without changing the
+  proof runner or source window.
+- Keep P7 work limited to planning until the credited proof window completes or
+  is explicitly abandoned.

--- a/initiatives/ai-metrics-stack/history/outputs/p6-proof-runner-isolation-and-runbook.md
+++ b/initiatives/ai-metrics-stack/history/outputs/p6-proof-runner-isolation-and-runbook.md
@@ -1,0 +1,184 @@
+# P6 Proof Runner Isolation And Runbook
+
+## Status
+
+Implemented on May 9, 2026 during the restarted P6 proof window.
+
+The credited proof window still started on May 9, 2026 02:26
+America/Chicago. The earliest completion remains May 16, 2026 02:26
+America/Chicago. This change isolates the host runner that executes the
+workstation timer; it does not widen source discovery, change timer budgets, or
+move the proof data root.
+
+## Proof Runner Isolation
+
+- Created a dedicated Git worktree:
+  `/home/elpresidank/YeeBois/projects/beep-effect-worktrees/ai-metrics-p6-proof`
+- Pinned it at commit
+  `63c419721c735bfb860ccfa9bf1b31efbb23e33c`.
+- Kept it detached from a branch and locked it with Git worktree metadata:
+  `AI metrics P6 proof runner pinned through 2026-05-16`.
+- Bootstrapped the worktree with `bun install --frozen-lockfile`.
+- Re-rendered and installed the workstation user timer so
+  `beep-ai-metrics-forwarder.service` uses:
+  - `WorkingDirectory=/home/elpresidank/YeeBois/projects/beep-effect-worktrees/ai-metrics-p6-proof`
+  - `--data-root /home/elpresidank/YeeBois/projects/beep-effect/.beep/ai-metrics`
+  - `EnvironmentFile=%h/.config/beep/ai-metrics.env`
+- Preserved existing runtime secret values in `~/.config/beep/ai-metrics.env`;
+  checked-in files still use only 1Password secret references.
+- Verified the installed service uses the proof worktree and original proof
+  data root, and does not pin `/home/elpresidank/.bun/bin/bun`.
+
+## Isolation Evidence
+
+- Timer state after installation:
+  - unit: `beep-ai-metrics-forwarder.timer`
+  - state: `enabled`, `active`
+  - next scheduled run: May 9, 2026 04:22:14 America/Chicago
+  - last trigger: May 9, 2026 04:04:06 America/Chicago
+- Forced service run after installation:
+  - state: `inactive`
+  - result: `success`
+  - exit status: `0`
+  - start: May 9, 2026 04:05:18 America/Chicago
+  - exit: May 9, 2026 04:05:47 America/Chicago
+- Latest bounded forwarder status after isolation:
+  - ingest run: `forwarder-1778317519950`
+  - config snapshot:
+    `config-6c5738fd0e1932ced6043ab52c7df04e52278b1024470769243b724c265f7d52`
+  - source files: `5`
+  - derived turns: `3516`
+  - source coverage:
+    - Codex: `132` candidates, `5` included, `limitedByMaxFiles=true`,
+      `10` size-excluded
+    - Claude Code: `0` candidates, `0` included
+    - OpenClaw: `0` candidates, `0` included
+  - Parquet export:
+    `/home/elpresidank/YeeBois/projects/beep-effect/.beep/ai-metrics/derived/parquet/forwarder-1778317519950`
+- Phoenix health after isolation:
+  - endpoint: `https://dankserver.tailc7c348.ts.net:8447/`
+  - HTTP status: `200`
+  - `x-phoenix-server-version: 15.5.0`
+
+## Source Availability
+
+Recent source discovery remains Codex-only for the credited proof window:
+
+- Codex: `142` recent candidates, `50` included with `--max-files 50`
+- Claude Code: `0` recent candidates
+- OpenClaw: `0` recent candidates
+
+All-time discovery proves the non-Codex source adapters still have available
+inputs outside the active proof window:
+
+- Codex: `3151` candidates, `50` included with `--all --max-files 50`
+- Claude Code: `396` candidates, `50` included with `--all --max-files 50`
+- OpenClaw: `1` candidate, `1` included with `--all --max-files 50`
+
+The P6 proof keeps the bounded recent window and current timer budgets stable.
+Backfill or broader source windows are deferred to P7 topology planning.
+
+## Labels And Benchmarks
+
+- The label queue returned `10` deploy-safe queued Codex task rows after
+  isolation. No new labels were written because labels require explicit human
+  outcome judgment.
+- Added a real benchmark case for the isolation workflow:
+  `ai-metrics-p6-proof-runner-isolation`
+- Recorded a benchmark run for the isolated-runner config snapshot:
+  `benchmark-run-6f5eacb09e645a4edbeb95a1a1c258eb806ad918d4f269d8adbb139ac18d05b9`
+- Benchmark checks:
+  - `worktree-lock`
+  - `timer-working-directory`
+  - `absolute-data-root`
+  - `phoenix-health`
+- Prompt hash:
+  `7ee6aa38d0218345d0ed90ba6eeaf957104b288d776ad3ead8c67887dd8f8295`
+
+The generated weekly report after isolation is:
+
+- Markdown:
+  `/home/elpresidank/YeeBois/projects/beep-effect/.beep/ai-metrics/reports/weekly-1777712918992-1778317718992.md`
+- JSON:
+  `/home/elpresidank/YeeBois/projects/beep-effect/.beep/ai-metrics/reports/weekly-1777712918992-1778317718992.json`
+
+Scorecard summary:
+
+| configSnapshotId | tasks | labels | benchmarks | completionReady | gaps |
+| --- | ---: | ---: | ---: | --- | --- |
+| `config-6c5738fd0e1932ced6043ab52c7df04e52278b1024470769243b724c265f7d52` | 5 | 0 | 1 | no | `no_labels`, unavailable model/tool/cost metrics |
+| `config-d0b05a2d64c9c40c21e0df11f8cfc611be5ce41139f52f4db79b77f73ca895bc` | 5 | 1 | 1 | yes | unavailable model/tool/cost metrics |
+| `config-910eecbb488885f42c4caea393b4dd4512bee62869a1f0df7c9a27d42839ebf1` | 10 | 0 | 0 | no | `no_labels`, `no_benchmark_runs`, unavailable model/tool/cost metrics |
+
+## Daily Health Checklist
+
+Run these commands serially. Do not run DuckDB-backed AI metrics commands in
+parallel against the same local database.
+
+Record dated daily results in
+[p6-pre-may16-readiness-ledger.md](./p6-pre-may16-readiness-ledger.md) until the
+proof window can be closed.
+
+```sh
+git -C /home/elpresidank/YeeBois/projects/beep-effect status --short --branch
+git -C /home/elpresidank/YeeBois/projects/beep-effect-worktrees/ai-metrics-p6-proof status --short --branch
+git -C /home/elpresidank/YeeBois/projects/beep-effect worktree list --porcelain
+
+systemctl --user list-timers beep-ai-metrics-forwarder.timer --no-pager
+systemctl --user show beep-ai-metrics-forwarder.service \
+  --property=ActiveState,Result,ExecMainStatus,ExecMainStartTimestamp,ExecMainExitTimestamp \
+  --no-pager
+systemctl --user cat beep-ai-metrics-forwarder.service --no-pager
+
+jq '{ingestRunId,configSnapshotId,sourceFileCount,turnCount,sourceCoverage,parquetExportDir}' \
+  /home/elpresidank/YeeBois/projects/beep-effect/.beep/ai-metrics/forwarder/status/latest.json
+
+curl -kIs --max-time 10 https://dankserver.tailc7c348.ts.net:8447/ | sed -n '1,12p'
+
+bun run beep ai-metrics sources discover \
+  --target local \
+  --hash-salt local-smoke \
+  --json \
+  --max-files 50
+
+bun run beep ai-metrics label queue \
+  --target dankserver \
+  --data-root /home/elpresidank/YeeBois/projects/beep-effect/.beep/ai-metrics \
+  --hash-salt-secret-ref 'op://TBK/ai-metrics/hash-salt' \
+  --raw-archive-key-secret-ref 'op://TBK/ai-metrics/raw-archive-key' \
+  --json \
+  --limit 10
+
+bun run beep ai-metrics benchmark case list \
+  --target dankserver \
+  --data-root /home/elpresidank/YeeBois/projects/beep-effect/.beep/ai-metrics \
+  --hash-salt-secret-ref 'op://TBK/ai-metrics/hash-salt' \
+  --raw-archive-key-secret-ref 'op://TBK/ai-metrics/raw-archive-key' \
+  --json
+```
+
+## Final P6 Closeout Template
+
+Do not mark P6 complete until after May 16, 2026 02:26 America/Chicago.
+
+After the proof window, generate the final report:
+
+```sh
+bun run beep ai-metrics report weekly \
+  --target dankserver \
+  --data-root /home/elpresidank/YeeBois/projects/beep-effect/.beep/ai-metrics \
+  --hash-salt-secret-ref 'op://TBK/ai-metrics/hash-salt' \
+  --raw-archive-key-secret-ref 'op://TBK/ai-metrics/raw-archive-key' \
+  --json
+```
+
+The final closeout should record:
+
+- exact proof window start and end
+- timer state and last successful service run
+- latest forwarder run id, source coverage, derived turns, and Parquet export
+- Phoenix health and version
+- labels and benchmark runs linked to the scored config snapshots
+- final weekly report paths and `completionReady` status
+- remaining explicit not-scored gaps for model/tool/token/cost metrics
+- whether any proof interruption happened, and whether the clock restarted

--- a/initiatives/ai-metrics-stack/history/outputs/p7-topology-first-production-plan.md
+++ b/initiatives/ai-metrics-stack/history/outputs/p7-topology-first-production-plan.md
@@ -1,0 +1,140 @@
+# P7 Topology-First Production Plan
+
+## Status
+
+Planned. P7 starts after the P6 seven-day proof is credited or intentionally
+abandoned.
+
+P7 must not rewrite the P6 proof while it is running. Its job is to turn the
+workstation-owned proof into a production topology with explicit ownership,
+privacy boundaries, retention, and real provider or gateway metrics.
+
+## Goal
+
+Move from workstation-owned live collection to a production collection topology
+that can answer the same scorecard questions without depending on a mutable
+developer checkout.
+
+The center of gravity is topology first:
+
+1. Decide where raw transcript access is owned.
+2. Decide what may sync off the workstation.
+3. Prove retention, deletion, restore, and re-derivation.
+4. Add provider/gateway usage metrics only after the raw/derived boundary is
+   explicit.
+5. Expand dashboard backends only when the backend-specific API need is real.
+
+## Doctrine Fit
+
+- `@beep/repo-ai-metrics` remains the tooling library that owns developer AI
+  analytics semantics.
+- `@beep/repo-cli` remains the operator workflow surface.
+- `@beep/duckdb` remains the DuckDB driver boundary.
+- `@beep/observability` remains general runtime observability and does not
+  absorb AI metrics semantics.
+- `@beep/infra` owns deployable topology on dankserver.
+- Backend-specific SDKs become `drivers/*` only when the initiative needs a
+  real API wrapper beyond OTLP/install/export contracts.
+
+No architecture doctrine change is required for P7 planning. This is
+initiative-level topology and operator workflow design inside the existing
+tooling, infra, driver, and observability boundaries.
+
+## P7a: Collection Topology Decision
+
+Decide one production topology before implementation:
+
+- workstation scheduled collection with redacted sync to dankserver
+- workstation raw archive with remote derived mirror
+- server-owned collection with explicit transcript sync
+- hybrid collection where raw remains local and only derived DuckDB/Parquet plus
+  OTLP spans leave the workstation
+
+The recommended default is hybrid collection: raw encrypted archives remain
+workstation-local unless a transcript-sync design earns explicit privacy
+approval; derived DuckDB/Parquet and OTLP spans may sync to dankserver after
+the metadata allowlist is re-verified.
+
+Acceptance gates:
+
+- topology diagram and trust boundary written in the initiative packet
+- explicit raw, derived, OTLP, report, and dashboard data classes
+- failure policy for missed syncs, partial runs, and duplicate ingest ids
+- proof that local source paths and transcript bodies do not leave the
+  workstation
+
+## P7b: Retention, Restore, And Deletion
+
+Promote P6 runbook notes into executable operator workflows.
+
+Required capabilities:
+
+- list retained raw archive objects and derived exports by window
+- drill archive decrypt without printing transcript text
+- re-derive DuckDB and Parquet from retained raw archive objects
+- delete a proof window from raw, derived, report, and optional remote mirrors
+- compact or prune old Parquet/report outputs after the retention window
+
+Acceptance gates:
+
+- restore drill from retained raw archive to derived report
+- deletion drill against a disposable local target
+- clear distinction between ignored local evidence and tracked initiative
+  documentation
+
+## P7c: Provider And Gateway Metrics
+
+Add real model-call, tool-invocation, token, cost, and latency data only from
+sources that can prove their privacy and attribution contract.
+
+Candidate sources:
+
+- xAI passive usage where available
+- Venice.ai passive usage where available
+- LiteLLM gateway enrichment
+- OpenClaw gateway metadata beyond P1-safe service-unit metadata
+- backend enrichment from Langfuse, Opik, or PostHog only if their APIs become
+  a real source of measured data
+
+Acceptance gates:
+
+- rows in `ai_metrics_model_calls` and `ai_metrics_tool_invocations` are real,
+  not synthetic placeholders
+- unavailable metrics remain explicit `*_unavailable_not_scored` gaps
+- scorecards explain when cost/latency fields are measured versus unavailable
+- provider/model/gateway identifiers are low-cardinality and deploy-safe
+
+## P7d: Dashboard And Backend Expansion
+
+Keep Phoenix as the default UI until a second backend has a specific job.
+
+Backend expansion rules:
+
+- Langfuse, Opik, and PostHog remain install/export targets by default.
+- Add a backend-specific driver only for a backend API that cannot be modeled
+  as OTLP export, static report output, or operator install config.
+- Do not expose raw prompt, output, transcript body, local path, or secret
+  values in any dashboard.
+
+Acceptance gates:
+
+- backend target decision recorded in the initiative packet
+- redacted payload proof for any new backend
+- operator command or infra path that can reproduce the deployment
+
+## P7e: Production Readiness
+
+P7 is complete when the stack can survive normal operator use without relying on
+the mutable development checkout.
+
+Completion gates:
+
+- collection topology is implemented and documented
+- timer/scheduler ownership is explicit and observable
+- sync or mirror failure modes are visible in status artifacts
+- retention, restore, deletion, and compaction workflows are proven
+- real provider/gateway metrics populate measured tables, or remain explicitly
+  unavailable and not scored
+- final scorecard explains which data came from raw archive, derived storage,
+  OTLP traces, labels, benchmarks, and provider/gateway enrichment
+

--- a/initiatives/ai-metrics-stack/ops/manifest.json
+++ b/initiatives/ai-metrics-stack/ops/manifest.json
@@ -93,8 +93,26 @@
           "name": "Fresh Review Data And Ops Hardening",
           "status": "completed",
           "output": "history/outputs/p6a-closeout-proof-restart.md"
+        },
+        {
+          "id": "P6b",
+          "name": "Proof Runner Isolation And Waiting-Window Runbook",
+          "status": "completed",
+          "output": "history/outputs/p6-proof-runner-isolation-and-runbook.md"
+        },
+        {
+          "id": "P6c",
+          "name": "Pre-May-16 Readiness Ledger",
+          "status": "in_progress",
+          "output": "history/outputs/p6-pre-may16-readiness-ledger.md"
         }
       ]
+    },
+    {
+      "id": "P7",
+      "name": "Topology-First Productionization",
+      "status": "planned",
+      "output": "history/outputs/p7-topology-first-production-plan.md"
     }
   ],
   "commandGates": [
@@ -123,6 +141,10 @@
       "command": "bun run beep ai-metrics forwarder timer --target dankserver --data-root .beep/ai-metrics --hash-salt-secret-ref 'op://TBK/ai-metrics/hash-salt' --raw-archive-key-secret-ref 'op://TBK/ai-metrics/raw-archive-key' --json"
     },
     {
+      "id": "ai-metrics-proof-runner-timer-smoke",
+      "command": "cd /home/elpresidank/YeeBois/projects/beep-effect-worktrees/ai-metrics-p6-proof && bun run beep ai-metrics forwarder timer --target dankserver --repo-root /home/elpresidank/YeeBois/projects/beep-effect-worktrees/ai-metrics-p6-proof --data-root /home/elpresidank/YeeBois/projects/beep-effect/.beep/ai-metrics --hash-salt-secret-ref 'op://TBK/ai-metrics/hash-salt' --raw-archive-key-secret-ref 'op://TBK/ai-metrics/raw-archive-key' --otlp-base-url 'https://dankserver.tailc7c348.ts.net:8447' --interval-minutes 15 --max-file-bytes 8388608 --max-files 5 --json"
+    },
+    {
       "id": "ai-metrics-archive-drill",
       "command": "BEEP_AI_METRICS_RAW_ARCHIVE_KEY=\"$(op read 'op://TBK/ai-metrics/raw-archive-key')\" bun run beep ai-metrics archive drill --target dankserver --data-root .beep/ai-metrics --hash-salt-secret-ref 'op://TBK/ai-metrics/hash-salt' --raw-archive-key-secret-ref 'op://TBK/ai-metrics/raw-archive-key' --json"
     },
@@ -145,10 +167,11 @@
   ],
   "knownGaps": [
     "The credited seven-day proof window is in progress until at least May 16, 2026 02:26 America/Chicago",
-    "Additional outcome labels and benchmark runs should be added as more timer-collected work accumulates",
+    "The workstation timer now runs from a locked pinned proof worktree while proof data remains under the main checkout .beep/ai-metrics root",
+    "The isolated-runner config has two benchmark runs but still requires at least one explicit human-approved outcome label",
     "Optional LiteLLM deployment remains deferred beyond the Phoenix-only P5b slice",
     "xAI, Venice, LiteLLM, and gateway enrichment remain deferred beyond P2",
     "Server-owned collection remains a P7 topology target requiring transcript access/sync and privacy design"
   ],
-  "nextAction": "Keep the workstation timer running through May 16, 2026 02:26 America/Chicago, add more labels and benchmark runs as data accumulates, then generate the final credited seven-day report."
+  "nextAction": "Keep the isolated proof-runner timer running through May 16, 2026 02:26 America/Chicago, add at least one human-approved label for the isolated-runner config, regenerate the scorecard, then generate the final credited seven-day report after the proof window elapses."
 }


### PR DESCRIPTION
## Summary

- Records the isolated P6 proof runner, daily runbook, and final closeout template.
- Adds a May 9 pre-May-16 readiness ledger with fresh timer, Phoenix, source discovery, benchmark, report, and label-gate evidence.
- Adds the topology-first P7 planning packet and links the new evidence through the initiative plan, README, and manifest.

## Validation

- `jq . initiatives/ai-metrics-stack/ops/manifest.json`
- `git diff --check`
- `bun run config-sync`
- `bun run check`

## Notes

The isolated-runner scorecard now has two benchmark runs but still requires at least one explicit human-approved outcome label before it can become completion-ready. The credited proof window still cannot close before May 16, 2026 02:26 America/Chicago.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kriegcloud/codesmith/beep-effect/pr/131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->