### PR TITLE
docs: close jsdoc quality v1

### DIFF
--- a/initiatives/jsdoc-quality-enforcement/PLAN.md
+++ b/initiatives/jsdoc-quality-enforcement/PLAN.md
@@ -2,7 +2,7 @@
 
 ## Current Plan
 
-V1 is implemented as a report-only quality workflow:
+V1 is complete as a report-only quality workflow:
 
 - `@beep/repo-cli` owns `beep docgen quality`, scope selection, report writing,
   and advisory remediation packets.
@@ -17,6 +17,8 @@ V1 is implemented as a report-only quality workflow:
   policy.
 - [ops/manifest.json](./ops/manifest.json) remains the machine-readable packet
   index.
+- Post-P6 report stability evidence is captured in
+  [research/post-p6-report-stability-eval.md](./research/post-p6-report-stability-eval.md).
 
 ## Phase Posture
 
@@ -29,6 +31,7 @@ V1 is implemented as a report-only quality workflow:
 | P4 | Complete | Implement report-only V1 quality workflow. | `beep docgen quality`, tests, guidance updates |
 | P5 | Complete | Evaluate enforcement readiness. | `research/enforcement-readiness-eval.md`, compact summary artifact |
 | P6 | Complete | Harden before any enforcement. | Schema v2 package status, bounded JSON/report runtime, re-export/type-only policy, capped packets |
+| P7 | Complete | Re-run post-P6 sample and close V1. | `research/post-p6-report-stability-eval.md`, post-P6 compact summary artifact |
 
 ## V1 Implementation Changes
 
@@ -58,9 +61,9 @@ V1 is implemented as a report-only quality workflow:
 
 ## Future Work
 
-- Run a post-P6 report sample before proposing any blocking threshold.
+- Treat blocking enforcement as a future initiative, not a continuation of V1.
 - Consider package opt-in warning mode before changed-files-only blocking after
-  P6 hardening proves stable signal in routine use.
+  teams have reviewed package baselines and real documentation remediation PRs.
 - Decide whether advisory packets should grow into guided Codex remediation
   execution after capped packet batches are reviewed in real remediation work.
 - Revisit local/Qwen workers only behind an eval-only mode with measured

--- a/initiatives/jsdoc-quality-enforcement/README.md
+++ b/initiatives/jsdoc-quality-enforcement/README.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-V1 implemented; P6 hardening complete; still report-only
+V1 complete; report-only initiative closed
 
 ## Overview
 
@@ -17,7 +17,8 @@ findings, and emits bounded advisory Codex remediation packets. P6 adds schema
 v2 package status metadata, faster schema-heavy reports, re-export edge policy,
 type-only example evidence, and capped packet output. Diagnostics and
 related-symbol fields are reserved for follow-up enrichment when unavailable.
-The command is not a blocking gate.
+Post-P6 evaluation completed the architecture-stratified package sample with no
+timeouts, including `@beep/schema`. The command is not a blocking gate.
 
 ## Read This First
 
@@ -30,7 +31,9 @@ The command is not a blocking gate.
 ## Operating Rules
 
 - Treat V1 quality findings as advisory report output only.
-- Do not add blocking enforcement until post-P6 reports prove stable signal.
+- Do not add blocking enforcement in this initiative.
+- Future enforcement requires a new decision plan with measured package
+  baselines and finding-code precision.
 - Keep `@example` universal for owning exported symbols; re-export declarations
   are graph edges, not exception categories.
 - Place curated future evaluation reports in `research/`.

--- a/initiatives/jsdoc-quality-enforcement/SPEC.md
+++ b/initiatives/jsdoc-quality-enforcement/SPEC.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-V1 implemented
+V1 complete; report-only
 
 ## Owner
 
@@ -135,6 +135,7 @@ under [history/outputs/](./history/outputs) when they are useful provenance.
   `AGENTS.md` guidance.
 - Cost, caching, batching, and incremental adoption strategy for repo-wide
   documentation quality review.
+- Post-P6 report stability across an architecture-stratified package sample.
 
 ## Non-Goals
 
@@ -158,3 +159,5 @@ under [history/outputs/](./history/outputs) when they are useful provenance.
   and Codex remediation packet output.
 - Guidance surfaces record the universal `@example` and whole-block usefulness
   policy.
+- Post-P6 evaluation proves the representative package sample completes without
+  timeouts and records bounded Codex packet behavior.

--- a/initiatives/jsdoc-quality-enforcement/history/outputs/jsdoc-quality-post-p6-summary.json
+++ b/initiatives/jsdoc-quality-enforcement/history/outputs/jsdoc-quality-post-p6-summary.json
@@ -1,0 +1,326 @@
+{
+  "schemaVersion": "1.0.0",
+  "generatedAt": "2026-05-09T09:42:18Z",
+  "source": "beep docgen quality",
+  "scope": "post-P6 architecture-stratified package sample",
+  "commands": [
+    "bun run beep docgen quality -p <package> --json --output /tmp/jsdoc-quality-post-p6/<slug>.json",
+    "bun run beep docgen quality -p <package> --json --score codex --packet-limit 25 --output /tmp/jsdoc-quality-post-p6/<slug>.codex.json"
+  ],
+  "totals": {
+    "completedPackages": 10,
+    "failedPackages": 0,
+    "subjects": 2828,
+    "passing": 769,
+    "warnings": 768,
+    "failures": 1291,
+    "maxDurationMs": 3197,
+    "schemaDurationMs": 1948
+  },
+  "aggregateFindingCounts": {
+    "example-lacks-observable-result": 794,
+    "example-only-voids-result": 591,
+    "example-too-trivial": 82,
+    "missing-effects-for-effectful-symbol": 73,
+    "missing-example": 1173,
+    "missing-description": 367,
+    "missing-category": 7,
+    "missing-since": 5
+  },
+  "samplePackages": [
+    {
+      "slug": "repo-cli",
+      "family": "tooling",
+      "packageName": "@beep/repo-cli",
+      "packagePath": "packages/tooling/tool/cli",
+      "status": "completed",
+      "durationMs": 3197,
+      "timedOut": false,
+      "error": null,
+      "schemaVersion": 2,
+      "rubricVersion": "jsdoc-quality-v1",
+      "scorer": "deterministic-rubric-v1",
+      "summary": {
+        "subjects": 544,
+        "passing": 89,
+        "warnings": 130,
+        "failures": 325,
+        "remediationPackets": 0
+      },
+      "omittedPacketCount": 0,
+      "findingCounts": {
+        "example-lacks-observable-result": 47,
+        "example-only-voids-result": 15,
+        "example-too-trivial": 82,
+        "missing-effects-for-effectful-symbol": 38,
+        "missing-example": 325
+      }
+    },
+    {
+      "slug": "repo-docgen",
+      "family": "tooling",
+      "packageName": "@beep/repo-docgen",
+      "packagePath": "packages/tooling/tool/docgen",
+      "status": "completed",
+      "durationMs": 2331,
+      "timedOut": false,
+      "error": null,
+      "schemaVersion": 2,
+      "rubricVersion": "jsdoc-quality-v1",
+      "scorer": "deterministic-rubric-v1",
+      "summary": {
+        "subjects": 67,
+        "passing": 11,
+        "warnings": 56,
+        "failures": 0,
+        "remediationPackets": 0
+      },
+      "omittedPacketCount": 0,
+      "findingCounts": {
+        "example-lacks-observable-result": 56,
+        "example-only-voids-result": 56,
+        "missing-effects-for-effectful-symbol": 11
+      }
+    },
+    {
+      "slug": "repo-utils",
+      "family": "tooling",
+      "packageName": "@beep/repo-utils",
+      "packagePath": "packages/tooling/library/repo-utils",
+      "status": "completed",
+      "durationMs": 1911,
+      "timedOut": false,
+      "error": null,
+      "schemaVersion": 2,
+      "rubricVersion": "jsdoc-quality-v1",
+      "scorer": "deterministic-rubric-v1",
+      "summary": {
+        "subjects": 608,
+        "passing": 104,
+        "warnings": 389,
+        "failures": 115,
+        "remediationPackets": 0
+      },
+      "omittedPacketCount": 0,
+      "findingCounts": {
+        "example-lacks-observable-result": 502,
+        "example-only-voids-result": 419,
+        "missing-description": 115,
+        "missing-effects-for-effectful-symbol": 14
+      }
+    },
+    {
+      "slug": "schema",
+      "family": "foundation",
+      "packageName": "@beep/schema",
+      "packagePath": "packages/foundation/modeling/schema",
+      "status": "completed",
+      "durationMs": 1948,
+      "timedOut": false,
+      "error": null,
+      "schemaVersion": 2,
+      "rubricVersion": "jsdoc-quality-v1",
+      "scorer": "deterministic-rubric-v1",
+      "summary": {
+        "subjects": 1281,
+        "passing": 306,
+        "warnings": 136,
+        "failures": 839,
+        "remediationPackets": 0
+      },
+      "omittedPacketCount": 0,
+      "findingCounts": {
+        "example-lacks-observable-result": 134,
+        "example-only-voids-result": 92,
+        "missing-category": 7,
+        "missing-description": 241,
+        "missing-effects-for-effectful-symbol": 8,
+        "missing-example": 836,
+        "missing-since": 5
+      }
+    },
+    {
+      "slug": "types",
+      "family": "foundation",
+      "packageName": "@beep/types",
+      "packagePath": "packages/foundation/primitive/types",
+      "status": "completed",
+      "durationMs": 365,
+      "timedOut": false,
+      "error": null,
+      "schemaVersion": 2,
+      "rubricVersion": "jsdoc-quality-v1",
+      "scorer": "deterministic-rubric-v1",
+      "summary": {
+        "subjects": 11,
+        "passing": 11,
+        "warnings": 0,
+        "failures": 0,
+        "remediationPackets": 0
+      },
+      "omittedPacketCount": 0,
+      "findingCounts": {}
+    },
+    {
+      "slug": "openai",
+      "family": "drivers",
+      "packageName": "@beep/openai",
+      "packagePath": "packages/drivers/openai",
+      "status": "completed",
+      "durationMs": 55,
+      "timedOut": false,
+      "error": null,
+      "schemaVersion": 2,
+      "rubricVersion": "jsdoc-quality-v1",
+      "scorer": "deterministic-rubric-v1",
+      "summary": {
+        "subjects": 2,
+        "passing": 1,
+        "warnings": 0,
+        "failures": 1,
+        "remediationPackets": 0
+      },
+      "omittedPacketCount": 0,
+      "findingCounts": {
+        "missing-description": 1,
+        "missing-example": 1
+      }
+    },
+    {
+      "slug": "shared-domain",
+      "family": "shared",
+      "packageName": "@beep/shared-domain",
+      "packagePath": "packages/shared/domain",
+      "status": "completed",
+      "durationMs": 1622,
+      "timedOut": false,
+      "error": null,
+      "schemaVersion": 2,
+      "rubricVersion": "jsdoc-quality-v1",
+      "scorer": "deterministic-rubric-v1",
+      "summary": {
+        "subjects": 185,
+        "passing": 183,
+        "warnings": 2,
+        "failures": 0,
+        "remediationPackets": 0
+      },
+      "omittedPacketCount": 0,
+      "findingCounts": {
+        "missing-effects-for-effectful-symbol": 2
+      }
+    },
+    {
+      "slug": "fixture-domain",
+      "family": "fixture",
+      "packageName": "@beep/fixture-lab-specimen-domain",
+      "packagePath": "packages/fixture-lab/specimen/domain",
+      "status": "completed",
+      "durationMs": 1490,
+      "timedOut": false,
+      "error": null,
+      "schemaVersion": 2,
+      "rubricVersion": "jsdoc-quality-v1",
+      "scorer": "deterministic-rubric-v1",
+      "summary": {
+        "subjects": 11,
+        "passing": 11,
+        "warnings": 0,
+        "failures": 0,
+        "remediationPackets": 0
+      },
+      "omittedPacketCount": 0,
+      "findingCounts": {}
+    },
+    {
+      "slug": "workspace-domain",
+      "family": "slice",
+      "packageName": "@beep/workspace-domain",
+      "packagePath": "packages/workspace/domain",
+      "status": "completed",
+      "durationMs": 1437,
+      "timedOut": false,
+      "error": null,
+      "schemaVersion": 2,
+      "rubricVersion": "jsdoc-quality-v1",
+      "scorer": "deterministic-rubric-v1",
+      "summary": {
+        "subjects": 39,
+        "passing": 39,
+        "warnings": 0,
+        "failures": 0,
+        "remediationPackets": 0
+      },
+      "omittedPacketCount": 0,
+      "findingCounts": {}
+    },
+    {
+      "slug": "identity",
+      "family": "foundation",
+      "packageName": "@beep/identity",
+      "packagePath": "packages/foundation/modeling/identity",
+      "status": "completed",
+      "durationMs": 1181,
+      "timedOut": false,
+      "error": null,
+      "schemaVersion": 2,
+      "rubricVersion": "jsdoc-quality-v1",
+      "scorer": "deterministic-rubric-v1",
+      "summary": {
+        "subjects": 80,
+        "passing": 14,
+        "warnings": 55,
+        "failures": 11,
+        "remediationPackets": 0
+      },
+      "omittedPacketCount": 0,
+      "findingCounts": {
+        "example-lacks-observable-result": 55,
+        "example-only-voids-result": 9,
+        "missing-description": 10,
+        "missing-example": 11
+      }
+    }
+  ],
+  "codexPacketProbes": {
+    "packetLimit": 25,
+    "probes": [
+      {
+        "slug": "repo-cli",
+        "packageName": "@beep/repo-cli",
+        "packagePath": "packages/tooling/tool/cli",
+        "status": "completed",
+        "durationMs": 2942,
+        "subjects": 544,
+        "failures": 325,
+        "warnings": 130,
+        "remediationPackets": 25,
+        "omittedPacketCount": 430
+      },
+      {
+        "slug": "schema",
+        "packageName": "@beep/schema",
+        "packagePath": "packages/foundation/modeling/schema",
+        "status": "completed",
+        "durationMs": 1897,
+        "subjects": 1281,
+        "failures": 839,
+        "warnings": 136,
+        "remediationPackets": 25,
+        "omittedPacketCount": 950
+      },
+      {
+        "slug": "identity",
+        "packageName": "@beep/identity",
+        "packagePath": "packages/foundation/modeling/identity",
+        "status": "completed",
+        "durationMs": 1095,
+        "subjects": 80,
+        "failures": 11,
+        "warnings": 55,
+        "remediationPackets": 25,
+        "omittedPacketCount": 41
+      }
+    ]
+  }
+}

--- a/initiatives/jsdoc-quality-enforcement/ops/manifest.json
+++ b/initiatives/jsdoc-quality-enforcement/ops/manifest.json
@@ -3,7 +3,7 @@
   "initiative": {
     "id": "jsdoc-quality-enforcement",
     "title": "JSDoc Quality Enforcement",
-    "status": "p6-hardened",
+    "status": "v1-complete-report-only",
     "created": "2026-05-08",
     "updated": "2026-05-09",
     "packetAnchorDocument": "SPEC.md"
@@ -41,9 +41,18 @@
       "title": "Enforcement Readiness Evaluation",
       "status": "complete",
       "output": "research/enforcement-readiness-eval.md"
+    },
+    {
+      "id": "post-p6-report-stability-eval",
+      "title": "Post-P6 Report Stability Evaluation",
+      "status": "complete",
+      "output": "research/post-p6-report-stability-eval.md"
     }
   ],
-  "evaluationOutputs": ["history/outputs/jsdoc-quality-p5-summary.json"],
+  "evaluationOutputs": [
+    "history/outputs/jsdoc-quality-p5-summary.json",
+    "history/outputs/jsdoc-quality-post-p6-summary.json"
+  ],
   "implementedSurfaces": [
     "packages/tooling/tool/cli/src/commands/Docgen/index.ts",
     "packages/tooling/tool/cli/src/commands/Docgen/internal/Quality.ts",
@@ -60,5 +69,5 @@
     "local model workers",
     "example exception categories"
   ],
-  "nextAction": "Run post-P6 report samples and consider package opt-in warnings only after the hardened report signal proves stable."
+  "nextAction": "V1 is complete as report-only. Future enforcement requires a new decision plan with measured package baselines and finding-code precision."
 }

--- a/initiatives/jsdoc-quality-enforcement/research/post-p6-report-stability-eval.md
+++ b/initiatives/jsdoc-quality-enforcement/research/post-p6-report-stability-eval.md
@@ -1,0 +1,105 @@
+# Post-P6 Report Stability Evaluation
+
+## Question
+
+Did the P6 hardening work remove the blockers that kept V1 from closing as a
+report-only JSDoc quality workflow?
+
+## Scope
+
+This pass re-ran the P5 architecture-stratified package sample after P6 landed:
+
+- tooling: `@beep/repo-cli`, `@beep/repo-docgen`, `@beep/repo-utils`
+- foundation: `@beep/schema`, `@beep/types`, `@beep/identity`
+- drivers: `@beep/openai`
+- shared kernel: `@beep/shared-domain`
+- executable architecture fixture: `@beep/fixture-lab-specimen-domain`
+- product slice domain: `@beep/workspace-domain`
+
+The pass did not remediate source JSDoc, add blocking enforcement, run model
+edits, change the rubric, or evaluate local model workers.
+
+## Repo Evidence
+
+Raw package reports were written under `/tmp/jsdoc-quality-post-p6/` during the
+local run. The committed compact summary is
+[`../history/outputs/jsdoc-quality-post-p6-summary.json`](../history/outputs/jsdoc-quality-post-p6-summary.json).
+
+All ten deterministic package-local reports completed:
+
+| Package | Family | Runtime | Subjects | Pass | Warn | Fail |
+|---|---:|---:|---:|---:|---:|---:|
+| `@beep/repo-cli` | tooling | 3.197s | 544 | 89 | 130 | 325 |
+| `@beep/repo-docgen` | tooling | 2.331s | 67 | 11 | 56 | 0 |
+| `@beep/repo-utils` | tooling | 1.911s | 608 | 104 | 389 | 115 |
+| `@beep/schema` | foundation | 1.948s | 1281 | 306 | 136 | 839 |
+| `@beep/types` | foundation | 0.365s | 11 | 11 | 0 | 0 |
+| `@beep/openai` | drivers | 0.055s | 2 | 1 | 0 | 1 |
+| `@beep/shared-domain` | shared | 1.622s | 185 | 183 | 2 | 0 |
+| `@beep/fixture-lab-specimen-domain` | fixture | 1.490s | 11 | 11 | 0 | 0 |
+| `@beep/workspace-domain` | slice | 1.437s | 39 | 39 | 0 | 0 |
+| `@beep/identity` | foundation | 1.181s | 80 | 14 | 55 | 11 |
+
+Aggregate deterministic findings across the sample:
+
+| Finding code | Count |
+|---|---:|
+| `missing-example` | 1173 |
+| `example-lacks-observable-result` | 794 |
+| `example-only-voids-result` | 591 |
+| `missing-description` | 367 |
+| `example-too-trivial` | 82 |
+| `missing-effects-for-effectful-symbol` | 73 |
+| `missing-category` | 7 |
+| `missing-since` | 5 |
+
+Selective `--score codex --packet-limit 25` probes also completed without
+executing edits:
+
+| Package | Runtime | Packets | Omitted |
+|---|---:|---:|---:|
+| `@beep/repo-cli` | 2.942s | 25 | 430 |
+| `@beep/schema` | 1.897s | 25 | 950 |
+| `@beep/identity` | 1.095s | 25 | 41 |
+
+## P5 Comparison
+
+P5 found real signal but was not closure-ready: `@beep/schema` did not finish
+within the evaluation ceiling, `@beep/repo-utils` took 124.636s, and
+`@beep/repo-cli` took 75.250s in deterministic mode. P6 removed those runtime
+blockers in this local post-P6 sample. The same representative package set now
+has zero partial reports, zero timeouts, and a maximum deterministic runtime of
+3.197s.
+
+The finding counts changed because P6 intentionally narrowed the subject model
+and rubric behavior: re-export declarations are graph edges instead of quality
+subjects, type-only examples can be useful without runtime output, and advisory
+Codex packets are capped. Treat the post-P6 counts as the new report baseline,
+not an enforcement threshold.
+
+## Recommendation
+
+Close the current initiative as V1 complete, report-only.
+
+The report machinery is now stable enough for routine advisory use and for
+future remediation planning. It is still not appropriate to make findings
+blocking inside this initiative because the sample intentionally contains 1,291
+failures and 768 warnings across existing source documentation. Those are useful
+work queues, not an evaluated pass/fail threshold.
+
+Future enforcement should be proposed as a separate, narrower initiative after
+teams have used the report output to remediate or explicitly accept package
+baselines. A sensible next experiment is package opt-in warning mode, followed
+by changed-files blocking only for high-confidence finding codes once precision
+is measured on real documentation PRs.
+
+## Closure Decision
+
+- V1 quality reporting is implemented and hardened.
+- V1 remains advisory and report-only.
+- Universal `@example` remains the policy for owning exported symbols.
+- Re-export declarations remain export graph edges, not exception categories.
+- Codex packets remain bounded advisory work queues.
+- Local model workers remain outside V1.
+- Blocking enforcement is explicitly future work and should require a new
+  decision plan.

--- a/standards/jsdoc-documentation.inventory.md
+++ b/standards/jsdoc-documentation.inventory.md
@@ -1,6 +1,6 @@
 # JSDoc Documentation Compliance Inventory
 
-Generated: 2026-05-09T09:28:12.290Z
+Generated: 2026-05-09T09:51:57.516Z
 
 ## Scope
 


### PR DESCRIPTION
## Summary

- closes the JSDoc quality enforcement initiative as V1 complete, report-only
- adds post-P6 report stability evidence and a compact summary artifact
- records that future blocking enforcement requires a new decision plan with measured baselines

## Evidence

- post-P6 deterministic sample: 10/10 packages completed, max runtime 3.197s, schema runtime 1.948s
- Codex packet probes completed with --packet-limit 25 and omitted packet counts recorded

## Verification

- bun run check
- bun run lint
- bun run test
- bun run jsdoc:inventory
- bun run docgen:affected
- git diff --check
- jq empty initiatives/jsdoc-quality-enforcement/ops/manifest.json initiatives/jsdoc-quality-enforcement/history/outputs/jsdoc-quality-post-p6-summary.json standards/jsdoc-documentation.inventory.jsonc

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kriegcloud/codesmith/beep-effect/pr/132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->