### PR TITLE
Enforce Effect.fn generator law

### DIFF
--- a/.changeset/smart-forks-happen.md
+++ b/.changeset/smart-forks-happen.md
@@ -1,0 +1,4 @@
+---
+---
+
+Record Effect.fn law coverage and internal generator refactors without package release.

--- a/packages/drivers/ffmpeg/src/FFmpeg.service.ts
+++ b/packages/drivers/ffmpeg/src/FFmpeg.service.ts
@@ -489,54 +489,53 @@ const consumeProgressLine = (
 const emitEvent = (sink: FFmpegEventSink | undefined, event: FFmpegEvent): Effect.Effect<void, never> =>
   sink === undefined ? Effect.void : sink(event);
 
-const collectProgressText = (
+const collectProgressText = Effect.fn("FFmpeg.collectProgressText")(function* (
   stream: Stream.Stream<Uint8Array, PlatformError.PlatformError>,
   expected: number,
   sink: FFmpegEventSink | undefined
-): Effect.Effect<string, PlatformError.PlatformError> =>
-  Effect.gen(function* () {
-    const state = yield* Ref.make<ProgressState>({
-      block: {},
-      buffer: "",
-      stdout: "",
-    });
-
-    yield* stream.pipe(
-      Stream.decodeText(),
-      Stream.runForEach((chunk) =>
-        Effect.gen(function* () {
-          const current = yield* Ref.get(state);
-          const combined = `${current.buffer}${chunk}`;
-          const hasTrailingLineBreak = Str.endsWith("\n")(combined);
-          const lines = Str.split(/\r?\n/)(combined);
-          const completeLines = hasTrailingLineBreak ? lines : A.dropRight(lines, 1);
-          const buffer = hasTrailingLineBreak
-            ? ""
-            : pipe(
-                A.last(lines),
-                O.getOrElse(() => "")
-              );
-          let nextState: ProgressState = {
-            ...current,
-            buffer,
-            stdout: `${current.stdout}${chunk}`,
-          };
-
-          for (const line of completeLines) {
-            const [updated, event] = consumeProgressLine(nextState, line, expected);
-            nextState = updated;
-            if (O.isSome(event)) {
-              yield* emitEvent(sink, event.value);
-            }
-          }
-
-          yield* Ref.set(state, nextState);
-        })
-      )
-    );
-
-    return (yield* Ref.get(state)).stdout;
+): Effect.fn.Return<string, PlatformError.PlatformError> {
+  const state = yield* Ref.make<ProgressState>({
+    block: {},
+    buffer: "",
+    stdout: "",
   });
+
+  yield* stream.pipe(
+    Stream.decodeText(),
+    Stream.runForEach(
+      Effect.fnUntraced(function* (chunk) {
+        const current = yield* Ref.get(state);
+        const combined = `${current.buffer}${chunk}`;
+        const hasTrailingLineBreak = Str.endsWith("\n")(combined);
+        const lines = Str.split(/\r?\n/)(combined);
+        const completeLines = hasTrailingLineBreak ? lines : A.dropRight(lines, 1);
+        const buffer = hasTrailingLineBreak
+          ? ""
+          : pipe(
+              A.last(lines),
+              O.getOrElse(() => "")
+            );
+        let nextState: ProgressState = {
+          ...current,
+          buffer,
+          stdout: `${current.stdout}${chunk}`,
+        };
+
+        for (const line of completeLines) {
+          const [updated, event] = consumeProgressLine(nextState, line, expected);
+          nextState = updated;
+          if (O.isSome(event)) {
+            yield* emitEvent(sink, event.value);
+          }
+        }
+
+        yield* Ref.set(state, nextState);
+      })
+    )
+  );
+
+  return (yield* Ref.get(state)).stdout;
+});
 
 const runExtractProcess = (
   spawner: ChildProcessSpawner.ChildProcessSpawner["Service"],
@@ -561,79 +560,84 @@ const runExtractProcess = (
     )
   );
 
-const ensureFile = (fs: FileSystem.FileSystem, filePath: string, label: string): Effect.Effect<void, FFmpegError> =>
-  Effect.gen(function* () {
-    const stat = yield* fs
-      .stat(filePath)
+const ensureFile = Effect.fn("FFmpeg.ensureFile")(function* (
+  fs: FileSystem.FileSystem,
+  filePath: string,
+  label: string
+): Effect.fn.Return<void, FFmpegError> {
+  const stat = yield* fs
+    .stat(filePath)
+    .pipe(
+      Effect.mapError((cause) =>
+        FFmpegError.fromUnknown("extractFrames", `Failed to stat ${label}: "${filePath}"`, { cause })
+      )
+    );
+  if (stat.type !== "File") {
+    return yield* new FFmpegError({
+      message: `Expected ${label} to be a file: "${filePath}"`,
+      operation: "extractFrames",
+    });
+  }
+});
+
+const ensureDirectory = Effect.fn("FFmpeg.ensureDirectory")(function* (
+  fs: FileSystem.FileSystem,
+  dirPath: string,
+  label: string
+): Effect.fn.Return<void, FFmpegError> {
+  const exists = yield* fs
+    .exists(dirPath)
+    .pipe(
+      Effect.mapError((cause) =>
+        FFmpegError.fromUnknown("extractFrames", `Failed to inspect ${label}: "${dirPath}"`, { cause })
+      )
+    );
+  if (!exists) {
+    yield* fs
+      .makeDirectory(dirPath, { recursive: true })
       .pipe(
         Effect.mapError((cause) =>
-          FFmpegError.fromUnknown("extractFrames", `Failed to stat ${label}: "${filePath}"`, { cause })
+          FFmpegError.fromUnknown("extractFrames", `Failed to create ${label}: "${dirPath}"`, { cause })
         )
       );
-    if (stat.type !== "File") {
-      return yield* new FFmpegError({
-        message: `Expected ${label} to be a file: "${filePath}"`,
-        operation: "extractFrames",
-      });
-    }
-  });
+    return;
+  }
 
-const ensureDirectory = (fs: FileSystem.FileSystem, dirPath: string, label: string): Effect.Effect<void, FFmpegError> =>
-  Effect.gen(function* () {
-    const exists = yield* fs
-      .exists(dirPath)
-      .pipe(
-        Effect.mapError((cause) =>
-          FFmpegError.fromUnknown("extractFrames", `Failed to inspect ${label}: "${dirPath}"`, { cause })
-        )
-      );
-    if (!exists) {
-      yield* fs
-        .makeDirectory(dirPath, { recursive: true })
-        .pipe(
-          Effect.mapError((cause) =>
-            FFmpegError.fromUnknown("extractFrames", `Failed to create ${label}: "${dirPath}"`, { cause })
-          )
-        );
-      return;
-    }
+  const stat = yield* fs
+    .stat(dirPath)
+    .pipe(
+      Effect.mapError((cause) =>
+        FFmpegError.fromUnknown("extractFrames", `Failed to stat ${label}: "${dirPath}"`, { cause })
+      )
+    );
+  if (stat.type !== "Directory") {
+    return yield* new FFmpegError({
+      message: `Expected ${label} to be a directory: "${dirPath}"`,
+      operation: "extractFrames",
+    });
+  }
+});
 
-    const stat = yield* fs
-      .stat(dirPath)
-      .pipe(
-        Effect.mapError((cause) =>
-          FFmpegError.fromUnknown("extractFrames", `Failed to stat ${label}: "${dirPath}"`, { cause })
-        )
-      );
-    if (stat.type !== "Directory") {
-      return yield* new FFmpegError({
-        message: `Expected ${label} to be a directory: "${dirPath}"`,
-        operation: "extractFrames",
-      });
-    }
-  });
-
-const preflightWritable = (
+const preflightWritable = Effect.fn("FFmpeg.preflightWritable")(function* (
   fs: FileSystem.FileSystem,
   filePath: string,
   overwrite: boolean,
   label: string
-): Effect.Effect<void, FFmpegError> =>
-  Effect.gen(function* () {
-    const exists = yield* fs
-      .exists(filePath)
-      .pipe(
-        Effect.mapError((cause) =>
-          FFmpegError.fromUnknown("extractFrames", `Failed to inspect ${label}: "${filePath}"`, { cause })
-        )
-      );
-    if (exists && !overwrite) {
-      return yield* new FFmpegError({
-        message: `Refusing to overwrite existing ${label}: "${filePath}"`,
-        operation: "extractFrames",
-      });
-    }
-  });
+): Effect.fn.Return<void, FFmpegError> {
+  const exists = yield* fs
+    .exists(filePath)
+    .pipe(
+      Effect.mapError((cause) =>
+        FFmpegError.fromUnknown("extractFrames", `Failed to inspect ${label}: "${filePath}"`, { cause })
+      )
+    );
+  if (exists && !overwrite) {
+    return yield* new FFmpegError({
+      message: `Refusing to overwrite existing ${label}: "${filePath}"`,
+      operation: "extractFrames",
+    });
+  }
+});
 
 const makeExtractContext = Effect.fn("FFmpeg.makeExtractContext")(function* (
   path: Path.Path,
@@ -919,64 +923,63 @@ const makeService = Effect.fn("FFmpeg.make")(function* (configInput?: FFmpegConf
             )
           )
         ),
-      (tempDir) =>
-        Effect.gen(function* () {
-          const tempPattern = path.join(tempDir, `${context.prefix}_%0${context.padding}d.png`);
-          const args = buildExtractFramesArgs({
-            fps: context.fpsText,
-            outputPattern: tempPattern,
-            videoPath: context.videoPath,
-          });
-          const command = ChildProcess.make(config.ffmpegPath, args, {
-            forceKillAfter: `${config.forceKillAfterMillis} millis`,
-            stdin: "ignore",
-            stderr: "pipe",
-            stdout: "pipe",
-          });
+      Effect.fnUntraced(function* (tempDir) {
+        const tempPattern = path.join(tempDir, `${context.prefix}_%0${context.padding}d.png`);
+        const args = buildExtractFramesArgs({
+          fps: context.fpsText,
+          outputPattern: tempPattern,
+          videoPath: context.videoPath,
+        });
+        const command = ChildProcess.make(config.ffmpegPath, args, {
+          forceKillAfter: `${config.forceKillAfterMillis} millis`,
+          stdin: "ignore",
+          stderr: "pipe",
+          stdout: "pipe",
+        });
 
-          yield* emitEvent(
-            onEvent,
-            new FFmpegStartedEvent({
-              args,
-              command: config.ffmpegPath,
-              kind: "started",
-              outDir: context.outDir,
-              videoPath: context.videoPath,
-            })
-          );
-
-          const result = yield* runExtractProcess(spawner, command, context.expectedFrameCount, onEvent);
-          if (result.exitCode !== 0) {
-            return yield* new FFmpegError({
-              command: config.ffmpegPath,
-              exitCode: result.exitCode,
-              message: `ffmpeg could not extract frames for "${context.videoPath}".`,
-              operation: "extractFrames",
-              stderr: Str.trim(result.stderr),
-              stdout: Str.trim(result.stdout),
-            });
-          }
-
-          const tempFrames = yield* readTempFrames(fs, path, tempDir, context.prefix);
-          const frames = yield* commitFrames(fs, path, context, tempDir, tempFrames).pipe(Effect.uninterruptible);
-          const resultValue = new ExtractFramesResult({
-            frameCount: A.length(frames),
-            frames,
-            manifestPath: context.manifestPath,
+        yield* emitEvent(
+          onEvent,
+          new FFmpegStartedEvent({
+            args,
+            command: config.ffmpegPath,
+            kind: "started",
             outDir: context.outDir,
             videoPath: context.videoPath,
+          })
+        );
+
+        const result = yield* runExtractProcess(spawner, command, context.expectedFrameCount, onEvent);
+        if (result.exitCode !== 0) {
+          return yield* new FFmpegError({
+            command: config.ffmpegPath,
+            exitCode: result.exitCode,
+            message: `ffmpeg could not extract frames for "${context.videoPath}".`,
+            operation: "extractFrames",
+            stderr: Str.trim(result.stderr),
+            stdout: Str.trim(result.stdout),
           });
-          yield* emitEvent(
-            onEvent,
-            new FFmpegCompletedEvent({
-              frameCount: resultValue.frameCount,
-              kind: "completed",
-              manifestPath: resultValue.manifestPath,
-              outDir: resultValue.outDir,
-            })
-          );
-          return resultValue;
-        }),
+        }
+
+        const tempFrames = yield* readTempFrames(fs, path, tempDir, context.prefix);
+        const frames = yield* commitFrames(fs, path, context, tempDir, tempFrames).pipe(Effect.uninterruptible);
+        const resultValue = new ExtractFramesResult({
+          frameCount: A.length(frames),
+          frames,
+          manifestPath: context.manifestPath,
+          outDir: context.outDir,
+          videoPath: context.videoPath,
+        });
+        yield* emitEvent(
+          onEvent,
+          new FFmpegCompletedEvent({
+            frameCount: resultValue.frameCount,
+            kind: "completed",
+            manifestPath: resultValue.manifestPath,
+            outDir: resultValue.outDir,
+          })
+        );
+        return resultValue;
+      }),
       (tempDir) => fs.remove(tempDir, { recursive: true, force: true }).pipe(Effect.ignore)
     );
   });

--- a/packages/drivers/openai-compat/src/OpenAiCompat.language-model.ts
+++ b/packages/drivers/openai-compat/src/OpenAiCompat.language-model.ts
@@ -559,37 +559,36 @@ const prepareResponseFormat = (
   });
 };
 
-const makeRequest = (
+const makeRequest = Effect.fn("OpenAiCompatLanguageModel.makeRequest")(function* (
   moduleName: string,
   model: string,
   config: OpenAiCompatLanguageModelConfig,
   options: LanguageModel.ProviderOptions,
   toolNameMapper: Tool.NameMapper<ReadonlyArray<Tool.Any>>,
   stream: boolean
-): Effect.Effect<OpenAiCompatChatCompletionRequest, AiError.AiError> =>
-  Effect.gen(function* () {
-    const messages = yield* prepareMessages(moduleName, toolNameMapper, options.prompt);
-    const tools = yield* prepareTools(moduleName, config, options);
-    const responseFormat = yield* prepareResponseFormat(moduleName, config, options.responseFormat);
-    return new OpenAiCompatChatCompletionRequest({
-      messages,
-      model,
-      ...R.getSomes({
-        max_completion_tokens: O.fromUndefinedOr(config.maxCompletionTokens),
-        max_tokens: O.fromUndefinedOr(config.maxTokens),
-        parallel_tool_calls: O.fromUndefinedOr(config.parallelToolCalls),
-        response_format: responseFormat,
-        seed: O.fromUndefinedOr(config.seed),
-        stream: stream ? O.some(true) : O.none(),
-        stream_options: stream ? O.some({ include_usage: true }) : O.none(),
-        temperature: O.fromUndefinedOr(config.temperature),
-        tool_choice: prepareToolChoice(toolNameMapper, options.toolChoice),
-        tools,
-        top_p: O.fromUndefinedOr(config.topP),
-        user: O.fromUndefinedOr(config.user),
-      }),
-    });
+): Effect.fn.Return<OpenAiCompatChatCompletionRequest, AiError.AiError> {
+  const messages = yield* prepareMessages(moduleName, toolNameMapper, options.prompt);
+  const tools = yield* prepareTools(moduleName, config, options);
+  const responseFormat = yield* prepareResponseFormat(moduleName, config, options.responseFormat);
+  return new OpenAiCompatChatCompletionRequest({
+    messages,
+    model,
+    ...R.getSomes({
+      max_completion_tokens: O.fromUndefinedOr(config.maxCompletionTokens),
+      max_tokens: O.fromUndefinedOr(config.maxTokens),
+      parallel_tool_calls: O.fromUndefinedOr(config.parallelToolCalls),
+      response_format: responseFormat,
+      seed: O.fromUndefinedOr(config.seed),
+      stream: stream ? O.some(true) : O.none(),
+      stream_options: stream ? O.some({ include_usage: true }) : O.none(),
+      temperature: O.fromUndefinedOr(config.temperature),
+      tool_choice: prepareToolChoice(toolNameMapper, options.toolChoice),
+      tools,
+      top_p: O.fromUndefinedOr(config.topP),
+      user: O.fromUndefinedOr(config.user),
+    }),
   });
+});
 
 const makeToolCallPart = (
   moduleName: string,
@@ -682,46 +681,45 @@ const makeCompletedStreamToolCallsParts = (
     Effect.map(A.flatten)
   );
 
-const makeChoiceParts = (
+const makeChoiceParts = Effect.fn("OpenAiCompatLanguageModel.makeChoiceParts")(function* (
   moduleName: string,
   toolNameMapper: Tool.NameMapper<ReadonlyArray<Tool.Any>>,
   response: OpenAiCompatChatCompletionResponse
-): Effect.Effect<Array<Response.PartEncoded>, AiError.AiError> =>
-  Effect.gen(function* () {
-    if (A.length(response.choices) > 1) {
-      yield* Effect.logDebug({
-        choiceCount: A.length(response.choices),
-        component: moduleName,
-        event: "additional-choices-ignored",
-        method: "makeResponse",
-      });
-    }
-    const choice = yield* pipe(
-      response.choices,
-      A.head,
-      O.match({
-        onNone: () =>
-          Effect.fail(makeInvalidOutput(moduleName, "makeResponse", "Provider response did not include a choice.")),
-        onSome: Effect.succeed,
-      })
-    );
-    const textParts = pipe(
-      choice.message,
-      O.flatMap((message) => message.content),
-      O.flatMap(nonEmptyStringOption),
-      O.match({
-        onNone: A.empty<Response.PartEncoded>,
-        onSome: (text) => [Response.makePart("text", { text })],
-      })
-    );
-    const toolParts = yield* pipe(
-      choice.message,
-      O.flatMap((message) => message.tool_calls),
-      O.getOrElse(A.empty<OpenAiCompatToolCall>),
-      Effect.forEach((toolCall) => makeToolCallPart(moduleName, toolNameMapper, toolCall))
-    );
-    return [...textParts, ...toolParts, makeFinishPart(response.usage, choice.finish_reason)];
-  });
+): Effect.fn.Return<Array<Response.PartEncoded>, AiError.AiError> {
+  if (A.length(response.choices) > 1) {
+    yield* Effect.logDebug({
+      choiceCount: A.length(response.choices),
+      component: moduleName,
+      event: "additional-choices-ignored",
+      method: "makeResponse",
+    });
+  }
+  const choice = yield* pipe(
+    response.choices,
+    A.head,
+    O.match({
+      onNone: () =>
+        Effect.fail(makeInvalidOutput(moduleName, "makeResponse", "Provider response did not include a choice.")),
+      onSome: Effect.succeed,
+    })
+  );
+  const textParts = pipe(
+    choice.message,
+    O.flatMap((message) => message.content),
+    O.flatMap(nonEmptyStringOption),
+    O.match({
+      onNone: A.empty<Response.PartEncoded>,
+      onSome: (text) => [Response.makePart("text", { text })],
+    })
+  );
+  const toolParts = yield* pipe(
+    choice.message,
+    O.flatMap((message) => message.tool_calls),
+    O.getOrElse(A.empty<OpenAiCompatToolCall>),
+    Effect.forEach((toolCall) => makeToolCallPart(moduleName, toolNameMapper, toolCall))
+  );
+  return [...textParts, ...toolParts, makeFinishPart(response.usage, choice.finish_reason)];
+});
 
 const finishStreamParts = (state: StreamState): ReadonlyArray<Response.StreamPartEncoded> =>
   state.finished
@@ -731,93 +729,92 @@ const finishStreamParts = (state: StreamState): ReadonlyArray<Response.StreamPar
         makeFinishPart(state.usage, state.finishReason),
       ];
 
-const makeStreamChoiceParts = (
+const makeStreamChoiceParts = Effect.fn("OpenAiCompatLanguageModel.makeStreamChoiceParts")(function* (
   moduleName: string,
   toolNameMapper: Tool.NameMapper<ReadonlyArray<Tool.Any>>,
   state: StreamState,
   chunk: OpenAiCompatChatCompletionChunk
-): Effect.Effect<readonly [StreamState, ReadonlyArray<Response.StreamPartEncoded>], AiError.AiError> =>
-  Effect.gen(function* () {
-    let activeToolCalls = state.activeToolCalls;
-    let finishReason = state.finishReason;
-    const usage = O.isSome(chunk.usage) ? chunk.usage : state.usage;
-    const choiceParts = yield* pipe(
-      chunk.choices,
-      Effect.forEach((choice) =>
-        Effect.gen(function* () {
-          const textParts = pipe(
-            choice.delta,
-            O.flatMap((delta) => delta.content),
-            O.flatMap(nonEmptyStringOption),
-            O.match({
-              onNone: A.empty<Response.StreamPartEncoded>,
-              onSome: (delta) => [
-                ...(state.textStarted ? [] : [Response.makePart("text-start", { id: "0" })]),
-                Response.makePart("text-delta", { delta, id: "0" }),
-              ],
-            })
-          );
-          const [nextActiveToolCalls, toolDeltaParts] = pipe(
-            choice.delta,
-            O.flatMap((delta) => delta.tool_calls),
-            O.getOrElse(A.empty<OpenAiCompatToolCallDelta>),
-            A.reduce(
-              Tuple.make(activeToolCalls, A.empty<Response.StreamPartEncoded>()),
-              ([currentActiveToolCalls, currentParts], toolCall, indexInChunk) => {
-                const [updatedActiveToolCalls, deltaParts] = makeToolCallDeltaParts(
-                  toolNameMapper,
-                  chunk,
-                  currentActiveToolCalls,
-                  toolCall,
-                  indexInChunk
-                );
-                return Tuple.make(updatedActiveToolCalls, [...currentParts, ...deltaParts]);
-              }
-            )
-          );
-          activeToolCalls = nextActiveToolCalls;
-          const hasFinish = O.isSome(choice.finish_reason);
-          if (hasFinish) {
-            finishReason = choice.finish_reason;
-          }
-          const completedToolParts = hasFinish
-            ? yield* makeCompletedStreamToolCallsParts(moduleName, activeToolCalls)
-            : [];
-          if (hasFinish) {
-            activeToolCalls = {};
-          }
-          const parts: ReadonlyArray<Response.StreamPartEncoded> = [
-            ...textParts,
-            ...toolDeltaParts,
-            ...completedToolParts,
-            ...(hasFinish && (state.textStarted || A.isReadonlyArrayNonEmpty(textParts))
-              ? [Response.makePart("text-end", { id: "0" })]
-              : []),
-          ];
-          return parts;
-        })
-      )
+): Effect.fn.Return<readonly [StreamState, ReadonlyArray<Response.StreamPartEncoded>], AiError.AiError> {
+  let activeToolCalls = state.activeToolCalls;
+  let finishReason = state.finishReason;
+  const usage = O.isSome(chunk.usage) ? chunk.usage : state.usage;
+  const choiceParts = yield* pipe(
+    chunk.choices,
+    Effect.forEach(
+      Effect.fnUntraced(function* (choice) {
+        const textParts = pipe(
+          choice.delta,
+          O.flatMap((delta) => delta.content),
+          O.flatMap(nonEmptyStringOption),
+          O.match({
+            onNone: A.empty<Response.StreamPartEncoded>,
+            onSome: (delta) => [
+              ...(state.textStarted ? [] : [Response.makePart("text-start", { id: "0" })]),
+              Response.makePart("text-delta", { delta, id: "0" }),
+            ],
+          })
+        );
+        const [nextActiveToolCalls, toolDeltaParts] = pipe(
+          choice.delta,
+          O.flatMap((delta) => delta.tool_calls),
+          O.getOrElse(A.empty<OpenAiCompatToolCallDelta>),
+          A.reduce(
+            Tuple.make(activeToolCalls, A.empty<Response.StreamPartEncoded>()),
+            ([currentActiveToolCalls, currentParts], toolCall, indexInChunk) => {
+              const [updatedActiveToolCalls, deltaParts] = makeToolCallDeltaParts(
+                toolNameMapper,
+                chunk,
+                currentActiveToolCalls,
+                toolCall,
+                indexInChunk
+              );
+              return Tuple.make(updatedActiveToolCalls, [...currentParts, ...deltaParts]);
+            }
+          )
+        );
+        activeToolCalls = nextActiveToolCalls;
+        const hasFinish = O.isSome(choice.finish_reason);
+        if (hasFinish) {
+          finishReason = choice.finish_reason;
+        }
+        const completedToolParts = hasFinish
+          ? yield* makeCompletedStreamToolCallsParts(moduleName, activeToolCalls)
+          : [];
+        if (hasFinish) {
+          activeToolCalls = {};
+        }
+        const parts: ReadonlyArray<Response.StreamPartEncoded> = [
+          ...textParts,
+          ...toolDeltaParts,
+          ...completedToolParts,
+          ...(hasFinish && (state.textStarted || A.isReadonlyArrayNonEmpty(textParts))
+            ? [Response.makePart("text-end", { id: "0" })]
+            : []),
+        ];
+        return parts;
+      })
+    )
+  );
+  const shouldFinish =
+    !state.finished && O.isSome(usage) && (O.isSome(finishReason) || !A.isReadonlyArrayNonEmpty(chunk.choices));
+  const parts: Array<Response.StreamPartEncoded> = pipe(choiceParts, A.flatten);
+  const finishedParts = shouldFinish ? [makeFinishPart(usage, finishReason)] : [];
+  const allParts = [...parts, ...finishedParts];
+  const textStarted =
+    state.textStarted ||
+    pipe(
+      allParts,
+      A.some((part) => part.type === "text-start")
     );
-    const shouldFinish =
-      !state.finished && O.isSome(usage) && (O.isSome(finishReason) || !A.isReadonlyArrayNonEmpty(chunk.choices));
-    const parts: Array<Response.StreamPartEncoded> = pipe(choiceParts, A.flatten);
-    const finishedParts = shouldFinish ? [makeFinishPart(usage, finishReason)] : [];
-    const allParts = [...parts, ...finishedParts];
-    const textStarted =
-      state.textStarted ||
-      pipe(
-        allParts,
-        A.some((part) => part.type === "text-start")
-      );
-    const textEnded =
-      state.textEnded ||
-      pipe(
-        allParts,
-        A.some((part) => part.type === "text-end")
-      );
-    const finished = state.finished || shouldFinish;
-    return Tuple.make({ activeToolCalls, finishReason, finished, textEnded, textStarted, usage }, allParts);
-  });
+  const textEnded =
+    state.textEnded ||
+    pipe(
+      allParts,
+      A.some((part) => part.type === "text-end")
+    );
+  const finished = state.finished || shouldFinish;
+  return Tuple.make({ activeToolCalls, finishReason, finished, textEnded, textStarted, usage }, allParts);
+});
 
 const makeStreamResponse = (
   moduleName: string,

--- a/packages/drivers/venice-ai/src/VeniceAiLanguageModel.ts
+++ b/packages/drivers/venice-ai/src/VeniceAiLanguageModel.ts
@@ -169,8 +169,8 @@ const streamChatCompletion = (
  * @category constructors
  * @since 0.0.0
  */
-export const make = (options: VeniceAiLanguageModelOptions): Effect.Effect<LanguageModel.Service, never, VeniceAI> =>
-  Effect.gen(function* () {
+export const make: (options: VeniceAiLanguageModelOptions) => Effect.Effect<LanguageModel.Service, never, VeniceAI> =
+  Effect.fn("VeniceAiLanguageModel.make")(function* (options) {
     const venice = yield* VeniceAI;
     return yield* makeFromProvider({
       ...(options.config === undefined ? {} : { config: options.config }),

--- a/packages/drivers/xai/src/XAiLanguageModel.ts
+++ b/packages/drivers/xai/src/XAiLanguageModel.ts
@@ -168,19 +168,20 @@ const streamChatCompletion = (
  * @category constructors
  * @since 0.0.0
  */
-export const make = (options: XAiLanguageModelOptions): Effect.Effect<LanguageModel.Service, never, XAi> =>
-  Effect.gen(function* () {
-    const xai = yield* XAi;
-    return yield* makeFromProvider({
-      ...(options.config === undefined ? {} : { config: options.config }),
-      model: options.model,
-      moduleName,
-      provider: {
-        createChatCompletion: (request) => createChatCompletion(xai, request),
-        streamChatCompletion: (request) => streamChatCompletion(xai, request),
-      },
-    });
+export const make: (options: XAiLanguageModelOptions) => Effect.Effect<LanguageModel.Service, never, XAi> = Effect.fn(
+  "XAiLanguageModel.make"
+)(function* (options) {
+  const xai = yield* XAi;
+  return yield* makeFromProvider({
+    ...(options.config === undefined ? {} : { config: options.config }),
+    model: options.model,
+    moduleName,
+    provider: {
+      createChatCompletion: (request) => createChatCompletion(xai, request),
+      streamChatCompletion: (request) => streamChatCompletion(xai, request),
+    },
   });
+});
 
 /**
  * Builds an xAI Effect AI language-model layer.

--- a/packages/foundation/capability/nlp/src/Wink/WinkCorpusManager.ts
+++ b/packages/foundation/capability/nlp/src/Wink/WinkCorpusManager.ts
@@ -221,24 +221,21 @@ const decodeTermScorePairs = (
   return Effect.fail(CorpusManagerError.fromMessage(`Invalid ${context}: expected [string, number][]`, corpusId));
 };
 
-const readNormalizedTokensFromWink = (
+const readNormalizedTokensFromWink = Effect.fn("Nlp.Wink.WinkCorpusManager.readNormalizedTokensFromWink")(function* (
   engine: WinkEngineService,
   document: Document,
   corpusId: string
-): Effect.Effect<ReadonlyArray<string>, CorpusManagerError> =>
-  Effect.gen(function* () {
-    const its = yield* engine.its.pipe(
-      Effect.mapError((cause) => CorpusManagerError.fromCause(cause, "Failed to access wink helpers", { corpusId }))
+): Effect.fn.Return<ReadonlyArray<string>, CorpusManagerError> {
+  const its = yield* engine.its.pipe(
+    Effect.mapError((cause) => CorpusManagerError.fromCause(cause, "Failed to access wink helpers", { corpusId }))
+  );
+  const winkDoc = yield* engine
+    .getWinkDoc(document.text)
+    .pipe(
+      Effect.mapError((cause) => CorpusManagerError.fromCause(cause, "Failed to tokenize document text", { corpusId }))
     );
-    const winkDoc = yield* engine
-      .getWinkDoc(document.text)
-      .pipe(
-        Effect.mapError((cause) =>
-          CorpusManagerError.fromCause(cause, "Failed to tokenize document text", { corpusId })
-        )
-      );
-    return yield* decodeStringArray(winkDoc.tokens().out(its.normal), "normalized token output", corpusId);
-  });
+  return yield* decodeStringArray(winkDoc.tokens().out(its.normal), "normalized token output", corpusId);
+});
 
 const removeCorpusSession = (
   sessions: HashMap.HashMap<string, CorpusSessionState>,
@@ -353,60 +350,61 @@ const makeWinkCorpusManager = Effect.gen(function* () {
       onTrue: () => Effect.succeed(pipe(Chunk.toReadonlyArray(document.tokens), A.map(normalizeTokenText))),
     });
 
-  const compileState = (state: CorpusSessionState): Effect.Effect<CompiledCorpus, CorpusManagerError> =>
-    Effect.gen(function* () {
-      const its = yield* engine.its.pipe(
-        Effect.mapError((cause) =>
-          CorpusManagerError.fromCause(cause, "Failed to access wink helpers", { corpusId: state.corpusId })
-        )
-      );
-      const vectorizer = bm25(state.config);
+  const compileState = Effect.fnUntraced(function* (
+    state: CorpusSessionState
+  ): Effect.fn.Return<CompiledCorpus, CorpusManagerError> {
+    const its = yield* engine.its.pipe(
+      Effect.mapError((cause) =>
+        CorpusManagerError.fromCause(cause, "Failed to access wink helpers", { corpusId: state.corpusId })
+      )
+    );
+    const vectorizer = bm25(state.config);
 
-      for (const document of state.documents) {
-        const tokens = yield* readNormalizedTokens(document, state.corpusId);
-        yield* Effect.try({
-          try: () => {
-            vectorizer.learn(A.fromIterable(tokens));
-          },
-          catch: (cause) =>
-            CorpusManagerError.fromCause(cause, "Failed to learn a document into the compiled corpus", {
-              corpusId: state.corpusId,
-            }),
-        });
-      }
-
-      const terms = yield* Effect.try({
-        try: () => vectorizer.out(its.terms),
+    for (const document of state.documents) {
+      const tokens = yield* readNormalizedTokens(document, state.corpusId);
+      yield* Effect.try({
+        try: () => {
+          vectorizer.learn(A.fromIterable(tokens));
+        },
         catch: (cause) =>
-          CorpusManagerError.fromCause(cause, "Failed to compute corpus terms", { corpusId: state.corpusId }),
+          CorpusManagerError.fromCause(cause, "Failed to learn a document into the compiled corpus", {
+            corpusId: state.corpusId,
+          }),
+      });
+    }
+
+    const terms = yield* Effect.try({
+      try: () => vectorizer.out(its.terms),
+      catch: (cause) =>
+        CorpusManagerError.fromCause(cause, "Failed to compute corpus terms", { corpusId: state.corpusId }),
+    }).pipe(
+      Effect.flatMap(
+        Effect.fnUntraced(function* (raw) {
+          return yield* decodeStringArray(raw, "corpus term output", state.corpusId);
+        })
+      )
+    );
+
+    const documentVectors = yield* Effect.forEach(state.documents, (_document, index) =>
+      Effect.try({
+        try: () => vectorizer.doc(index).out(its.vector),
+        catch: (cause) =>
+          CorpusManagerError.fromCause(cause, "Failed to compute document vector", { corpusId: state.corpusId }),
       }).pipe(
         Effect.flatMap(
           Effect.fnUntraced(function* (raw) {
-            return yield* decodeStringArray(raw, "corpus term output", state.corpusId);
+            return yield* decodeNumberArray(raw, "document vector output", state.corpusId);
           })
         )
-      );
+      )
+    );
 
-      const documentVectors = yield* Effect.forEach(state.documents, (_document, index) =>
-        Effect.try({
-          try: () => vectorizer.doc(index).out(its.vector),
-          catch: (cause) =>
-            CorpusManagerError.fromCause(cause, "Failed to compute document vector", { corpusId: state.corpusId }),
-        }).pipe(
-          Effect.flatMap(
-            Effect.fnUntraced(function* (raw) {
-              return yield* decodeNumberArray(raw, "document vector output", state.corpusId);
-            })
-          )
-        )
-      );
-
-      return {
-        documentVectors,
-        terms,
-        vectorizer,
-      };
-    });
+    return {
+      documentVectors,
+      terms,
+      vectorizer,
+    };
+  });
 
   const ensureCompiled = (
     state: CorpusSessionState
@@ -657,8 +655,9 @@ const makeWinkCorpusManager = Effect.gen(function* () {
         vector: compiled.vectorizer.vectorOf(A.fromIterable(queryTokens)),
       });
 
-      const scored = yield* Effect.forEach(compiledState.documents, (document, index) =>
-        Effect.gen(function* () {
+      const scored = yield* Effect.forEach(
+        compiledState.documents,
+        Effect.fnUntraced(function* (document, index) {
           const candidateVector = DocumentVector.make({
             documentId: document.id,
             terms: compiled.terms,

--- a/packages/foundation/capability/observability/src/experimental/server/DevToolsRelay.ts
+++ b/packages/foundation/capability/observability/src/experimental/server/DevToolsRelay.ts
@@ -216,8 +216,8 @@ export const layerDevToolsRelayServer: Layer.Layer<
   Layer.tap((services) => {
     const relay = Context.get(services, DevToolsRelayService);
 
-    return DevToolsServer.run((client) =>
-      Effect.gen(function* () {
+    return DevToolsServer.run(
+      Effect.fnUntraced(function* (client) {
         yield* client.send({ _tag: "MetricsRequest" });
 
         while (true) {

--- a/packages/foundation/capability/semantic-web/src/adapters/canonicalization.ts
+++ b/packages/foundation/capability/semantic-web/src/adapters/canonicalization.ts
@@ -55,35 +55,34 @@ const semanticCanonicalizationBudgetFailureFragments = [
 ] as const;
 const semanticCanonicalizationBudgetMessage = `Semantic canonicalization exceeded the configured resource budget (maxWorkFactor=${SemanticCanonicalizationMaxWorkFactor}, timeout=${SemanticCanonicalizationTimeoutMs}ms).`;
 
-const hashCanonicalText = (canonicalText: string): Effect.Effect<typeof Sha256Hex.Type, CanonicalizationError> =>
-  Effect.gen(function* () {
-    const hex = yield* Effect.tryPromise({
-      try: async () => {
-        const bytes = new TextEncoder().encode(canonicalText);
-        const digest = await crypto.subtle.digest("SHA-256", bytes);
-        return pipe(
-          A.fromIterable(new Uint8Array(digest)),
-          A.map((value) => Str.padStart(2, "0")(value.toString(16))),
-          A.join("")
-        );
-      },
-      catch: () =>
+const hashCanonicalText = Effect.fn("SemanticWeb.hashCanonicalText")(function* (canonicalText: string) {
+  const hex = yield* Effect.tryPromise({
+    try: async () => {
+      const bytes = new TextEncoder().encode(canonicalText);
+      const digest = await crypto.subtle.digest("SHA-256", bytes);
+      return pipe(
+        A.fromIterable(new Uint8Array(digest)),
+        A.map((value) => Str.padStart(2, "0")(value.toString(16))),
+        A.join("")
+      );
+    },
+    catch: () =>
+      new CanonicalizationError({
+        reason: "fingerprintFailure",
+        message: "Failed to hash canonical dataset text.",
+      }),
+  });
+
+  return yield* S.decodeUnknownEffect(Sha256Hex)(hex).pipe(
+    Effect.mapError(
+      () =>
         new CanonicalizationError({
           reason: "fingerprintFailure",
-          message: "Failed to hash canonical dataset text.",
-        }),
-    });
-
-    return yield* S.decodeUnknownEffect(Sha256Hex)(hex).pipe(
-      Effect.mapError(
-        () =>
-          new CanonicalizationError({
-            reason: "fingerprintFailure",
-            message: "Failed to decode SHA-256 dataset fingerprint.",
-          })
-      )
-    );
-  });
+          message: "Failed to decode SHA-256 dataset fingerprint.",
+        })
+    )
+  );
+});
 
 const enforceWorkLimit = (
   quads: ReadonlyArray<Quad>,
@@ -192,35 +191,31 @@ const mapCanonizeFailure = (error: unknown): CanonicalizationError => {
       });
 };
 
-const canonicalizeSemantically = (
+const canonicalizeSemantically = Effect.fn("SemanticWeb.canonicalizeSemantically")(function* (
   quads: ReadonlyArray<Quad>
-): Effect.Effect<
-  { readonly canonicalText: string; readonly dataset: ReturnType<typeof makeDataset> },
-  CanonicalizationError
-> =>
-  Effect.gen(function* () {
-    const canonicalText = yield* Effect.tryPromise<string, CanonicalizationError>({
-      try: () =>
-        // Keep the semantic path on an explicit CPU budget instead of relying on upstream defaults.
-        canonize(toCanonizeDataset(quads), {
-          algorithm: "RDFC-1.0",
-          format: "application/n-quads",
-          maxWorkFactor: SemanticCanonicalizationMaxWorkFactor,
-          signal: AbortSignal.timeout(SemanticCanonicalizationTimeoutMs),
-        }),
-      catch: mapCanonizeFailure,
-    });
-
-    const parsed = yield* Effect.try({
-      try: () => NQuads.parse(canonicalText),
-      catch: mapCanonizeFailure,
-    });
-
-    return {
-      canonicalText: canonicalText.trimEnd(),
-      dataset: makeDataset(pipe(parsed, A.map(fromCanonizeQuad))),
-    };
+) {
+  const canonicalText = yield* Effect.tryPromise<string, CanonicalizationError>({
+    try: () =>
+      // Keep the semantic path on an explicit CPU budget instead of relying on upstream defaults.
+      canonize(toCanonizeDataset(quads), {
+        algorithm: "RDFC-1.0",
+        format: "application/n-quads",
+        maxWorkFactor: SemanticCanonicalizationMaxWorkFactor,
+        signal: AbortSignal.timeout(SemanticCanonicalizationTimeoutMs),
+      }),
+    catch: mapCanonizeFailure,
   });
+
+  const parsed = yield* Effect.try({
+    try: () => NQuads.parse(canonicalText),
+    catch: mapCanonizeFailure,
+  });
+
+  return {
+    canonicalText: canonicalText.trimEnd(),
+    dataset: makeDataset(pipe(parsed, A.map(fromCanonizeQuad))),
+  };
+});
 
 const canonicalizeLexically = (quads: ReadonlyArray<Quad>) => {
   const sorted = sortDatasetQuads(makeDataset(quads));

--- a/packages/foundation/capability/semantic-web/src/adapters/jsonld-document.ts
+++ b/packages/foundation/capability/semantic-web/src/adapters/jsonld-document.ts
@@ -332,42 +332,40 @@ const literalLexicalForm = (value: string | number | boolean): string =>
     Match.orElse((scalar) => `${scalar}`)
   );
 
-const literalFromValue = (
+const literalFromValue = Effect.fn("JsonLdDocument.literalFromValue")(function* (
   value: JsonLdLiteralValue,
   context: ContextOption,
   base: O.Option<string>
-): Effect.Effect<ObjectTerm, JsonLdDocumentError> =>
-  Effect.gen(function* () {
-    const scalar = value["@value"];
-    const datatype = O.isSome(value["@type"])
-      ? resolveJsonLdIdentifier(value["@type"].value, context, base)
-      : datatypeFromScalar(scalar);
-    const language = O.isSome(value["@language"]) ? value["@language"].value : undefined;
-    const datatypeNode = yield* makeNamedNodeEffect(datatype, "invalidNodeReference", datatype);
-    return yield* makeLiteralEffect({
-      datatype: datatypeNode,
-      language,
-      reason: "bridgingFailure",
-      subject: datatype,
-      value: literalLexicalForm(scalar),
-    });
+): Effect.fn.Return<ObjectTerm, JsonLdDocumentError> {
+  const scalar = value["@value"];
+  const datatype = O.isSome(value["@type"])
+    ? resolveJsonLdIdentifier(value["@type"].value, context, base)
+    : datatypeFromScalar(scalar);
+  const language = O.isSome(value["@language"]) ? value["@language"].value : undefined;
+  const datatypeNode = yield* makeNamedNodeEffect(datatype, "invalidNodeReference", datatype);
+  return yield* makeLiteralEffect({
+    datatype: datatypeNode,
+    language,
+    reason: "bridgingFailure",
+    subject: datatype,
+    value: literalLexicalForm(scalar),
   });
+});
 
-const compactLiteralValue = (
+const compactLiteralValue = Effect.fn("JsonLdDocument.compactLiteralValue")(function* (
   value: JsonLdLiteralValue,
   context: ContextOption
-): Effect.Effect<JsonLdLiteralValue, JsonLdDocumentError> =>
-  Effect.gen(function* () {
-    const type = yield* mapOptionEffect(value["@type"], (identifier) =>
-      decodeIriReference(compactIdentifier(context, identifier), "bridgingFailure", identifier)
-    );
+): Effect.fn.Return<JsonLdLiteralValue, JsonLdDocumentError> {
+  const type = yield* mapOptionEffect(value["@type"], (identifier) =>
+    decodeIriReference(compactIdentifier(context, identifier), "bridgingFailure", identifier)
+  );
 
-    return JsonLdLiteralValue.make({
-      "@value": value["@value"],
-      "@type": type,
-      "@language": value["@language"],
-    });
+  return JsonLdLiteralValue.make({
+    "@value": value["@value"],
+    "@type": type,
+    "@language": value["@language"],
   });
+});
 
 const compactPropertyValues = (
   values: ReadonlyArray<JsonLdPropertyValue>,
@@ -397,23 +395,22 @@ const compactPropertyEntry = (
     (compactedValues) => [compactIdentifier(O.some(context), key), compactedValues] as const
   );
 
-const compactNode = (
+const compactNode = Effect.fn("JsonLdDocument.compactNode")(function* (
   node: JsonLdNodeObject,
   context: JsonLdContext
-): Effect.Effect<JsonLdNodeObject, JsonLdDocumentError> =>
-  Effect.gen(function* () {
-    const id = yield* mapOptionEffect(node["@id"], compactNodeIdentifier(O.some(context), "bridgingFailure"));
-    const type = yield* mapOptionEffect(node["@type"], compactIriReferenceValues(O.some(context), "bridgingFailure"));
-    const properties = yield* Effect.forEach(pipe(node.properties, R.toEntries), ([key, values]) =>
-      compactPropertyEntry(key, values, context)
-    );
+): Effect.fn.Return<JsonLdNodeObject, JsonLdDocumentError> {
+  const id = yield* mapOptionEffect(node["@id"], compactNodeIdentifier(O.some(context), "bridgingFailure"));
+  const type = yield* mapOptionEffect(node["@type"], compactIriReferenceValues(O.some(context), "bridgingFailure"));
+  const properties = yield* Effect.forEach(pipe(node.properties, R.toEntries), ([key, values]) =>
+    compactPropertyEntry(key, values, context)
+  );
 
-    return JsonLdNodeObject.make({
-      "@id": id,
-      "@type": type,
-      properties: R.fromEntries(properties),
-    });
+  return JsonLdNodeObject.make({
+    "@id": id,
+    "@type": type,
+    properties: R.fromEntries(properties),
   });
+});
 
 const byStringAscending: Order.Order<string> = Order.String;
 const byRecordEntryKeyAscending = <Value>(): Order.Order<readonly [string, Value]> =>
@@ -507,22 +504,21 @@ const validateLoaderPolicy = (
       )
     : Effect.succeed(loaderPolicy);
 
-const expandLiteralValue = (
+const expandLiteralValue = Effect.fn("JsonLdDocument.expandLiteralValue")(function* (
   value: JsonLdLiteralValue,
   context: ContextOption,
   base: O.Option<string>
-): Effect.Effect<JsonLdLiteralValue, JsonLdDocumentError> =>
-  Effect.gen(function* () {
-    const type = yield* mapOptionEffect(value["@type"], (identifier) =>
-      decodeIriReference(resolveJsonLdIdentifier(identifier, context, base), "invalidNodeReference", identifier)
-    );
+): Effect.fn.Return<JsonLdLiteralValue, JsonLdDocumentError> {
+  const type = yield* mapOptionEffect(value["@type"], (identifier) =>
+    decodeIriReference(resolveJsonLdIdentifier(identifier, context, base), "invalidNodeReference", identifier)
+  );
 
-    return JsonLdLiteralValue.make({
-      "@value": value["@value"],
-      "@type": type,
-      "@language": value["@language"],
-    });
+  return JsonLdLiteralValue.make({
+    "@value": value["@value"],
+    "@type": type,
+    "@language": value["@language"],
   });
+});
 
 const expandJsonLdPropertyValue = (
   value: JsonLdPropertyValue,
@@ -543,59 +539,56 @@ const expandJsonLdPropertyValue = (
       )
     : expandLiteralValue(value, context, base);
 
-const expandJsonLdNode = (
+const expandJsonLdNode = Effect.fn("JsonLdDocument.expandJsonLdNode")(function* (
   node: JsonLdNodeObject,
   context: ContextOption,
   base: O.Option<string>
-): Effect.Effect<JsonLdNodeObject, JsonLdDocumentError> =>
-  Effect.gen(function* () {
-    const propertyEntries = pipe(node.properties, R.toEntries, A.sort(byRecordEntryKeyAscending()));
-    const expandedProperties = yield* Effect.forEach(propertyEntries, ([key, values]) => {
+): Effect.fn.Return<JsonLdNodeObject, JsonLdDocumentError> {
+  const propertyEntries = pipe(node.properties, R.toEntries, A.sort(byRecordEntryKeyAscending()));
+  const expandedProperties = yield* Effect.forEach(
+    propertyEntries,
+    Effect.fnUntraced(function* ([key, values]) {
       const predicateIri = resolveJsonLdIdentifier(key, context, base);
       if (!schemePrefix.test(predicateIri)) {
-        return Effect.fail(makeDocumentError("unknownPredicate", `Unable to expand JSON-LD property key: ${key}`, key));
+        return yield* makeDocumentError("unknownPredicate", `Unable to expand JSON-LD property key: ${key}`, key);
       }
 
-      return Effect.gen(function* () {
-        const expandedValues = yield* Effect.forEach(values, (value) =>
-          expandJsonLdPropertyValue(value, context, base)
-        );
+      const expandedValues = yield* Effect.forEach(values, (value) => expandJsonLdPropertyValue(value, context, base));
 
-        return [predicateIri, expandedValues] as const;
-      });
-    });
-    const id = yield* mapOptionEffect(node["@id"], (identifier) =>
-      decodeJsonLdNodeIdentifier(resolveJsonLdIdentifier(identifier, context, base), "invalidNodeReference", identifier)
-    );
-    const type = yield* mapOptionEffect(node["@type"], (values) =>
-      Effect.forEach(values, (value) =>
-        decodeIriReference(resolveJsonLdIdentifier(value, context, base), "invalidNodeReference", value)
-      )
-    );
+      return [predicateIri, expandedValues] as const;
+    })
+  );
+  const id = yield* mapOptionEffect(node["@id"], (identifier) =>
+    decodeJsonLdNodeIdentifier(resolveJsonLdIdentifier(identifier, context, base), "invalidNodeReference", identifier)
+  );
+  const type = yield* mapOptionEffect(node["@type"], (values) =>
+    Effect.forEach(values, (value) =>
+      decodeIriReference(resolveJsonLdIdentifier(value, context, base), "invalidNodeReference", value)
+    )
+  );
 
-    return JsonLdNodeObject.make({
-      "@id": id,
-      "@type": type,
-      properties: R.fromEntries(expandedProperties),
-    });
+  return JsonLdNodeObject.make({
+    "@id": id,
+    "@type": type,
+    properties: R.fromEntries(expandedProperties),
   });
+});
 
-const expandJsonLdDocument = (
+const expandJsonLdDocument = Effect.fn("JsonLdDocument.expandJsonLdDocument")(function* (
   document: JsonLdDocument,
   loaderPolicy: O.Option<typeof JsonLdDocumentLoaderPolicy.Type>
-): Effect.Effect<JsonLdDocument, JsonLdDocumentError> =>
-  Effect.gen(function* () {
-    yield* validateLoaderPolicy(loaderPolicy);
-    const context = document["@context"];
-    const base = resolveDocumentBase(loaderPolicy, context);
-    const graph = yield* Effect.forEach(document["@graph"], (node) => expandJsonLdNode(node, context, base));
-    return normalizeJsonLdDocumentStructure(
-      JsonLdDocument.make({
-        "@context": O.none(),
-        "@graph": graph,
-      })
-    );
-  });
+): Effect.fn.Return<JsonLdDocument, JsonLdDocumentError> {
+  yield* validateLoaderPolicy(loaderPolicy);
+  const context = document["@context"];
+  const base = resolveDocumentBase(loaderPolicy, context);
+  const graph = yield* Effect.forEach(document["@graph"], (node) => expandJsonLdNode(node, context, base));
+  return normalizeJsonLdDocumentStructure(
+    JsonLdDocument.make({
+      "@context": O.none(),
+      "@graph": graph,
+    })
+  );
+});
 
 const hasAnonymousJsonLdNode = (document: JsonLdDocument): boolean =>
   pipe(
@@ -603,28 +596,27 @@ const hasAnonymousJsonLdNode = (document: JsonLdDocument): boolean =>
     A.some((node) => O.isNone(node["@id"]))
   );
 
-const normalizeJsonLdDocument = (
+const normalizeJsonLdDocument = Effect.fn("JsonLdDocument.normalizeJsonLdDocument")(function* (
   request: NormalizeJsonLdDocumentRequest
-): Effect.Effect<JsonLdDocument, JsonLdDocumentError> =>
-  Effect.gen(function* () {
-    const safeMode = pipe(
-      request.safeMode,
-      O.getOrElse(() => false)
+): Effect.fn.Return<JsonLdDocument, JsonLdDocumentError> {
+  const safeMode = pipe(
+    request.safeMode,
+    O.getOrElse(() => false)
+  );
+  if (safeMode && hasAnonymousJsonLdNode(request.document)) {
+    return yield* makeDocumentError(
+      "normalizationFailure",
+      "Safe-mode normalization requires explicit @id values for every JSON-LD node."
     );
-    if (safeMode && hasAnonymousJsonLdNode(request.document)) {
-      return yield* makeDocumentError(
-        "normalizationFailure",
-        "Safe-mode normalization requires explicit @id values for every JSON-LD node."
-      );
-    }
+  }
 
-    if (request.profile === "expanded-v1") {
-      return yield* expandJsonLdDocument(request.document, request.loaderPolicy);
-    }
+  if (request.profile === "expanded-v1") {
+    return yield* expandJsonLdDocument(request.document, request.loaderPolicy);
+  }
 
-    yield* validateLoaderPolicy(request.loaderPolicy);
-    return normalizeJsonLdDocumentStructure(request.document);
-  });
+  yield* validateLoaderPolicy(request.loaderPolicy);
+  return normalizeJsonLdDocumentStructure(request.document);
+});
 
 const matchesFrameType = (node: JsonLdNodeObject, frameType: string, context: ContextOption): boolean =>
   pipe(
@@ -707,20 +699,18 @@ const identifierFromSubject = (subject: Subject): string =>
 const identifierFromObject = (object: Extract<ObjectTerm, { readonly termType: "NamedNode" | "BlankNode" }>): string =>
   object.termType === "BlankNode" ? `_:${object.value}` : object.value;
 
-const literalValueFromRdf = (
+const literalValueFromRdf = Effect.fn("JsonLdDocument.literalValueFromRdf")(function* (
   quad: Quad,
   context: ContextOption
-): Effect.Effect<JsonLdLiteralValue, JsonLdDocumentError> => {
+): Effect.fn.Return<JsonLdLiteralValue, JsonLdDocumentError> {
   const object = quad.object;
 
   if (object.termType !== "Literal") {
-    return Effect.succeed(
-      JsonLdLiteralValue.make({
-        "@value": "",
-        "@type": O.none(),
-        "@language": O.none(),
-      })
-    );
+    return JsonLdLiteralValue.make({
+      "@value": "",
+      "@type": O.none(),
+      "@language": O.none(),
+    });
   }
 
   const scalar =
@@ -730,25 +720,23 @@ const literalValueFromRdf = (
         ? Number(object.value)
         : object.value;
 
-  return Effect.gen(function* () {
-    const type =
-      object.datatype.value === XSD_STRING.value
-        ? O.none<typeof IRIReference.Type>()
-        : O.some(
-            yield* decodeIriReference(
-              compactIdentifier(context, object.datatype.value),
-              "bridgingFailure",
-              object.datatype.value
-            )
-          );
+  const type =
+    object.datatype.value === XSD_STRING.value
+      ? O.none<typeof IRIReference.Type>()
+      : O.some(
+          yield* decodeIriReference(
+            compactIdentifier(context, object.datatype.value),
+            "bridgingFailure",
+            object.datatype.value
+          )
+        );
 
-    return JsonLdLiteralValue.make({
-      "@value": scalar,
-      "@type": type,
-      "@language": O.isSome(object.language) ? O.some(object.language.value) : O.none(),
-    });
+  return JsonLdLiteralValue.make({
+    "@value": scalar,
+    "@type": type,
+    "@language": O.isSome(object.language) ? O.some(object.language.value) : O.none(),
   });
-};
+});
 
 /**
  * JSON-LD document service live layer.
@@ -904,8 +892,8 @@ export const JsonLdDocumentServiceLive = Layer.succeed(
         nodes,
         R.values,
         A.sort(byMutableNodeIdAscending),
-        Effect.forEach((node) =>
-          Effect.gen(function* () {
+        Effect.forEach(
+          Effect.fnUntraced(function* (node) {
             const type = yield* pipe(
               node.types,
               A.match({

--- a/packages/foundation/modeling/schema/src/Cuid.ts
+++ b/packages/foundation/modeling/schema/src/Cuid.ts
@@ -145,25 +145,32 @@ function hash(input: string): Effect.Effect<string> {
   });
 }
 
-function cuidFromSeed({ counter, fingerprint, random, timestamp }: CuidSeed): Effect.Effect<Cuid> {
-  return Effect.gen(function* () {
-    // First letter is always a random lowercase letter from the seed
-    const firstLetter = String.fromCharCode((random[0] % ALPHABET_LENGTH) + ALPHABET_START_CODE);
-
-    // Convert components to base36
-    const time = timestamp.toString(36);
-    const count = counter.toString(36);
-
-    // Create entropy from remaining random bytes
-    const salt = createEntropy(4, random.slice(1));
-
-    // Hash all components together
-    const hashInput = `${time}${salt}${count}${fingerprint}`;
-    const hashed = yield* hash(hashInput);
-
-    // Construct the final CUID
-    const id = `${firstLetter}${hashed.substring(0, DEFAULT_LENGTH - 1)}`;
-
-    return Cuid.make(id);
-  });
+function cuidFromSeed(seed: CuidSeed): Effect.Effect<Cuid> {
+  return makeCuidFromSeed(seed);
 }
+
+const makeCuidFromSeed = Effect.fn("Schema.Cuid.cuidFromSeed")(function* ({
+  counter,
+  fingerprint,
+  random,
+  timestamp,
+}: CuidSeed) {
+  // First letter is always a random lowercase letter from the seed
+  const firstLetter = String.fromCharCode((random[0] % ALPHABET_LENGTH) + ALPHABET_START_CODE);
+
+  // Convert components to base36
+  const time = timestamp.toString(36);
+  const count = counter.toString(36);
+
+  // Create entropy from remaining random bytes
+  const salt = createEntropy(4, random.slice(1));
+
+  // Hash all components together
+  const hashInput = `${time}${salt}${count}${fingerprint}`;
+  const hashed = yield* hash(hashInput);
+
+  // Construct the final CUID
+  const id = `${firstLetter}${hashed.substring(0, DEFAULT_LENGTH - 1)}`;
+
+  return Cuid.make(id);
+});

--- a/packages/foundation/modeling/schema/src/Graph.ts
+++ b/packages/foundation/modeling/schema/src/Graph.ts
@@ -180,34 +180,37 @@ const makeGraphEquivalence =
     return true;
   };
 
-const populateMutableGraph = <Node, Edge, Kind extends GraphKindValue>(
+const populateMutableGraph = Effect.fn("Schema.Graph.populateMutableGraph")(function* <
+  Node,
+  Edge,
+  Kind extends GraphKindValue,
+>(
   mutable: Graph_.MutableGraph<Node, Edge, Kind>,
   encoded: GraphEncoded<Node, Edge, Kind>,
   actual: unknown
-): Effect.Effect<Graph_.MutableGraph<Node, Edge, Kind>, SchemaIssue.Issue> =>
-  Effect.gen(function* () {
-    for (const [expectedIndex, node] of sortRawNodeEntries(encoded.nodes)) {
-      const receivedIndex = Graph_.addNode(mutable, node);
+): Effect.fn.Return<Graph_.MutableGraph<Node, Edge, Kind>, SchemaIssue.Issue> {
+  for (const [expectedIndex, node] of sortRawNodeEntries(encoded.nodes)) {
+    const receivedIndex = Graph_.addNode(mutable, node);
 
-      if (receivedIndex !== expectedIndex) {
-        return yield* Effect.fail(makeGraphConstructionIssue(actual, "node", expectedIndex, receivedIndex));
-      }
+    if (receivedIndex !== expectedIndex) {
+      return yield* Effect.fail(makeGraphConstructionIssue(actual, "node", expectedIndex, receivedIndex));
     }
+  }
 
-    for (const { index, source, target, data } of sortRawEdgeEntries(encoded.edges)) {
-      const receivedIndex = yield* Effect.try({
-        try: () => Graph_.addEdge(mutable, source, target, data),
-        catch: (cause) =>
-          makeInvalidGraphIssue(actual, P.isError(cause) ? cause.message : "Failed to construct graph edge"),
-      });
+  for (const { index, source, target, data } of sortRawEdgeEntries(encoded.edges)) {
+    const receivedIndex = yield* Effect.try({
+      try: () => Graph_.addEdge(mutable, source, target, data),
+      catch: (cause) =>
+        makeInvalidGraphIssue(actual, P.isError(cause) ? cause.message : "Failed to construct graph edge"),
+    });
 
-      if (receivedIndex !== index) {
-        return yield* Effect.fail(makeGraphConstructionIssue(actual, "edge", index, receivedIndex));
-      }
+    if (receivedIndex !== index) {
+      return yield* Effect.fail(makeGraphConstructionIssue(actual, "edge", index, receivedIndex));
     }
+  }
 
-    return mutable;
-  });
+  return mutable;
+});
 
 const rebuildImmutableGraph = <Node, Edge>(
   encoded: GraphEncoded<Node, Edge>,

--- a/packages/foundation/modeling/schema/src/csv/format/CsvFormatter.ts
+++ b/packages/foundation/modeling/schema/src/csv/format/CsvFormatter.ts
@@ -84,14 +84,13 @@ const formatField = (value: string, fieldIndex: number, options: CsvCodecOptions
   );
 };
 
-const formatCsvHeaderRowEffect = (
+const formatCsvHeaderRowEffect = Effect.fn("CsvFormatter.formatCsvHeaderRowEffect")(function* (
   headers: ReadonlyArray<string>,
   options: CsvCodecOptions
-): Effect.Effect<string, CsvError> =>
-  Effect.gen(function* () {
-    const fields = yield* Effect.forEach(headers, (header, index) => formatField(header, index, options));
-    return A.join(fields, options.delimiter);
-  });
+): Effect.fn.Return<string, CsvError> {
+  const fields = yield* Effect.forEach(headers, (header, index) => formatField(header, index, options));
+  return A.join(fields, options.delimiter);
+});
 
 /**
  * Format a CSV header row.
@@ -110,14 +109,13 @@ export const formatCsvHeaderRow: {
  * @category utilities
  * @since 0.0.0
  */
-const formatCsvDataRowEffect = (
+const formatCsvDataRowEffect = Effect.fn("CsvFormatter.formatCsvDataRowEffect")(function* (
   fields: ReadonlyArray<string>,
   options: CsvCodecOptions
-): Effect.Effect<string, CsvError> =>
-  Effect.gen(function* () {
-    const encodedFields = yield* Effect.forEach(fields, (field, index) => formatField(field, index, options));
-    return A.join(encodedFields, options.delimiter);
-  });
+): Effect.fn.Return<string, CsvError> {
+  const encodedFields = yield* Effect.forEach(fields, (field, index) => formatField(field, index, options));
+  return A.join(encodedFields, options.delimiter);
+});
 
 /**
  * Format a CSV data row.
@@ -136,16 +134,15 @@ export const formatCsvDataRow: {
  * @category utilities
  * @since 0.0.0
  */
-const formatCsvDocumentEffect = (
+const formatCsvDocumentEffect = Effect.fn("CsvFormatter.formatCsvDocumentEffect")(function* (
   headers: ReadonlyArray<string>,
   rows: ReadonlyArray<ReadonlyArray<string>>,
   options: CsvCodecOptions
-): Effect.Effect<string, CsvError> =>
-  Effect.gen(function* () {
-    const header = yield* formatCsvHeaderRow(headers, options);
-    const dataRows = yield* Effect.forEach(rows, (row) => formatCsvDataRow(row, options));
-    return pipe([header, ...dataRows], A.join(rowDelimiter));
-  });
+): Effect.fn.Return<string, CsvError> {
+  const header = yield* formatCsvHeaderRow(headers, options);
+  const dataRows = yield* Effect.forEach(rows, (row) => formatCsvDataRow(row, options));
+  return pipe([header, ...dataRows], A.join(rowDelimiter));
+});
 
 /**
  * Format a whole CSV document.

--- a/packages/foundation/modeling/schema/src/csv/parse/CsvParser.ts
+++ b/packages/foundation/modeling/schema/src/csv/parse/CsvParser.ts
@@ -250,79 +250,78 @@ export class ParsedRow extends S.Class<ParsedRow>($I`ParsedRow`)(
   })
 ) {}
 
-const parseRowAt = (
+const parseRowAt = Effect.fn("CsvParser.parseRowAt")(function* (
   input: string,
   cursor: number,
   parserOptions: ParserOptions
-): Effect.Effect<ParsedRow, CsvError, never> =>
-  Effect.gen(function* () {
-    let currentCursor = cursor;
-    let row = A.empty<string>();
+): Effect.fn.Return<ParsedRow, CsvError> {
+  let currentCursor = cursor;
+  let row = A.empty<string>();
 
-    while (true) {
-      const rowDelimiterLength = getRowDelimiterLength(input, currentCursor);
+  while (true) {
+    const rowDelimiterLength = getRowDelimiterLength(input, currentCursor);
 
-      if (rowDelimiterLength > 0) {
-        return {
-          cursor: currentCursor + rowDelimiterLength,
-          row,
-        };
-      }
-
-      if (currentCursor >= input.length) {
-        return {
-          cursor: currentCursor,
-          row,
-        };
-      }
-
-      const field = yield* parseField(input, currentCursor, parserOptions);
-      row = A.append(row, field.value);
-      currentCursor = field.cursor;
-
-      const nextRowDelimiterLength = getRowDelimiterLength(input, currentCursor);
-
-      if (nextRowDelimiterLength > 0) {
-        return {
-          cursor: currentCursor + nextRowDelimiterLength,
-          row,
-        };
-      }
-
-      if (currentCursor >= input.length) {
-        return {
-          cursor: currentCursor,
-          row,
-        };
-      }
-
-      if (input.at(currentCursor) === parserOptions.delimiter) {
-        currentCursor += 1;
-
-        if (currentCursor >= input.length) {
-          row = A.append(row, "");
-          return {
-            cursor: currentCursor,
-            row,
-          };
-        }
-
-        const trailingDelimiterLength = getRowDelimiterLength(input, currentCursor);
-
-        if (trailingDelimiterLength > 0) {
-          row = A.append(row, "");
-          return {
-            cursor: currentCursor + trailingDelimiterLength,
-            row,
-          };
-        }
-
-        continue;
-      }
-
-      return yield* csvError("Parse Error: parser cursor did not terminate on a delimiter or newline.", currentCursor);
+    if (rowDelimiterLength > 0) {
+      return {
+        cursor: currentCursor + rowDelimiterLength,
+        row,
+      };
     }
-  });
+
+    if (currentCursor >= input.length) {
+      return {
+        cursor: currentCursor,
+        row,
+      };
+    }
+
+    const field = yield* parseField(input, currentCursor, parserOptions);
+    row = A.append(row, field.value);
+    currentCursor = field.cursor;
+
+    const nextRowDelimiterLength = getRowDelimiterLength(input, currentCursor);
+
+    if (nextRowDelimiterLength > 0) {
+      return {
+        cursor: currentCursor + nextRowDelimiterLength,
+        row,
+      };
+    }
+
+    if (currentCursor >= input.length) {
+      return {
+        cursor: currentCursor,
+        row,
+      };
+    }
+
+    if (input.at(currentCursor) === parserOptions.delimiter) {
+      currentCursor += 1;
+
+      if (currentCursor >= input.length) {
+        row = A.append(row, "");
+        return {
+          cursor: currentCursor,
+          row,
+        };
+      }
+
+      const trailingDelimiterLength = getRowDelimiterLength(input, currentCursor);
+
+      if (trailingDelimiterLength > 0) {
+        row = A.append(row, "");
+        return {
+          cursor: currentCursor + trailingDelimiterLength,
+          row,
+        };
+      }
+
+      continue;
+    }
+
+    return yield* csvError("Parse Error: parser cursor did not terminate on a delimiter or newline.", currentCursor);
+  }
+});
 
 const advancePastComment = (input: string, cursor: number): number => {
   let currentCursor = cursor;
@@ -346,31 +345,30 @@ const isCommentStart = (input: string, cursor: number, parserOptions: ParserOpti
     onSome: (comment) => input.at(cursor) === comment,
   });
 
-const parseCsvRowsEffect = (
+const parseCsvRowsEffect = Effect.fn("CsvParser.parseCsvRowsEffect")(function* (
   input: string,
   parserOptions: ParserOptions
-): Effect.Effect<ReadonlyArray<ReadonlyArray<string>>, CsvError, never> =>
-  Effect.gen(function* () {
-    const source = removeBom(input);
-    let cursor = 0;
-    let rows = A.empty<ReadonlyArray<string>>();
+): Effect.fn.Return<ReadonlyArray<ReadonlyArray<string>>, CsvError> {
+  const source = removeBom(input);
+  let cursor = 0;
+  let rows = A.empty<ReadonlyArray<string>>();
 
-    while (cursor < source.length) {
-      if (isCommentStart(source, cursor, parserOptions)) {
-        cursor = advancePastComment(source, cursor);
-        continue;
-      }
-
-      const parsedRow = yield* parseRowAt(source, cursor, parserOptions);
-      cursor = parsedRow.cursor;
-
-      if (!(parserOptions.ignoreEmpty && isEmptyRow(parsedRow.row))) {
-        rows = A.append(rows, parsedRow.row);
-      }
+  while (cursor < source.length) {
+    if (isCommentStart(source, cursor, parserOptions)) {
+      cursor = advancePastComment(source, cursor);
+      continue;
     }
 
-    return rows;
-  });
+    const parsedRow = yield* parseRowAt(source, cursor, parserOptions);
+    cursor = parsedRow.cursor;
+
+    if (!(parserOptions.ignoreEmpty && isEmptyRow(parsedRow.row))) {
+      rows = A.append(rows, parsedRow.row);
+    }
+  }
+
+  return rows;
+});
 
 /**
  * Parse full CSV text into raw row arrays using low-level parser options.

--- a/packages/foundation/modeling/schema/src/http/headers/Csp.ts
+++ b/packages/foundation/modeling/schema/src/http/headers/Csp.ts
@@ -522,34 +522,33 @@ const createContentSecurityPolicyValue = (
       }),
   }).pipe(Effect.map((value) => (P.isUndefined(value) || Str.isEmpty(value) ? O.none<string>() : O.some(value))));
 
-const decodeContentSecurityPolicyHeader = (
+const decodeContentSecurityPolicyHeader = Effect.fn("Csp.decodeContentSecurityPolicyHeader")(function* (
   input: ContentSecurityPolicyOption | undefined
-): Effect.Effect<ContentSecurityPolicyResponseHeaderEncoded, SchemaIssue.Issue> =>
-  Effect.gen(function* () {
-    if (P.isUndefined(input) || input === false) {
-      return {
-        name: headerName,
-        value: undefined,
-      } as const;
-    }
-
-    const value = yield* createContentSecurityPolicyValue(input).pipe(
-      Effect.mapError((error) => new SchemaIssue.InvalidValue(O.some(error), { message: error.message }))
-    );
-
-    if (O.isNone(value)) {
-      return yield* Effect.fail(
-        new SchemaIssue.InvalidValue(O.some(input), {
-          message: "Invalid Content-Security-Policy configuration",
-        })
-      );
-    }
-
+): Effect.fn.Return<ContentSecurityPolicyResponseHeaderEncoded, SchemaIssue.Issue> {
+  if (P.isUndefined(input) || input === false) {
     return {
-      name: getProperHeaderName(Boolean(input.reportOnly)),
-      value: value.value,
+      name: headerName,
+      value: undefined,
     } as const;
-  });
+  }
+
+  const value = yield* createContentSecurityPolicyValue(input).pipe(
+    Effect.mapError((error) => new SchemaIssue.InvalidValue(O.some(error), { message: error.message }))
+  );
+
+  if (O.isNone(value)) {
+    return yield* Effect.fail(
+      new SchemaIssue.InvalidValue(O.some(input), {
+        message: "Invalid Content-Security-Policy configuration",
+      })
+    );
+  }
+
+  return {
+    name: getProperHeaderName(Boolean(input.reportOnly)),
+    value: value.value,
+  } as const;
+});
 
 /**
  * @category formatting

--- a/packages/foundation/modeling/schema/src/http/headers/ExpectCT.ts
+++ b/packages/foundation/modeling/schema/src/http/headers/ExpectCT.ts
@@ -82,65 +82,65 @@ export class ExpectCTResponseHeader extends S.Class<ExpectCTResponseHeader>($I`E
 
 type ExpectCTResponseHeaderEncoded = typeof ExpectCTResponseHeader.Encoded;
 
-const formatExpectCTValue = (config: ExpectCTConfig): Effect.Effect<string, SecureHeaderError> =>
-  Effect.gen(function* () {
-    const reportUriValue = config.reportURI;
+const formatExpectCTValue = Effect.fn("ExpectCT.formatExpectCTValue")(function* (
+  config: ExpectCTConfig
+): Effect.fn.Return<string, SecureHeaderError> {
+  const reportUriValue = config.reportURI;
 
-    const reportURI: O.Option<string> = P.isUndefined(reportUriValue)
-      ? O.none<string>()
-      : O.some(
-          yield* Effect.try({
-            try: () => String(internal.encodeStrictURI(reportUriValue)),
-            catch: () =>
-              new ExpectCtError({
-                message: `Invalid value for "reportURI" option in ${headerName}: ${String(reportUriValue)}`,
-                cause: O.none(),
-              }),
-          })
-        );
+  const reportURI: O.Option<string> = P.isUndefined(reportUriValue)
+    ? O.none<string>()
+    : O.some(
+        yield* Effect.try({
+          try: () => String(internal.encodeStrictURI(reportUriValue)),
+          catch: () =>
+            new ExpectCtError({
+              message: `Invalid value for "reportURI" option in ${headerName}: ${String(reportUriValue)}`,
+              cause: O.none(),
+            }),
+        })
+      );
 
-    return pipe(
-      A.make(
-        `max-age=${config.maxAge ?? defaultMaxAge}`,
-        config.enforce === true ? "enforce" : undefined,
-        pipe(
-          reportURI,
-          O.map((value) => `report-uri=${value}`),
-          O.getOrUndefined
-        )
-      ),
-      A.filter(P.isNotUndefined),
-      A.join(", ")
-    );
-  });
+  return pipe(
+    A.make(
+      `max-age=${config.maxAge ?? defaultMaxAge}`,
+      config.enforce === true ? "enforce" : undefined,
+      pipe(
+        reportURI,
+        O.map((value) => `report-uri=${value}`),
+        O.getOrUndefined
+      )
+    ),
+    A.filter(P.isNotUndefined),
+    A.join(", ")
+  );
+});
 
-const decodeExpectCTValue = (
+const decodeExpectCTValue = Effect.fn("ExpectCT.decodeExpectCTValue")(function* (
   input: ExpectCTOption | undefined
-): Effect.Effect<ExpectCTResponseHeaderEncoded, SchemaIssue.Issue> =>
-  Effect.gen(function* () {
-    if (P.isUndefined(input) || input === false) {
-      return {
-        name: headerName,
-        value: undefined,
-      } as const;
-    }
-
-    if (input === true) {
-      return {
-        name: headerName,
-        value: `max-age=${defaultMaxAge}`,
-      } as const;
-    }
-
-    const value = yield* formatExpectCTValue(input[1]).pipe(
-      Effect.mapError((error) => new SchemaIssue.InvalidValue(O.some(error), { message: error.message }))
-    );
-
+): Effect.fn.Return<ExpectCTResponseHeaderEncoded, SchemaIssue.Issue> {
+  if (P.isUndefined(input) || input === false) {
     return {
       name: headerName,
-      value,
+      value: undefined,
     } as const;
-  });
+  }
+
+  if (input === true) {
+    return {
+      name: headerName,
+      value: `max-age=${defaultMaxAge}`,
+    } as const;
+  }
+
+  const value = yield* formatExpectCTValue(input[1]).pipe(
+    Effect.mapError((error) => new SchemaIssue.InvalidValue(O.some(error), { message: error.message }))
+  );
+
+  return {
+    name: headerName,
+    value,
+  } as const;
+});
 
 /**
  * @category schemas

--- a/packages/foundation/modeling/schema/src/http/headers/FrameGuard.ts
+++ b/packages/foundation/modeling/schema/src/http/headers/FrameGuard.ts
@@ -110,23 +110,24 @@ const encodeAllowFromUri = (value: internal.StringOrUrl, message: string): Effec
       }),
   });
 
-const formatFrameGuardValue = (option: FrameGuardMode | FrameGuardAllowFrom): Effect.Effect<string, FrameGuardError> =>
-  Effect.gen(function* () {
-    if (option === "deny" || option === "sameorigin") {
-      return option;
-    }
+const formatFrameGuardValue = Effect.fn("FrameGuard.formatFrameGuardValue")(function* (
+  option: FrameGuardMode | FrameGuardAllowFrom
+): Effect.fn.Return<string, FrameGuardError> {
+  if (option === "deny" || option === "sameorigin") {
+    return option;
+  }
 
-    if (A.isArray(option) && option[0] === "allow-from") {
-      const uri = yield* encodeAllowFromUri(option[1].uri, `Invalid value for ${headerName}: ${String(option[1].uri)}`);
+  if (A.isArray(option) && option[0] === "allow-from") {
+    const uri = yield* encodeAllowFromUri(option[1].uri, `Invalid value for ${headerName}: ${String(option[1].uri)}`);
 
-      return `${option[0]} ${uri}`;
-    }
+    return `${option[0]} ${uri}`;
+  }
 
-    return yield* new FrameGuardError({
-      message: `Invalid value for ${headerName}: ${option}`,
-      cause: O.none(),
-    });
+  return yield* new FrameGuardError({
+    message: `Invalid value for ${headerName}: ${option}`,
+    cause: O.none(),
   });
+});
 
 /**
  * @category schemas
@@ -136,31 +137,33 @@ export const FrameGuardHeader = S.Union([FrameGuardOption, S.Undefined]).pipe(
   S.decodeTo(
     FrameGuardResponseHeader,
     SchemaTransformation.transformOrFail({
-      decode: (input): Effect.Effect<FrameGuardResponseHeaderEncoded, SchemaIssue.Issue> =>
-        Effect.gen(function* () {
-          if (P.isUndefined(input)) {
-            return {
-              name: headerName,
-              value: defaultValue,
-            } as const;
-          }
-
-          if (input === false) {
-            return {
-              name: headerName,
-              value: undefined,
-            } as const;
-          }
-
-          const value = yield* formatFrameGuardValue(input).pipe(
-            Effect.mapError((error) => new SchemaIssue.InvalidValue(O.some(error), { message: error.message }))
-          );
-
+      decode: Effect.fn("FrameGuard.decode")(function* (input): Effect.fn.Return<
+        FrameGuardResponseHeaderEncoded,
+        SchemaIssue.Issue
+      > {
+        if (P.isUndefined(input)) {
           return {
             name: headerName,
-            value,
+            value: defaultValue,
           } as const;
-        }),
+        }
+
+        if (input === false) {
+          return {
+            name: headerName,
+            value: undefined,
+          } as const;
+        }
+
+        const value = yield* formatFrameGuardValue(input).pipe(
+          Effect.mapError((error) => new SchemaIssue.InvalidValue(O.some(error), { message: error.message }))
+        );
+
+        return {
+          name: headerName,
+          value,
+        } as const;
+      }),
       encode: internal.makeHeaderEncodeForbidden("FrameGuardHeader"),
     })
   ),

--- a/packages/foundation/modeling/schema/src/http/headers/ReferrerPolicy.ts
+++ b/packages/foundation/modeling/schema/src/http/headers/ReferrerPolicy.ts
@@ -96,28 +96,27 @@ export class ReferrerPolicyResponseHeader extends S.Class<ReferrerPolicyResponse
 
 type ReferrerPolicyResponseHeaderEncoded = typeof ReferrerPolicyResponseHeader.Encoded;
 
-const formatReferrerPolicyValue = (
+const formatReferrerPolicyValue = Effect.fn("ReferrerPolicy.formatReferrerPolicyValue")(function* (
   option: ReferrerPolicyValue | ReferrerPolicyValueList
-): Effect.Effect<string, ReferrerPolicyError> =>
-  Effect.gen(function* () {
-    const values = internal.wrapArray(option);
+): Effect.fn.Return<string, ReferrerPolicyError> {
+  const values = internal.wrapArray(option);
 
-    if (A.some(values, (value) => value === ("unsafe-url" as never))) {
-      return yield* new ReferrerPolicyError({
-        message: `Cannot specify a dangerous value for ${headerName}: unsafe-url`,
-        cause: O.none(),
-      });
-    }
-
-    if (A.every(values, S.is(ReferrerPolicyValue))) {
-      return A.join(values, ", ");
-    }
-
+  if (A.some(values, (value) => value === ("unsafe-url" as never))) {
     return yield* new ReferrerPolicyError({
-      message: `Invalid value for ${headerName}: ${String(option)}`,
+      message: `Cannot specify a dangerous value for ${headerName}: unsafe-url`,
       cause: O.none(),
     });
+  }
+
+  if (A.every(values, S.is(ReferrerPolicyValue))) {
+    return A.join(values, ", ");
+  }
+
+  return yield* new ReferrerPolicyError({
+    message: `Invalid value for ${headerName}: ${String(option)}`,
+    cause: O.none(),
   });
+});
 
 /**
  * @category schemas
@@ -127,24 +126,26 @@ export const ReferrerPolicyHeader = S.Union([ReferrerPolicyOption, S.Undefined])
   S.decodeTo(
     ReferrerPolicyResponseHeader,
     SchemaTransformation.transformOrFail({
-      decode: (input): Effect.Effect<ReferrerPolicyResponseHeaderEncoded, SchemaIssue.Issue> =>
-        Effect.gen(function* () {
-          if (P.isUndefined(input) || input === false) {
-            return {
-              name: headerName,
-              value: undefined,
-            } as const;
-          }
-
-          const value = yield* formatReferrerPolicyValue(input).pipe(
-            Effect.mapError((error) => new SchemaIssue.InvalidValue(O.some(error), { message: error.message }))
-          );
-
+      decode: Effect.fn("ReferrerPolicy.decode")(function* (input): Effect.fn.Return<
+        ReferrerPolicyResponseHeaderEncoded,
+        SchemaIssue.Issue
+      > {
+        if (P.isUndefined(input) || input === false) {
           return {
             name: headerName,
-            value,
+            value: undefined,
           } as const;
-        }),
+        }
+
+        const value = yield* formatReferrerPolicyValue(input).pipe(
+          Effect.mapError((error) => new SchemaIssue.InvalidValue(O.some(error), { message: error.message }))
+        );
+
+        return {
+          name: headerName,
+          value,
+        } as const;
+      }),
       encode: internal.makeHeaderEncodeForbidden("ReferrerPolicyHeader"),
     })
   ),

--- a/packages/foundation/modeling/schema/src/http/headers/XSSProtection.ts
+++ b/packages/foundation/modeling/schema/src/http/headers/XSSProtection.ts
@@ -109,31 +109,32 @@ const encodeReportUri = (value: internal.StringOrUrl): Effect.Effect<string, Xss
       }),
   });
 
-const formatXSSProtectionValue = (option: undefined | XSSProtectionOption): Effect.Effect<string, XssProtectionError> =>
-  Effect.gen(function* () {
-    if (P.isUndefined(option) || option === "sanitize") {
-      return "1";
-    }
+const formatXSSProtectionValue = Effect.fn("XSSProtection.formatXSSProtectionValue")(function* (
+  option: undefined | XSSProtectionOption
+): Effect.fn.Return<string, XssProtectionError> {
+  if (P.isUndefined(option) || option === "sanitize") {
+    return "1";
+  }
 
-    if (option === false) {
-      return "0";
-    }
+  if (option === false) {
+    return "0";
+  }
 
-    if (option === "block-rendering") {
-      return "1; mode=block";
-    }
+  if (option === "block-rendering") {
+    return "1; mode=block";
+  }
 
-    if (A.isArray(option) && option[0] === "report") {
-      const uri = yield* encodeReportUri(option[1].uri);
+  if (A.isArray(option) && option[0] === "report") {
+    const uri = yield* encodeReportUri(option[1].uri);
 
-      return `1; report=${uri}`;
-    }
+    return `1; report=${uri}`;
+  }
 
-    return yield* new XssProtectionError({
-      message: `Invalid value for ${headerName}: ${option}`,
-      cause: O.none(),
-    });
+  return yield* new XssProtectionError({
+    message: `Invalid value for ${headerName}: ${option}`,
+    cause: O.none(),
   });
+});
 
 /**
  * @category schemas

--- a/packages/foundation/ui-system/ui/package.json
+++ b/packages/foundation/ui-system/ui/package.json
@@ -27,10 +27,10 @@
   "dependencies": {
     "@base-ui/react": "catalog:",
     "@effect/atom-react": "catalog:",
+    "@elevenlabs/client": "catalog:",
     "@emotion/cache": "catalog:",
     "@emotion/react": "catalog:",
     "@emotion/styled": "catalog:",
-    "@elevenlabs/client": "catalog:",
     "@lexical/react": "catalog:",
     "@lexical/rich-text": "catalog:",
     "@mui/material": "catalog:",

--- a/packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts
+++ b/packages/tooling/library/repo-utils/src/TSMorph/TSMorph.service.ts
@@ -907,161 +907,160 @@ export const createTSMorphService = Effect.fn("createTSMorphService")(function* 
     return yield* buildResolvedScope(resolvedRepoRootPath, resolvedTsConfigPath, mode, referencePolicy);
   });
 
-  const resolveScopeById = (scopeId: string): Effect.Effect<TsMorphProjectScope, TSMorphServiceError> =>
-    Effect.gen(function* () {
-      const cachedScope = MutableHashMap.get(resolvedScopes, scopeId);
-      if (O.isSome(cachedScope)) {
-        return cachedScope.value;
-      }
+  const resolveScopeById = Effect.fnUntraced(function* (
+    scopeId: string
+  ): Effect.fn.Return<TsMorphProjectScope, TSMorphServiceError> {
+    const cachedScope = MutableHashMap.get(resolvedScopes, scopeId);
+    if (O.isSome(cachedScope)) {
+      return cachedScope.value;
+    }
 
-      const [tsConfigPath, _scopeSeparator, mode, _policySeparator, referencePolicy] = yield* decodeOrFail(
-        decodeProjectScopeIdParts,
-        scopeId,
-        (message) =>
-          new TsMorphScopeResolutionError({
-            entrypoint: scopeId,
-            message: `Failed to parse scope id "${scopeId}": ${message}`,
-          })
-      );
+    const [tsConfigPath, _scopeSeparator, mode, _policySeparator, referencePolicy] = yield* decodeOrFail(
+      decodeProjectScopeIdParts,
+      scopeId,
+      (message) =>
+        new TsMorphScopeResolutionError({
+          entrypoint: scopeId,
+          message: `Failed to parse scope id "${scopeId}": ${message}`,
+        })
+    );
 
-      const repoRootPath = yield* resolveRepoRoot(O.none());
-      const resolvedTsConfigPath = yield* resolveTsConfigPath(repoRootPath, tsConfigPath);
-      return yield* buildResolvedScope(repoRootPath, resolvedTsConfigPath, mode, referencePolicy);
-    });
+    const repoRootPath = yield* resolveRepoRoot(O.none());
+    const resolvedTsConfigPath = yield* resolveTsConfigPath(repoRootPath, tsConfigPath);
+    return yield* buildResolvedScope(repoRootPath, resolvedTsConfigPath, mode, referencePolicy);
+  });
 
-  const loadSourceFile = (
+  const loadSourceFile = Effect.fnUntraced(function* (
     scope: TsMorphProjectScope,
     filePath: TypeScriptFilePath
-  ): Effect.Effect<
+  ): Effect.fn.Return<
     {
       readonly sourceFile: SourceFile;
       readonly filePath: TypeScriptFilePath;
     },
     TSMorphServiceError
-  > =>
-    Effect.gen(function* () {
-      const { absoluteFilePath, filePath: normalizedFilePath } = yield* resolveScopedFilePath(
-        scope.repoRootPath,
-        filePath
-      );
+  > {
+    const { absoluteFilePath, filePath: normalizedFilePath } = yield* resolveScopedFilePath(
+      scope.repoRootPath,
+      filePath
+    );
 
+    if (
+      scope.referencePolicy === TsMorphReferencePolicy.Enum.workspaceOnly &&
+      isOutsideAncestor(pathApi, scope.workspaceDirectoryPath, absoluteFilePath)
+    ) {
+      return yield* new TsMorphSourceFileError({
+        scopeId: O.some(scope.scopeId),
+        filePath: S.decodeOption(TypeScriptFilePath)(normalizedFilePath),
+        message: `File "${normalizedFilePath}" is outside the workspace directory "${scope.workspaceDirectoryPath}" for scope "${scope.scopeId}".`,
+      });
+    }
+
+    const project = yield* projectPool.getOrCreate(scope);
+    const existingSourceFile = project.getSourceFile(absoluteFilePath);
+    const sourceFile = existingSourceFile ?? project.addSourceFileAtPathIfExists(absoluteFilePath);
+
+    if (sourceFile === undefined) {
+      return yield* new TsMorphSourceFileError({
+        scopeId: O.some(scope.scopeId),
+        filePath: S.decodeOption(TypeScriptFilePath)(normalizedFilePath),
+        message: `File "${normalizedFilePath}" could not be loaded into ts-morph project scope "${scope.scopeId}".`,
+      });
+    }
+
+    if (existingSourceFile === undefined) {
+      MutableHashMap.remove(symbolIndexPool, scope.cacheKey);
+    }
+
+    return {
+      sourceFile,
+      filePath: normalizedFilePath,
+    };
+  });
+
+  const collectScopeSymbolIndex = Effect.fnUntraced(function* (
+    scope: TsMorphProjectScope
+  ): Effect.fn.Return<ScopeSymbolIndex, TSMorphServiceError> {
+    const project = yield* projectPool.getOrCreate(scope);
+    const entries = A.empty<ScopeSymbolEntry>();
+
+    for (const sourceFile of project.getSourceFiles()) {
+      const absoluteFilePath = pathApi.normalize(sourceFile.getFilePath());
       if (
         scope.referencePolicy === TsMorphReferencePolicy.Enum.workspaceOnly &&
         isOutsideAncestor(pathApi, scope.workspaceDirectoryPath, absoluteFilePath)
       ) {
-        return yield* new TsMorphSourceFileError({
-          scopeId: O.some(scope.scopeId),
-          filePath: S.decodeOption(TypeScriptFilePath)(normalizedFilePath),
-          message: `File "${normalizedFilePath}" is outside the workspace directory "${scope.workspaceDirectoryPath}" for scope "${scope.scopeId}".`,
-        });
+        continue;
       }
 
-      const project = yield* projectPool.getOrCreate(scope);
-      const existingSourceFile = project.getSourceFile(absoluteFilePath);
-      const sourceFile = existingSourceFile ?? project.addSourceFileAtPathIfExists(absoluteFilePath);
-
-      if (sourceFile === undefined) {
-        return yield* new TsMorphSourceFileError({
-          scopeId: O.some(scope.scopeId),
-          filePath: S.decodeOption(TypeScriptFilePath)(normalizedFilePath),
-          message: `File "${normalizedFilePath}" could not be loaded into ts-morph project scope "${scope.scopeId}".`,
-        });
+      const repoRelativeFilePath = pathApi.normalize(pathApi.relative(scope.repoRootPath, absoluteFilePath));
+      if (
+        repoRelativeFilePath.length === 0 ||
+        pathApi.isAbsolute(repoRelativeFilePath) ||
+        Str.startsWith("..")(repoRelativeFilePath)
+      ) {
+        continue;
       }
 
-      if (existingSourceFile === undefined) {
-        MutableHashMap.remove(symbolIndexPool, scope.cacheKey);
+      const implementationFilePath = decodeTypeScriptImplementationFilePathOption(repoRelativeFilePath);
+      if (O.isSome(implementationFilePath)) {
+        const sourceEntries = yield* collectOutlineEntries(implementationFilePath.value, sourceFile);
+        entries.push(...sourceEntries);
       }
+    }
 
-      return {
-        sourceFile,
-        filePath: normalizedFilePath,
-      };
-    });
+    const sortedEntries = A.sort(entries, byScopeSymbolEntryAscending);
+    const entriesById = MutableHashMap.empty<string, ScopeSymbolEntry>();
+    const entriesByFilePath = MutableHashMap.empty<string, ReadonlyArray<ScopeSymbolEntry>>();
 
-  const collectScopeSymbolIndex = (scope: TsMorphProjectScope): Effect.Effect<ScopeSymbolIndex, TSMorphServiceError> =>
-    Effect.gen(function* () {
-      const project = yield* projectPool.getOrCreate(scope);
-      const entries = A.empty<ScopeSymbolEntry>();
+    for (const entry of entries) {
+      const fileEntries = O.getOrElse(
+        MutableHashMap.get(entriesByFilePath, entry.symbol.filePath),
+        A.empty<ScopeSymbolEntry>
+      );
+      MutableHashMap.set(entriesByFilePath, entry.symbol.filePath, A.append(fileEntries, entry));
+    }
 
-      for (const sourceFile of project.getSourceFiles()) {
-        const absoluteFilePath = pathApi.normalize(sourceFile.getFilePath());
-        if (
-          scope.referencePolicy === TsMorphReferencePolicy.Enum.workspaceOnly &&
-          isOutsideAncestor(pathApi, scope.workspaceDirectoryPath, absoluteFilePath)
-        ) {
-          continue;
-        }
+    for (const entry of sortedEntries) {
+      MutableHashMap.set(entriesById, entry.symbol.id, entry);
+    }
 
-        const repoRelativeFilePath = pathApi.normalize(pathApi.relative(scope.repoRootPath, absoluteFilePath));
-        if (
-          repoRelativeFilePath.length === 0 ||
-          pathApi.isAbsolute(repoRelativeFilePath) ||
-          Str.startsWith("..")(repoRelativeFilePath)
-        ) {
-          continue;
-        }
+    return {
+      entries: sortedEntries,
+      entriesById,
+      entriesByFilePath,
+    } satisfies ScopeSymbolIndex;
+  });
 
-        const implementationFilePath = decodeTypeScriptImplementationFilePathOption(repoRelativeFilePath);
-        if (O.isSome(implementationFilePath)) {
-          const sourceEntries = yield* collectOutlineEntries(implementationFilePath.value, sourceFile);
-          entries.push(...sourceEntries);
-        }
-      }
-
-      const sortedEntries = A.sort(entries, byScopeSymbolEntryAscending);
-      const entriesById = MutableHashMap.empty<string, ScopeSymbolEntry>();
-      const entriesByFilePath = MutableHashMap.empty<string, ReadonlyArray<ScopeSymbolEntry>>();
-
-      for (const entry of entries) {
-        const fileEntries = O.getOrElse(
-          MutableHashMap.get(entriesByFilePath, entry.symbol.filePath),
-          A.empty<ScopeSymbolEntry>
-        );
-        MutableHashMap.set(entriesByFilePath, entry.symbol.filePath, A.append(fileEntries, entry));
-      }
-
-      for (const entry of sortedEntries) {
-        MutableHashMap.set(entriesById, entry.symbol.id, entry);
-      }
-
-      return {
-        entries: sortedEntries,
-        entriesById,
-        entriesByFilePath,
-      } satisfies ScopeSymbolIndex;
-    });
-
-  const getOrCreateScopeSymbolIndex = (
+  const getOrCreateScopeSymbolIndex = Effect.fnUntraced(function* (
     scope: TsMorphProjectScope
-  ): Effect.Effect<ScopeSymbolIndex, TSMorphServiceError> =>
-    Effect.gen(function* () {
-      const cachedSymbolIndex = MutableHashMap.get(symbolIndexPool, scope.cacheKey);
-      if (O.isSome(cachedSymbolIndex)) {
-        return cachedSymbolIndex.value;
-      }
+  ): Effect.fn.Return<ScopeSymbolIndex, TSMorphServiceError> {
+    const cachedSymbolIndex = MutableHashMap.get(symbolIndexPool, scope.cacheKey);
+    if (O.isSome(cachedSymbolIndex)) {
+      return cachedSymbolIndex.value;
+    }
 
-      const symbolIndex = yield* collectScopeSymbolIndex(scope);
-      MutableHashMap.set(symbolIndexPool, scope.cacheKey, symbolIndex);
-      return symbolIndex;
-    });
+    const symbolIndex = yield* collectScopeSymbolIndex(scope);
+    MutableHashMap.set(symbolIndexPool, scope.cacheKey, symbolIndex);
+    return symbolIndex;
+  });
 
-  const findScopeSymbolEntry = (
+  const findScopeSymbolEntry = Effect.fnUntraced(function* (
     scope: TsMorphProjectScope,
     symbolId: SymbolId
-  ): Effect.Effect<ScopeSymbolEntry, TSMorphServiceError> =>
-    Effect.gen(function* () {
-      const symbolIndex = yield* getOrCreateScopeSymbolIndex(scope);
-      const entry = MutableHashMap.get(symbolIndex.entriesById, symbolId);
-      if (O.isSome(entry)) {
-        return entry.value;
-      }
+  ): Effect.fn.Return<ScopeSymbolEntry, TSMorphServiceError> {
+    const symbolIndex = yield* getOrCreateScopeSymbolIndex(scope);
+    const entry = MutableHashMap.get(symbolIndex.entriesById, symbolId);
+    if (O.isSome(entry)) {
+      return entry.value;
+    }
 
-      return yield* new TsMorphSymbolNotFoundError({
-        scopeId: scope.scopeId,
-        symbolId,
-        message: `Symbol "${symbolId}" could not be resolved within scope "${scope.scopeId}".`,
-      });
+    return yield* new TsMorphSymbolNotFoundError({
+      scopeId: scope.scopeId,
+      symbolId,
+      message: `Symbol "${symbolId}" could not be resolved within scope "${scope.scopeId}".`,
     });
+  });
 
   const resolveProjectScope: TSMorphServiceShape["resolveProjectScope"] = Effect.fn(function* (request) {
     return yield* resolveScopeFromEntrypoint(

--- a/packages/tooling/test-kit/test-utils/src/SqlTest.ts
+++ b/packages/tooling/test-kit/test-utils/src/SqlTest.ts
@@ -26,6 +26,8 @@ const PgliteDockerContextUrl = new URL("../docker/pglite", import.meta.url);
 const PgliteHealthCheckCommand =
   "node -e \"const { Client } = require('pg'); const client = new Client({ host: '127.0.0.1', port: Number(process.env.PGPORT || '5432'), database: process.env.PGDATABASE, user: process.env.PGUSER, password: process.env.PGPASSWORD, ssl: false }); client.connect().then(() => client.query('select 1')).then(() => client.end()).catch((cause) => { console.error(cause); process.exit(1); });\"";
 const PgliteHealthCheckIntervalMs = 1_000;
+const PgExternalClientEndTimeout = Duration.seconds(1);
+const PgExternalSchemaDropTimeout = Duration.seconds(10);
 let pgliteImageBuild = O.none<Promise<GenericContainer>>();
 
 const SqlTestHarnessPhase = LiteralKit(["provision", "migrate", "seed", "teardown"]).annotate(
@@ -768,11 +770,30 @@ const createPgExternalSchema = Effect.fn("SqlTest.PgExternalTestDriver.createSch
   );
 });
 
+const resetPgExternalSearchPath = Effect.fn("SqlTest.PgExternalTestDriver.resetSearchPath")(function* (
+  sql: SqlClient.SqlClient
+) {
+  yield* sql`SET search_path TO public`.pipe(
+    Effect.catch(() => Effect.logWarning("Failed to reset external PostgreSQL search_path before schema teardown.")),
+    Effect.asVoid
+  );
+});
+
 const dropPgExternalSchema = Effect.fn("SqlTest.PgExternalTestDriver.dropSchema")(function* (
   sql: SqlClient.SqlClient,
   schemaName: string
 ) {
-  yield* sql`DROP SCHEMA IF EXISTS ${sql(schemaName)} CASCADE`.pipe(
+  yield* Effect.gen(function* () {
+    yield* resetPgExternalSearchPath(sql);
+    yield* sql`DROP SCHEMA IF EXISTS ${sql(schemaName)} CASCADE`;
+  }).pipe(
+    Effect.timeoutOption(PgExternalSchemaDropTimeout),
+    Effect.flatMap(
+      O.match({
+        onNone: () => Effect.logWarning(`Timed out dropping external PostgreSQL test schema ${schemaName}.`),
+        onSome: () => Effect.void,
+      })
+    ),
     Effect.catch(() => Effect.logWarning(`Failed to drop external PostgreSQL test schema ${schemaName}.`)),
     Effect.asVoid
   );
@@ -864,7 +885,7 @@ const buildPgExternalLayer = Effect.fn("SqlTest.PgExternalTestDriver.build")(
                 }),
             }),
             (client) =>
-              Effect.promise(() => client.end()).pipe(Effect.timeoutOption(Duration.seconds(1)), Effect.asVoid)
+              Effect.promise(() => client.end()).pipe(Effect.timeoutOption(PgExternalClientEndTimeout), Effect.asVoid)
           ),
           acquireForStream: false,
         }).pipe(

--- a/packages/tooling/test-kit/test-utils/test/integration/SqlTest.pglite.test.ts
+++ b/packages/tooling/test-kit/test-utils/test/integration/SqlTest.pglite.test.ts
@@ -123,10 +123,11 @@ const isContainerInspectable = Effect.fn("SqlTestIntegration.isContainerInspecta
       return true;
     },
     catch: () => false,
-  }).pipe(Effect.catch(Effect.succeed), Effect.timeoutOption(ContainerInspectTimeout));
+  }).pipe(Effect.option, Effect.timeoutOption(ContainerInspectTimeout));
 
   return pipe(
     inspected,
+    O.flatten,
     O.getOrElse(() => false)
   );
 });

--- a/packages/tooling/tool/cli/src/commands/Architecture/OperationPlan.ts
+++ b/packages/tooling/tool/cli/src/commands/Architecture/OperationPlan.ts
@@ -1974,8 +1974,9 @@ export const makeArchitectureOperationPlan = Effect.fn(function* (
   yield* validateRequestedRoles(target, roles);
   const selectedFiles = selectFiles(target, roles);
 
-  const writeOperations = yield* Effect.forEach(selectedFiles, (file) =>
-    Effect.gen(function* () {
+  const writeOperations = yield* Effect.forEach(
+    selectedFiles,
+    Effect.fnUntraced(function* (file) {
       const operationPath = targetPathFor(file.path, target);
       const targetFileExists = isPackageLevelFile(file.path)
         ? yield* fs.exists(path.join(repoRoot, operationPath)).pipe(Effect.orElseSucceed(thunkFalse))

--- a/packages/tooling/tool/cli/src/commands/Codegen.ts
+++ b/packages/tooling/tool/cli/src/commands/Codegen.ts
@@ -285,7 +285,7 @@ export const codegenCommand = Command.make(
 
     // Read package.json to extract the package name for the header
     const packageJsonPath = pathSvc.join(packageDir, "package.json");
-    const packageName = yield* Effect.fnUntraced(function* () {
+    const packageName = yield* Effect.gen(function* () {
       const json = yield* fsUtils.readJson(packageJsonPath).pipe(Effect.orElseSucceed(O.none));
       if (
         O.isSome(json) &&
@@ -299,7 +299,7 @@ export const codegenCommand = Command.make(
         return json.value.name;
       }
       return pathSvc.basename(packageDir);
-    })();
+    });
 
     yield* Console.log(`Scanning ${srcDir} for modules...`);
 

--- a/packages/tooling/tool/cli/src/commands/Codegen.ts
+++ b/packages/tooling/tool/cli/src/commands/Codegen.ts
@@ -175,8 +175,9 @@ const discoverModules = Effect.fn(function* (srcDir: string) {
     Effect.fn(function* (dir, prefix) {
       const entries = yield* fs.readDirectory(dir).pipe(Effect.orElseSucceed(A.empty<string>));
 
-      const discovered = yield* Effect.forEach(entries, (entry) =>
-        Effect.gen(function* () {
+      const discovered = yield* Effect.forEach(
+        entries,
+        Effect.fnUntraced(function* (entry) {
           const fullPath = path.join(dir, entry);
 
           // Check if this entry is a directory
@@ -284,7 +285,7 @@ export const codegenCommand = Command.make(
 
     // Read package.json to extract the package name for the header
     const packageJsonPath = pathSvc.join(packageDir, "package.json");
-    const packageName = yield* Effect.gen(function* () {
+    const packageName = yield* Effect.fnUntraced(function* () {
       const json = yield* fsUtils.readJson(packageJsonPath).pipe(Effect.orElseSucceed(O.none));
       if (
         O.isSome(json) &&
@@ -298,7 +299,7 @@ export const codegenCommand = Command.make(
         return json.value.name;
       }
       return pathSvc.basename(packageDir);
-    });
+    })();
 
     yield* Console.log(`Scanning ${srcDir} for modules...`);
 

--- a/packages/tooling/tool/cli/src/commands/Codex.ts
+++ b/packages/tooling/tool/cli/src/commands/Codex.ts
@@ -76,7 +76,7 @@ export const runCodexQualityReviewFixLoop = Effect.fn("Codex.runCodexQualityRevi
   const initiativeSummary = A.isReadonlyArrayEmpty(summaryParts) ? defaultInitiativeSummary : A.join(summaryParts, " ");
   const prompt = qualityReviewPrompt(initiativeSummary);
   const exitCode = yield* Effect.scoped(
-    Effect.fnUntraced(function* () {
+    Effect.gen(function* () {
       const handle = yield* ChildProcess.make("codex", ["exec", "--cd", repoRoot, "-"], {
         cwd: repoRoot,
         stdin: Stream.make(textEncoder.encode(prompt)),
@@ -85,7 +85,7 @@ export const runCodexQualityReviewFixLoop = Effect.fn("Codex.runCodexQualityRevi
       });
 
       return yield* handle.exitCode;
-    })()
+    })
   ).pipe(
     Effect.mapError(
       (cause) =>

--- a/packages/tooling/tool/cli/src/commands/Codex.ts
+++ b/packages/tooling/tool/cli/src/commands/Codex.ts
@@ -76,7 +76,7 @@ export const runCodexQualityReviewFixLoop = Effect.fn("Codex.runCodexQualityRevi
   const initiativeSummary = A.isReadonlyArrayEmpty(summaryParts) ? defaultInitiativeSummary : A.join(summaryParts, " ");
   const prompt = qualityReviewPrompt(initiativeSummary);
   const exitCode = yield* Effect.scoped(
-    Effect.gen(function* () {
+    Effect.fnUntraced(function* () {
       const handle = yield* ChildProcess.make("codex", ["exec", "--cd", repoRoot, "-"], {
         cwd: repoRoot,
         stdin: Stream.make(textEncoder.encode(prompt)),
@@ -85,7 +85,7 @@ export const runCodexQualityReviewFixLoop = Effect.fn("Codex.runCodexQualityRevi
       });
 
       return yield* handle.exitCode;
-    })
+    })()
   ).pipe(
     Effect.mapError(
       (cause) =>

--- a/packages/tooling/tool/cli/src/commands/Docgen/index.ts
+++ b/packages/tooling/tool/cli/src/commands/Docgen/index.ts
@@ -230,8 +230,8 @@ const docgenInitCommand = Command.make(
     dryRun: dryRunFlag,
     force: forceFlag,
   },
-  ({ package: selector, dryRun, force }) =>
-    Effect.gen(function* () {
+  Effect.fn(
+    function* ({ package: selector, dryRun, force }) {
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
       const repoRoot = yield* findRepoRoot();
@@ -257,22 +257,22 @@ const docgenInitCommand = Command.make(
 
       yield* fs.writeFileString(configPath, content);
       yield* Console.log(`docgen: wrote ${configPath}`);
-    }).pipe(
-      Effect.catchTag(
-        "DomainError",
-        Effect.fn(function* (error) {
-          process.exitCode = 1;
-          yield* Console.error(`docgen: ${error.message}`);
-        })
-      ),
-      Effect.catchTag(
-        "NoSuchFileError",
-        Effect.fn(function* (error) {
-          process.exitCode = 1;
-          yield* Console.error(`docgen: ${error.message}`);
-        })
-      )
+    },
+    Effect.catchTag(
+      "DomainError",
+      Effect.fn(function* (error) {
+        process.exitCode = 1;
+        yield* Console.error(`docgen: ${error.message}`);
+      })
+    ),
+    Effect.catchTag(
+      "NoSuchFileError",
+      Effect.fn(function* (error) {
+        process.exitCode = 1;
+        yield* Console.error(`docgen: ${error.message}`);
+      })
     )
+  )
 ).pipe(Command.withDescription("Create or refresh docgen.json for a workspace package"));
 
 const docgenStatusCommand = Command.make(
@@ -281,8 +281,8 @@ const docgenStatusCommand = Command.make(
     verbose: verboseFlag,
     json: jsonFlag,
   },
-  ({ verbose, json }) =>
-    Effect.gen(function* () {
+  Effect.fn(
+    function* ({ verbose, json }) {
       const packages = yield* discoverDocgenWorkspacePackages();
       const configuredAndGenerated = packages.filter((pkg) => pkg.status === "configured-and-generated");
       const configuredNotGenerated = packages.filter((pkg) => pkg.status === "configured-not-generated");
@@ -329,22 +329,22 @@ const docgenStatusCommand = Command.make(
           }
         }
       }
-    }).pipe(
-      Effect.catchTag(
-        "DomainError",
-        Effect.fn(function* (error) {
-          process.exitCode = 1;
-          yield* Console.error(`docgen: ${error.message}`);
-        })
-      ),
-      Effect.catchTag(
-        "NoSuchFileError",
-        Effect.fn(function* (error) {
-          process.exitCode = 1;
-          yield* Console.error(`docgen: ${error.message}`);
-        })
-      )
+    },
+    Effect.catchTag(
+      "DomainError",
+      Effect.fn(function* (error) {
+        process.exitCode = 1;
+        yield* Console.error(`docgen: ${error.message}`);
+      })
+    ),
+    Effect.catchTag(
+      "NoSuchFileError",
+      Effect.fn(function* (error) {
+        process.exitCode = 1;
+        yield* Console.error(`docgen: ${error.message}`);
+      })
     )
+  )
 ).pipe(Command.withDescription("Show docgen configuration and generation status across the workspace"));
 
 const docgenGenerateCommand = Command.make(
@@ -356,8 +356,8 @@ const docgenGenerateCommand = Command.make(
     parallel: parallelFlag,
     json: jsonFlag,
   },
-  ({ package: packageSelector, filter: filterSelector, validateExamples, parallel, json }) =>
-    Effect.gen(function* () {
+  Effect.fn(
+    function* ({ package: packageSelector, filter: filterSelector, validateExamples, parallel, json }) {
       void validateExamples;
       const selector = yield* resolvePackageSelector(packageSelector, filterSelector);
       const targets = yield* resolveGenerateTargets(selector);
@@ -380,22 +380,22 @@ const docgenGenerateCommand = Command.make(
       }
 
       yield* logGenerationResults(results);
-    }).pipe(
-      Effect.catchTag(
-        "DomainError",
-        Effect.fn(function* (error) {
-          process.exitCode = 1;
-          yield* Console.error(`docgen: ${error.message}`);
-        })
-      ),
-      Effect.catchTag(
-        "NoSuchFileError",
-        Effect.fn(function* (error) {
-          process.exitCode = 1;
-          yield* Console.error(`docgen: ${error.message}`);
-        })
-      )
+    },
+    Effect.catchTag(
+      "DomainError",
+      Effect.fn(function* (error) {
+        process.exitCode = 1;
+        yield* Console.error(`docgen: ${error.message}`);
+      })
+    ),
+    Effect.catchTag(
+      "NoSuchFileError",
+      Effect.fn(function* (error) {
+        process.exitCode = 1;
+        yield* Console.error(`docgen: ${error.message}`);
+      })
     )
+  )
 ).pipe(
   Command.withDescription(
     "Run the repo-local @beep/repo-docgen implementation for one package or every configured package"
@@ -411,8 +411,8 @@ const docgenRunCommand = Command.make(
     parallel: parallelFlag,
     clean: cleanFlag,
   },
-  ({ package: packageSelector, filter: filterSelector, validateExamples, parallel, clean }) =>
-    Effect.gen(function* () {
+  Effect.fn(
+    function* ({ package: packageSelector, filter: filterSelector, validateExamples, parallel, clean }) {
       void validateExamples;
       const selector = yield* resolvePackageSelector(packageSelector, filterSelector);
       const targets = yield* resolveGenerateTargets(selector);
@@ -438,22 +438,22 @@ const docgenRunCommand = Command.make(
         ...R.getSomes({ package: selector }),
       });
       yield* logAggregateResults(aggregateResults);
-    }).pipe(
-      Effect.catchTag(
-        "DomainError",
-        Effect.fn(function* (error) {
-          process.exitCode = 1;
-          yield* Console.error(`docgen: ${error.message}`);
-        })
-      ),
-      Effect.catchTag(
-        "NoSuchFileError",
-        Effect.fn(function* (error) {
-          process.exitCode = 1;
-          yield* Console.error(`docgen: ${error.message}`);
-        })
-      )
+    },
+    Effect.catchTag(
+      "DomainError",
+      Effect.fn(function* (error) {
+        process.exitCode = 1;
+        yield* Console.error(`docgen: ${error.message}`);
+      })
+    ),
+    Effect.catchTag(
+      "NoSuchFileError",
+      Effect.fn(function* (error) {
+        process.exitCode = 1;
+        yield* Console.error(`docgen: ${error.message}`);
+      })
     )
+  )
 ).pipe(
   Command.withDescription(
     "Run generation and aggregation together using a single package selector so both phases stay in scope"
@@ -467,30 +467,30 @@ const docgenAggregateCommand = Command.make(
     filter: filterFlag,
     clean: cleanFlag,
   },
-  ({ package: packageSelector, filter: filterSelector, clean }) =>
-    Effect.gen(function* () {
+  Effect.fn(
+    function* ({ package: packageSelector, filter: filterSelector, clean }) {
       const selector = yield* resolvePackageSelector(packageSelector, filterSelector);
       const results = yield* aggregateGeneratedDocs({
         clean,
         ...R.getSomes({ package: selector }),
       });
       yield* logAggregateResults(results);
-    }).pipe(
-      Effect.catchTag(
-        "DomainError",
-        Effect.fn(function* (error) {
-          process.exitCode = 1;
-          yield* Console.error(`docgen: ${error.message}`);
-        })
-      ),
-      Effect.catchTag(
-        "NoSuchFileError",
-        Effect.fn(function* (error) {
-          process.exitCode = 1;
-          yield* Console.error(`docgen: ${error.message}`);
-        })
-      )
+    },
+    Effect.catchTag(
+      "DomainError",
+      Effect.fn(function* (error) {
+        process.exitCode = 1;
+        yield* Console.error(`docgen: ${error.message}`);
+      })
+    ),
+    Effect.catchTag(
+      "NoSuchFileError",
+      Effect.fn(function* (error) {
+        process.exitCode = 1;
+        yield* Console.error(`docgen: ${error.message}`);
+      })
     )
+  )
 ).pipe(Command.withDescription("Copy generated package docs into the current root docs layout"));
 
 const docgenAnalyzeCommand = Command.make(
@@ -501,8 +501,8 @@ const docgenAnalyzeCommand = Command.make(
     json: jsonFlag,
     fixMode: fixModeFlag,
   },
-  ({ package: selector, output, json, fixMode }) =>
-    Effect.gen(function* () {
+  Effect.fn(
+    function* ({ package: selector, output, json, fixMode }) {
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
       const targets = yield* resolveAnalyzeTargets(selector);
@@ -558,22 +558,22 @@ const docgenAnalyzeCommand = Command.make(
         yield* fs.writeFileString(destination, generateAnalysisReport(analysis, fixMode));
         yield* Console.log(`docgen: wrote ${destination}`);
       }
-    }).pipe(
-      Effect.catchTag(
-        "DomainError",
-        Effect.fn(function* (error) {
-          process.exitCode = 1;
-          yield* Console.error(`docgen: ${error.message}`);
-        })
-      ),
-      Effect.catchTag(
-        "NoSuchFileError",
-        Effect.fn(function* (error) {
-          process.exitCode = 1;
-          yield* Console.error(`docgen: ${error.message}`);
-        })
-      )
+    },
+    Effect.catchTag(
+      "DomainError",
+      Effect.fn(function* (error) {
+        process.exitCode = 1;
+        yield* Console.error(`docgen: ${error.message}`);
+      })
+    ),
+    Effect.catchTag(
+      "NoSuchFileError",
+      Effect.fn(function* (error) {
+        process.exitCode = 1;
+        yield* Console.error(`docgen: ${error.message}`);
+      })
     )
+  )
 ).pipe(Command.withDescription("Analyze JSDoc coverage and write a human-first report"));
 
 const docgenCheckCommand = Command.make(
@@ -583,8 +583,8 @@ const docgenCheckCommand = Command.make(
     parallel: parallelFlag,
     json: jsonFlag,
   },
-  ({ package: selector, parallel, json }) =>
-    Effect.gen(function* () {
+  Effect.fn(
+    function* ({ package: selector, parallel, json }) {
       const targets = yield* resolveAnalyzeTargets(selector);
 
       if (targets.length === 0) {
@@ -649,22 +649,22 @@ const docgenCheckCommand = Command.make(
       if (failures.length > 0) {
         process.exitCode = 1;
       }
-    }).pipe(
-      Effect.catchTag(
-        "DomainError",
-        Effect.fn(function* (error) {
-          process.exitCode = 1;
-          yield* Console.error(`docgen: ${error.message}`);
-        })
-      ),
-      Effect.catchTag(
-        "NoSuchFileError",
-        Effect.fn(function* (error) {
-          process.exitCode = 1;
-          yield* Console.error(`docgen: ${error.message}`);
-        })
-      )
+    },
+    Effect.catchTag(
+      "DomainError",
+      Effect.fn(function* (error) {
+        process.exitCode = 1;
+        yield* Console.error(`docgen: ${error.message}`);
+      })
+    ),
+    Effect.catchTag(
+      "NoSuchFileError",
+      Effect.fn(function* (error) {
+        process.exitCode = 1;
+        yield* Console.error(`docgen: ${error.message}`);
+      })
     )
+  )
 ).pipe(Command.withDescription("Fail when package exports are missing required JSDoc/docgen metadata"));
 
 const docgenQualityCommand = Command.make(
@@ -678,8 +678,8 @@ const docgenQualityCommand = Command.make(
     score: qualityScoreFlag,
     packetLimit: packetLimitFlag,
   },
-  ({ package: packageSelector, all, changedFiles, output, json, score, packetLimit }) =>
-    Effect.gen(function* () {
+  Effect.fn(
+    function* ({ package: packageSelector, all, changedFiles, output, json, score, packetLimit }) {
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
       const { scope, targets } = yield* resolveDocgenQualityTargets({
@@ -727,22 +727,22 @@ const docgenQualityCommand = Command.make(
       }
 
       yield* Console.log(content);
-    }).pipe(
-      Effect.catchTag(
-        "DomainError",
-        Effect.fn(function* (error) {
-          process.exitCode = 1;
-          yield* Console.error(`docgen: ${error.message}`);
-        })
-      ),
-      Effect.catchTag(
-        "NoSuchFileError",
-        Effect.fn(function* (error) {
-          process.exitCode = 1;
-          yield* Console.error(`docgen: ${error.message}`);
-        })
-      )
+    },
+    Effect.catchTag(
+      "DomainError",
+      Effect.fn(function* (error) {
+        process.exitCode = 1;
+        yield* Console.error(`docgen: ${error.message}`);
+      })
+    ),
+    Effect.catchTag(
+      "NoSuchFileError",
+      Effect.fn(function* (error) {
+        process.exitCode = 1;
+        yield* Console.error(`docgen: ${error.message}`);
+      })
     )
+  )
 ).pipe(
   Command.withDescription(
     "Produce a report-only exported-symbol JSDoc quality report with bounded advisory remediation packets"
@@ -761,8 +761,8 @@ const docgenQualityWorkerEvalCommand = Command.make(
     reasoningEffort: qualityWorkerEvalReasoningEffortFlag,
     packetLimit: qualityWorkerEvalPacketLimitFlag,
   },
-  ({ package: packageSelector, all, input, output, provider, model, reasoningEffort, packetLimit }) =>
-    Effect.gen(function* () {
+  Effect.fn(
+    function* ({ package: packageSelector, all, input, output, provider, model, reasoningEffort, packetLimit }) {
       const fs = yield* FileSystem.FileSystem;
       const sourceCount = (O.isSome(input) ? 1 : 0) + (O.isSome(packageSelector) ? 1 : 0) + (all ? 1 : 0);
       const resolvedReasoningEffort = Match.value(provider).pipe(
@@ -799,7 +799,7 @@ const docgenQualityWorkerEvalCommand = Command.make(
             scope: "input" as const,
             sourceQualityReport: input.value,
           }
-        : yield* Effect.gen(function* () {
+        : yield* Effect.fnUntraced(function* () {
             const { scope, targets } = yield* resolveDocgenQualityTargets({
               all,
               changedFiles: false,
@@ -822,7 +822,7 @@ const docgenQualityWorkerEvalCommand = Command.make(
               scope: scope === "all" ? ("all" as const) : ("package" as const),
               sourceQualityReport: `generated:${scope}`,
             };
-          });
+          })();
 
       const report = yield* analyzeDocgenQualityWorkerEval({
         model,
@@ -842,22 +842,22 @@ const docgenQualityWorkerEvalCommand = Command.make(
       }
 
       yield* Console.log(content);
-    }).pipe(
-      Effect.catchTag(
-        "DomainError",
-        Effect.fn(function* (error) {
-          process.exitCode = 1;
-          yield* Console.error(`docgen: ${error.message}`);
-        })
-      ),
-      Effect.catchTag(
-        "NoSuchFileError",
-        Effect.fn(function* (error) {
-          process.exitCode = 1;
-          yield* Console.error(`docgen: ${error.message}`);
-        })
-      )
+    },
+    Effect.catchTag(
+      "DomainError",
+      Effect.fn(function* (error) {
+        process.exitCode = 1;
+        yield* Console.error(`docgen: ${error.message}`);
+      })
+    ),
+    Effect.catchTag(
+      "NoSuchFileError",
+      Effect.fn(function* (error) {
+        process.exitCode = 1;
+        yield* Console.error(`docgen: ${error.message}`);
+      })
     )
+  )
 ).pipe(
   Command.withDescription("Run read-only worker evaluation over deterministic docgen quality remediation packets")
 );

--- a/packages/tooling/tool/cli/src/commands/Docgen/index.ts
+++ b/packages/tooling/tool/cli/src/commands/Docgen/index.ts
@@ -799,7 +799,7 @@ const docgenQualityWorkerEvalCommand = Command.make(
             scope: "input" as const,
             sourceQualityReport: input.value,
           }
-        : yield* Effect.fnUntraced(function* () {
+        : yield* Effect.gen(function* () {
             const { scope, targets } = yield* resolveDocgenQualityTargets({
               all,
               changedFiles: false,
@@ -822,7 +822,7 @@ const docgenQualityWorkerEvalCommand = Command.make(
               scope: scope === "all" ? ("all" as const) : ("package" as const),
               sourceQualityReport: `generated:${scope}`,
             };
-          })();
+          });
 
       const report = yield* analyzeDocgenQualityWorkerEval({
         model,

--- a/packages/tooling/tool/cli/src/commands/Docgen/internal/Operations.ts
+++ b/packages/tooling/tool/cli/src/commands/Docgen/internal/Operations.ts
@@ -1032,9 +1032,8 @@ const copyDocsTree: (
   packageName: string,
   sourceRoot: string,
   canonicalSourceRoot: string
-) => Effect.Effect<number, DomainError, FileSystem.FileSystem | Path.Path> = Effect.fn(
-  "DocgenOperations.copyDocsTree"
-)(function* (sourceDir, destinationDir, packageName, sourceRoot, canonicalSourceRoot) {
+) => Effect.Effect<number, DomainError, FileSystem.FileSystem | Path.Path> = Effect.fn("DocgenOperations.copyDocsTree")(
+  function* (sourceDir, destinationDir, packageName, sourceRoot, canonicalSourceRoot) {
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
 
@@ -1115,7 +1114,8 @@ const copyDocsTree: (
     }
 
     return copiedFiles;
-});
+  }
+);
 
 /**
  * Normalize a workspace-relative package path to the current root docs output layout.
@@ -1484,137 +1484,137 @@ export const aggregateGeneratedDocs: (options?: {
   readonly clean?: boolean | undefined;
   readonly package?: string | undefined;
 }) {
-    const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
-    const repoRoot = yield* findRepoRoot();
-    yield* assertNoOrphanDocgenConfigPaths(repoRoot);
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const repoRoot = yield* findRepoRoot();
+  yield* assertNoOrphanDocgenConfigPaths(repoRoot);
 
-    const docsRoot = path.join(repoRoot, "docs");
-    const selectedPackage = P.isUndefined(options?.package)
-      ? undefined
-      : yield* resolveDocgenWorkspacePackage(options.package, { rootDir: repoRoot });
-    const packages = P.isUndefined(selectedPackage)
-      ? A.filter(yield* discoverDocgenWorkspacePackages(repoRoot), (pkg) => pkg.hasGeneratedDocs)
-      : selectedPackage.hasGeneratedDocs
-        ? [selectedPackage]
-        : A.empty();
+  const docsRoot = path.join(repoRoot, "docs");
+  const selectedPackage = P.isUndefined(options?.package)
+    ? undefined
+    : yield* resolveDocgenWorkspacePackage(options.package, { rootDir: repoRoot });
+  const packages = P.isUndefined(selectedPackage)
+    ? A.filter(yield* discoverDocgenWorkspacePackages(repoRoot), (pkg) => pkg.hasGeneratedDocs)
+    : selectedPackage.hasGeneratedDocs
+      ? [selectedPackage]
+      : A.empty();
 
-    if (selectedPackage !== undefined && A.isReadonlyArrayEmpty(packages)) {
+  if (selectedPackage !== undefined && A.isReadonlyArrayEmpty(packages)) {
+    return yield* new DomainError({
+      message: `Package "${selectedPackage.name}" does not have generated docs. Run "bun run beep docgen generate -p ${selectedPackage.relativePath}" first.`,
+    });
+  }
+
+  if (A.isReadonlyArrayEmpty(packages)) {
+    return A.empty();
+  }
+
+  if (P.isUndefined(options?.package)) {
+    const seen = MutableHashSet.empty<string>();
+    const duplicates = MutableHashSet.empty<string>();
+
+    for (const pkg of packages) {
+      if (MutableHashSet.has(seen, pkg.docsOutputPath)) {
+        MutableHashSet.add(duplicates, pkg.docsOutputPath);
+        continue;
+      }
+      MutableHashSet.add(seen, pkg.docsOutputPath);
+    }
+
+    if (MutableHashSet.size(duplicates) > 0) {
       return yield* new DomainError({
-        message: `Package "${selectedPackage.name}" does not have generated docs. Run "bun run beep docgen generate -p ${selectedPackage.relativePath}" first.`,
+        message: `Duplicate docs output paths detected: ${pipe(
+          A.fromIterable(duplicates),
+          A.sort(Order.String),
+          A.join(", ")
+        )}`,
       });
     }
+  }
 
-    if (A.isReadonlyArrayEmpty(packages)) {
-      return A.empty();
+  if (options?.clean === true) {
+    if (selectedPackage !== undefined) {
+      const destinationDir = path.join(docsRoot, selectedPackage.docsOutputPath);
+      yield* fs
+        .remove(destinationDir, {
+          recursive: true,
+          force: true,
+        })
+        .pipe(Effect.mapError(DomainError.newCause(`Failed to remove "${destinationDir}"`)));
+    } else {
+      yield* fs
+        .remove(docsRoot, {
+          recursive: true,
+          force: true,
+        })
+        .pipe(Effect.mapError(DomainError.newCause(`Failed to remove "${docsRoot}"`)));
     }
+  }
 
-    if (P.isUndefined(options?.package)) {
-      const seen = MutableHashSet.empty<string>();
-      const duplicates = MutableHashSet.empty<string>();
+  yield* fs
+    .makeDirectory(docsRoot, { recursive: true })
+    .pipe(Effect.mapError(DomainError.newCause(`Failed to create "${docsRoot}"`)));
 
-      for (const pkg of packages) {
-        if (MutableHashSet.has(seen, pkg.docsOutputPath)) {
-          MutableHashSet.add(duplicates, pkg.docsOutputPath);
-          continue;
-        }
-        MutableHashSet.add(seen, pkg.docsOutputPath);
-      }
+  const sortedPackages = A.sort(packages, byDocsOutputPathAscending);
+  return yield* Effect.forEach(
+    sortedPackages,
+    Effect.fnUntraced(function* (pkg, index) {
+      const sourceDir = path.join(pkg.absolutePath, ...DOCS_MODULES_SEGMENTS);
+      const destinationDir = path.join(docsRoot, pkg.docsOutputPath);
+      const hasDocs = yield* fs.exists(sourceDir).pipe(Effect.orElseSucceed(thunkFalse));
 
-      if (MutableHashSet.size(duplicates) > 0) {
+      if (!hasDocs) {
         return yield* new DomainError({
-          message: `Duplicate docs output paths detected: ${pipe(
-            A.fromIterable(duplicates),
-            A.sort(Order.String),
-            A.join(", ")
-          )}`,
+          message: `Package "${pkg.name}" does not have generated docs. Run "bun run beep docgen generate -p ${pkg.relativePath}" first.`,
         });
       }
-    }
 
-    if (options?.clean === true) {
-      if (selectedPackage !== undefined) {
-        const destinationDir = path.join(docsRoot, selectedPackage.docsOutputPath);
-        yield* fs
-          .remove(destinationDir, {
-            recursive: true,
-            force: true,
-          })
-          .pipe(Effect.mapError(DomainError.newCause(`Failed to remove "${destinationDir}"`)));
-      } else {
-        yield* fs
-          .remove(docsRoot, {
-            recursive: true,
-            force: true,
-          })
-          .pipe(Effect.mapError(DomainError.newCause(`Failed to remove "${docsRoot}"`)));
+      const canonicalPackageDir = yield* fs
+        .realPath(pkg.absolutePath)
+        .pipe(Effect.mapError(DomainError.newCause(`Failed to resolve "${pkg.absolutePath}"`)));
+      const canonicalSourceDir = yield* fs
+        .realPath(sourceDir)
+        .pipe(Effect.mapError(DomainError.newCause(`Failed to resolve "${sourceDir}"`)));
+      const expectedCanonicalSourceDir = path.join(canonicalPackageDir, ...DOCS_MODULES_SEGMENTS);
+
+      if (canonicalSourceDir !== expectedCanonicalSourceDir) {
+        return yield* new DomainError({
+          message: `Refusing to aggregate docs for package "${pkg.name}" because "${sourceDir}" resolves outside the package docs/modules tree.`,
+        });
       }
-    }
 
-    yield* fs
-      .makeDirectory(docsRoot, { recursive: true })
-      .pipe(Effect.mapError(DomainError.newCause(`Failed to create "${docsRoot}"`)));
-
-    const sortedPackages = A.sort(packages, byDocsOutputPathAscending);
-    return yield* Effect.forEach(
-      sortedPackages,
-      Effect.fnUntraced(function* (pkg, index) {
-        const sourceDir = path.join(pkg.absolutePath, ...DOCS_MODULES_SEGMENTS);
-        const destinationDir = path.join(docsRoot, pkg.docsOutputPath);
-        const hasDocs = yield* fs.exists(sourceDir).pipe(Effect.orElseSucceed(thunkFalse));
-
-        if (!hasDocs) {
-          return yield* new DomainError({
-            message: `Package "${pkg.name}" does not have generated docs. Run "bun run beep docgen generate -p ${pkg.relativePath}" first.`,
-          });
-        }
-
-        const canonicalPackageDir = yield* fs
-          .realPath(pkg.absolutePath)
-          .pipe(Effect.mapError(DomainError.newCause(`Failed to resolve "${pkg.absolutePath}"`)));
-        const canonicalSourceDir = yield* fs
-          .realPath(sourceDir)
-          .pipe(Effect.mapError(DomainError.newCause(`Failed to resolve "${sourceDir}"`)));
-        const expectedCanonicalSourceDir = path.join(canonicalPackageDir, ...DOCS_MODULES_SEGMENTS);
-
-        if (canonicalSourceDir !== expectedCanonicalSourceDir) {
-          return yield* new DomainError({
-            message: `Refusing to aggregate docs for package "${pkg.name}" because "${sourceDir}" resolves outside the package docs/modules tree.`,
-          });
-        }
-
-        yield* fs
-          .remove(destinationDir, {
-            recursive: true,
-            force: true,
-          })
-          .pipe(
-            Effect.mapError(
-              (cause) =>
-                new DomainError({
-                  message: `Failed to reset "${destinationDir}"`,
-                  cause,
-                })
-            )
-          );
-        const fileCount = yield* copyDocsTree(sourceDir, destinationDir, pkg.name, sourceDir, canonicalSourceDir);
-        yield* fs
-          .writeFileString(
-            path.join(destinationDir, "index.md"),
-            generateDocsIndexContent(pkg.name, pkg.docsOutputPath, index + 2)
+      yield* fs
+        .remove(destinationDir, {
+          recursive: true,
+          force: true,
+        })
+        .pipe(
+          Effect.mapError(
+            (cause) =>
+              new DomainError({
+                message: `Failed to reset "${destinationDir}"`,
+                cause,
+              })
           )
-          .pipe(Effect.mapError(DomainError.newCause(`Failed to write docs index for "${pkg.name}"`)));
+        );
+      const fileCount = yield* copyDocsTree(sourceDir, destinationDir, pkg.name, sourceDir, canonicalSourceDir);
+      yield* fs
+        .writeFileString(
+          path.join(destinationDir, "index.md"),
+          generateDocsIndexContent(pkg.name, pkg.docsOutputPath, index + 2)
+        )
+        .pipe(Effect.mapError(DomainError.newCause(`Failed to write docs index for "${pkg.name}"`)));
 
-        return new DocgenAggregateResult({
-          packageName: pkg.name,
-          packagePath: pkg.relativePath,
-          docsOutputPath: pkg.docsOutputPath,
-          fileCount,
-        });
-      }),
-      { concurrency: "unbounded" }
-    );
-  });
+      return new DocgenAggregateResult({
+        packageName: pkg.name,
+        packagePath: pkg.relativePath,
+        docsOutputPath: pkg.docsOutputPath,
+        fileCount,
+      });
+    }),
+    { concurrency: "unbounded" }
+  );
+});
 
 /**
  * Run the repo-local `@beep/repo-docgen` implementation for a single workspace package.
@@ -1630,7 +1630,8 @@ export const runDocgenForPackage: (
   DocgenGenerationResult,
   DocgenGenerationResult,
   FileSystem.FileSystem | Path.Path | ChildProcessSpawner
-> = Effect.fn("DocgenOperations.runDocgenForPackage")(function* (targetPackage) {
+> = Effect.fn("DocgenOperations.runDocgenForPackage")(
+  function* (targetPackage) {
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
     const repoRoot = yield* findRepoRoot(targetPackage.absolutePath);
@@ -1642,7 +1643,7 @@ export const runDocgenForPackage: (
       stderr: "pipe",
     });
     const result = yield* Effect.scoped(
-      Effect.fnUntraced(function* () {
+      Effect.gen(function* () {
         const handle = yield* command;
         const output = yield* handle.all.pipe(
           Stream.decodeText(),
@@ -1653,11 +1654,16 @@ export const runDocgenForPackage: (
           output: Str.trim(output),
           exitCode,
         };
-      })()
+      })
     ).pipe(
-      Effect.mapError((cause) => ({
-          output: pipe(cause, stringFromUnknown, Str.trim),
-          exitCode: 1,
+      Effect.result,
+      Effect.map(
+        Result.match({
+          onFailure: (cause) => ({
+            output: pipe(cause, stringFromUnknown, Str.trim),
+            exitCode: 1,
+          }),
+          onSuccess: (value) => value,
         })
       )
     );
@@ -1694,14 +1700,21 @@ export const runDocgenForPackage: (
       ...(result.output.length === 0 ? {} : { output: result.output }),
     });
   },
-  Effect.mapError(
-    (cause) =>
-      new DocgenGenerationResult({
-        packageName: targetPackage.name,
-        packagePath: targetPackage.relativePath,
-        success: false,
-        error: "docgen execution failed before completion",
-        output: pipe(cause, stringFromUnknown, Str.trim),
-      })
-  )
+  (effect, targetPackage) =>
+    effect.pipe(
+      Effect.result,
+      Effect.map(
+        Result.match({
+          onFailure: (cause) =>
+            new DocgenGenerationResult({
+              packageName: targetPackage.name,
+              packagePath: targetPackage.relativePath,
+              success: false,
+              error: "docgen execution failed before completion",
+              output: pipe(cause, stringFromUnknown, Str.trim),
+            }),
+          onSuccess: (result) => result,
+        })
+      )
+    )
 );

--- a/packages/tooling/tool/cli/src/commands/Docgen/internal/Operations.ts
+++ b/packages/tooling/tool/cli/src/commands/Docgen/internal/Operations.ts
@@ -1026,14 +1026,15 @@ const expectedCanonicalDocgenPath = (
     : path.join(canonicalSourceRoot, ...Str.split("/")(relativeFromSourceRoot));
 };
 
-const copyDocsTree = (
+const copyDocsTree: (
   sourceDir: string,
   destinationDir: string,
   packageName: string,
   sourceRoot: string,
   canonicalSourceRoot: string
-): Effect.Effect<number, DomainError, FileSystem.FileSystem | Path.Path> =>
-  Effect.gen(function* () {
+) => Effect.Effect<number, DomainError, FileSystem.FileSystem | Path.Path> = Effect.fn(
+  "DocgenOperations.copyDocsTree"
+)(function* (sourceDir, destinationDir, packageName, sourceRoot, canonicalSourceRoot) {
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
 
@@ -1114,7 +1115,7 @@ const copyDocsTree = (
     }
 
     return copiedFiles;
-  });
+});
 
 /**
  * Normalize a workspace-relative package path to the current root docs output layout.
@@ -1218,22 +1219,21 @@ export const discoverDocgenWorkspacePackages: (
   const workspaceDirs = yield* resolveWorkspaceDirs(repoRoot);
   const packages = yield* Effect.forEach(
     HashMap.toEntries(workspaceDirs),
-    ([name, absolutePath]) =>
-      Effect.gen(function* () {
-        const relativePath = normalizeSlashes(path.relative(repoRoot, absolutePath));
-        const hasDocgenConfig = yield* packageHasDocgenConfig(absolutePath);
-        const hasGeneratedDocs = yield* packageHasGeneratedDocs(absolutePath);
+    Effect.fnUntraced(function* ([name, absolutePath]) {
+      const relativePath = normalizeSlashes(path.relative(repoRoot, absolutePath));
+      const hasDocgenConfig = yield* packageHasDocgenConfig(absolutePath);
+      const hasGeneratedDocs = yield* packageHasGeneratedDocs(absolutePath);
 
-        return new DocgenWorkspacePackage({
-          name,
-          relativePath,
-          absolutePath,
-          docsOutputPath: normalizeDocsOutputPath(relativePath),
-          hasDocgenConfig,
-          hasGeneratedDocs,
-          status: computePackageStatus(hasDocgenConfig, hasGeneratedDocs),
-        });
-      }),
+      return new DocgenWorkspacePackage({
+        name,
+        relativePath,
+        absolutePath,
+        docsOutputPath: normalizeDocsOutputPath(relativePath),
+        hasDocgenConfig,
+        hasGeneratedDocs,
+        status: computePackageStatus(hasDocgenConfig, hasGeneratedDocs),
+      });
+    }),
     { concurrency: "unbounded" }
   );
 
@@ -1473,15 +1473,17 @@ export const generateAnalysisJson = (analysis: DocgenPackageAnalysis): string =>
  * @category models
  * @since 0.0.0
  */
-export const aggregateGeneratedDocs = (options?: {
+export const aggregateGeneratedDocs: (options?: {
   readonly clean?: boolean | undefined;
   readonly package?: string | undefined;
-}): Effect.Effect<
+}) => Effect.Effect<
   ReadonlyArray<DocgenAggregateResult>,
   DomainError | NoSuchFileError,
   FileSystem.FileSystem | Path.Path | FsUtils
-> =>
-  Effect.gen(function* () {
+> = Effect.fn("DocgenOperations.aggregateGeneratedDocs")(function* (options?: {
+  readonly clean?: boolean | undefined;
+  readonly package?: string | undefined;
+}) {
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
     const repoRoot = yield* findRepoRoot();
@@ -1556,61 +1558,60 @@ export const aggregateGeneratedDocs = (options?: {
     const sortedPackages = A.sort(packages, byDocsOutputPathAscending);
     return yield* Effect.forEach(
       sortedPackages,
-      (pkg, index) =>
-        Effect.gen(function* () {
-          const sourceDir = path.join(pkg.absolutePath, ...DOCS_MODULES_SEGMENTS);
-          const destinationDir = path.join(docsRoot, pkg.docsOutputPath);
-          const hasDocs = yield* fs.exists(sourceDir).pipe(Effect.orElseSucceed(thunkFalse));
+      Effect.fnUntraced(function* (pkg, index) {
+        const sourceDir = path.join(pkg.absolutePath, ...DOCS_MODULES_SEGMENTS);
+        const destinationDir = path.join(docsRoot, pkg.docsOutputPath);
+        const hasDocs = yield* fs.exists(sourceDir).pipe(Effect.orElseSucceed(thunkFalse));
 
-          if (!hasDocs) {
-            return yield* new DomainError({
-              message: `Package "${pkg.name}" does not have generated docs. Run "bun run beep docgen generate -p ${pkg.relativePath}" first.`,
-            });
-          }
-
-          const canonicalPackageDir = yield* fs
-            .realPath(pkg.absolutePath)
-            .pipe(Effect.mapError(DomainError.newCause(`Failed to resolve "${pkg.absolutePath}"`)));
-          const canonicalSourceDir = yield* fs
-            .realPath(sourceDir)
-            .pipe(Effect.mapError(DomainError.newCause(`Failed to resolve "${sourceDir}"`)));
-          const expectedCanonicalSourceDir = path.join(canonicalPackageDir, ...DOCS_MODULES_SEGMENTS);
-
-          if (canonicalSourceDir !== expectedCanonicalSourceDir) {
-            return yield* new DomainError({
-              message: `Refusing to aggregate docs for package "${pkg.name}" because "${sourceDir}" resolves outside the package docs/modules tree.`,
-            });
-          }
-
-          yield* fs
-            .remove(destinationDir, {
-              recursive: true,
-              force: true,
-            })
-            .pipe(
-              Effect.mapError(
-                (cause) =>
-                  new DomainError({
-                    message: `Failed to reset "${destinationDir}"`,
-                    cause,
-                  })
-              )
-            );
-          const fileCount = yield* copyDocsTree(sourceDir, destinationDir, pkg.name, sourceDir, canonicalSourceDir);
-          yield* fs
-            .writeFileString(
-              path.join(destinationDir, "index.md"),
-              generateDocsIndexContent(pkg.name, pkg.docsOutputPath, index + 2)
-            )
-            .pipe(Effect.mapError(DomainError.newCause(`Failed to write docs index for "${pkg.name}"`)));
-
-          return new DocgenAggregateResult({
-            packageName: pkg.name,
-            packagePath: pkg.relativePath,
-            docsOutputPath: pkg.docsOutputPath,
-            fileCount,
+        if (!hasDocs) {
+          return yield* new DomainError({
+            message: `Package "${pkg.name}" does not have generated docs. Run "bun run beep docgen generate -p ${pkg.relativePath}" first.`,
           });
-        }),
+        }
+
+        const canonicalPackageDir = yield* fs
+          .realPath(pkg.absolutePath)
+          .pipe(Effect.mapError(DomainError.newCause(`Failed to resolve "${pkg.absolutePath}"`)));
+        const canonicalSourceDir = yield* fs
+          .realPath(sourceDir)
+          .pipe(Effect.mapError(DomainError.newCause(`Failed to resolve "${sourceDir}"`)));
+        const expectedCanonicalSourceDir = path.join(canonicalPackageDir, ...DOCS_MODULES_SEGMENTS);
+
+        if (canonicalSourceDir !== expectedCanonicalSourceDir) {
+          return yield* new DomainError({
+            message: `Refusing to aggregate docs for package "${pkg.name}" because "${sourceDir}" resolves outside the package docs/modules tree.`,
+          });
+        }
+
+        yield* fs
+          .remove(destinationDir, {
+            recursive: true,
+            force: true,
+          })
+          .pipe(
+            Effect.mapError(
+              (cause) =>
+                new DomainError({
+                  message: `Failed to reset "${destinationDir}"`,
+                  cause,
+                })
+            )
+          );
+        const fileCount = yield* copyDocsTree(sourceDir, destinationDir, pkg.name, sourceDir, canonicalSourceDir);
+        yield* fs
+          .writeFileString(
+            path.join(destinationDir, "index.md"),
+            generateDocsIndexContent(pkg.name, pkg.docsOutputPath, index + 2)
+          )
+          .pipe(Effect.mapError(DomainError.newCause(`Failed to write docs index for "${pkg.name}"`)));
+
+        return new DocgenAggregateResult({
+          packageName: pkg.name,
+          packagePath: pkg.relativePath,
+          docsOutputPath: pkg.docsOutputPath,
+          fileCount,
+        });
+      }),
       { concurrency: "unbounded" }
     );
   });
@@ -1625,10 +1626,11 @@ export const aggregateGeneratedDocs = (options?: {
  */
 export const runDocgenForPackage: (
   targetPackage: DocgenWorkspacePackage
-) => Effect.Effect<DocgenGenerationResult, never, FileSystem.FileSystem | Path.Path | ChildProcessSpawner> = (
-  targetPackage
-) => {
-  return Effect.gen(function* () {
+) => Effect.Effect<
+  DocgenGenerationResult,
+  DocgenGenerationResult,
+  FileSystem.FileSystem | Path.Path | ChildProcessSpawner
+> = Effect.fn("DocgenOperations.runDocgenForPackage")(function* (targetPackage) {
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
     const repoRoot = yield* findRepoRoot(targetPackage.absolutePath);
@@ -1640,7 +1642,7 @@ export const runDocgenForPackage: (
       stderr: "pipe",
     });
     const result = yield* Effect.scoped(
-      Effect.gen(function* () {
+      Effect.fnUntraced(function* () {
         const handle = yield* command;
         const output = yield* handle.all.pipe(
           Stream.decodeText(),
@@ -1651,10 +1653,9 @@ export const runDocgenForPackage: (
           output: Str.trim(output),
           exitCode,
         };
-      })
+      })()
     ).pipe(
-      Effect.catch((cause) =>
-        Effect.succeed({
+      Effect.mapError((cause) => ({
           output: pipe(cause, stringFromUnknown, Str.trim),
           exitCode: 1,
         })
@@ -1692,17 +1693,15 @@ export const runDocgenForPackage: (
       moduleCount,
       ...(result.output.length === 0 ? {} : { output: result.output }),
     });
-  }).pipe(
-    Effect.catch((cause) =>
-      Effect.succeed(
-        new DocgenGenerationResult({
-          packageName: targetPackage.name,
-          packagePath: targetPackage.relativePath,
-          success: false,
-          error: "docgen execution failed before completion",
-          output: pipe(cause, stringFromUnknown, Str.trim),
-        })
-      )
-    )
-  );
-};
+  },
+  Effect.mapError(
+    (cause) =>
+      new DocgenGenerationResult({
+        packageName: targetPackage.name,
+        packagePath: targetPackage.relativePath,
+        success: false,
+        error: "docgen execution failed before completion",
+        output: pipe(cause, stringFromUnknown, Str.trim),
+      })
+  )
+);

--- a/packages/tooling/tool/cli/src/commands/Docgen/internal/Quality.ts
+++ b/packages/tooling/tool/cli/src/commands/Docgen/internal/Quality.ts
@@ -15,7 +15,7 @@ import { DomainError, findRepoRoot } from "@beep/repo-utils";
 import { ContentHashFromSourceText } from "@beep/repo-utils/TSMorph/index";
 import { LiteralKit } from "@beep/schema";
 import { thunkEmptyStr } from "@beep/utils";
-import { DateTime, Duration, Effect, FileSystem, flow, Match, Order, Path, pipe, Stream } from "effect";
+import { DateTime, Duration, Effect, FileSystem, flow, Match, Order, Path, pipe, Result, Stream } from "effect";
 import * as A from "effect/Array";
 import * as O from "effect/Option";
 import * as P from "effect/Predicate";
@@ -464,7 +464,7 @@ const runGitLines = Effect.fn("DocgenQuality.runGitLines")(function* (repoRoot: 
     stdout: "pipe",
   });
   const output = yield* Effect.scoped(
-    Effect.fnUntraced(function* () {
+    Effect.gen(function* () {
       const handle = yield* process;
       const text = yield* handle.stdout.pipe(
         Stream.decodeText(),
@@ -476,7 +476,7 @@ const runGitLines = Effect.fn("DocgenQuality.runGitLines")(function* (repoRoot: 
         return yield* new DomainError({ message: `git ${A.join(args, " ")} failed with exit code ${exitCode}.` });
       }
       return text;
-    })()
+    })
   );
   return pipe(output.split(/\r?\n/), A.map(Str.trim), A.filter(Str.isNonEmpty));
 });
@@ -486,7 +486,7 @@ const collectWorkingTreeChangedFiles = Effect.fn("DocgenQuality.collectWorkingTr
 ) {
   const files = yield* Effect.forEach(
     WORKING_TREE_CHANGED_FILE_COMMANDS,
-    (args) => runGitLines(repoRoot, args).pipe(Effect.mapError(() => A.empty<string>())),
+    (args) => runGitLines(repoRoot, args).pipe(Effect.option, Effect.map(O.getOrElse(A.empty<string>))),
     { concurrency: "unbounded" }
   );
   return pipe(A.flatten(files), A.map(normalizeSlashes), A.dedupe);
@@ -1699,7 +1699,7 @@ export const analyzePackageQuality = Effect.fn("DocgenQuality.analyzePackageQual
   }
 ) {
   const budget = makeRuntimeBudget(options?.packageTimeout ?? DEFAULT_PACKAGE_TIMEOUT);
-  return yield* Effect.fnUntraced(function* () {
+  return yield* Effect.gen(function* () {
     const candidateResult = yield* collectPackageSubjectCandidates(target, budget);
     const finalizedSubjects = yield* Effect.forEach(candidateResult.candidates, finalizeSubject);
     const subjects = yield* withGeneratedDocSnippets(
@@ -1719,14 +1719,19 @@ export const analyzePackageQuality = Effect.fn("DocgenQuality.analyzePackageQual
       status,
       timedOut,
     });
-  })().pipe(
-    Effect.mapError((error) =>
-      emptyPackageReport({
-        durationMs: budgetDurationMs(budget),
-        error: errorMessage(error),
-        status: "failed",
-        target,
-        timedOut: false,
+  }).pipe(
+    Effect.result,
+    Effect.map(
+      Result.match({
+        onFailure: (error) =>
+          emptyPackageReport({
+            durationMs: budgetDurationMs(budget),
+            error: errorMessage(error),
+            status: "failed",
+            target,
+            timedOut: false,
+          }),
+        onSuccess: (report) => report,
       })
     )
   );

--- a/packages/tooling/tool/cli/src/commands/Docgen/internal/Quality.ts
+++ b/packages/tooling/tool/cli/src/commands/Docgen/internal/Quality.ts
@@ -464,7 +464,7 @@ const runGitLines = Effect.fn("DocgenQuality.runGitLines")(function* (repoRoot: 
     stdout: "pipe",
   });
   const output = yield* Effect.scoped(
-    Effect.gen(function* () {
+    Effect.fnUntraced(function* () {
       const handle = yield* process;
       const text = yield* handle.stdout.pipe(
         Stream.decodeText(),
@@ -476,7 +476,7 @@ const runGitLines = Effect.fn("DocgenQuality.runGitLines")(function* (repoRoot: 
         return yield* new DomainError({ message: `git ${A.join(args, " ")} failed with exit code ${exitCode}.` });
       }
       return text;
-    })
+    })()
   );
   return pipe(output.split(/\r?\n/), A.map(Str.trim), A.filter(Str.isNonEmpty));
 });
@@ -486,7 +486,7 @@ const collectWorkingTreeChangedFiles = Effect.fn("DocgenQuality.collectWorkingTr
 ) {
   const files = yield* Effect.forEach(
     WORKING_TREE_CHANGED_FILE_COMMANDS,
-    (args) => runGitLines(repoRoot, args).pipe(Effect.catch(() => Effect.succeed(A.empty<string>()))),
+    (args) => runGitLines(repoRoot, args).pipe(Effect.mapError(() => A.empty<string>())),
     { concurrency: "unbounded" }
   );
   return pipe(A.flatten(files), A.map(normalizeSlashes), A.dedupe);
@@ -1699,7 +1699,7 @@ export const analyzePackageQuality = Effect.fn("DocgenQuality.analyzePackageQual
   }
 ) {
   const budget = makeRuntimeBudget(options?.packageTimeout ?? DEFAULT_PACKAGE_TIMEOUT);
-  return yield* Effect.gen(function* () {
+  return yield* Effect.fnUntraced(function* () {
     const candidateResult = yield* collectPackageSubjectCandidates(target, budget);
     const finalizedSubjects = yield* Effect.forEach(candidateResult.candidates, finalizeSubject);
     const subjects = yield* withGeneratedDocSnippets(
@@ -1719,17 +1719,15 @@ export const analyzePackageQuality = Effect.fn("DocgenQuality.analyzePackageQual
       status,
       timedOut,
     });
-  }).pipe(
-    Effect.catch((error) =>
-      Effect.succeed(
-        emptyPackageReport({
-          durationMs: budgetDurationMs(budget),
-          error: errorMessage(error),
-          status: "failed",
-          target,
-          timedOut: false,
-        })
-      )
+  })().pipe(
+    Effect.mapError((error) =>
+      emptyPackageReport({
+        durationMs: budgetDurationMs(budget),
+        error: errorMessage(error),
+        status: "failed",
+        target,
+        timedOut: false,
+      })
     )
   );
 });

--- a/packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts
+++ b/packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts
@@ -797,8 +797,8 @@ const resolveCodexSdkVersion = Effect.fn("DocgenQualityWorkerEval.resolveCodexSd
   return metadata.version;
 });
 
-const resolveCodexSdkVersionOrUnknown: Effect.Effect<string, string, FileSystem.FileSystem | Path.Path> =
-  resolveCodexSdkVersion().pipe(Effect.mapError(() => "unknown"));
+const resolveCodexSdkVersionOrUnknown: Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =
+  resolveCodexSdkVersion().pipe(Effect.option, Effect.map(O.getOrElse(() => "unknown")));
 
 type CodexSdkModule = typeof import("@openai/codex-sdk");
 

--- a/packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts
+++ b/packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts
@@ -797,8 +797,8 @@ const resolveCodexSdkVersion = Effect.fn("DocgenQualityWorkerEval.resolveCodexSd
   return metadata.version;
 });
 
-const resolveCodexSdkVersionOrUnknown: Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> =
-  resolveCodexSdkVersion().pipe(Effect.catch(() => Effect.succeed("unknown")));
+const resolveCodexSdkVersionOrUnknown: Effect.Effect<string, string, FileSystem.FileSystem | Path.Path> =
+  resolveCodexSdkVersion().pipe(Effect.mapError(() => "unknown"));
 
 type CodexSdkModule = typeof import("@openai/codex-sdk");
 

--- a/packages/tooling/tool/cli/src/commands/Docs.ts
+++ b/packages/tooling/tool/cli/src/commands/Docs.ts
@@ -104,9 +104,11 @@ const DocsSections: ReadonlyArray<DocsSection> = [
     summary: "Effect-first quality law summary and validation entry points.",
     lines: [
       "Use Effect-first APIs and aliases defined by repository law.",
+      "Reusable functions that directly return Effect.gen must use Effect.fn or Effect.fnUntraced.",
       "Reject unsafe typing escapes and untyped runtime errors.",
       "Keep domain logic free of native mutable runtime containers.",
       "Finish only when check, lint, test, and docgen pass.",
+      "Run: bun run beep laws effect-fn --check",
       "Run: bun run check",
       "Run: bun run lint",
       "Run: bun run test",

--- a/packages/tooling/tool/cli/src/commands/Docs.ts
+++ b/packages/tooling/tool/cli/src/commands/Docs.ts
@@ -217,13 +217,12 @@ const docsFindCommand = Command.make(
       onNonEmpty: Effect.fn(function* (sections) {
         yield* Effect.forEach(
           sections,
-          (section, index) =>
-            Effect.gen(function* () {
-              if (index > 0) {
-                yield* Console.log("");
-              }
-              yield* printSection(section);
-            }),
+          Effect.fnUntraced(function* (section, index) {
+            if (index > 0) {
+              yield* Console.log("");
+            }
+            yield* printSection(section);
+          }),
           { discard: true }
         );
       }),

--- a/packages/tooling/tool/cli/src/commands/Files/Files.progress.ts
+++ b/packages/tooling/tool/cli/src/commands/Files/Files.progress.ts
@@ -112,61 +112,58 @@ export const runFilesProgressAll: {
   ): Effect.Effect<ReadonlyArray<A2>, E, R | Terminal.Terminal>;
 } = dual(
   2,
-  <A2, E, R>(
+  Effect.fnUntraced(function* <A2, E, R>(
     effects: ReadonlyArray<Effect.Effect<A2, E, R>>,
     options: FilesProgressRunOptions
-  ): Effect.Effect<ReadonlyArray<A2>, E, R | Terminal.Terminal> => {
+  ): Effect.fn.Return<ReadonlyArray<A2>, E, R | Terminal.Terminal> {
     const total = A.length(effects);
     const concurrency = progressConcurrency(total, options.concurrency);
 
     if (!isFilesProgressEnabled(options.enabled) || total === 0) {
-      return Effect.all(effects, { concurrency });
+      return yield* Effect.all(effects, { concurrency });
     }
 
-    return Effect.fnUntraced(function* () {
-      const terminal = yield* Terminal.Terminal;
-      const completedRef = yield* Ref.make(0);
-      const finishedRef = yield* Ref.make(false);
-      const renderAt = (completed: number, newline: boolean) =>
-        terminal
-          .display(
-            `${clearCurrentLine}${renderFilesProgressBar({
-              completed,
-              label: options.label,
-              total,
-            })}${newline ? "\n" : ""}`
-          )
-          .pipe(Effect.ignore);
-      const renderLock = yield* Semaphore.make(1);
-      const renderLocked = (completed: number, newline: boolean) => renderLock.withPermit(renderAt(completed, newline));
-      const trackedEffects = A.map(effects, (effect) =>
-        effect.pipe(
-          Effect.tap(() =>
-            Ref.updateAndGet(completedRef, (value) => Math.min(total, value + 1)).pipe(
-              Effect.flatMap((completed) => renderLocked(completed, false))
-            )
-          )
+    const terminal = yield* Terminal.Terminal;
+    const completedRef = yield* Ref.make(0);
+    const finishedRef = yield* Ref.make(false);
+    const renderAt = (completed: number, newline: boolean) =>
+      terminal
+        .display(
+          `${clearCurrentLine}${renderFilesProgressBar({
+            completed,
+            label: options.label,
+            total,
+          })}${newline ? "\n" : ""}`
         )
-      );
-
-      yield* renderLocked(0, false);
-      return yield* Effect.all(trackedEffects, { concurrency }).pipe(
+        .pipe(Effect.ignore);
+    const renderLock = yield* Semaphore.make(1);
+    const renderLocked = (completed: number, newline: boolean) => renderLock.withPermit(renderAt(completed, newline));
+    const trackedEffects = A.map(effects, (effect) =>
+      effect.pipe(
         Effect.tap(() =>
-          Effect.fnUntraced(function* () {
-            yield* Ref.set(finishedRef, true);
-            yield* renderLocked(total, true);
-          })()
-        ),
-        Effect.ensuring(
-          Ref.get(finishedRef).pipe(
-            Effect.flatMap((finished) => (finished ? Effect.void : terminal.display("\n").pipe(Effect.ignore)))
+          Ref.updateAndGet(completedRef, (value) => Math.min(total, value + 1)).pipe(
+            Effect.flatMap((completed) => renderLocked(completed, false))
           )
         )
-      );
-    })();
-  }
-);
+      )
+    );
 
+    yield* renderLocked(0, false);
+    return yield* Effect.all(trackedEffects, { concurrency }).pipe(
+      Effect.tap(
+        Effect.fnUntraced(function* () {
+          yield* Ref.set(finishedRef, true);
+          yield* renderLocked(total, true);
+        })
+      ),
+      Effect.ensuring(
+        Ref.get(finishedRef).pipe(
+          Effect.flatMap((finished) => (finished ? Effect.void : terminal.display("\n").pipe(Effect.ignore)))
+        )
+      )
+    );
+  })
+);
 /**
  * Map items to effects, then run them with bounded concurrency and optional TTY progress.
  *

--- a/packages/tooling/tool/cli/src/commands/Files/Files.progress.ts
+++ b/packages/tooling/tool/cli/src/commands/Files/Files.progress.ts
@@ -123,7 +123,7 @@ export const runFilesProgressAll: {
       return Effect.all(effects, { concurrency });
     }
 
-    return Effect.gen(function* () {
+    return Effect.fnUntraced(function* () {
       const terminal = yield* Terminal.Terminal;
       const completedRef = yield* Ref.make(0);
       const finishedRef = yield* Ref.make(false);
@@ -152,10 +152,10 @@ export const runFilesProgressAll: {
       yield* renderLocked(0, false);
       return yield* Effect.all(trackedEffects, { concurrency }).pipe(
         Effect.tap(() =>
-          Effect.gen(function* () {
+          Effect.fnUntraced(function* () {
             yield* Ref.set(finishedRef, true);
             yield* renderLocked(total, true);
-          })
+          })()
         ),
         Effect.ensuring(
           Ref.get(finishedRef).pipe(
@@ -163,7 +163,7 @@ export const runFilesProgressAll: {
           )
         )
       );
-    });
+    })();
   }
 );
 

--- a/packages/tooling/tool/cli/src/commands/Files/Files.service.ts
+++ b/packages/tooling/tool/cli/src/commands/Files/Files.service.ts
@@ -1099,124 +1099,153 @@ const buildCreateCaptionFilesPlan = Effect.fn("Files.buildCreateCaptionFilesPlan
   yield* runFilesProgressForEach(
     sourceNames,
     Effect.fnUntraced(function* (sourceName) {
-        const sourcePath = path.join(directory, sourceName);
-        const canonicalPath = yield* fs.realPath(sourcePath).pipe(Effect.option);
+      const sourcePath = path.join(directory, sourceName);
+      const canonicalPath = yield* fs.realPath(sourcePath).pipe(Effect.option);
 
-        if (O.isNone(canonicalPath)) {
-          skipped = A.append(
-            skipped,
-            makeCreateCaptionFilesSkippedEntry(
-              sourceName,
-              sourcePath,
-              O.none<string>(),
-              O.none<string>(),
-              "symlink",
-              "Could not resolve source entry."
-            )
+      if (O.isNone(canonicalPath)) {
+        skipped = A.append(
+          skipped,
+          makeCreateCaptionFilesSkippedEntry(
+            sourceName,
+            sourcePath,
+            O.none<string>(),
+            O.none<string>(),
+            "symlink",
+            "Could not resolve source entry."
+          )
+        );
+        return;
+      }
+
+      if (!stringEquivalence(canonicalPath.value, path.join(canonicalDir, sourceName))) {
+        skipped = A.append(
+          skipped,
+          makeCreateCaptionFilesSkippedEntry(
+            sourceName,
+            sourcePath,
+            O.none<string>(),
+            O.none<string>(),
+            "symlink",
+            "Symlink entries are not captioned."
+          )
+        );
+        return;
+      }
+
+      const stat = yield* fs
+        .stat(sourcePath)
+        .pipe(Effect.mapError((cause) => formatPlatformError("Failed to stat source entry", sourcePath, { cause })));
+
+      if (stat.type === "Directory") {
+        skipped = A.append(
+          skipped,
+          makeCreateCaptionFilesSkippedEntry(
+            sourceName,
+            sourcePath,
+            O.none<string>(),
+            O.none<string>(),
+            "directory",
+            "Directories are not captioned."
+          )
+        );
+        return;
+      }
+
+      if (stat.type !== "File") {
+        skipped = A.append(
+          skipped,
+          makeCreateCaptionFilesSkippedEntry(
+            sourceName,
+            sourcePath,
+            O.none<string>(),
+            O.none<string>(),
+            "non-media",
+            "Only regular image files receive caption sidecars."
+          )
+        );
+        return;
+      }
+
+      const extension = path.extname(sourceName);
+      if (stringEquivalence(extension, "") || stringEquivalence(extension, ".")) {
+        skipped = A.append(
+          skipped,
+          makeCreateCaptionFilesSkippedEntry(
+            sourceName,
+            sourcePath,
+            O.none<string>(),
+            O.none<string>(),
+            "extensionless",
+            "Extensionless files are not captioned."
+          )
+        );
+        return;
+      }
+
+      const mediaKind = mediaKindFromExtension(extension);
+      if (O.isNone(mediaKind)) {
+        skipped = A.append(
+          skipped,
+          makeCreateCaptionFilesSkippedEntry(
+            sourceName,
+            sourcePath,
+            O.some(extension),
+            O.none<string>(),
+            "non-media",
+            "Only recognized image files receive caption sidecars."
+          )
+        );
+        return;
+      }
+
+      if (mediaKind.value === "video") {
+        skipped = A.append(
+          skipped,
+          makeCreateCaptionFilesSkippedEntry(
+            sourceName,
+            sourcePath,
+            O.some(extension),
+            O.none<string>(),
+            "video",
+            "Video caption sidecars are out of scope for this operation."
+          )
+        );
+        return;
+      }
+
+      const captionName = `${path.basename(sourceName, extension)}.txt`;
+      const captionPath = path.join(directory, captionName);
+
+      if (HashSet.has(plannedCaptionNames, captionName)) {
+        skipped = A.append(
+          skipped,
+          makeCreateCaptionFilesSkippedEntry(
+            sourceName,
+            sourcePath,
+            O.some(extension),
+            O.some(captionName),
+            "caption-target-collision",
+            `Another image in this run already targets "${captionName}".`
+          )
+        );
+        return;
+      }
+
+      const captionExists = yield* fs
+        .exists(captionPath)
+        .pipe(
+          Effect.mapError((cause) => formatPlatformError("Failed to inspect caption target", captionPath, { cause }))
+        );
+      let overwritesExisting = false;
+
+      if (captionExists) {
+        const captionStat = yield* fs
+          .stat(captionPath)
+          .pipe(
+            Effect.mapError((cause) => formatPlatformError("Failed to stat caption target", captionPath, { cause }))
           );
-          return;
-        }
 
-        if (!stringEquivalence(canonicalPath.value, path.join(canonicalDir, sourceName))) {
-          skipped = A.append(
-            skipped,
-            makeCreateCaptionFilesSkippedEntry(
-              sourceName,
-              sourcePath,
-              O.none<string>(),
-              O.none<string>(),
-              "symlink",
-              "Symlink entries are not captioned."
-            )
-          );
-          return;
-        }
-
-        const stat = yield* fs
-          .stat(sourcePath)
-          .pipe(Effect.mapError((cause) => formatPlatformError("Failed to stat source entry", sourcePath, { cause })));
-
-        if (stat.type === "Directory") {
-          skipped = A.append(
-            skipped,
-            makeCreateCaptionFilesSkippedEntry(
-              sourceName,
-              sourcePath,
-              O.none<string>(),
-              O.none<string>(),
-              "directory",
-              "Directories are not captioned."
-            )
-          );
-          return;
-        }
-
-        if (stat.type !== "File") {
-          skipped = A.append(
-            skipped,
-            makeCreateCaptionFilesSkippedEntry(
-              sourceName,
-              sourcePath,
-              O.none<string>(),
-              O.none<string>(),
-              "non-media",
-              "Only regular image files receive caption sidecars."
-            )
-          );
-          return;
-        }
-
-        const extension = path.extname(sourceName);
-        if (stringEquivalence(extension, "") || stringEquivalence(extension, ".")) {
-          skipped = A.append(
-            skipped,
-            makeCreateCaptionFilesSkippedEntry(
-              sourceName,
-              sourcePath,
-              O.none<string>(),
-              O.none<string>(),
-              "extensionless",
-              "Extensionless files are not captioned."
-            )
-          );
-          return;
-        }
-
-        const mediaKind = mediaKindFromExtension(extension);
-        if (O.isNone(mediaKind)) {
-          skipped = A.append(
-            skipped,
-            makeCreateCaptionFilesSkippedEntry(
-              sourceName,
-              sourcePath,
-              O.some(extension),
-              O.none<string>(),
-              "non-media",
-              "Only recognized image files receive caption sidecars."
-            )
-          );
-          return;
-        }
-
-        if (mediaKind.value === "video") {
-          skipped = A.append(
-            skipped,
-            makeCreateCaptionFilesSkippedEntry(
-              sourceName,
-              sourcePath,
-              O.some(extension),
-              O.none<string>(),
-              "video",
-              "Video caption sidecars are out of scope for this operation."
-            )
-          );
-          return;
-        }
-
-        const captionName = `${path.basename(sourceName, extension)}.txt`;
-        const captionPath = path.join(directory, captionName);
-
-        if (HashSet.has(plannedCaptionNames, captionName)) {
+        if (captionStat.type !== "File") {
           skipped = A.append(
             skipped,
             makeCreateCaptionFilesSkippedEntry(
@@ -1224,74 +1253,45 @@ const buildCreateCaptionFilesPlan = Effect.fn("Files.buildCreateCaptionFilesPlan
               sourcePath,
               O.some(extension),
               O.some(captionName),
-              "caption-target-collision",
-              `Another image in this run already targets "${captionName}".`
+              "caption-target-not-file",
+              `Caption target "${captionName}" already exists and is not a file.`
             )
           );
           return;
         }
 
-        const captionExists = yield* fs
-          .exists(captionPath)
-          .pipe(
-            Effect.mapError((cause) => formatPlatformError("Failed to inspect caption target", captionPath, { cause }))
+        if (!options.overwrite) {
+          skipped = A.append(
+            skipped,
+            makeCreateCaptionFilesSkippedEntry(
+              sourceName,
+              sourcePath,
+              O.some(extension),
+              O.some(captionName),
+              "caption-exists",
+              `Caption target "${captionName}" already exists.`
+            )
           );
-        let overwritesExisting = false;
-
-        if (captionExists) {
-          const captionStat = yield* fs
-            .stat(captionPath)
-            .pipe(
-              Effect.mapError((cause) => formatPlatformError("Failed to stat caption target", captionPath, { cause }))
-            );
-
-          if (captionStat.type !== "File") {
-            skipped = A.append(
-              skipped,
-              makeCreateCaptionFilesSkippedEntry(
-                sourceName,
-                sourcePath,
-                O.some(extension),
-                O.some(captionName),
-                "caption-target-not-file",
-                `Caption target "${captionName}" already exists and is not a file.`
-              )
-            );
-            return;
-          }
-
-          if (!options.overwrite) {
-            skipped = A.append(
-              skipped,
-              makeCreateCaptionFilesSkippedEntry(
-                sourceName,
-                sourcePath,
-                O.some(extension),
-                O.some(captionName),
-                "caption-exists",
-                `Caption target "${captionName}" already exists.`
-              )
-            );
-            return;
-          }
-
-          overwritesExisting = true;
+          return;
         }
 
-        plannedCaptionNames = HashSet.add(plannedCaptionNames, captionName);
-        entries = A.append(
-          entries,
-          new CreateCaptionFilesPlanEntry({
-            captionName,
-            captionPath,
-            captionRelativePath: path.relative(directory, captionPath),
-            extension,
-            overwritesExisting,
-            sourceName,
-            sourcePath,
-            sourceRelativePath: path.relative(directory, sourcePath),
-          })
-        );
+        overwritesExisting = true;
+      }
+
+      plannedCaptionNames = HashSet.add(plannedCaptionNames, captionName);
+      entries = A.append(
+        entries,
+        new CreateCaptionFilesPlanEntry({
+          captionName,
+          captionPath,
+          captionRelativePath: path.relative(directory, captionPath),
+          extension,
+          overwritesExisting,
+          sourceName,
+          sourcePath,
+          sourceRelativePath: path.relative(directory, sourcePath),
+        })
+      );
     }),
     {
       concurrency: 1,
@@ -1753,14 +1753,14 @@ const runFfprobe = Effect.fn("Files.runFfprobe")(function* (
     }
   );
   const result = yield* Effect.scoped(
-    Effect.fnUntraced(function* () {
+    Effect.gen(function* () {
       const handle = yield* command;
       const [stdout, stderr, exitCode] = yield* Effect.all(
         [collectText(handle.stdout), collectText(handle.stderr), handle.exitCode],
         { concurrency: "unbounded" }
       );
       return { exitCode, stderr, stdout };
-    })()
+    })
   ).pipe(
     Effect.mapError(
       (cause) =>
@@ -2813,138 +2813,136 @@ const applyNormalizePlan = Effect.fn("Files.applyNormalizePlan")(function* (
         )
       ),
     Effect.fnUntraced(function* (tempDir) {
-        const tempEntries = A.map(plan.entries, (entry, index) => ({
-          entry,
-          tempPath: path.join(
-            tempDir,
-            `${formatIndex(index, `${A.length(plan.entries)}`.length + 1)}-${entry.outputName}`
-          ),
-        }));
-        let completedEntries = A.empty<NormalizePlanEntry>();
-        let duplicateMoves = A.empty<NormalizeDuplicateMove>();
-        let duplicateSkippedEntries = A.empty<NormalizeSkippedEntry>();
-        let duplicateMoveTargets = HashSet.empty<string>();
-        let readyTempEntries = A.empty<{ readonly entry: NormalizePlanEntry; readonly tempPath: string }>();
-        let seenOutputs = HashMap.empty<FileSha256Hash, ReadonlyArray<NormalizeSeenOutput>>();
+      const tempEntries = A.map(plan.entries, (entry, index) => ({
+        entry,
+        tempPath: path.join(
+          tempDir,
+          `${formatIndex(index, `${A.length(plan.entries)}`.length + 1)}-${entry.outputName}`
+        ),
+      }));
+      let completedEntries = A.empty<NormalizePlanEntry>();
+      let duplicateMoves = A.empty<NormalizeDuplicateMove>();
+      let duplicateSkippedEntries = A.empty<NormalizeSkippedEntry>();
+      let duplicateMoveTargets = HashSet.empty<string>();
+      let readyTempEntries = A.empty<{ readonly entry: NormalizePlanEntry; readonly tempPath: string }>();
+      let seenOutputs = HashMap.empty<FileSha256Hash, ReadonlyArray<NormalizeSeenOutput>>();
 
-        yield* runFilesProgressForEach(
-          tempEntries,
-          Effect.fnUntraced(function* ({ entry, tempPath }) {
-              yield* normalizeImageToTemp(entry, tempPath, maxLongEdge);
-              const outputStat = yield* fs
-                .stat(tempPath)
-                .pipe(
-                  Effect.mapError((cause) =>
-                    formatPlatformError("Failed to stat normalized image", tempPath, { cause })
-                  )
-                );
-              const outputHash = dedupe ? O.some(yield* hashFileSha256(tempPath)) : O.none<FileSha256Hash>();
-              const candidates = O.isSome(outputHash)
-                ? pipe(HashMap.get(seenOutputs, outputHash.value), O.getOrElse(A.empty<NormalizeSeenOutput>))
-                : A.empty<NormalizeSeenOutput>();
-              const duplicate = O.isSome(outputHash)
-                ? yield* findDuplicateOutput(candidates, tempPath)
-                : O.none<NormalizeSeenOutput>();
+      yield* runFilesProgressForEach(
+        tempEntries,
+        Effect.fnUntraced(function* ({ entry, tempPath }) {
+          yield* normalizeImageToTemp(entry, tempPath, maxLongEdge);
+          const outputStat = yield* fs
+            .stat(tempPath)
+            .pipe(
+              Effect.mapError((cause) => formatPlatformError("Failed to stat normalized image", tempPath, { cause }))
+            );
+          const outputHash = dedupe ? O.some(yield* hashFileSha256(tempPath)) : O.none<FileSha256Hash>();
+          const candidates = O.isSome(outputHash)
+            ? pipe(HashMap.get(seenOutputs, outputHash.value), O.getOrElse(A.empty<NormalizeSeenOutput>))
+            : A.empty<NormalizeSeenOutput>();
+          const duplicate = O.isSome(outputHash)
+            ? yield* findDuplicateOutput(candidates, tempPath)
+            : O.none<NormalizeSeenOutput>();
 
-              if (O.isSome(duplicate) && O.isSome(outputHash)) {
-                const moveTarget = O.map(plan.duplicateDirectory, (duplicateDirectory) => {
-                  const targetPath = path.join(duplicateDirectory, entry.sourceName);
+          if (O.isSome(duplicate) && O.isSome(outputHash)) {
+            const moveTarget = O.map(plan.duplicateDirectory, (duplicateDirectory) => {
+              const targetPath = path.join(duplicateDirectory, entry.sourceName);
 
-                  return {
-                    path: targetPath,
-                    relativePath: path.relative(duplicateDirectory, targetPath),
-                  };
+              return {
+                path: targetPath,
+                relativePath: path.relative(duplicateDirectory, targetPath),
+              };
+            });
+            const skippedEntry = makeNormalizeDuplicateSkippedEntry(
+              entry,
+              outputHash.value,
+              duplicate.value.entry,
+              moveTarget
+            );
+
+            if (O.isSome(moveTarget)) {
+              if (HashSet.has(duplicateMoveTargets, moveTarget.value.path)) {
+                return yield* new FilesCommandError({
+                  message: `Refusing duplicate normalize duplicate move target: "${moveTarget.value.path}"`,
                 });
-                const skippedEntry = makeNormalizeDuplicateSkippedEntry(
-                  entry,
-                  outputHash.value,
-                  duplicate.value.entry,
-                  moveTarget
-                );
-
-                if (O.isSome(moveTarget)) {
-                  if (HashSet.has(duplicateMoveTargets, moveTarget.value.path)) {
-                    return yield* new FilesCommandError({
-                      message: `Refusing duplicate normalize duplicate move target: "${moveTarget.value.path}"`,
-                    });
-                  }
-
-                  duplicateMoveTargets = HashSet.add(duplicateMoveTargets, moveTarget.value.path);
-                  yield* preflightOverwritableFile(moveTarget.value.path, overwrite, "duplicate source file");
-                  duplicateMoves = A.append(duplicateMoves, {
-                    sourcePath: entry.sourcePath,
-                    targetPath: moveTarget.value.path,
-                  });
-                }
-
-                duplicateSkippedEntries = A.append(duplicateSkippedEntries, skippedEntry);
-                return;
               }
 
-              const completedEntry = withOutputMetadata(entry, `${outputStat.size}`, outputHash);
-              completedEntries = A.append(completedEntries, completedEntry);
-              readyTempEntries = A.append(readyTempEntries, { entry: completedEntry, tempPath });
+              duplicateMoveTargets = HashSet.add(duplicateMoveTargets, moveTarget.value.path);
+              yield* preflightOverwritableFile(moveTarget.value.path, overwrite, "duplicate source file");
+              duplicateMoves = A.append(duplicateMoves, {
+                sourcePath: entry.sourcePath,
+                targetPath: moveTarget.value.path,
+              });
+            }
 
-              if (O.isSome(outputHash)) {
-                seenOutputs = HashMap.set(
-                  seenOutputs,
-                  outputHash.value,
-                  A.append(candidates, { entry: completedEntry, outputHash: outputHash.value, tempPath })
-                );
-              }
-            }),
-          {
-            concurrency: 1,
-            label: "normalize write",
+            duplicateSkippedEntries = A.append(duplicateSkippedEntries, skippedEntry);
+            return;
           }
-        );
 
-        const manifest = makeNormalizeManifest(plan, completedEntries, duplicateSkippedEntries);
-        const manifestContent = yield* renderNormalizeManifest(plan.manifestPath, manifest);
-        const tempManifestPath = path.join(tempDir, "normalize-manifest.json");
-        yield* fs
-          .writeFileString(tempManifestPath, manifestContent)
-          .pipe(
-            Effect.mapError((cause) =>
-              formatPlatformError("Failed to write temporary normalize manifest", tempManifestPath, { cause })
-            )
-          );
+          const completedEntry = withOutputMetadata(entry, `${outputStat.size}`, outputHash);
+          completedEntries = A.append(completedEntries, completedEntry);
+          readyTempEntries = A.append(readyTempEntries, { entry: completedEntry, tempPath });
 
-        yield* runFilesProgressForEach(
-          readyTempEntries,
-          Effect.fnUntraced(function* ({ entry, tempPath }) {
-              if (overwrite) {
-                yield* fs.remove(entry.outputPath, { force: true }).pipe(Effect.ignore);
-              }
-              yield* renameOrFail(tempPath, entry.outputPath, tempDir);
-            }),
-          {
-            concurrency: FilesConcurrency.scan,
-            label: "normalize move",
+          if (O.isSome(outputHash)) {
+            seenOutputs = HashMap.set(
+              seenOutputs,
+              outputHash.value,
+              A.append(candidates, { entry: completedEntry, outputHash: outputHash.value, tempPath })
+            );
           }
-        );
-
-        yield* runFilesProgressForEach(
-          duplicateMoves,
-          Effect.fnUntraced(function* (duplicateMove) {
-              if (overwrite) {
-                yield* fs.remove(duplicateMove.targetPath, { force: true }).pipe(Effect.ignore);
-              }
-              yield* renameOrFail(duplicateMove.sourcePath, duplicateMove.targetPath, tempDir);
-            }),
-          {
-            concurrency: FilesConcurrency.scan,
-            label: "duplicates move",
-          }
-        );
-
-        if (overwrite) {
-          yield* fs.remove(plan.manifestPath, { force: true }).pipe(Effect.ignore);
+        }),
+        {
+          concurrency: 1,
+          label: "normalize write",
         }
-        yield* renameOrFail(tempManifestPath, plan.manifestPath, tempDir);
+      );
 
-        return { completedEntries, duplicateMoves, duplicateSkippedEntries };
-      }),
+      const manifest = makeNormalizeManifest(plan, completedEntries, duplicateSkippedEntries);
+      const manifestContent = yield* renderNormalizeManifest(plan.manifestPath, manifest);
+      const tempManifestPath = path.join(tempDir, "normalize-manifest.json");
+      yield* fs
+        .writeFileString(tempManifestPath, manifestContent)
+        .pipe(
+          Effect.mapError((cause) =>
+            formatPlatformError("Failed to write temporary normalize manifest", tempManifestPath, { cause })
+          )
+        );
+
+      yield* runFilesProgressForEach(
+        readyTempEntries,
+        Effect.fnUntraced(function* ({ entry, tempPath }) {
+          if (overwrite) {
+            yield* fs.remove(entry.outputPath, { force: true }).pipe(Effect.ignore);
+          }
+          yield* renameOrFail(tempPath, entry.outputPath, tempDir);
+        }),
+        {
+          concurrency: FilesConcurrency.scan,
+          label: "normalize move",
+        }
+      );
+
+      yield* runFilesProgressForEach(
+        duplicateMoves,
+        Effect.fnUntraced(function* (duplicateMove) {
+          if (overwrite) {
+            yield* fs.remove(duplicateMove.targetPath, { force: true }).pipe(Effect.ignore);
+          }
+          yield* renameOrFail(duplicateMove.sourcePath, duplicateMove.targetPath, tempDir);
+        }),
+        {
+          concurrency: FilesConcurrency.scan,
+          label: "duplicates move",
+        }
+      );
+
+      if (overwrite) {
+        yield* fs.remove(plan.manifestPath, { force: true }).pipe(Effect.ignore);
+      }
+      yield* renameOrFail(tempManifestPath, plan.manifestPath, tempDir);
+
+      return { completedEntries, duplicateMoves, duplicateSkippedEntries };
+    }),
     (tempDir) => fs.remove(tempDir, { recursive: true, force: true }).pipe(Effect.ignore)
   );
 });
@@ -2984,52 +2982,52 @@ const applyArchivePoorCandidatesPlan = Effect.fn("Files.applyArchivePoorCandidat
         )
       ),
     Effect.fnUntraced(function* (tempDir) {
-        const manifest = makeArchivePoorCandidatesManifest(plan);
-        const manifestContent = yield* renderArchivePoorCandidatesManifest(plan.manifestPath, manifest);
-        const tempManifestPath = path.join(tempDir, "archive-poor-candidates-manifest.json");
+      const manifest = makeArchivePoorCandidatesManifest(plan);
+      const manifestContent = yield* renderArchivePoorCandidatesManifest(plan.manifestPath, manifest);
+      const tempManifestPath = path.join(tempDir, "archive-poor-candidates-manifest.json");
 
-        yield* fs
-          .writeFileString(tempManifestPath, manifestContent)
-          .pipe(
-            Effect.mapError((cause) =>
-              formatPlatformError("Failed to write temporary archive manifest", tempManifestPath, { cause })
-            )
-          );
-
-        yield* runFilesProgressForEach(
-          archivedEntries(plan.entries),
-          Effect.fnUntraced(function* (entry) {
-              const archivePath = O.fromUndefinedOr(entry.archivePath);
-
-              if (O.isNone(archivePath)) {
-                return yield* new FilesCommandError({
-                  message: `Missing archive target for selected source: "${entry.sourcePath}"`,
-                });
-              }
-
-              if (overwrite) {
-                yield* fs.remove(archivePath.value, { force: true }).pipe(Effect.ignore);
-              }
-              yield* renameOrFail(entry.sourcePath, archivePath.value, tempDir);
-
-              for (const sidecar of entry.sidecars) {
-                if (overwrite) {
-                  yield* fs.remove(sidecar.archivePath, { force: true }).pipe(Effect.ignore);
-                }
-                yield* renameOrFail(sidecar.sourcePath, sidecar.archivePath, tempDir);
-              }
-            }),
-          {
-            concurrency: FilesConcurrency.scan,
-            label: "archive move",
-          }
+      yield* fs
+        .writeFileString(tempManifestPath, manifestContent)
+        .pipe(
+          Effect.mapError((cause) =>
+            formatPlatformError("Failed to write temporary archive manifest", tempManifestPath, { cause })
+          )
         );
 
-        if (overwrite) {
-          yield* fs.remove(plan.manifestPath, { force: true }).pipe(Effect.ignore);
+      yield* runFilesProgressForEach(
+        archivedEntries(plan.entries),
+        Effect.fnUntraced(function* (entry) {
+          const archivePath = O.fromUndefinedOr(entry.archivePath);
+
+          if (O.isNone(archivePath)) {
+            return yield* new FilesCommandError({
+              message: `Missing archive target for selected source: "${entry.sourcePath}"`,
+            });
+          }
+
+          if (overwrite) {
+            yield* fs.remove(archivePath.value, { force: true }).pipe(Effect.ignore);
+          }
+          yield* renameOrFail(entry.sourcePath, archivePath.value, tempDir);
+
+          for (const sidecar of entry.sidecars) {
+            if (overwrite) {
+              yield* fs.remove(sidecar.archivePath, { force: true }).pipe(Effect.ignore);
+            }
+            yield* renameOrFail(sidecar.sourcePath, sidecar.archivePath, tempDir);
+          }
+        }),
+        {
+          concurrency: FilesConcurrency.scan,
+          label: "archive move",
         }
-        yield* renameOrFail(tempManifestPath, plan.manifestPath, tempDir);
-      }),
+      );
+
+      if (overwrite) {
+        yield* fs.remove(plan.manifestPath, { force: true }).pipe(Effect.ignore);
+      }
+      yield* renameOrFail(tempManifestPath, plan.manifestPath, tempDir);
+    }),
     (tempDir) => fs.remove(tempDir, { recursive: true, force: true }).pipe(Effect.ignore)
   );
 });
@@ -3121,13 +3119,10 @@ const renameOrFail: (
   sourcePath: string,
   targetPath: string,
   tempDir: string
-) => Effect.Effect<void, FilesCommandError, FileSystem.FileSystem> = Effect.fn("Files.renameOrFail")(function* (
-  sourcePath,
-  targetPath,
-  tempDir
-) {
-  const fs = yield* FileSystem.FileSystem;
-  yield* fs.rename(sourcePath, targetPath).pipe(
+) => Effect.Effect<void, FilesCommandError, FileSystem.FileSystem> = Effect.fn("Files.renameOrFail")(
+  function* (sourcePath, targetPath, tempDir) {
+    const fs = yield* FileSystem.FileSystem;
+    yield* fs.rename(sourcePath, targetPath).pipe(
       Effect.mapError(
         (cause) =>
           new FilesCommandError({
@@ -3136,7 +3131,8 @@ const renameOrFail: (
           })
       )
     );
-});
+  }
+);
 
 const withDetectFacesMovedNoFaceTarget = (
   entry: DetectFacesEntry,
@@ -3395,14 +3391,14 @@ const runFfmpegStripMetadata = Effect.fn("Files.runFfmpegStripMetadata")(functio
     }
   );
   const result = yield* Effect.scoped(
-    Effect.fnUntraced(function* () {
+    Effect.gen(function* () {
       const handle = yield* command;
       const [stdout, stderr, exitCode] = yield* Effect.all(
         [collectText(handle.stdout), collectText(handle.stderr), handle.exitCode],
         { concurrency: "unbounded" }
       );
       return { exitCode, stderr, stdout };
-    })()
+    })
   ).pipe(
     Effect.mapError(
       (cause) =>
@@ -3462,25 +3458,25 @@ const applyStripMetadataPlan = Effect.fn("Files.applyStripMetadataPlan")(functio
         )
       ),
     Effect.fnUntraced(function* (tempDir) {
-        const tempEntries = makeStripMetadataTempEntries(tempDir, plan, path);
-        const rewriteConcurrency = A.some(plan, (entry) => entry.mediaKind === "video")
-          ? FilesConcurrency.ffmpeg
-          : FilesConcurrency.image;
+      const tempEntries = makeStripMetadataTempEntries(tempDir, plan, path);
+      const rewriteConcurrency = A.some(plan, (entry) => entry.mediaKind === "video")
+        ? FilesConcurrency.ffmpeg
+        : FilesConcurrency.image;
 
-        yield* runFilesProgressForEach(tempEntries, ({ entry, tempPath }) => stripMetadataToTemp(entry, tempPath), {
-          concurrency: rewriteConcurrency,
-          label: "strip rewrite",
-        });
+      yield* runFilesProgressForEach(tempEntries, ({ entry, tempPath }) => stripMetadataToTemp(entry, tempPath), {
+        concurrency: rewriteConcurrency,
+        label: "strip rewrite",
+      });
 
-        yield* runFilesProgressForEach(
-          tempEntries,
-          ({ entry, tempPath }) => renameOrFail(tempPath, entry.sourcePath, tempDir),
-          {
-            concurrency: FilesConcurrency.scan,
-            label: "strip replace",
-          }
-        );
-      }),
+      yield* runFilesProgressForEach(
+        tempEntries,
+        ({ entry, tempPath }) => renameOrFail(tempPath, entry.sourcePath, tempDir),
+        {
+          concurrency: FilesConcurrency.scan,
+          label: "strip replace",
+        }
+      );
+    }),
     (tempDir) => fs.remove(tempDir, { recursive: true, force: true }).pipe(Effect.ignore)
   );
 });
@@ -3501,25 +3497,25 @@ const applyCropBordersPlan = Effect.fn("Files.applyCropBordersPlan")(function* (
         )
       ),
     Effect.fnUntraced(function* (tempDir) {
-        const tempEntries = A.map(plan, (entry, index) => ({
-          entry,
-          tempPath: path.join(tempDir, `${formatIndex(index, `${A.length(plan)}`.length + 1)}-${entry.sourceName}`),
-        }));
+      const tempEntries = A.map(plan, (entry, index) => ({
+        entry,
+        tempPath: path.join(tempDir, `${formatIndex(index, `${A.length(plan)}`.length + 1)}-${entry.sourceName}`),
+      }));
 
-        yield* runFilesProgressForEach(tempEntries, ({ entry, tempPath }) => cropImageBordersToTemp(entry, tempPath), {
-          concurrency: FilesConcurrency.image,
-          label: "crop rewrite",
-        });
+      yield* runFilesProgressForEach(tempEntries, ({ entry, tempPath }) => cropImageBordersToTemp(entry, tempPath), {
+        concurrency: FilesConcurrency.image,
+        label: "crop rewrite",
+      });
 
-        yield* runFilesProgressForEach(
-          tempEntries,
-          ({ entry, tempPath }) => renameOrFail(tempPath, entry.sourcePath, tempDir),
-          {
-            concurrency: FilesConcurrency.scan,
-            label: "crop replace",
-          }
-        );
-      }),
+      yield* runFilesProgressForEach(
+        tempEntries,
+        ({ entry, tempPath }) => renameOrFail(tempPath, entry.sourcePath, tempDir),
+        {
+          concurrency: FilesConcurrency.scan,
+          label: "crop replace",
+        }
+      );
+    }),
     (tempDir) => fs.remove(tempDir, { recursive: true, force: true }).pipe(Effect.ignore)
   );
 });
@@ -3613,7 +3609,7 @@ export const printFilesIndex = Effect.fn("Files.printFilesIndex")(function* () {
 const createCaptionFilesImpl = Effect.fn("FilesCommandService.createCaptionFiles")(function* (
   options: CreateCaptionFilesOptions
 ): Effect.fn.Return<CreateCaptionFilesSummary, FilesCommandError, FilesCommandServiceRequirements> {
-  const program = Effect.fnUntraced(function* () {
+  const program = Effect.gen(function* () {
     const validatedOptions = yield* validateCreateCaptionFilesOptions(options);
     const plan = yield* buildCreateCaptionFilesPlan(validatedOptions);
     const plannedCount = A.length(plan.entries);
@@ -3669,7 +3665,7 @@ const createCaptionFilesImpl = Effect.fn("FilesCommandService.createCaptionFiles
       plannedCount,
       skippedCount,
     });
-  })();
+  });
 
   return yield* profilePhase(program, {
     phase: "files.create-captions",
@@ -3683,7 +3679,7 @@ const createCaptionFilesImpl = Effect.fn("FilesCommandService.createCaptionFiles
 const archivePoorCandidatesImpl = Effect.fn("FilesCommandService.archivePoorCandidates")(function* (
   options: ArchivePoorCandidatesOptions
 ): Effect.fn.Return<ArchivePoorCandidatesSummary, FilesCommandError, FilesCommandServiceRequirements> {
-  const program = Effect.fnUntraced(function* () {
+  const program = Effect.gen(function* () {
     const validatedOptions = yield* validateArchivePoorCandidatesOptions(options);
     const sidecarExtensions = yield* parseSidecarExtensions(validatedOptions.sidecars);
     const plan = yield* buildArchivePoorCandidatesPlan(validatedOptions, sidecarExtensions);
@@ -3758,7 +3754,7 @@ const archivePoorCandidatesImpl = Effect.fn("FilesCommandService.archivePoorCand
       movedSidecarCount,
       skippedCount,
     });
-  })();
+  });
 
   return yield* profilePhase(program, {
     phase: "files.archive-poor-candidates",
@@ -3776,7 +3772,7 @@ const archivePoorCandidatesImpl = Effect.fn("FilesCommandService.archivePoorCand
 const cropBordersFilesImpl = Effect.fn("FilesCommandService.cropBordersFiles")(function* (
   options: CropBordersOptions
 ): Effect.fn.Return<CropBordersSummary, FilesCommandError, FilesCommandServiceRequirements> {
-  const program = Effect.fnUntraced(function* () {
+  const program = Effect.gen(function* () {
     const plan = yield* buildCropBordersPlan(options);
     const plannedCount = A.length(plan.entries);
 
@@ -3839,7 +3835,7 @@ const cropBordersFilesImpl = Effect.fn("FilesCommandService.cropBordersFiles")(f
       plannedCount,
       skippedCount: plan.skippedCount,
     });
-  })();
+  });
 
   return yield* profilePhase(program, {
     phase: "files.crop-borders",
@@ -3856,7 +3852,7 @@ const cropBordersFilesImpl = Effect.fn("FilesCommandService.cropBordersFiles")(f
 const detectBordersFilesImpl = Effect.fn("FilesCommandService.detectBordersFiles")(function* (
   options: DetectBordersOptions
 ): Effect.fn.Return<DetectBordersReport, FilesCommandError, FilesCommandServiceRequirements> {
-  const program = Effect.fnUntraced(function* () {
+  const program = Effect.gen(function* () {
     const validatedOptions = yield* validateDetectBordersOptions(options);
     const progressEnabled = !validatedOptions.json;
     const collection = yield* collectDetectBordersFiles(validatedOptions.dir, progressEnabled);
@@ -3931,7 +3927,7 @@ const detectBordersFilesImpl = Effect.fn("FilesCommandService.detectBordersFiles
     yield* logDetectBordersEntries(entries);
 
     return report;
-  })();
+  });
 
   if (options.json) {
     return yield* program;
@@ -3956,7 +3952,7 @@ const detectFacesFilesImpl = Effect.fn("FilesCommandService.detectFacesFiles")(f
   FilesCommandError,
   FileSystem.FileSystem | Path.Path | Terminal.Terminal | ChildProcessSpawner.ChildProcessSpawner
 > {
-  const program = Effect.fnUntraced(function* () {
+  const program = Effect.gen(function* () {
     const path = yield* Path.Path;
     const validatedOptions = yield* validateDetectFacesOptions(options);
     const progressEnabled = !validatedOptions.json;
@@ -3972,8 +3968,9 @@ const detectFacesFilesImpl = Effect.fn("FilesCommandService.detectFacesFiles")(f
     let skipped = collection.skipped;
 
     if (A.isReadonlyArrayNonEmpty(collection.files)) {
-      yield* withDetector(new FaceDetectionModelConfig({ modelPath: validatedOptions.modelPath }), (detector) =>
-        Effect.fnUntraced(function* () {
+      yield* withDetector(
+        new FaceDetectionModelConfig({ modelPath: validatedOptions.modelPath }),
+        Effect.fnUntraced(function* (detector) {
           const analysisResults = yield* runFilesProgressForEach(
             collection.files,
             (file) => analyzeDetectFacesFile(detector, file, validatedOptions).pipe(Effect.result),
@@ -4001,7 +3998,7 @@ const detectFacesFilesImpl = Effect.fn("FilesCommandService.detectFacesFiles")(f
 
             entries = A.append(entries, result.success);
           }
-        })()
+        })
       ).pipe(
         Effect.provideService(FaceDetectionService, makeFaceDetectionService()),
         Effect.mapError(
@@ -4070,7 +4067,7 @@ const detectFacesFilesImpl = Effect.fn("FilesCommandService.detectFacesFiles")(f
     yield* logDetectFacesEntries(entries, sortedSkipped);
 
     return report;
-  })();
+  });
 
   if (options.json) {
     return yield* program;
@@ -4090,7 +4087,7 @@ const detectFacesFilesImpl = Effect.fn("FilesCommandService.detectFacesFiles")(f
 const normalizeFilesImpl = Effect.fn("FilesCommandService.normalizeFiles")(function* (
   options: NormalizeFilesOptions
 ): Effect.fn.Return<NormalizeSummary, FilesCommandError, FilesCommandServiceRequirements> {
-  const program = Effect.fnUntraced(function* () {
+  const program = Effect.gen(function* () {
     const maxLongEdge = yield* validateNormalizeMaxLongEdge(options.maxLongEdge);
     const dedupe = options.dedupe || O.isSome(options.moveDuplicatesTo);
     const validatedOptions = new NormalizeFilesOptions({
@@ -4183,7 +4180,7 @@ const normalizeFilesImpl = Effect.fn("FilesCommandService.normalizeFiles")(funct
       resizedCount: completedResizedCount,
       skippedCount: skippedCount + duplicateCount,
     });
-  })();
+  });
 
   return yield* profilePhase(program, {
     phase: "files.normalize",

--- a/packages/tooling/tool/cli/src/commands/Files/Files.service.ts
+++ b/packages/tooling/tool/cli/src/commands/Files/Files.service.ts
@@ -1098,8 +1098,7 @@ const buildCreateCaptionFilesPlan = Effect.fn("Files.buildCreateCaptionFilesPlan
 
   yield* runFilesProgressForEach(
     sourceNames,
-    (sourceName) =>
-      Effect.gen(function* () {
+    Effect.fnUntraced(function* (sourceName) {
         const sourcePath = path.join(directory, sourceName);
         const canonicalPath = yield* fs.realPath(sourcePath).pipe(Effect.option);
 
@@ -1293,7 +1292,7 @@ const buildCreateCaptionFilesPlan = Effect.fn("Files.buildCreateCaptionFilesPlan
             sourceRelativePath: path.relative(directory, sourcePath),
           })
         );
-      }),
+    }),
     {
       concurrency: 1,
       label: "captions plan",
@@ -1754,14 +1753,14 @@ const runFfprobe = Effect.fn("Files.runFfprobe")(function* (
     }
   );
   const result = yield* Effect.scoped(
-    Effect.gen(function* () {
+    Effect.fnUntraced(function* () {
       const handle = yield* command;
       const [stdout, stderr, exitCode] = yield* Effect.all(
         [collectText(handle.stdout), collectText(handle.stderr), handle.exitCode],
         { concurrency: "unbounded" }
       );
       return { exitCode, stderr, stdout };
-    })
+    })()
   ).pipe(
     Effect.mapError(
       (cause) =>
@@ -2813,8 +2812,7 @@ const applyNormalizePlan = Effect.fn("Files.applyNormalizePlan")(function* (
           formatPlatformError("Failed to create temporary normalize directory", plan.outputDirectory, { cause })
         )
       ),
-    (tempDir) =>
-      Effect.gen(function* () {
+    Effect.fnUntraced(function* (tempDir) {
         const tempEntries = A.map(plan.entries, (entry, index) => ({
           entry,
           tempPath: path.join(
@@ -2831,8 +2829,7 @@ const applyNormalizePlan = Effect.fn("Files.applyNormalizePlan")(function* (
 
         yield* runFilesProgressForEach(
           tempEntries,
-          ({ entry, tempPath }) =>
-            Effect.gen(function* () {
+          Effect.fnUntraced(function* ({ entry, tempPath }) {
               yield* normalizeImageToTemp(entry, tempPath, maxLongEdge);
               const outputStat = yield* fs
                 .stat(tempPath)
@@ -2915,8 +2912,7 @@ const applyNormalizePlan = Effect.fn("Files.applyNormalizePlan")(function* (
 
         yield* runFilesProgressForEach(
           readyTempEntries,
-          ({ entry, tempPath }) =>
-            Effect.gen(function* () {
+          Effect.fnUntraced(function* ({ entry, tempPath }) {
               if (overwrite) {
                 yield* fs.remove(entry.outputPath, { force: true }).pipe(Effect.ignore);
               }
@@ -2930,8 +2926,7 @@ const applyNormalizePlan = Effect.fn("Files.applyNormalizePlan")(function* (
 
         yield* runFilesProgressForEach(
           duplicateMoves,
-          (duplicateMove) =>
-            Effect.gen(function* () {
+          Effect.fnUntraced(function* (duplicateMove) {
               if (overwrite) {
                 yield* fs.remove(duplicateMove.targetPath, { force: true }).pipe(Effect.ignore);
               }
@@ -2988,8 +2983,7 @@ const applyArchivePoorCandidatesPlan = Effect.fn("Files.applyArchivePoorCandidat
           formatPlatformError("Failed to create temporary archive directory", plan.archiveDirectory, { cause })
         )
       ),
-    (tempDir) =>
-      Effect.gen(function* () {
+    Effect.fnUntraced(function* (tempDir) {
         const manifest = makeArchivePoorCandidatesManifest(plan);
         const manifestContent = yield* renderArchivePoorCandidatesManifest(plan.manifestPath, manifest);
         const tempManifestPath = path.join(tempDir, "archive-poor-candidates-manifest.json");
@@ -3004,8 +2998,7 @@ const applyArchivePoorCandidatesPlan = Effect.fn("Files.applyArchivePoorCandidat
 
         yield* runFilesProgressForEach(
           archivedEntries(plan.entries),
-          (entry) =>
-            Effect.gen(function* () {
+          Effect.fnUntraced(function* (entry) {
               const archivePath = O.fromUndefinedOr(entry.archivePath);
 
               if (O.isNone(archivePath)) {
@@ -3124,14 +3117,17 @@ const logRenamePlan = Effect.fn("Files.logRenamePlan")(function* (plan: Readonly
   });
 });
 
-const renameOrFail = (
+const renameOrFail: (
   sourcePath: string,
   targetPath: string,
   tempDir: string
-): Effect.Effect<void, FilesCommandError, FileSystem.FileSystem> =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    yield* fs.rename(sourcePath, targetPath).pipe(
+) => Effect.Effect<void, FilesCommandError, FileSystem.FileSystem> = Effect.fn("Files.renameOrFail")(function* (
+  sourcePath,
+  targetPath,
+  tempDir
+) {
+  const fs = yield* FileSystem.FileSystem;
+  yield* fs.rename(sourcePath, targetPath).pipe(
       Effect.mapError(
         (cause) =>
           new FilesCommandError({
@@ -3140,7 +3136,7 @@ const renameOrFail = (
           })
       )
     );
-  });
+});
 
 const withDetectFacesMovedNoFaceTarget = (
   entry: DetectFacesEntry,
@@ -3399,14 +3395,14 @@ const runFfmpegStripMetadata = Effect.fn("Files.runFfmpegStripMetadata")(functio
     }
   );
   const result = yield* Effect.scoped(
-    Effect.gen(function* () {
+    Effect.fnUntraced(function* () {
       const handle = yield* command;
       const [stdout, stderr, exitCode] = yield* Effect.all(
         [collectText(handle.stdout), collectText(handle.stderr), handle.exitCode],
         { concurrency: "unbounded" }
       );
       return { exitCode, stderr, stdout };
-    })
+    })()
   ).pipe(
     Effect.mapError(
       (cause) =>
@@ -3465,8 +3461,7 @@ const applyStripMetadataPlan = Effect.fn("Files.applyStripMetadataPlan")(functio
           formatPlatformError("Failed to create temporary strip directory", directory, { cause })
         )
       ),
-    (tempDir) =>
-      Effect.gen(function* () {
+    Effect.fnUntraced(function* (tempDir) {
         const tempEntries = makeStripMetadataTempEntries(tempDir, plan, path);
         const rewriteConcurrency = A.some(plan, (entry) => entry.mediaKind === "video")
           ? FilesConcurrency.ffmpeg
@@ -3505,8 +3500,7 @@ const applyCropBordersPlan = Effect.fn("Files.applyCropBordersPlan")(function* (
           formatPlatformError("Failed to create temporary crop-borders directory", directory, { cause })
         )
       ),
-    (tempDir) =>
-      Effect.gen(function* () {
+    Effect.fnUntraced(function* (tempDir) {
         const tempEntries = A.map(plan, (entry, index) => ({
           entry,
           tempPath: path.join(tempDir, `${formatIndex(index, `${A.length(plan)}`.length + 1)}-${entry.sourceName}`),
@@ -3619,7 +3613,7 @@ export const printFilesIndex = Effect.fn("Files.printFilesIndex")(function* () {
 const createCaptionFilesImpl = Effect.fn("FilesCommandService.createCaptionFiles")(function* (
   options: CreateCaptionFilesOptions
 ): Effect.fn.Return<CreateCaptionFilesSummary, FilesCommandError, FilesCommandServiceRequirements> {
-  const program = Effect.gen(function* () {
+  const program = Effect.fnUntraced(function* () {
     const validatedOptions = yield* validateCreateCaptionFilesOptions(options);
     const plan = yield* buildCreateCaptionFilesPlan(validatedOptions);
     const plannedCount = A.length(plan.entries);
@@ -3675,7 +3669,7 @@ const createCaptionFilesImpl = Effect.fn("FilesCommandService.createCaptionFiles
       plannedCount,
       skippedCount,
     });
-  });
+  })();
 
   return yield* profilePhase(program, {
     phase: "files.create-captions",
@@ -3689,7 +3683,7 @@ const createCaptionFilesImpl = Effect.fn("FilesCommandService.createCaptionFiles
 const archivePoorCandidatesImpl = Effect.fn("FilesCommandService.archivePoorCandidates")(function* (
   options: ArchivePoorCandidatesOptions
 ): Effect.fn.Return<ArchivePoorCandidatesSummary, FilesCommandError, FilesCommandServiceRequirements> {
-  const program = Effect.gen(function* () {
+  const program = Effect.fnUntraced(function* () {
     const validatedOptions = yield* validateArchivePoorCandidatesOptions(options);
     const sidecarExtensions = yield* parseSidecarExtensions(validatedOptions.sidecars);
     const plan = yield* buildArchivePoorCandidatesPlan(validatedOptions, sidecarExtensions);
@@ -3764,7 +3758,7 @@ const archivePoorCandidatesImpl = Effect.fn("FilesCommandService.archivePoorCand
       movedSidecarCount,
       skippedCount,
     });
-  });
+  })();
 
   return yield* profilePhase(program, {
     phase: "files.archive-poor-candidates",
@@ -3782,7 +3776,7 @@ const archivePoorCandidatesImpl = Effect.fn("FilesCommandService.archivePoorCand
 const cropBordersFilesImpl = Effect.fn("FilesCommandService.cropBordersFiles")(function* (
   options: CropBordersOptions
 ): Effect.fn.Return<CropBordersSummary, FilesCommandError, FilesCommandServiceRequirements> {
-  const program = Effect.gen(function* () {
+  const program = Effect.fnUntraced(function* () {
     const plan = yield* buildCropBordersPlan(options);
     const plannedCount = A.length(plan.entries);
 
@@ -3845,7 +3839,7 @@ const cropBordersFilesImpl = Effect.fn("FilesCommandService.cropBordersFiles")(f
       plannedCount,
       skippedCount: plan.skippedCount,
     });
-  });
+  })();
 
   return yield* profilePhase(program, {
     phase: "files.crop-borders",
@@ -3862,7 +3856,7 @@ const cropBordersFilesImpl = Effect.fn("FilesCommandService.cropBordersFiles")(f
 const detectBordersFilesImpl = Effect.fn("FilesCommandService.detectBordersFiles")(function* (
   options: DetectBordersOptions
 ): Effect.fn.Return<DetectBordersReport, FilesCommandError, FilesCommandServiceRequirements> {
-  const program = Effect.gen(function* () {
+  const program = Effect.fnUntraced(function* () {
     const validatedOptions = yield* validateDetectBordersOptions(options);
     const progressEnabled = !validatedOptions.json;
     const collection = yield* collectDetectBordersFiles(validatedOptions.dir, progressEnabled);
@@ -3937,7 +3931,7 @@ const detectBordersFilesImpl = Effect.fn("FilesCommandService.detectBordersFiles
     yield* logDetectBordersEntries(entries);
 
     return report;
-  });
+  })();
 
   if (options.json) {
     return yield* program;
@@ -3962,7 +3956,7 @@ const detectFacesFilesImpl = Effect.fn("FilesCommandService.detectFacesFiles")(f
   FilesCommandError,
   FileSystem.FileSystem | Path.Path | Terminal.Terminal | ChildProcessSpawner.ChildProcessSpawner
 > {
-  const program = Effect.gen(function* () {
+  const program = Effect.fnUntraced(function* () {
     const path = yield* Path.Path;
     const validatedOptions = yield* validateDetectFacesOptions(options);
     const progressEnabled = !validatedOptions.json;
@@ -3979,7 +3973,7 @@ const detectFacesFilesImpl = Effect.fn("FilesCommandService.detectFacesFiles")(f
 
     if (A.isReadonlyArrayNonEmpty(collection.files)) {
       yield* withDetector(new FaceDetectionModelConfig({ modelPath: validatedOptions.modelPath }), (detector) =>
-        Effect.gen(function* () {
+        Effect.fnUntraced(function* () {
           const analysisResults = yield* runFilesProgressForEach(
             collection.files,
             (file) => analyzeDetectFacesFile(detector, file, validatedOptions).pipe(Effect.result),
@@ -4007,7 +4001,7 @@ const detectFacesFilesImpl = Effect.fn("FilesCommandService.detectFacesFiles")(f
 
             entries = A.append(entries, result.success);
           }
-        })
+        })()
       ).pipe(
         Effect.provideService(FaceDetectionService, makeFaceDetectionService()),
         Effect.mapError(
@@ -4076,7 +4070,7 @@ const detectFacesFilesImpl = Effect.fn("FilesCommandService.detectFacesFiles")(f
     yield* logDetectFacesEntries(entries, sortedSkipped);
 
     return report;
-  });
+  })();
 
   if (options.json) {
     return yield* program;
@@ -4096,7 +4090,7 @@ const detectFacesFilesImpl = Effect.fn("FilesCommandService.detectFacesFiles")(f
 const normalizeFilesImpl = Effect.fn("FilesCommandService.normalizeFiles")(function* (
   options: NormalizeFilesOptions
 ): Effect.fn.Return<NormalizeSummary, FilesCommandError, FilesCommandServiceRequirements> {
-  const program = Effect.gen(function* () {
+  const program = Effect.fnUntraced(function* () {
     const maxLongEdge = yield* validateNormalizeMaxLongEdge(options.maxLongEdge);
     const dedupe = options.dedupe || O.isSome(options.moveDuplicatesTo);
     const validatedOptions = new NormalizeFilesOptions({
@@ -4189,7 +4183,7 @@ const normalizeFilesImpl = Effect.fn("FilesCommandService.normalizeFiles")(funct
       resizedCount: completedResizedCount,
       skippedCount: skippedCount + duplicateCount,
     });
-  });
+  })();
 
   return yield* profilePhase(program, {
     phase: "files.normalize",

--- a/packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts
+++ b/packages/tooling/tool/cli/src/commands/Graphiti/internal/ProxyServices.ts
@@ -379,11 +379,11 @@ const parseContainerHealth = (value: string): S.Schema.Type<typeof ContainerHeal
     O.getOrElse(() => unknownContainerHealthState)
   );
 
-const readContainerHealth = (
+const readContainerHealth: (
   dependencyHealthEnabled: boolean,
   containerName: string
-): Effect.Effect<S.Schema.Type<typeof ContainerHealthState>> =>
-  Effect.gen(function* () {
+) => Effect.Effect<S.Schema.Type<typeof ContainerHealthState>> = Effect.fnUntraced(
+  function* (dependencyHealthEnabled, containerName) {
     if (!dependencyHealthEnabled) {
       return "unknown";
     }
@@ -402,7 +402,8 @@ const readContainerHealth = (
 
     const value = new TextDecoder("utf-8").decode(result.stdout);
     return parseContainerHealth(value);
-  });
+  }
+);
 
 /**
  * Construct dependency health service implementation.
@@ -416,49 +417,50 @@ const readContainerHealth = (
  * @category models
  * @since 0.0.0
  */
-export const makeGraphitiDependencyHealthService = (
+export const makeGraphitiDependencyHealthService: (
   config: GraphitiProxyConfig
-): Effect.Effect<GraphitiDependencyHealthService["Service"]> =>
-  Effect.gen(function* () {
-    const cacheRef = yield* Ref.make({
-      checkedAtMs: 0,
-      snapshot: unknownDependencySnapshot(),
-    });
-
-    const snapshot = Effect.gen(function* () {
-      const nowMs = yield* Clock.currentTimeMillis;
-      const cache = yield* Ref.get(cacheRef);
-
-      if (nowMs - cache.checkedAtMs < config.dependencyHealthTtlMs) {
-        return cache.snapshot;
-      }
-
-      const falkor = yield* readContainerHealth(config.dependencyHealthEnabled, config.falkorContainer);
-      const graphiti = yield* readContainerHealth(config.dependencyHealthEnabled, config.graphitiContainer);
-
-      const status =
-        config.dependencyHealthEnabled && (falkor !== "healthy" || graphiti !== "healthy") ? "degraded" : "ok";
-
-      const nextSnapshot = new DependencyHealthSnapshot({
-        status,
-        details: new DependencyHealthDetails({
-          falkor,
-          graphiti,
-        }),
-      });
-
-      yield* Ref.set(cacheRef, {
-        checkedAtMs: nowMs,
-        snapshot: nextSnapshot,
-      });
-
-      return nextSnapshot;
-    });
-
-    return GraphitiDependencyHealthService.of({
-      snapshot,
-    });
+) => Effect.Effect<GraphitiDependencyHealthService["Service"]> = Effect.fn(
+  "GraphitiProxyServices.makeGraphitiDependencyHealthService"
+)(function* (config) {
+  const cacheRef = yield* Ref.make({
+    checkedAtMs: 0,
+    snapshot: unknownDependencySnapshot(),
   });
+
+  const snapshot = Effect.gen(function* () {
+    const nowMs = yield* Clock.currentTimeMillis;
+    const cache = yield* Ref.get(cacheRef);
+
+    if (nowMs - cache.checkedAtMs < config.dependencyHealthTtlMs) {
+      return cache.snapshot;
+    }
+
+    const falkor = yield* readContainerHealth(config.dependencyHealthEnabled, config.falkorContainer);
+    const graphiti = yield* readContainerHealth(config.dependencyHealthEnabled, config.graphitiContainer);
+
+    const status =
+      config.dependencyHealthEnabled && (falkor !== "healthy" || graphiti !== "healthy") ? "degraded" : "ok";
+
+    const nextSnapshot = new DependencyHealthSnapshot({
+      status,
+      details: new DependencyHealthDetails({
+        falkor,
+        graphiti,
+      }),
+    });
+
+    yield* Ref.set(cacheRef, {
+      checkedAtMs: nowMs,
+      snapshot: nextSnapshot,
+    });
+
+    return nextSnapshot;
+  });
+
+  return GraphitiDependencyHealthService.of({
+    snapshot,
+  });
+});
 
 /**
  * Construct upstream forwarder service implementation.
@@ -478,10 +480,10 @@ export const makeGraphitiProxyForwarderService = (
   const upstreamBase = new URL(config.upstream);
   const allowedEndpointPath = normalizeEndpointPath(upstreamBase.pathname);
 
-  const forward = (
+  const forward: (
     request: HttpServerRequest.HttpServerRequest
-  ): Effect.Effect<HttpServerResponse.HttpServerResponse, never, HttpClient.HttpClient> =>
-    Effect.gen(function* () {
+  ) => Effect.Effect<HttpServerResponse.HttpServerResponse, never, HttpClient.HttpClient> = Effect.fnUntraced(
+    function* (request) {
       if (isAbsoluteRequestTarget(request.url)) {
         return proxyErrorResponse("upstream_failure", "Graphiti proxy rejects absolute-form request targets.", {
           status: 400,
@@ -553,8 +555,8 @@ export const makeGraphitiProxyForwarderService = (
               : proxyErrorResponse("upstream_failure", Inspectable.toStringUnknown(error, 0), { status: 502 })
           ),
         onSuccess: flow(
-          O.map((upstreamResponse) =>
-            Effect.gen(function* () {
+          O.map(
+            Effect.fnUntraced(function* (upstreamResponse) {
               const bodyBuffer = yield* Effect.orElseSucceed(upstreamResponse.arrayBuffer, () => new ArrayBuffer(0));
               return HttpServerResponse.uint8Array(new Uint8Array(bodyBuffer), {
                 status: upstreamResponse.status,
@@ -571,7 +573,8 @@ export const makeGraphitiProxyForwarderService = (
           )
         ),
       });
-    });
+    }
+  );
 
   return GraphitiProxyForwarderService.of({
     forward,
@@ -603,150 +606,136 @@ export const makeGraphitiProxyQueueService: {
   ) => Effect.Effect<GraphitiProxyQueueService["Service"], never, HttpClient.HttpClient | Scope.Scope>;
 } = dual(
   2,
-  (
+  Effect.fn("GraphitiProxyServices.makeGraphitiProxyQueueService")(function* (
     config: GraphitiProxyConfig,
     forwarderService: GraphitiProxyForwarderService["Service"]
-  ): Effect.Effect<GraphitiProxyQueueService["Service"], never, HttpClient.HttpClient | Scope.Scope> =>
-    Effect.gen(function* () {
-      const queue = yield* Queue.dropping<{
-        readonly request: HttpServerRequest.HttpServerRequest;
-        readonly responseDeferred: Deferred.Deferred<HttpServerResponse.HttpServerResponse>;
-      }>(config.maxQueue);
+  ): Effect.fn.Return<GraphitiProxyQueueService["Service"], never, HttpClient.HttpClient | Scope.Scope> {
+    const queue = yield* Queue.dropping<{
+      readonly request: HttpServerRequest.HttpServerRequest;
+      readonly responseDeferred: Deferred.Deferred<HttpServerResponse.HttpServerResponse>;
+    }>(config.maxQueue);
 
-      const acceptingRef = yield* Ref.make(true);
-      const activeRef = yield* Ref.make(0);
-      const peakQueueDepthRef = yield* Ref.make(0);
-      const processedRef = yield* Ref.make(0);
-      const failedRef = yield* Ref.make(0);
-      const rejectedRef = yield* Ref.make(0);
-      const drainDeferred = yield* Deferred.make<void>();
+    const acceptingRef = yield* Ref.make(true);
+    const activeRef = yield* Ref.make(0);
+    const peakQueueDepthRef = yield* Ref.make(0);
+    const processedRef = yield* Ref.make(0);
+    const failedRef = yield* Ref.make(0);
+    const rejectedRef = yield* Ref.make(0);
+    const drainDeferred = yield* Deferred.make<void>();
 
-      const checkDrain = Effect.gen(function* () {
-        const accepting = yield* Ref.get(acceptingRef);
-        if (accepting) {
-          return;
-        }
+    const checkDrain = Effect.fnUntraced(function* () {
+      const accepting = yield* Ref.get(acceptingRef);
+      if (accepting) {
+        return;
+      }
 
-        const active = yield* Ref.get(activeRef);
-        const queued = yield* Queue.size(queue);
-        if (active === 0 && queued === 0) {
-          yield* Deferred.succeed(drainDeferred, undefined).pipe(Effect.ignore);
-        }
-      });
+      const active = yield* Ref.get(activeRef);
+      const queued = yield* Queue.size(queue);
+      if (active === 0 && queued === 0) {
+        yield* Deferred.succeed(drainDeferred, undefined).pipe(Effect.ignore);
+      }
+    });
 
-      const worker = Effect.forever(
-        Effect.gen(function* () {
-          const job = yield* Queue.take(queue);
-          yield* Ref.update(activeRef, (active) => active + 1);
+    const worker = Effect.forever(
+      Effect.gen(function* () {
+        const job = yield* Queue.take(queue);
+        yield* Ref.update(activeRef, (active) => active + 1);
 
-          const response = yield* forwarderService.forward(job.request).pipe(
-            Effect.catchDefect((cause) =>
-              Effect.gen(function* () {
-                yield* Ref.update(failedRef, (failed) => failed + 1);
-                return proxyErrorResponse("upstream_failure", Inspectable.toStringUnknown(cause, 0), { status: 502 });
-              })
-            )
-          );
-
-          const queued = yield* Queue.size(queue);
-          const active = yield* Ref.get(activeRef);
-
-          const responseWithHeaders = pipe(
-            response,
-            HttpServerResponse.setHeader("x-graphiti-proxy-queued", `${queued}`),
-            HttpServerResponse.setHeader("x-graphiti-proxy-active", `${active}`)
-          );
-
-          yield* Deferred.succeed(job.responseDeferred, responseWithHeaders).pipe(Effect.ignore);
-          yield* Ref.update(processedRef, (processed) => processed + 1);
-        }).pipe(
-          Effect.ensuring(
-            Ref.update(activeRef, (active) => (active > 0 ? active - 1 : 0)).pipe(
-              Effect.andThen(
-                Effect.fnUntraced(function* () {
-                  return yield* checkDrain;
-                })
-              )
-            )
+        const response = yield* forwarderService.forward(job.request).pipe(
+          Effect.catchDefect(
+            Effect.fnUntraced(function* (cause) {
+              yield* Ref.update(failedRef, (failed) => failed + 1);
+              return proxyErrorResponse("upstream_failure", Inspectable.toStringUnknown(cause, 0), { status: 502 });
+            })
           )
-        )
-      ).pipe(Effect.catchDefect(() => Effect.void));
+        );
 
-      const workerSlots = A.range(1, config.concurrency);
-      yield* Effect.forEach(workerSlots, () => worker.pipe(Effect.forkScoped), {
-        concurrency: "unbounded",
-      });
-
-      const enqueue = (
-        request: HttpServerRequest.HttpServerRequest
-      ): Effect.Effect<HttpServerResponse.HttpServerResponse> =>
-        Effect.gen(function* () {
-          const accepting = yield* Ref.get(acceptingRef);
-          if (!accepting) {
-            return proxyErrorResponse("shutting_down", "Graphiti proxy is shutting down.", {
-              status: 503,
-              headers: {
-                "retry-after": "1",
-              },
-            });
-          }
-
-          const responseDeferred = yield* Deferred.make<HttpServerResponse.HttpServerResponse>();
-          const offered = yield* Queue.offer(queue, { request, responseDeferred });
-
-          if (!offered) {
-            yield* Ref.update(rejectedRef, (rejected) => rejected + 1);
-            return proxyErrorResponse("queue_full", `Graphiti proxy queue full (max ${config.maxQueue})`, {
-              status: 503,
-              headers: {
-                "retry-after": "1",
-              },
-            });
-          }
-
-          const queued = yield* Queue.size(queue);
-          yield* Ref.update(peakQueueDepthRef, (peak) => (queued > peak ? queued : peak));
-
-          return yield* Deferred.await(responseDeferred);
-        });
-
-      const snapshot = Effect.gen(function* () {
         const queued = yield* Queue.size(queue);
         const active = yield* Ref.get(activeRef);
-        const peakQueueDepth = yield* Ref.get(peakQueueDepthRef);
-        const processed = yield* Ref.get(processedRef);
-        const failed = yield* Ref.get(failedRef);
-        const rejected = yield* Ref.get(rejectedRef);
 
-        return new ProxyQueueStats({
-          active,
-          queued,
-          peakQueueDepth,
-          processed,
-          failed,
-          rejected,
-          concurrency: config.concurrency,
-          maxQueue: config.maxQueue,
-          upstream: config.upstream,
-        });
-      });
+        const responseWithHeaders = pipe(
+          response,
+          HttpServerResponse.setHeader("x-graphiti-proxy-queued", `${queued}`),
+          HttpServerResponse.setHeader("x-graphiti-proxy-active", `${active}`)
+        );
 
-      const beginShutdown = Ref.set(acceptingRef, false).pipe(
-        Effect.andThen(
-          Effect.fnUntraced(function* () {
-            return yield* checkDrain;
-          })
+        yield* Deferred.succeed(job.responseDeferred, responseWithHeaders).pipe(Effect.ignore);
+        yield* Ref.update(processedRef, (processed) => processed + 1);
+      }).pipe(
+        Effect.ensuring(
+          Ref.update(activeRef, (active) => (active > 0 ? active - 1 : 0)).pipe(Effect.andThen(checkDrain()))
         )
-      );
+      )
+    ).pipe(Effect.catchDefect(() => Effect.void));
 
-      const awaitDrain = (timeoutMs: number): Effect.Effect<boolean> =>
-        Deferred.await(drainDeferred).pipe(Effect.timeoutOption(Duration.millis(timeoutMs)), Effect.map(O.isSome));
+    const workerSlots = A.range(1, config.concurrency);
+    yield* Effect.forEach(workerSlots, () => worker.pipe(Effect.forkScoped), {
+      concurrency: "unbounded",
+    });
 
-      return GraphitiProxyQueueService.of({
-        enqueue,
-        snapshot,
-        beginShutdown,
-        awaitDrain,
+    const enqueue: (
+      request: HttpServerRequest.HttpServerRequest
+    ) => Effect.Effect<HttpServerResponse.HttpServerResponse> = Effect.fnUntraced(function* (request) {
+      const accepting = yield* Ref.get(acceptingRef);
+      if (!accepting) {
+        return proxyErrorResponse("shutting_down", "Graphiti proxy is shutting down.", {
+          status: 503,
+          headers: {
+            "retry-after": "1",
+          },
+        });
+      }
+
+      const responseDeferred = yield* Deferred.make<HttpServerResponse.HttpServerResponse>();
+      const offered = yield* Queue.offer(queue, { request, responseDeferred });
+
+      if (!offered) {
+        yield* Ref.update(rejectedRef, (rejected) => rejected + 1);
+        return proxyErrorResponse("queue_full", `Graphiti proxy queue full (max ${config.maxQueue})`, {
+          status: 503,
+          headers: {
+            "retry-after": "1",
+          },
+        });
+      }
+
+      const queued = yield* Queue.size(queue);
+      yield* Ref.update(peakQueueDepthRef, (peak) => (queued > peak ? queued : peak));
+
+      return yield* Deferred.await(responseDeferred);
+    });
+
+    const snapshot = Effect.gen(function* () {
+      const queued = yield* Queue.size(queue);
+      const active = yield* Ref.get(activeRef);
+      const peakQueueDepth = yield* Ref.get(peakQueueDepthRef);
+      const processed = yield* Ref.get(processedRef);
+      const failed = yield* Ref.get(failedRef);
+      const rejected = yield* Ref.get(rejectedRef);
+
+      return new ProxyQueueStats({
+        active,
+        queued,
+        peakQueueDepth,
+        processed,
+        failed,
+        rejected,
+        concurrency: config.concurrency,
+        maxQueue: config.maxQueue,
+        upstream: config.upstream,
       });
-    })
+    });
+
+    const beginShutdown = Ref.set(acceptingRef, false).pipe(Effect.andThen(checkDrain()));
+
+    const awaitDrain = (timeoutMs: number): Effect.Effect<boolean> =>
+      Deferred.await(drainDeferred).pipe(Effect.timeoutOption(Duration.millis(timeoutMs)), Effect.map(O.isSome));
+
+    return GraphitiProxyQueueService.of({
+      enqueue,
+      snapshot,
+      beginShutdown,
+      awaitDrain,
+    });
+  })
 );

--- a/packages/tooling/tool/cli/src/commands/Laws/AllowlistCheck.ts
+++ b/packages/tooling/tool/cli/src/commands/Laws/AllowlistCheck.ts
@@ -274,8 +274,13 @@ export const runAllowlistCheck = Effect.fn(function* (options: AllowlistCheckOpt
   }
 
   const decodedResult = yield* decodeEffectLawsAllowlist(parsedResult.success).pipe(
-    Effect.map(Result.succeed),
-    Effect.mapError((error) => Result.fail(formatSchemaDiagnostics(error.issue)))
+    Effect.result,
+    Effect.map(
+      Result.match({
+        onFailure: (error) => Result.fail(formatSchemaDiagnostics(error.issue)),
+        onSuccess: Result.succeed,
+      })
+    )
   );
 
   if (Result.isFailure(decodedResult)) {

--- a/packages/tooling/tool/cli/src/commands/Laws/AllowlistCheck.ts
+++ b/packages/tooling/tool/cli/src/commands/Laws/AllowlistCheck.ts
@@ -275,7 +275,7 @@ export const runAllowlistCheck = Effect.fn(function* (options: AllowlistCheckOpt
 
   const decodedResult = yield* decodeEffectLawsAllowlist(parsedResult.success).pipe(
     Effect.map(Result.succeed),
-    Effect.catch((error) => Effect.succeed(Result.fail(formatSchemaDiagnostics(error.issue))))
+    Effect.mapError((error) => Result.fail(formatSchemaDiagnostics(error.issue)))
   );
 
   if (Result.isFailure(decodedResult)) {

--- a/packages/tooling/tool/cli/src/commands/Laws/DualArity.ts
+++ b/packages/tooling/tool/cli/src/commands/Laws/DualArity.ts
@@ -836,7 +836,7 @@ const collectCandidateDiagnostics = (
 
 const makeOwnerResolver = Effect.fn("DualArity.makeOwnerResolver")(function* () {
   const workspaces = yield* resolveWorkspaceDirs(process.cwd()).pipe(
-    Effect.catch(() => Effect.succeed(HashMap.empty()))
+    Effect.mapError(() => HashMap.empty<string, string>())
   );
   const workspaceEntries = pipe(
     HashMap.toEntries(workspaces),

--- a/packages/tooling/tool/cli/src/commands/Laws/DualArity.ts
+++ b/packages/tooling/tool/cli/src/commands/Laws/DualArity.ts
@@ -836,7 +836,8 @@ const collectCandidateDiagnostics = (
 
 const makeOwnerResolver = Effect.fn("DualArity.makeOwnerResolver")(function* () {
   const workspaces = yield* resolveWorkspaceDirs(process.cwd()).pipe(
-    Effect.mapError(() => HashMap.empty<string, string>())
+    Effect.option,
+    Effect.map(O.getOrElse(() => HashMap.empty<string, string>()))
   );
   const workspaceEntries = pipe(
     HashMap.toEntries(workspaces),

--- a/packages/tooling/tool/cli/src/commands/Laws/EffectFn.ts
+++ b/packages/tooling/tool/cli/src/commands/Laws/EffectFn.ts
@@ -1,0 +1,459 @@
+/**
+ * Repo-local Effect.fn supplemental law.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import {
+  TSMorphService,
+  type TSMorphServiceError,
+  TsMorphProjectInspectionRequest,
+} from "@beep/repo-utils/TSMorph/index";
+import { LiteralKit } from "@beep/schema";
+import { Effect, Order, Path, pipe } from "effect";
+import * as A from "effect/Array";
+import * as O from "effect/Option";
+import * as P from "effect/Predicate";
+import * as S from "effect/Schema";
+import {
+  type ArrowFunction,
+  type CallExpression,
+  type FunctionDeclaration,
+  type FunctionExpression,
+  type MethodDeclaration,
+  Node,
+  type SourceFile,
+  SyntaxKind,
+} from "ts-morph";
+import { isExcludedTypeScriptSourcePath, toPosixPath } from "../Shared/TypeScriptSourceExclusions.ts";
+
+const $I = $RepoCliId.create("commands/Laws/EffectFn");
+
+const INCLUDED_GLOBS = ["apps/**/*.{ts,tsx}", "packages/**/*.{ts,tsx}", "infra/**/*.ts"] as const;
+const EFFECT_FN_RULE_ID = "beep-laws/effect-fn";
+
+const EffectFnRecommendation = LiteralKit(["Effect.fn", "Effect.fnUntraced"]);
+
+type EffectFnRecommendation = typeof EffectFnRecommendation.Type;
+type EffectFnOwner = ArrowFunction | FunctionDeclaration | FunctionExpression | MethodDeclaration;
+type ScannedSourceFile = readonly [file: string, sourceFile: SourceFile];
+
+const decodeProjectInspectionRequest = S.decodeUnknownEffect(TsMorphProjectInspectionRequest);
+
+/**
+ * Runtime options for the Effect.fn supplemental law.
+ *
+ * @example
+ * ```ts
+ * import { EffectFnRulesOptions } from "@beep/repo-cli/commands/Laws/EffectFn"
+ *
+ * const options = new EffectFnRulesOptions({
+ *   strictCheck: true,
+ *   excludePaths: ["packages/demo/test/index.ts"],
+ * })
+ *
+ * console.log(options.strictCheck)
+ * ```
+ * @category models
+ * @since 0.0.0
+ */
+export class EffectFnRulesOptions extends S.Class<EffectFnRulesOptions>($I`EffectFnRulesOptions`)(
+  {
+    strictCheck: S.Boolean.pipe(
+      S.withConstructorDefault(Effect.succeed(false)),
+      S.withDecodingDefault(Effect.succeed(false))
+    ),
+    excludePaths: S.Array(S.String).pipe(
+      S.withConstructorDefault(Effect.succeed(A.empty<string>())),
+      S.withDecodingDefault(Effect.succeed(A.empty<string>()))
+    ),
+  },
+  $I.annote("EffectFnRulesOptions", {
+    description: "Runtime options for the repo-local Effect.fn supplemental law.",
+  })
+) {}
+
+/**
+ * Single Effect.fn supplemental law diagnostic.
+ *
+ * @example
+ * ```ts
+ * import { EffectFnDiagnostic } from "@beep/repo-cli/commands/Laws/EffectFn"
+ *
+ * const diagnostic = new EffectFnDiagnostic({
+ *   file: "packages/demo/src/index.ts",
+ *   line: 4,
+ *   column: 42,
+ *   ruleId: "beep-laws/effect-fn",
+ *   ownerName: "loadDemo",
+ *   recommendation: "Effect.fn",
+ *   message: "Function \"loadDemo\" directly returns Effect.gen; wrap it with Effect.fn.",
+ * })
+ *
+ * console.log(diagnostic.recommendation)
+ * ```
+ * @category models
+ * @since 0.0.0
+ */
+export class EffectFnDiagnostic extends S.Class<EffectFnDiagnostic>($I`EffectFnDiagnostic`)(
+  {
+    file: S.String,
+    line: S.Number,
+    column: S.Number,
+    ruleId: S.String,
+    ownerName: S.String,
+    recommendation: EffectFnRecommendation,
+    message: S.String,
+  },
+  $I.annote("EffectFnDiagnostic", {
+    description: "Diagnostic emitted when a reusable function directly returns Effect.gen.",
+  })
+) {}
+
+/**
+ * Summary of Effect.fn supplemental law results.
+ *
+ * @example
+ * ```ts
+ * import { EffectFnRulesSummary } from "@beep/repo-cli/commands/Laws/EffectFn"
+ *
+ * const summary = new EffectFnRulesSummary({
+ *   scannedFiles: 12,
+ *   touchedFiles: 1,
+ *   violationCount: 1,
+ *   strictFailure: true,
+ * })
+ *
+ * console.log(summary.strictFailure)
+ * ```
+ * @category models
+ * @since 0.0.0
+ */
+export class EffectFnRulesSummary extends S.Class<EffectFnRulesSummary>($I`EffectFnRulesSummary`)(
+  {
+    scannedFiles: S.Number,
+    touchedFiles: S.Number,
+    violationCount: S.Number,
+    strictFailure: S.Boolean,
+    affectedFiles: S.Array(S.String).pipe(
+      S.withConstructorDefault(Effect.succeed(A.empty<string>())),
+      S.withDecodingDefault(Effect.succeed(A.empty<string>()))
+    ),
+    diagnostics: S.Array(EffectFnDiagnostic).pipe(
+      S.withConstructorDefault(Effect.succeed(A.empty<EffectFnDiagnostic>())),
+      S.withDecodingDefault(Effect.succeed(A.empty<EffectFnDiagnostic>()))
+    ),
+  },
+  $I.annote("EffectFnRulesSummary", {
+    description: "Summary of repo-local Effect.fn supplemental law results.",
+  })
+) {}
+
+const byScannedSourceFilePathAscending = Order.mapInput(Order.String, ([file]: ScannedSourceFile) => file);
+
+const isEffectFnOwner = (node: Node): node is EffectFnOwner =>
+  Node.isArrowFunction(node) ||
+  Node.isFunctionDeclaration(node) ||
+  Node.isFunctionExpression(node) ||
+  Node.isMethodDeclaration(node);
+
+const isGeneratorOwner = (owner: EffectFnOwner): boolean => !Node.isArrowFunction(owner) && owner.isGenerator();
+
+const parentOf = (node: Node): O.Option<Node> => O.fromUndefinedOr(node.getParent());
+
+const isSourceFileParent = (node: Node): boolean => pipe(parentOf(node), O.exists(Node.isSourceFile));
+
+const isSameNode = (left: Node, right: Node): boolean =>
+  left.getSourceFile() === right.getSourceFile() &&
+  left.getStart() === right.getStart() &&
+  left.getEnd() === right.getEnd();
+
+const unwrapParenthesized = (node: Node): Node =>
+  Node.isParenthesizedExpression(node) ? unwrapParenthesized(node.getExpression()) : node;
+
+const isEffectMemberCallExpression = (callExpression: CallExpression, memberNames: ReadonlyArray<string>): boolean => {
+  const expression = callExpression.getExpression();
+
+  return (
+    Node.isPropertyAccessExpression(expression) &&
+    expression.getExpression().getText() === "Effect" &&
+    A.contains(expression.getName())(memberNames)
+  );
+};
+
+const isEffectGenCall = (node: Node): node is CallExpression =>
+  Node.isCallExpression(node) && isEffectMemberCallExpression(node, ["gen"]);
+
+const isEffectFnConstructorCall = (callExpression: CallExpression): boolean => {
+  if (isEffectMemberCallExpression(callExpression, ["fn", "fnUntraced"])) {
+    return true;
+  }
+
+  const expression = callExpression.getExpression();
+  return Node.isCallExpression(expression) && isEffectMemberCallExpression(expression, ["fn", "fnUntraced"]);
+};
+
+const isEffectFnBody = (owner: EffectFnOwner): boolean =>
+  pipe(
+    parentOf(owner),
+    O.exists((parent) => Node.isCallExpression(parent) && isEffectFnConstructorCall(parent))
+  );
+
+const nearestOwner = (node: Node): O.Option<EffectFnOwner> => {
+  let current = node.getParent();
+
+  while (P.isNotUndefined(current)) {
+    if (isEffectFnOwner(current)) {
+      return O.some(current);
+    }
+
+    current = current.getParent();
+  }
+
+  return O.none();
+};
+
+const parentSkippingParentheses = (node: Node): readonly [directNode: Node, parent: O.Option<Node>] => {
+  let directNode = node;
+  let parent = directNode.getParent();
+
+  while (P.isNotUndefined(parent) && Node.isParenthesizedExpression(parent)) {
+    directNode = parent;
+    parent = directNode.getParent();
+  }
+
+  return [directNode, O.fromUndefinedOr(parent)] as const;
+};
+
+const getDirectReturnOwner = (callExpression: CallExpression): O.Option<EffectFnOwner> => {
+  const [, parent] = parentSkippingParentheses(callExpression);
+
+  return pipe(
+    parent,
+    O.flatMap((parentNode) => {
+      if (Node.isArrowFunction(parentNode) && isSameNode(unwrapParenthesized(parentNode.getBody()), callExpression)) {
+        return O.some(parentNode);
+      }
+
+      if (
+        Node.isReturnStatement(parentNode) &&
+        pipe(
+          O.fromUndefinedOr(parentNode.getExpression()),
+          O.map(unwrapParenthesized),
+          O.exists((expression) => isSameNode(expression, callExpression))
+        )
+      ) {
+        return nearestOwner(parentNode);
+      }
+
+      return O.none();
+    })
+  );
+};
+
+const ownerNameFromParent = (owner: EffectFnOwner): O.Option<string> =>
+  pipe(
+    parentOf(owner),
+    O.flatMap((parent) => {
+      if (
+        Node.isVariableDeclaration(parent) ||
+        Node.isPropertyAssignment(parent) ||
+        Node.isPropertyDeclaration(parent)
+      ) {
+        return O.some(parent.getName());
+      }
+
+      return O.none();
+    })
+  );
+
+const getOwnerName = (owner: EffectFnOwner): O.Option<string> => {
+  if (Node.isFunctionDeclaration(owner) || Node.isFunctionExpression(owner)) {
+    return pipe(
+      O.fromUndefinedOr(owner.getName()),
+      O.orElse(() => ownerNameFromParent(owner))
+    );
+  }
+
+  if (Node.isMethodDeclaration(owner)) {
+    return O.some(owner.getName());
+  }
+
+  return ownerNameFromParent(owner);
+};
+
+const hasTopLevelStatementOwner = (owner: EffectFnOwner): boolean => {
+  if (Node.isFunctionDeclaration(owner)) {
+    return isSourceFileParent(owner);
+  }
+
+  const parent = owner.getParent();
+
+  if (P.isNotUndefined(parent) && Node.isVariableDeclaration(parent)) {
+    const variableStatement = parent.getFirstAncestorByKind(SyntaxKind.VariableStatement);
+    return P.isNotUndefined(variableStatement) && isSourceFileParent(variableStatement);
+  }
+
+  if (
+    P.isNotUndefined(parent) &&
+    (Node.isPropertyAssignment(parent) || Node.isPropertyDeclaration(parent) || Node.isMethodDeclaration(owner))
+  ) {
+    const variableStatement = owner.getFirstAncestorByKind(SyntaxKind.VariableStatement);
+    if (P.isNotUndefined(variableStatement) && isSourceFileParent(variableStatement)) {
+      return true;
+    }
+
+    const classDeclaration = owner.getFirstAncestorByKind(SyntaxKind.ClassDeclaration);
+    if (P.isNotUndefined(classDeclaration) && isSourceFileParent(classDeclaration)) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const recommendationForOwner = (owner: EffectFnOwner): EffectFnRecommendation =>
+  hasTopLevelStatementOwner(owner) ? "Effect.fn" : "Effect.fnUntraced";
+
+const fallbackOwnerName = (owner: EffectFnOwner): string =>
+  pipe(
+    getOwnerName(owner),
+    O.getOrElse(() => (Node.isMethodDeclaration(owner) ? "method" : "callback"))
+  );
+
+const makeDiagnostic = (
+  sourceFile: SourceFile,
+  relativeFilePath: string,
+  owner: EffectFnOwner,
+  callExpression: CallExpression
+): EffectFnDiagnostic => {
+  const position = sourceFile.getLineAndColumnAtPos(callExpression.getStart());
+  const ownerName = fallbackOwnerName(owner);
+  const recommendation = recommendationForOwner(owner);
+  const suggestedName =
+    recommendation === "Effect.fn" ? ` named ${recommendation}("${ownerName}")` : ` ${recommendation}`;
+
+  return new EffectFnDiagnostic({
+    file: relativeFilePath,
+    line: position.line,
+    column: position.column,
+    ruleId: EFFECT_FN_RULE_ID,
+    ownerName,
+    recommendation,
+    message: `Reusable function '${ownerName}' directly returns Effect.gen(function*). Use${suggestedName} instead.`,
+  });
+};
+
+const collectEffectFnDiagnostics = (
+  relativeFilePath: string,
+  sourceFile: SourceFile
+): ReadonlyArray<EffectFnDiagnostic> => {
+  let diagnostics = A.empty<EffectFnDiagnostic>();
+
+  for (const callExpression of sourceFile.getDescendantsOfKind(SyntaxKind.CallExpression)) {
+    if (!isEffectGenCall(callExpression)) {
+      continue;
+    }
+
+    const owner = pipe(
+      getDirectReturnOwner(callExpression),
+      O.filter((candidate) => !isGeneratorOwner(candidate))
+    );
+    if (O.isNone(owner) || isEffectFnBody(owner.value)) {
+      continue;
+    }
+
+    diagnostics = A.append(diagnostics, makeDiagnostic(sourceFile, relativeFilePath, owner.value, callExpression));
+  }
+
+  return diagnostics;
+};
+
+/**
+ * Run the repo-local Effect.fn supplemental law.
+ *
+ * @param options - Runtime options for the check.
+ * @returns Effect that scans production TypeScript source and reports direct Effect.gen returns.
+ * @effects Requires the shared TSMorph service and platform path service to inspect repo TypeScript source files.
+ * @example
+ * ```ts
+ * import { Effect } from "effect"
+ * import { runEffectFnRules, EffectFnRulesOptions } from "@beep/repo-cli/commands/Laws/EffectFn"
+ *
+ * const program = Effect.map(
+ *   runEffectFnRules(new EffectFnRulesOptions({ strictCheck: true })),
+ *   (summary) => summary.violationCount,
+ * )
+ *
+ * console.log(program)
+ * ```
+ * @category utilities
+ * @since 0.0.0
+ */
+export const runEffectFnRules = Effect.fn("EffectFn.runEffectFnRules")(function* (
+  options: EffectFnRulesOptions
+): Effect.fn.Return<EffectFnRulesSummary, S.SchemaError | TSMorphServiceError, TSMorphService | Path.Path> {
+  const service = yield* TSMorphService;
+  const path = yield* Path.Path;
+
+  const isExcludedFile = (filePath: string): boolean => {
+    const normalized = toPosixPath(filePath);
+    if (A.some(options.excludePaths, (excludePath) => normalized === toPosixPath(excludePath))) {
+      return true;
+    }
+
+    return isExcludedTypeScriptSourcePath(normalized);
+  };
+
+  const request = yield* decodeProjectInspectionRequest({
+    entrypoint: {
+      _tag: "tsconfig",
+      tsConfigPath: "tsconfig.json",
+    },
+    repoRootPath: null,
+    mode: "syntax",
+    referencePolicy: "workspaceOnly",
+    filePaths: A.empty(),
+    sourceFileGlobs: A.fromIterable(INCLUDED_GLOBS),
+  });
+
+  return yield* service.inspectProject(request, ({ scope, sourceFiles }) => {
+    let scannedSourceFiles = A.empty<ScannedSourceFile>();
+
+    for (const sourceFile of sourceFiles) {
+      const relativeFilePath = toPosixPath(path.relative(scope.repoRootPath, sourceFile.getFilePath()));
+
+      if (isExcludedFile(relativeFilePath)) {
+        continue;
+      }
+
+      scannedSourceFiles = A.append(scannedSourceFiles, [relativeFilePath, sourceFile] as const);
+    }
+
+    scannedSourceFiles = A.sort(scannedSourceFiles, byScannedSourceFilePathAscending);
+
+    let diagnostics = A.empty<EffectFnDiagnostic>();
+    let affectedFiles = A.empty<string>();
+
+    for (const [relativeFilePath, sourceFile] of scannedSourceFiles) {
+      const fileDiagnostics = collectEffectFnDiagnostics(relativeFilePath, sourceFile);
+      if (A.isReadonlyArrayNonEmpty(fileDiagnostics)) {
+        affectedFiles = A.append(affectedFiles, relativeFilePath);
+        diagnostics = A.appendAll(diagnostics, fileDiagnostics);
+      }
+    }
+
+    const violationCount = A.length(diagnostics);
+
+    return new EffectFnRulesSummary({
+      scannedFiles: A.length(scannedSourceFiles),
+      touchedFiles: A.length(affectedFiles),
+      violationCount,
+      strictFailure: options.strictCheck && violationCount > 0,
+      affectedFiles,
+      diagnostics,
+    });
+  });
+});

--- a/packages/tooling/tool/cli/src/commands/Laws/index.ts
+++ b/packages/tooling/tool/cli/src/commands/Laws/index.ts
@@ -12,6 +12,7 @@ import * as S from "effect/Schema";
 import { Command, Flag } from "effect/unstable/cli";
 import { AllowlistCheckOptions, reportAllowlistCheckSummary, runAllowlistCheck } from "./AllowlistCheck.js";
 import { DualArityRulesOptions, runDualArityRules } from "./DualArity.js";
+import { EffectFnRulesOptions, runEffectFnRules } from "./EffectFn.js";
 import { EffectImportRulesOptions, runEffectImportRules } from "./EffectImports.js";
 import { NoNativeRuntimeRulesOptions, runNoNativeRuntimeRules } from "./NoNativeRuntime.js";
 import { runTerseEffectRules, TerseEffectRulesOptions } from "./TerseEffect.js";
@@ -96,6 +97,29 @@ class DualArityCommandOptions extends S.Class<DualArityCommandOptions>($I`DualAr
   },
   $I.annote("DualArityCommandOptions", {
     description: "CLI options for public API dual-arity command.",
+  })
+) {}
+
+/**
+ * CLI options for the Effect.fn supplemental law.
+ *
+ * @example
+ * ```ts
+ * console.log("EffectFnCommandOptions")
+ * ```
+ * @category models
+ * @since 0.0.0
+ */
+class EffectFnCommandOptions extends S.Class<EffectFnCommandOptions>($I`EffectFnCommandOptions`)(
+  {
+    check: S.Boolean.pipe(
+      S.withConstructorDefault(Effect.succeed(false)),
+      S.withDecodingDefault(Effect.succeed(false))
+    ),
+    exclude: S.String.pipe(S.withConstructorDefault(Effect.succeed("")), S.withDecodingDefault(Effect.succeed(""))),
+  },
+  $I.annote("EffectFnCommandOptions", {
+    description: "CLI options for the Effect.fn supplemental law.",
   })
 ) {}
 
@@ -275,6 +299,51 @@ const lawsDualArityCommand = Command.make(
 ).pipe(Command.withDescription("Check or refresh public helper dual-arity inventory"));
 
 /**
+ * CLI command for the Effect.fn supplemental law.
+ *
+ * @example
+ * ```ts
+ * console.log("lawsEffectFnCommand")
+ * ```
+ * @category utilities
+ * @since 0.0.0
+ */
+const lawsEffectFnCommand = Command.make(
+  "effect-fn",
+  {
+    check: Flag.boolean("check").pipe(Flag.withDescription("Fail when reusable functions directly return Effect.gen")),
+    exclude: Flag.string("exclude").pipe(
+      Flag.withDescription("Comma-separated list of file paths to exclude"),
+      Flag.withDefault("")
+    ),
+  },
+  Effect.fn(function* ({ check, exclude }) {
+    const options = new EffectFnCommandOptions({ check, exclude });
+    const summary = yield* runEffectFnRules(
+      new EffectFnRulesOptions({
+        strictCheck: options.check,
+        excludePaths: parseExcludePaths(options.exclude),
+      })
+    );
+
+    yield* Console.log(`[effect-governance-effect-fn] mode=${options.check ? "check" : "report"}`);
+    yield* Console.log(`[effect-governance-effect-fn] scanned_files=${summary.scannedFiles}`);
+    yield* Console.log(`[effect-governance-effect-fn] touched_files=${summary.touchedFiles}`);
+    yield* Console.log(`[effect-governance-effect-fn] violations=${summary.violationCount}`);
+
+    for (const diagnostic of summary.diagnostics) {
+      yield* Console.log(
+        `- ${diagnostic.file}:${diagnostic.line}:${diagnostic.column} [${diagnostic.ruleId}] ${diagnostic.message}`
+      );
+    }
+
+    if (summary.strictFailure) {
+      process.exitCode = 1;
+    }
+  })
+).pipe(Command.withDescription("Check reusable Effect.gen-returning functions use Effect.fn or Effect.fnUntraced"));
+
+/**
  * CLI command for repo-local native runtime governance checks.
  *
  * @example
@@ -372,6 +441,7 @@ export const lawsCommand = Command.make(
     yield* Console.log("- bun run beep laws native-runtime --check");
     yield* Console.log("- bun run beep laws dual-arity --check");
     yield* Console.log("- bun run beep laws dual-arity --write");
+    yield* Console.log("- bun run beep laws effect-fn --check");
     yield* Console.log("- bun run beep laws terse-effect --check");
     yield* Console.log("- bun run beep laws terse-effect --write");
     yield* Console.log("- bun run beep laws allowlist-check");
@@ -382,6 +452,7 @@ export const lawsCommand = Command.make(
     lawsEffectImportsCommand,
     lawsNativeRuntimeCommand,
     lawsDualArityCommand,
+    lawsEffectFnCommand,
     lawsTerseEffectCommand,
     lawsAllowlistCheckCommand,
   ])

--- a/packages/tooling/tool/cli/src/commands/Quality/ScriptCommands.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/ScriptCommands.ts
@@ -113,7 +113,7 @@ const runStep = Effect.fn("QualityScriptCommands.runStep")(function* (
 ): Effect.fn.Return<void, QualityScriptCommandError, ChildProcessSpawner.ChildProcessSpawner> {
   yield* Console.log(`[beep-cli] ${step.label}: ${commandText(step.command, step.args)}`);
   const exitCode = yield* Effect.scoped(
-    Effect.fnUntraced(function* () {
+    Effect.gen(function* () {
       const handle = yield* ChildProcess.make(step.command, [...step.args], {
         cwd: step.cwd,
         env: step.env,
@@ -123,7 +123,7 @@ const runStep = Effect.fn("QualityScriptCommands.runStep")(function* (
         stderr: "inherit",
       });
       return yield* handle.exitCode;
-    })()
+    })
   ).pipe(
     Effect.mapError(
       (cause) =>
@@ -157,7 +157,7 @@ const collectOutput = Effect.fn("QualityScriptCommands.collectOutput")(function*
   ChildProcessSpawner.ChildProcessSpawner
 > {
   return yield* Effect.scoped(
-    Effect.fnUntraced(function* () {
+    Effect.gen(function* () {
       const handle = yield* ChildProcess.make(step.command, [...step.args], {
         cwd: step.cwd,
         env: step.env,
@@ -177,7 +177,7 @@ const collectOutput = Effect.fn("QualityScriptCommands.collectOutput")(function*
         output: Str.trim(output),
         exitCode,
       };
-    })()
+    })
   ).pipe(
     Effect.mapError(
       (cause) =>

--- a/packages/tooling/tool/cli/src/commands/Quality/ScriptCommands.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/ScriptCommands.ts
@@ -113,7 +113,7 @@ const runStep = Effect.fn("QualityScriptCommands.runStep")(function* (
 ): Effect.fn.Return<void, QualityScriptCommandError, ChildProcessSpawner.ChildProcessSpawner> {
   yield* Console.log(`[beep-cli] ${step.label}: ${commandText(step.command, step.args)}`);
   const exitCode = yield* Effect.scoped(
-    Effect.gen(function* () {
+    Effect.fnUntraced(function* () {
       const handle = yield* ChildProcess.make(step.command, [...step.args], {
         cwd: step.cwd,
         env: step.env,
@@ -123,7 +123,7 @@ const runStep = Effect.fn("QualityScriptCommands.runStep")(function* (
         stderr: "inherit",
       });
       return yield* handle.exitCode;
-    })
+    })()
   ).pipe(
     Effect.mapError(
       (cause) =>
@@ -157,7 +157,7 @@ const collectOutput = Effect.fn("QualityScriptCommands.collectOutput")(function*
   ChildProcessSpawner.ChildProcessSpawner
 > {
   return yield* Effect.scoped(
-    Effect.gen(function* () {
+    Effect.fnUntraced(function* () {
       const handle = yield* ChildProcess.make(step.command, [...step.args], {
         cwd: step.cwd,
         env: step.env,
@@ -177,7 +177,7 @@ const collectOutput = Effect.fn("QualityScriptCommands.collectOutput")(function*
         output: Str.trim(output),
         exitCode,
       };
-    })
+    })()
   ).pipe(
     Effect.mapError(
       (cause) =>

--- a/packages/tooling/tool/cli/src/commands/Quality/Tasks.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/Tasks.ts
@@ -379,8 +379,8 @@ const resolvePackageDir = Effect.fn("QualityTasks.resolvePackageDir")(function* 
   const path = yield* Path.Path;
   const root = path.resolve(repoRoot);
 
-  const findPackageDir = (current: string): Effect.Effect<O.Option<string>, QualityTaskConfigurationError> =>
-    Effect.gen(function* () {
+  const findPackageDir: (current: string) => Effect.Effect<O.Option<string>, QualityTaskConfigurationError> =
+    Effect.fn("QualityTasks.findPackageDir")(function* (current) {
       const packageJsonPath = path.join(current, "package.json");
       const exists = yield* fs.exists(packageJsonPath).pipe(Effect.orElseSucceed(thunkFalse));
 
@@ -466,17 +466,18 @@ const turboEnvOverrides = (command: string, args: ReadonlyArray<string>): Record
   };
 };
 
-const runExitCode = (command: string, args: ReadonlyArray<string>, cwd: string) =>
-  Effect.scoped(
-    Effect.gen(function* () {
+const runExitCode = Effect.fn("QualityTasks.runExitCode")(function* (command: string, args: ReadonlyArray<string>, cwd: string) {
+  return yield* Effect.scoped(
+    Effect.fnUntraced(function* () {
       const handle = yield* ChildProcess.make(command, [...args], {
         cwd,
         stdout: "ignore",
         stderr: "ignore",
       });
       return yield* handle.exitCode;
-    })
+    })()
   );
+});
 
 const canUseLocalEnv = Effect.fn("QualityTasks.canUseLocalEnv")(function* (
   repoRoot: string
@@ -517,7 +518,7 @@ const runStep = Effect.fn("QualityTasks.runStep")(function* (step: QualityTaskSt
   const resolved = yield* withLocalEnv(step);
   yield* Console.log(`[beep-cli] ${resolved.label}: ${commandText(resolved.command, resolved.args)}`);
   const exitCode = yield* Effect.scoped(
-    Effect.gen(function* () {
+    Effect.fnUntraced(function* () {
       const handle = yield* ChildProcess.make(resolved.command, [...resolved.args], {
         cwd: resolved.cwd,
         env: {
@@ -530,7 +531,7 @@ const runStep = Effect.fn("QualityTasks.runStep")(function* (step: QualityTaskSt
         stderr: "inherit",
       });
       return yield* handle.exitCode;
-    })
+    })()
   ).pipe(
     Effect.mapError(
       (cause) =>
@@ -669,10 +670,10 @@ const runSqlIntegrationTestLane = Effect.fn("QualityTasks.runSqlIntegrationTestL
   options: SqlIntegrationLaneOptions
 ) {
   yield* Effect.scoped(
-    Effect.gen(function* () {
+    Effect.fnUntraced(function* () {
       const resource = yield* options.acquireResource;
       yield* runStep(sqlIntegrationStep(options.repoRoot, options.args, resource, options.childCommand));
-    })
+    })()
   );
 });
 
@@ -1078,7 +1079,7 @@ export const runQualityTaskIfRequested: (
  */
 export const collectStepOutput = (step: QualityTaskStep) =>
   Effect.scoped(
-    Effect.gen(function* () {
+    Effect.fnUntraced(function* () {
       const handle = yield* ChildProcess.make(step.command, [...step.args], {
         cwd: step.cwd,
         stdout: "pipe",
@@ -1093,5 +1094,5 @@ export const collectStepOutput = (step: QualityTaskStep) =>
         output: Str.trim(output),
         exitCode,
       };
-    })
+    })()
   );

--- a/packages/tooling/tool/cli/src/commands/Quality/Tasks.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/Tasks.ts
@@ -379,27 +379,28 @@ const resolvePackageDir = Effect.fn("QualityTasks.resolvePackageDir")(function* 
   const path = yield* Path.Path;
   const root = path.resolve(repoRoot);
 
-  const findPackageDir: (current: string) => Effect.Effect<O.Option<string>, QualityTaskConfigurationError> =
-    Effect.fn("QualityTasks.findPackageDir")(function* (current) {
-      const packageJsonPath = path.join(current, "package.json");
-      const exists = yield* fs.exists(packageJsonPath).pipe(Effect.orElseSucceed(thunkFalse));
+  const findPackageDir: (current: string) => Effect.Effect<O.Option<string>, QualityTaskConfigurationError> = Effect.fn(
+    "QualityTasks.findPackageDir"
+  )(function* (current) {
+    const packageJsonPath = path.join(current, "package.json");
+    const exists = yield* fs.exists(packageJsonPath).pipe(Effect.orElseSucceed(thunkFalse));
 
-      if (exists) {
-        return current === root ? O.none() : O.some(current);
-      }
+    if (exists) {
+      return current === root ? O.none() : O.some(current);
+    }
 
-      if (current === root) {
-        return O.none();
-      }
+    if (current === root) {
+      return O.none();
+    }
 
-      const parent = path.dirname(current);
-      if (parent === current) {
-        return yield* new QualityTaskConfigurationError({
-          message: `Could not find package.json between ${cwd} and ${repoRoot}.`,
-        });
-      }
-      return yield* findPackageDir(parent);
-    });
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return yield* new QualityTaskConfigurationError({
+        message: `Could not find package.json between ${cwd} and ${repoRoot}.`,
+      });
+    }
+    return yield* findPackageDir(parent);
+  });
 
   return yield* findPackageDir(path.resolve(cwd));
 });
@@ -466,16 +467,20 @@ const turboEnvOverrides = (command: string, args: ReadonlyArray<string>): Record
   };
 };
 
-const runExitCode = Effect.fn("QualityTasks.runExitCode")(function* (command: string, args: ReadonlyArray<string>, cwd: string) {
+const runExitCode = Effect.fn("QualityTasks.runExitCode")(function* (
+  command: string,
+  args: ReadonlyArray<string>,
+  cwd: string
+) {
   return yield* Effect.scoped(
-    Effect.fnUntraced(function* () {
+    Effect.gen(function* () {
       const handle = yield* ChildProcess.make(command, [...args], {
         cwd,
         stdout: "ignore",
         stderr: "ignore",
       });
       return yield* handle.exitCode;
-    })()
+    })
   );
 });
 
@@ -518,7 +523,7 @@ const runStep = Effect.fn("QualityTasks.runStep")(function* (step: QualityTaskSt
   const resolved = yield* withLocalEnv(step);
   yield* Console.log(`[beep-cli] ${resolved.label}: ${commandText(resolved.command, resolved.args)}`);
   const exitCode = yield* Effect.scoped(
-    Effect.fnUntraced(function* () {
+    Effect.gen(function* () {
       const handle = yield* ChildProcess.make(resolved.command, [...resolved.args], {
         cwd: resolved.cwd,
         env: {
@@ -531,7 +536,7 @@ const runStep = Effect.fn("QualityTasks.runStep")(function* (step: QualityTaskSt
         stderr: "inherit",
       });
       return yield* handle.exitCode;
-    })()
+    })
   ).pipe(
     Effect.mapError(
       (cause) =>
@@ -670,10 +675,10 @@ const runSqlIntegrationTestLane = Effect.fn("QualityTasks.runSqlIntegrationTestL
   options: SqlIntegrationLaneOptions
 ) {
   yield* Effect.scoped(
-    Effect.fnUntraced(function* () {
+    Effect.gen(function* () {
       const resource = yield* options.acquireResource;
       yield* runStep(sqlIntegrationStep(options.repoRoot, options.args, resource, options.childCommand));
-    })()
+    })
   );
 });
 
@@ -775,6 +780,7 @@ const rootTestSteps = (repoRoot: string, args: ReadonlyArray<string>) => {
 const rootRepoLintPolicySteps = (repoRoot: string): ReadonlyArray<QualityTaskStep> => [
   repoCliStep(repoRoot, "lint:effect-imports", ["laws", "effect-imports", "--check"]),
   repoCliStep(repoRoot, "lint:terse-effect", ["laws", "terse-effect", "--check"]),
+  repoCliStep(repoRoot, "lint:effect-fn", ["laws", "effect-fn", "--check"]),
   repoCliStep(repoRoot, "lint:native-runtime", ["laws", "native-runtime", "--check"]),
   repoCliStep(repoRoot, "lint:dual-arity", ["laws", "dual-arity", "--check"]),
   repoCliStep(repoRoot, "lint:allowlist", ["laws", "allowlist-check"]),
@@ -1079,7 +1085,7 @@ export const runQualityTaskIfRequested: (
  */
 export const collectStepOutput = (step: QualityTaskStep) =>
   Effect.scoped(
-    Effect.fnUntraced(function* () {
+    Effect.gen(function* () {
       const handle = yield* ChildProcess.make(step.command, [...step.args], {
         cwd: step.cwd,
         stdout: "pipe",
@@ -1094,5 +1100,5 @@ export const collectStepOutput = (step: QualityTaskStep) =>
         output: Str.trim(output),
         exitCode,
       };
-    })()
+    })
   );

--- a/packages/tooling/tool/cli/test/effect-fn.test.ts
+++ b/packages/tooling/tool/cli/test/effect-fn.test.ts
@@ -1,0 +1,287 @@
+import { EffectFnRulesOptions, runEffectFnRules } from "@beep/repo-cli/commands/Laws/EffectFn";
+import { TSMorphServiceLive } from "@beep/repo-utils/TSMorph/index";
+import { NodeChildProcessSpawner, NodeServices } from "@effect/platform-node";
+import { Effect, FileSystem, Layer, Path, Stream } from "effect";
+import { ChildProcess } from "effect/unstable/process";
+import { describe, expect, it } from "vitest";
+
+const testLayer = Layer.mergeAll(
+  NodeServices.layer,
+  NodeChildProcessSpawner.layer.pipe(Layer.provideMerge(NodeServices.layer)),
+  TSMorphServiceLive.pipe(Layer.provideMerge(NodeServices.layer))
+);
+const CLI_ENTRYPOINT = new URL("../src/bin.ts", import.meta.url).pathname;
+const emptyString = () => "";
+
+const withTempWorkingDirectory = <A, E, R>(use: Effect.Effect<A, E, R>) =>
+  Effect.acquireUseRelease(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const tmpDir = yield* fs.makeTempDirectory();
+      const previousCwd = process.cwd();
+      process.chdir(tmpDir);
+      return { fs, previousCwd, tmpDir } as const;
+    }),
+    () => use,
+    ({ fs, previousCwd, tmpDir }) =>
+      Effect.gen(function* () {
+        process.chdir(previousCwd);
+        yield* fs.remove(tmpDir, { recursive: true });
+      })
+  );
+
+const writeProjectFile = Effect.fn(function* (relativePath: string, content: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const absolutePath = path.join(process.cwd(), relativePath);
+  const directoryPath = path.dirname(absolutePath);
+
+  yield* fs.makeDirectory(directoryPath, { recursive: true });
+  yield* fs.writeFileString(absolutePath, content);
+});
+
+const writeProjectScaffold = Effect.gen(function* () {
+  yield* writeProjectFile("bun.lock", "");
+  yield* writeProjectFile(
+    "tsconfig.json",
+    [
+      "{",
+      '  "compilerOptions": {',
+      '    "target": "ES2022",',
+      '    "module": "ESNext",',
+      '    "moduleResolution": "Bundler",',
+      '    "strict": true,',
+      '    "skipLibCheck": true',
+      "  },",
+      '  "include": ["apps/**/*.ts", "apps/**/*.tsx", "packages/**/*.ts", "packages/**/*.tsx", "infra/**/*.ts"]',
+      "}",
+      "",
+    ].join("\n")
+  );
+});
+
+const runCliCommand = Effect.fn("effect-fn.test.runCliCommand")(function* (...args: ReadonlyArray<string>) {
+  return yield* Effect.scoped(
+    Effect.gen(function* () {
+      const handle = yield* ChildProcess.make("bun", ["run", CLI_ENTRYPOINT, "--", ...args], {
+        cwd: process.cwd(),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const output = yield* handle.all.pipe(
+        Stream.decodeText(),
+        Stream.runFold(emptyString, (accumulator, chunk) => `${accumulator}${chunk}`)
+      );
+      const exitCode = yield* handle.exitCode;
+      return { exitCode, output } as const;
+    })
+  );
+});
+
+describe("effect fn laws", () => {
+  it("flags direct Effect.gen returns that tsgo effectFnOpportunity can miss", async () => {
+    await Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeProjectScaffold;
+          yield* writeProjectFile(
+            "packages/demo/src/index.ts",
+            [
+              'import { Effect } from "effect";',
+              "",
+              "declare const flag: boolean;",
+              "declare const effects: ReadonlyArray<Effect.Effect<string>>;",
+              "",
+              "export const annotatedExpression = (value: string): Effect.Effect<string> => Effect.gen(function* () {",
+              "  return yield* Effect.succeed(value);",
+              "});",
+              "",
+              "export const annotatedBlock = (value: string): Effect.Effect<string> => {",
+              "  const prefix = 'x';",
+              "  return Effect.gen(function* () {",
+              "    return `${prefix}${value}`;",
+              "  });",
+              "};",
+              "",
+              "export const conditional = (value: string): Effect.Effect<string> => {",
+              "  if (flag) return Effect.succeed(value);",
+              "  return Effect.gen(function* () {",
+              "    return yield* Effect.succeed(value);",
+              "  });",
+              "};",
+              "",
+              "export function declared(value: string): Effect.Effect<string> {",
+              "  return Effect.gen(function* () {",
+              "    return yield* Effect.succeed(value);",
+              "  });",
+              "}",
+              "",
+              "export const handlers = {",
+              "  method(value: string): Effect.Effect<string> {",
+              "    return Effect.gen(function* () {",
+              "      return yield* Effect.succeed(value);",
+              "    });",
+              "  },",
+              "};",
+              "",
+              "export const mapped = effects.map((effect) => {",
+              "  return Effect.gen(function* () {",
+              "    return yield* effect;",
+              "  });",
+              "});",
+              "",
+            ].join("\n")
+          );
+
+          const summary = yield* runEffectFnRules(
+            new EffectFnRulesOptions({
+              strictCheck: true,
+              excludePaths: [],
+            })
+          );
+
+          expect(summary.scannedFiles).toBe(1);
+          expect(summary.touchedFiles).toBe(1);
+          expect(summary.violationCount).toBe(6);
+          expect(summary.strictFailure).toBe(true);
+          expect(summary.affectedFiles).toEqual(["packages/demo/src/index.ts"]);
+          expect(summary.diagnostics.map((diagnostic) => diagnostic.ownerName)).toEqual([
+            "annotatedExpression",
+            "annotatedBlock",
+            "conditional",
+            "declared",
+            "method",
+            "callback",
+          ]);
+          expect(summary.diagnostics.map((diagnostic) => diagnostic.recommendation)).toEqual([
+            "Effect.fn",
+            "Effect.fn",
+            "Effect.fn",
+            "Effect.fn",
+            "Effect.fn",
+            "Effect.fnUntraced",
+          ]);
+        })
+      ).pipe(Effect.provide(testLayer))
+    );
+  });
+
+  it("ignores one-off effects, existing Effect.fn wrappers, excluded paths, and non-direct Effect.gen composition", async () => {
+    await Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeProjectScaffold;
+          yield* writeProjectFile(
+            "packages/demo/src/index.ts",
+            [
+              'import { Effect } from "effect";',
+              "",
+              "export const program = Effect.gen(function* () {",
+              "  return yield* Effect.succeed(1);",
+              "});",
+              "",
+              "export const scoped = () => Effect.scoped(Effect.gen(function* () {",
+              "  return yield* Effect.succeed(1);",
+              "}));",
+              "",
+              "export const already = Effect.fn('already')(function* (value: string) {",
+              "  return yield* Effect.succeed(value);",
+              "});",
+              "",
+              "export const alreadyUntraced = Effect.fnUntraced(function* (value: string) {",
+              "  return yield* Effect.succeed(value);",
+              "});",
+              "",
+            ].join("\n")
+          );
+          yield* writeProjectFile(
+            "packages/demo/test/index.ts",
+            [
+              'import { Effect } from "effect";',
+              "",
+              "export const ignored = (value: string): Effect.Effect<string> => Effect.gen(function* () {",
+              "  return yield* Effect.succeed(value);",
+              "});",
+              "",
+            ].join("\n")
+          );
+
+          const summary = yield* runEffectFnRules(
+            new EffectFnRulesOptions({
+              strictCheck: true,
+              excludePaths: [],
+            })
+          );
+
+          expect(summary.scannedFiles).toBe(1);
+          expect(summary.touchedFiles).toBe(0);
+          expect(summary.violationCount).toBe(0);
+          expect(summary.strictFailure).toBe(false);
+          expect(summary.affectedFiles).toEqual([]);
+          expect(summary.diagnostics).toEqual([]);
+        })
+      ).pipe(Effect.provide(testLayer))
+    );
+  });
+
+  it("honors explicit exclude paths", async () => {
+    await Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeProjectScaffold;
+          yield* writeProjectFile(
+            "packages/demo/src/index.ts",
+            [
+              'import { Effect } from "effect";',
+              "",
+              "export const ignored = (value: string): Effect.Effect<string> => Effect.gen(function* () {",
+              "  return yield* Effect.succeed(value);",
+              "});",
+              "",
+            ].join("\n")
+          );
+
+          const summary = yield* runEffectFnRules(
+            new EffectFnRulesOptions({
+              strictCheck: true,
+              excludePaths: ["packages/demo/src/index.ts"],
+            })
+          );
+
+          expect(summary.scannedFiles).toBe(0);
+          expect(summary.touchedFiles).toBe(0);
+          expect(summary.violationCount).toBe(0);
+          expect(summary.strictFailure).toBe(false);
+        })
+      ).pipe(Effect.provide(testLayer))
+    );
+  });
+
+  it("exits non-zero from the CLI command when strict check finds a violation", async () => {
+    await Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeProjectScaffold;
+          yield* writeProjectFile(
+            "packages/demo/src/index.ts",
+            [
+              'import { Effect } from "effect";',
+              "",
+              "export const loadDemo = (): Effect.Effect<string> => Effect.gen(function* () {",
+              '  return "demo";',
+              "});",
+              "",
+            ].join("\n")
+          );
+
+          const result = yield* runCliCommand("laws", "effect-fn", "--check");
+
+          expect(result.exitCode).not.toBe(0);
+          expect(result.output).toContain("[effect-governance-effect-fn] violations=1");
+          expect(result.output).toContain("packages/demo/src/index.ts");
+          expect(result.output).toContain('Use named Effect.fn("loadDemo") instead');
+        })
+      ).pipe(Effect.provide(testLayer))
+    );
+  }, 30_000);
+});

--- a/packages/tooling/tool/cli/test/effect-fn.test.ts
+++ b/packages/tooling/tool/cli/test/effect-fn.test.ts
@@ -2,6 +2,7 @@ import { EffectFnRulesOptions, runEffectFnRules } from "@beep/repo-cli/commands/
 import { TSMorphServiceLive } from "@beep/repo-utils/TSMorph/index";
 import { NodeChildProcessSpawner, NodeServices } from "@effect/platform-node";
 import { Effect, FileSystem, Layer, Path, Stream } from "effect";
+import * as Chunk from "effect/Chunk";
 import { ChildProcess } from "effect/unstable/process";
 import { describe, expect, it } from "vitest";
 
@@ -11,7 +12,6 @@ const testLayer = Layer.mergeAll(
   TSMorphServiceLive.pipe(Layer.provideMerge(NodeServices.layer))
 );
 const CLI_ENTRYPOINT = new URL("../src/bin.ts", import.meta.url).pathname;
-const emptyString = () => "";
 
 const withTempWorkingDirectory = <A, E, R>(use: Effect.Effect<A, E, R>) =>
   Effect.acquireUseRelease(
@@ -68,10 +68,7 @@ const runCliCommand = Effect.fn("effect-fn.test.runCliCommand")(function* (...ar
         stdout: "pipe",
         stderr: "pipe",
       });
-      const output = yield* handle.all.pipe(
-        Stream.decodeText(),
-        Stream.runFold(emptyString, (accumulator, chunk) => `${accumulator}${chunk}`)
-      );
+      const output = yield* handle.all.pipe(Stream.decodeText(), Stream.runCollect, Effect.map(Chunk.join("")));
       const exitCode = yield* handle.exitCode;
       return { exitCode, output } as const;
     })

--- a/packages/tooling/tool/cli/test/quality-tasks.test.ts
+++ b/packages/tooling/tool/cli/test/quality-tasks.test.ts
@@ -308,11 +308,18 @@ describe("quality task adapter", () => {
   it("delegates affected root lint to the aggregate repo lint lane and repo-wide policy checks", () => {
     const steps = rootQualityStepsForTesting("/repo", getInvocation(["lint", "--affected", "--summarize"]));
 
-    expect(steps).toHaveLength(16);
+    expect(steps).toHaveLength(17);
     expect(steps[0]?.args).toEqual(expectedTurboArgs("lint", ["--affected", "--summarize"]));
+    expect(steps[3]).toMatchObject({
+      label: "lint:effect-fn",
+      command: "bun",
+      args: ["run", "beep", "laws", "effect-fn", "--check"],
+      cwd: "/repo",
+    });
     expect(steps.slice(1).map((step) => step.label)).toEqual([
       "lint:effect-imports",
       "lint:terse-effect",
+      "lint:effect-fn",
       "lint:native-runtime",
       "lint:dual-arity",
       "lint:allowlist",

--- a/packages/tooling/tool/docgen/src/CLI.ts
+++ b/packages/tooling/tool/docgen/src/CLI.ts
@@ -132,8 +132,10 @@ const options = {
  * @category cli-commands
  * @since 0.0.0
  */
-export const docgenCommand = Command.make("docgen", options, (input) =>
-  Effect.gen(function* () {
+export const docgenCommand = Command.make(
+  "docgen",
+  options,
+  Effect.fnUntraced(function* (input) {
     const parseCompilerOptions = yield* resolveCompilerOptionsInput(
       input.parseTsconfigFile,
       input.parseCompilerOptionsText

--- a/packages/tooling/tool/docgen/src/Checker.ts
+++ b/packages/tooling/tool/docgen/src/Checker.ts
@@ -189,17 +189,15 @@ export function checkTypeAliases(models: ReadonlyArray<Domain.TypeAlias>) {
   return Effect.forEach(models, checkTypeAlias).pipe(Effect.map(A.flatten));
 }
 
-function checkNamespace(
+const checkNamespace = Effect.fn("checkNamespace")(function* (
   model: Domain.Namespace
-): Effect.Effect<Array<string>, never, Parser.Source | Configuration.Configuration> {
-  return Effect.gen(function* () {
-    const docErrors = yield* checkEntry(model, { enforceVersion: true });
-    const interfacesErrors = yield* checkInterfaces(model.interfaces);
-    const typeAliasesErrors = yield* checkTypeAliases(model.typeAliases);
-    const namespacesErrors = yield* checkNamespaces(model.namespaces);
-    return A.flatten([docErrors, interfacesErrors, typeAliasesErrors, namespacesErrors]);
-  });
-}
+): Effect.fn.Return<Array<string>, never, Parser.Source | Configuration.Configuration> {
+  const docErrors = yield* checkEntry(model, { enforceVersion: true });
+  const interfacesErrors = yield* checkInterfaces(model.interfaces);
+  const typeAliasesErrors = yield* checkTypeAliases(model.typeAliases);
+  const namespacesErrors = yield* checkNamespaces(model.namespaces);
+  return A.flatten([docErrors, interfacesErrors, typeAliasesErrors, namespacesErrors]);
+});
 
 /**
  * Checks documented namespaces and their nested members for required docgen annotations.

--- a/packages/tooling/tool/docgen/src/Configuration.ts
+++ b/packages/tooling/tool/docgen/src/Configuration.ts
@@ -228,70 +228,68 @@ const readJsoncFile = <Schema extends S.Decoder<unknown, never>>(
 
 const readPackageJson = (filePath: string) => readJsoncFile(filePath, PackageJsonSchema);
 
-const readDocgenConfig = (
+const readDocgenConfig = Effect.fn("Configuration.readDocgenConfig")(function* (
   filePath: string
-): Effect.Effect<O.Option<ConfigurationDocument>, Domain.DocgenError, FileSystem.FileSystem> =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const exists = yield* fs.exists(filePath).pipe(
-      Effect.mapError(
-        (cause) =>
-          new Domain.DocgenError({
-            message: `[Configuration.readDocgenConfig] Failed to check '${filePath}'\n${String(cause)}`,
-          })
-      )
-    );
+): Effect.fn.Return<O.Option<ConfigurationDocument>, Domain.DocgenError, FileSystem.FileSystem> {
+  const fs = yield* FileSystem.FileSystem;
+  const exists = yield* fs.exists(filePath).pipe(
+    Effect.mapError(
+      (cause) =>
+        new Domain.DocgenError({
+          message: `[Configuration.readDocgenConfig] Failed to check '${filePath}'\n${String(cause)}`,
+        })
+    )
+  );
 
-    if (!exists) {
-      return O.none();
-    }
+  if (!exists) {
+    return O.none();
+  }
 
-    const config = yield* readJsoncFile(filePath, ConfigurationSchema);
-    return O.some(config);
-  });
+  const config = yield* readJsoncFile(filePath, ConfigurationSchema);
+  return O.some(config);
+});
 
-const readTSConfig = (
+const readTSConfig = Effect.fn("Configuration.readTSConfig")(function* (
   fileName: string
-): Effect.Effect<
+): Effect.fn.Return<
   S.Schema.Type<typeof CompilerOptionsShape>,
   Domain.DocgenError,
   FileSystem.FileSystem | Path.Path | Domain.Process
-> =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
-    const process = yield* Domain.Process;
-    const cwd = yield* process.cwd;
-    const resolved = path.resolve(cwd, fileName);
-    const content = yield* fs.readFileString(resolved).pipe(
-      Effect.mapError(
-        (cause) =>
-          new Domain.DocgenError({
-            message: `[Configuration.readTSConfig] Failed to read TSConfig file '${resolved}'\n${String(cause)}`,
-          })
-      )
-    );
-    const tsconfig = yield* decodeTSConfigFromJsoncTextEffect(content).pipe(
-      Effect.mapError(
-        (cause) =>
-          new Domain.DocgenError({
-            message: `[Configuration.readTSConfig] Failed to decode TSConfig file '${resolved}'\n${cause.message}`,
-          })
-      )
-    );
-    if (O.isNone(tsconfig.compilerOptions)) {
-      return defaultCompilerOptions;
-    }
+> {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const process = yield* Domain.Process;
+  const cwd = yield* process.cwd;
+  const resolved = path.resolve(cwd, fileName);
+  const content = yield* fs.readFileString(resolved).pipe(
+    Effect.mapError(
+      (cause) =>
+        new Domain.DocgenError({
+          message: `[Configuration.readTSConfig] Failed to read TSConfig file '${resolved}'\n${String(cause)}`,
+        })
+    )
+  );
+  const tsconfig = yield* decodeTSConfigFromJsoncTextEffect(content).pipe(
+    Effect.mapError(
+      (cause) =>
+        new Domain.DocgenError({
+          message: `[Configuration.readTSConfig] Failed to decode TSConfig file '${resolved}'\n${cause.message}`,
+        })
+    )
+  );
+  if (O.isNone(tsconfig.compilerOptions)) {
+    return defaultCompilerOptions;
+  }
 
-    return yield* encodeCompilerOptions(tsconfig.compilerOptions.value).pipe(
-      Effect.mapError(
-        (cause) =>
-          new Domain.DocgenError({
-            message: `[Configuration.readTSConfig] Failed to encode compiler options from '${resolved}'\n${cause.message}`,
-          })
-      )
-    );
-  });
+  return yield* encodeCompilerOptions(tsconfig.compilerOptions.value).pipe(
+    Effect.mapError(
+      (cause) =>
+        new Domain.DocgenError({
+          message: `[Configuration.readTSConfig] Failed to encode compiler options from '${resolved}'\n${cause.message}`,
+        })
+    )
+  );
+});
 
 const resolveCompilerOptions = (
   fromCLI: O.Option<CompilerOptionsInput>,

--- a/packages/tooling/tool/docgen/src/Core.ts
+++ b/packages/tooling/tool/docgen/src/Core.ts
@@ -551,8 +551,9 @@ const getModuleMarkdownOutputPath = Effect.fn("getModuleMarkdownOutputPath")(fun
 });
 
 const getModuleMarkdownFiles = (modules: ReadonlyArray<Domain.Module>) =>
-  Effect.forEach(modules, (module, index) =>
-    Effect.gen(function* () {
+  Effect.forEach(
+    modules,
+    Effect.fnUntraced(function* (module, index) {
       const outputPath = yield* getModuleMarkdownOutputPath(module);
       const moduleContent = yield* Printer.printModule(module);
       const toc = markdownToc(moduleContent, { bullets: "-" }).content;

--- a/packages/tooling/tool/docgen/src/Parser.ts
+++ b/packages/tooling/tool/docgen/src/Parser.ts
@@ -166,13 +166,14 @@ const parseDoc = (text: string) => {
 
 const shouldIgnore = (doc: Domain.Doc): boolean => R.has(doc.tags, "internal") || R.has(doc.tags, "ignore");
 
-const parsePosition = (node: ast.Node): Effect.Effect<Domain.Position, never, Source> =>
-  Effect.gen(function* () {
-    const source = yield* Source;
-    const startPos = node.getStart();
-    const position = source.sourceFile.getLineAndColumnAtPos(startPos);
-    return Domain.Position.new(position.line, position.column);
-  });
+const parsePosition = Effect.fn("parsePosition")(function* (
+  node: ast.Node
+): Effect.fn.Return<Domain.Position, never, Source> {
+  const source = yield* Source;
+  const startPos = node.getStart();
+  const position = source.sourceFile.getLineAndColumnAtPos(startPos);
+  return Domain.Position.new(position.line, position.column);
+});
 
 const parseInterfaceDeclaration = Effect.fn("parseInterfaceDeclaration")(function* (id: ast.InterfaceDeclaration) {
   const doc = parseDoc(getJSDocText(id.getJsDocs()));
@@ -450,20 +451,20 @@ export const parseExports = Effect.gen(function* () {
   return A.flatten(exports);
 });
 
-const parseModuleDeclaration = (md: ast.ModuleDeclaration): Effect.Effect<Array<Domain.Namespace>, never, Source> => {
+const parseModuleDeclaration = Effect.fn("parseModuleDeclaration")(function* (
+  md: ast.ModuleDeclaration
+): Effect.fn.Return<Array<Domain.Namespace>, never, Source> {
   const doc = parseDoc(getJSDocText(md.getJsDocs()));
   if (shouldIgnore(doc)) {
-    return Effect.succeed([]);
+    return [];
   }
 
-  return Effect.gen(function* () {
-    const interfaces = yield* parseInterfaceDeclarations(md.getInterfaces());
-    const typeAliases = yield* parseTypeAliasDeclarations(md.getTypeAliases());
-    const namespaces = yield* parseModuleDeclarations(md.getModules());
-    const position = yield* parsePosition(md);
-    return [Domain.Namespace.new(md.getName(), doc, { position, interfaces, typeAliases, namespaces })];
-  });
-};
+  const interfaces = yield* parseInterfaceDeclarations(md.getInterfaces());
+  const typeAliases = yield* parseTypeAliasDeclarations(md.getTypeAliases());
+  const namespaces = yield* parseModuleDeclarations(md.getModules());
+  const position = yield* parsePosition(md);
+  return [Domain.Namespace.new(md.getName(), doc, { position, interfaces, typeAliases, namespaces })];
+});
 
 const parseModuleDeclarations = (namespaces: ReadonlyArray<ast.ModuleDeclaration>) =>
   Effect.forEach(
@@ -694,20 +695,18 @@ export const parseModule = Effect.gen(function* () {
  * @category parsing
  * @since 0.0.0
  */
-export const parseFile =
-  (project: ast.Project) =>
-  (file: Domain.File): Effect.Effect<Domain.Module, Array<string>, Path.Path> =>
-    Effect.gen(function* () {
-      const path = yield* Path.Path;
-      const sourceFile = project.getSourceFile(file.path);
-      const filePath = Str.split(path.sep)(file.path);
+export const parseFile = (project: ast.Project) =>
+  Effect.fnUntraced(function* (file: Domain.File): Effect.fn.Return<Domain.Module, Array<string>, Path.Path> {
+    const path = yield* Path.Path;
+    const sourceFile = project.getSourceFile(file.path);
+    const filePath = Str.split(path.sep)(file.path);
 
-      if (sourceFile !== undefined && filePath.length > 0) {
-        return yield* withSource(SourceShape.new(filePath, sourceFile), parseModule);
-      }
+    if (sourceFile !== undefined && filePath.length > 0) {
+      return yield* withSource(SourceShape.new(filePath, sourceFile), parseModule);
+    }
 
-      return yield* Effect.fail([`Unable to locate file: ${file.path}`]);
-    });
+    return yield* Effect.fail([`Unable to locate file: ${file.path}`]);
+  });
 
 const createProject = Effect.fn("createProject")(function* (files: ReadonlyArray<Domain.File>) {
   const config = yield* Configuration.Configuration;

--- a/packages/tooling/tool/docgen/src/Printer.ts
+++ b/packages/tooling/tool/docgen/src/Printer.ts
@@ -291,43 +291,40 @@ const printTypeAlias = (model: Domain.TypeAlias, indentation: number) =>
     postfix: "(type alias)",
   });
 
-const printNamespace = (
+const printNamespace = Effect.fn("printNamespace")(function* (
   model: Domain.Namespace,
   indentation: number
-): Effect.Effect<string, never, Configuration.Configuration | Parser.Source> =>
-  Effect.gen(function* () {
-    const header = yield* printModel(model.name, model.doc, {
-      position: model.position,
-      indentation,
-      postfix: "(namespace)",
-    });
-    const interfaces = yield* Effect.forEach(model.interfaces, (inter) => printInterface(inter, indentation + 1));
-    const typeAliases = yield* Effect.forEach(model.typeAliases, (typeAlias) =>
-      printTypeAlias(typeAlias, indentation + 1)
-    );
-    const namespaces = yield* Effect.forEach(model.namespaces, (namespace) =>
-      printNamespace(namespace, indentation + 1)
-    );
-
-    return (
-      header +
-      pipe(
-        interfaces,
-        A.map((value) => `\n\n${value}`),
-        A.join("")
-      ) +
-      pipe(
-        typeAliases,
-        A.map((value) => `\n\n${value}`),
-        A.join("")
-      ) +
-      pipe(
-        namespaces,
-        A.map((value) => `\n\n${value}`),
-        A.join("")
-      )
-    );
+): Effect.fn.Return<string, never, Configuration.Configuration | Parser.Source> {
+  const header = yield* printModel(model.name, model.doc, {
+    position: model.position,
+    indentation,
+    postfix: "(namespace)",
   });
+  const interfaces = yield* Effect.forEach(model.interfaces, (inter) => printInterface(inter, indentation + 1));
+  const typeAliases = yield* Effect.forEach(model.typeAliases, (typeAlias) =>
+    printTypeAlias(typeAlias, indentation + 1)
+  );
+  const namespaces = yield* Effect.forEach(model.namespaces, (namespace) => printNamespace(namespace, indentation + 1));
+
+  return (
+    header +
+    pipe(
+      interfaces,
+      A.map((value) => `\n\n${value}`),
+      A.join("")
+    ) +
+    pipe(
+      typeAliases,
+      A.map((value) => `\n\n${value}`),
+      A.join("")
+    ) +
+    pipe(
+      namespaces,
+      A.map((value) => `\n\n${value}`),
+      A.join("")
+    )
+  );
+});
 
 /**
  * Renders a single documented entity into markdown.
@@ -400,8 +397,9 @@ export const printModule = (module: Domain.Module) =>
             );
             const printables = A.sort(byCategory)(R.toEntries(grouped) as Array<[string, Array<Printable>]>);
 
-            const strings = yield* Effect.forEach(printables, ([category, categoryPrintables]) =>
-              Effect.gen(function* () {
+            const strings = yield* Effect.forEach(
+              printables,
+              Effect.fnUntraced(function* ([category, categoryPrintables]) {
                 const values = yield* Effect.forEach(sortByName(categoryPrintables), print);
                 return `\n\n# ${category}${pipe(
                   values,

--- a/standards/effect-laws-v1.md
+++ b/standards/effect-laws-v1.md
@@ -30,6 +30,7 @@ Compact, enforceable laws for this codebase. Keep agent-facing files terse; keep
 19. Use `LiteralKit` for internal literal domains when `.is`, `.thunk`, `$match`, or annotation-bearing schema values are part of the design.
 20. Model finite variants, lifecycle states, status/result cases, and case-specific payloads as discriminated unions; keep optional/nullish bags at external boundaries only when compatibility requires them.
 21. Prefer the tersest equivalent Effect helper form when behavior is unchanged: direct helper refs over trivial wrapper lambdas, `flow(...)` for passthrough `pipe(...)` callbacks, and shared thunk helpers when already in scope.
+22. Reusable functions that directly return `Effect.gen(function*)` must use `Effect.fn` or `Effect.fnUntraced`; zero-arg one-off effect values may stay as `Effect.gen`.
 
 ## Allowlist Contract
 

--- a/standards/jsdoc-documentation.inventory.md
+++ b/standards/jsdoc-documentation.inventory.md
@@ -1,6 +1,6 @@
 # JSDoc Documentation Compliance Inventory
 
-Generated: 2026-05-12T13:07:00.338Z
+Generated: 2026-05-14T17:40:17.140Z
 
 ## Scope
 
@@ -10,22 +10,22 @@ The package universe is the current `bun run topo-sort` output. This inventory c
 
 | Metric | Count |
 |---|---:|
-| packages | 57 |
+| packages | 59 |
 | cleanPackages | 22 |
 | packagesWithoutPublicSrcSurface | 1 |
-| packagesNeedingRemediation | 34 |
-| publicModules | 876 |
-| publicExports | 6041 |
-| openModules | 121 |
-| openExports | 2629 |
-| missingExportExamples | 2459 |
+| packagesNeedingRemediation | 36 |
+| publicModules | 888 |
+| publicExports | 6292 |
+| openModules | 116 |
+| openExports | 2828 |
+| missingExportExamples | 2658 |
 | missingExportCategories | 50 |
 | missingExportSince | 48 |
 | forbiddenTagFindings | 7 |
 | malformedConditionalTagFindings | 0 |
 | exampleImportFindings | 20 |
 | unsafeExampleFindings | 62 |
-| schemaAnnotationFindings | 132 |
+| schemaAnnotationFindings | 130 |
 | rootPolicyOpen | 0 |
 
 ## Root Policy
@@ -42,7 +42,7 @@ The package universe is the current `bun run topo-sort` output. This inventory c
 | Order | Package | Path | Status | Modules | Exports | Open Modules | Open Exports |
 |---:|---|---|---|---:|---:|---:|---:|
 | 1 | `@beep/types` | `packages/foundation/primitive/types` | clean | 5 | 10 | 0 | 0 |
-| 2 | `@beep/identity` | `packages/foundation/modeling/identity` | needs-remediation | 3 | 87 | 0 | 15 |
+| 2 | `@beep/identity` | `packages/foundation/modeling/identity` | needs-remediation | 3 | 89 | 0 | 16 |
 | 3 | `@beep/utils` | `packages/foundation/modeling/utils` | clean | 20 | 135 | 0 | 0 |
 | 4 | `@beep/data` | `packages/foundation/primitive/data` | clean | 7 | 39 | 0 | 0 |
 | 5 | `@beep/messages` | `packages/foundation/modeling/messages` | needs-remediation | 2 | 6 | 0 | 1 |
@@ -60,44 +60,46 @@ The package universe is the current `bun run topo-sort` output. This inventory c
 | 17 | `@beep/architecture-lab-use-cases` | `packages/architecture-lab/use-cases` | needs-remediation | 18 | 62 | 0 | 61 |
 | 18 | `@beep/postgres` | `packages/drivers/postgres` | needs-remediation | 7 | 35 | 0 | 5 |
 | 19 | `@beep/workspace-domain` | `packages/workspace/domain` | clean | 21 | 40 | 0 | 0 |
-| 20 | `@beep/repo-docgen` | `packages/tooling/tool/docgen` | needs-remediation | 8 | 66 | 0 | 21 |
-| 21 | `@beep/repo-ai-metrics` | `packages/tooling/library/ai-metrics` | clean | 14 | 172 | 0 | 0 |
-| 22 | `@beep/ffmpeg` | `packages/drivers/ffmpeg` | needs-remediation | 4 | 38 | 0 | 6 |
-| 23 | `@beep/observability` | `packages/foundation/capability/observability` | needs-remediation | 23 | 134 | 3 | 30 |
-| 24 | `@beep/repo-configs` | `packages/tooling/policy-pack/repo-configs` | needs-remediation | 24 | 130 | 0 | 5 |
-| 25 | `@beep/openai-compat` | `packages/drivers/openai-compat` | clean | 4 | 50 | 0 | 0 |
-| 26 | `@beep/ui` | `packages/foundation/ui-system/ui` | needs-remediation | 119 | 508 | 109 | 504 |
+| 20 | `@beep/face-detection` | `packages/drivers/face-detection` | needs-remediation | 4 | 27 | 0 | 23 |
+| 21 | `@beep/repo-docgen` | `packages/tooling/tool/docgen` | needs-remediation | 8 | 66 | 0 | 21 |
+| 22 | `@beep/repo-ai-metrics` | `packages/tooling/library/ai-metrics` | clean | 16 | 198 | 0 | 0 |
+| 23 | `@beep/ffmpeg` | `packages/drivers/ffmpeg` | needs-remediation | 4 | 38 | 0 | 6 |
+| 24 | `@beep/observability` | `packages/foundation/capability/observability` | needs-remediation | 23 | 134 | 3 | 30 |
+| 25 | `@beep/repo-configs` | `packages/tooling/policy-pack/repo-configs` | needs-remediation | 24 | 130 | 0 | 5 |
+| 26 | `@beep/openai-compat` | `packages/drivers/openai-compat` | clean | 4 | 50 | 0 | 0 |
 | 27 | `@beep/law-practice-domain` | `packages/law-practice/domain` | clean | 14 | 25 | 0 | 0 |
 | 28 | `@beep/agent-capability-use-cases` | `packages/agent-capability/use-cases` | needs-remediation | 13 | 47 | 0 | 11 |
 | 29 | `@beep/agent-capability-domain` | `packages/agent-capability/domain` | clean | 7 | 12 | 0 | 0 |
 | 30 | `@beep/epistemic-domain` | `packages/epistemic/domain` | clean | 13 | 21 | 0 | 0 |
 | 31 | `@beep/wealth-management-domain` | `packages/wealth-management/domain` | clean | 14 | 25 | 0 | 0 |
-| 32 | `@beep/architecture-lab-ui` | `packages/architecture-lab/ui` | needs-remediation | 3 | 7 | 0 | 6 |
-| 33 | `@beep/architecture-lab-server` | `packages/architecture-lab/server` | needs-remediation | 13 | 34 | 0 | 33 |
-| 34 | `@beep/root` | `.` | no-public-src-surface | 0 | 0 | 0 | 0 |
-| 35 | `@beep/workspace-tables` | `packages/workspace/tables` | needs-remediation | 7 | 10 | 0 | 2 |
-| 36 | `@beep/db-admin` | `packages/_internal/db-admin` | needs-remediation | 4 | 7 | 0 | 6 |
-| 37 | `@beep/architecture-lab-client` | `packages/architecture-lab/client` | needs-remediation | 3 | 7 | 0 | 6 |
-| 38 | `@beep/repo-cli` | `packages/tooling/tool/cli` | needs-remediation | 73 | 549 | 0 | 375 |
-| 39 | `@beep/shared-server` | `packages/shared/server` | clean | 1 | 1 | 0 | 0 |
-| 40 | `@beep/shared-config` | `packages/shared/config` | clean | 1 | 1 | 0 | 0 |
-| 41 | `@beep/sandbox` | `packages/foundation/capability/sandbox` | needs-remediation | 29 | 290 | 0 | 248 |
-| 42 | `@beep/shared-use-cases` | `packages/shared/use-cases` | clean | 1 | 1 | 0 | 0 |
-| 43 | `@beep/shared-tables` | `packages/shared/tables` | needs-remediation | 11 | 14 | 0 | 11 |
-| 44 | `@beep/md` | `packages/foundation/capability/md` | clean | 5 | 131 | 0 | 0 |
-| 45 | `@beep/semantic-web` | `packages/foundation/capability/semantic-web` | needs-remediation | 29 | 256 | 0 | 9 |
-| 46 | `@beep/venice-ai` | `packages/drivers/venice-ai` | clean | 3 | 35 | 0 | 0 |
-| 47 | `@beep/opip-web` | `apps/opip-web` | needs-remediation | 5 | 6 | 0 | 5 |
+| 32 | `@beep/ui` | `packages/foundation/ui-system/ui` | needs-remediation | 116 | 488 | 104 | 484 |
+| 33 | `@beep/architecture-lab-ui` | `packages/architecture-lab/ui` | needs-remediation | 3 | 7 | 0 | 6 |
+| 34 | `@beep/architecture-lab-server` | `packages/architecture-lab/server` | needs-remediation | 13 | 34 | 0 | 33 |
+| 35 | `@beep/root` | `.` | no-public-src-surface | 0 | 0 | 0 | 0 |
+| 36 | `@beep/workspace-tables` | `packages/workspace/tables` | needs-remediation | 7 | 10 | 0 | 2 |
+| 37 | `@beep/db-admin` | `packages/_internal/db-admin` | needs-remediation | 4 | 7 | 0 | 6 |
+| 38 | `@beep/architecture-lab-client` | `packages/architecture-lab/client` | needs-remediation | 3 | 7 | 0 | 6 |
+| 39 | `@beep/repo-cli` | `packages/tooling/tool/cli` | needs-remediation | 76 | 591 | 0 | 396 |
+| 40 | `@beep/shared-server` | `packages/shared/server` | clean | 1 | 1 | 0 | 0 |
+| 41 | `@beep/shared-config` | `packages/shared/config` | clean | 1 | 1 | 0 | 0 |
+| 42 | `@beep/sandbox` | `packages/foundation/capability/sandbox` | needs-remediation | 29 | 290 | 0 | 248 |
+| 43 | `@beep/shared-use-cases` | `packages/shared/use-cases` | clean | 1 | 1 | 0 | 0 |
+| 44 | `@beep/shared-tables` | `packages/shared/tables` | needs-remediation | 11 | 14 | 0 | 11 |
+| 45 | `@beep/md` | `packages/foundation/capability/md` | clean | 5 | 131 | 0 | 0 |
+| 46 | `@beep/semantic-web` | `packages/foundation/capability/semantic-web` | needs-remediation | 29 | 256 | 0 | 9 |
+| 47 | `@beep/venice-ai` | `packages/drivers/venice-ai` | clean | 3 | 35 | 0 | 0 |
 | 48 | `@beep/professional-runtime-proof` | `apps/professional-runtime-proof` | clean | 1 | 4 | 0 | 0 |
 | 49 | `@beep/acp` | `packages/drivers/acp` | needs-remediation | 10 | 406 | 0 | 1 |
 | 50 | `@beep/nlp` | `packages/foundation/capability/nlp` | needs-remediation | 49 | 278 | 0 | 31 |
 | 51 | `@beep/infra` | `infra` | clean | 2 | 10 | 0 | 0 |
-| 52 | `@beep/codedank-web` | `apps/codedank-web` | needs-remediation | 5 | 6 | 0 | 5 |
-| 53 | `@beep/xai` | `packages/drivers/xai` | clean | 7 | 62 | 0 | 0 |
-| 54 | `@beep/architecture-lab-proof` | `apps/architecture-lab-proof` | needs-remediation | 1 | 3 | 0 | 2 |
-| 55 | `@beep/shared-client` | `packages/shared/client` | clean | 1 | 1 | 0 | 0 |
-| 56 | `@beep/openai` | `packages/drivers/openai` | needs-remediation | 1 | 1 | 0 | 1 |
-| 57 | `@beep/shared-ui` | `packages/shared/ui` | clean | 4 | 7 | 0 | 0 |
+| 52 | `@beep/runpod` | `packages/drivers/runpod` | needs-remediation | 6 | 174 | 0 | 174 |
+| 53 | `@beep/codedank-web` | `apps/codedank-web` | needs-remediation | 5 | 6 | 0 | 5 |
+| 54 | `@beep/xai` | `packages/drivers/xai` | clean | 7 | 62 | 0 | 0 |
+| 55 | `@beep/architecture-lab-proof` | `apps/architecture-lab-proof` | needs-remediation | 1 | 3 | 0 | 2 |
+| 56 | `@beep/shared-client` | `packages/shared/client` | clean | 1 | 1 | 0 | 0 |
+| 57 | `@beep/openai` | `packages/drivers/openai` | needs-remediation | 1 | 1 | 0 | 1 |
+| 58 | `@beep/opip-web` | `apps/opip-web` | needs-remediation | 5 | 6 | 0 | 5 |
+| 59 | `@beep/shared-ui` | `packages/shared/ui` | clean | 4 | 7 | 0 | 0 |
 
 ## Open Findings
 
@@ -110,17 +112,18 @@ Export findings:
 - `src/Id.ts:150` `IdentitySegmentCountError` (class) - 1 schema annotation/type-alias gap(s)
 - `src/Id.ts:381` `IdentityString` (type) - 1 unsafe example violation(s)
 - `src/Id.ts:398` `IdentitySymbol` (type) - 1 unsafe example violation(s)
-- `src/packages.ts:640` `RepoPkgs` (const) - missing @example
-- `src/packages.ts:646` `$MdId` (const) - missing summary; missing @example
-- `src/packages.ts:652` `$CodedankWebId` (const) - missing summary; missing @example
-- `src/packages.ts:658` `$OpipWebId` (const) - missing summary; missing @example
-- `src/packages.ts:664` `$DrizzleId` (const) - missing summary; missing @example
-- `src/packages.ts:670` `$DuckdbId` (const) - missing summary; missing @example
-- `src/packages.ts:676` `$FfmpegId` (const) - missing summary; missing @example
-- `src/packages.ts:682` `$PostgresId` (const) - missing summary; missing @example
-- `src/packages.ts:845` `$OpenaiId` (const) - missing summary; missing @example
-- `src/packages.ts:851` `$VeniceAiId` (const) - missing summary; missing @example
-- `src/packages.ts:857` `$XaiId` (const) - missing summary; missing @example
+- `src/packages.ts:642` `RepoPkgs` (const) - missing @example
+- `src/packages.ts:648` `$MdId` (const) - missing summary; missing @example
+- `src/packages.ts:654` `$CodedankWebId` (const) - missing summary; missing @example
+- `src/packages.ts:660` `$OpipWebId` (const) - missing summary; missing @example
+- `src/packages.ts:666` `$DrizzleId` (const) - missing summary; missing @example
+- `src/packages.ts:672` `$DuckdbId` (const) - missing summary; missing @example
+- `src/packages.ts:678` `$FaceDetectionId` (const) - missing summary; missing @example
+- `src/packages.ts:684` `$FfmpegId` (const) - missing summary; missing @example
+- `src/packages.ts:690` `$PostgresId` (const) - missing summary; missing @example
+- `src/packages.ts:853` `$OpenaiId` (const) - missing summary; missing @example
+- `src/packages.ts:859` `$VeniceAiId` (const) - missing summary; missing @example
+- `src/packages.ts:865` `$XaiId` (const) - missing summary; missing @example
 
 ### @beep/messages
 
@@ -309,44 +312,44 @@ Export findings:
 - `src/Fn.ts:229` `FnSchemaStatics` (type) - missing @example
 - `src/Fn.ts:426` `AnyFn` (type) - missing @example
 - `src/Glob.ts:121` `Glob` (type) - missing @example
-- `src/Graph.ts:279` `NodeIndex` (type) - missing @example
-- `src/Graph.ts:311` `EdgeIndex` (const) - missing @example
-- `src/Graph.ts:324` `EdgeIndex` (type) - missing @example
-- `src/Graph.ts:332` `EdgeIndexFromString` (const) - missing @example
-- `src/Graph.ts:345` `GraphKind` (const) - missing @example
-- `src/Graph.ts:357` `GraphKind` (type) - missing @example
-- `src/Graph.ts:365` `EdgeEncoded` (type) - missing @example
-- `src/Graph.ts:473` `EdgeEncoded` (const) - missing @example
-- `src/Graph.ts:377` `GraphEncoded` (type) - missing @example
-- `src/Graph.ts:675` `GraphEncoded` (const) - missing @example
-- `src/Graph.ts:413` `EdgeEncodedSchema` (interface) - missing @example
-- `src/Graph.ts:430` `GraphEncodedSchema` (interface) - missing @example
-- `src/Graph.ts:450` `isEdge` (const) - missing @example
-- `src/Graph.ts:460` `isGraph` (const) - missing @example
-- `src/Graph.ts:493` `EdgeFromSelf` (interface) - missing @example
-- `src/Graph.ts:533` `EdgeFromSelf` (const) - missing @example
-- `src/Graph.ts:510` `EdgeTransform` (interface) - missing @example
-- `src/Graph.ts:596` `EdgeTransform` (const) - missing @example
-- `src/Graph.ts:522` `Edge` (interface) - missing @example
-- `src/Graph.ts:705` `GraphFromSelf` (interface) - missing @example
-- `src/Graph.ts:923` `GraphFromSelf` (const) - missing @example
-- `src/Graph.ts:723` `DirectedGraphFromSelf` (interface) - missing @example
-- `src/Graph.ts:941` `DirectedGraphFromSelf` (const) - missing @example
-- `src/Graph.ts:741` `UndirectedGraphFromSelf` (interface) - missing @example
-- `src/Graph.ts:962` `UndirectedGraphFromSelf` (const) - missing @example
-- `src/Graph.ts:759` `MutableGraphFromSelf` (interface) - missing @example
-- `src/Graph.ts:983` `MutableGraphFromSelf` (const) - missing @example
-- `src/Graph.ts:777` `MutableDirectedGraphFromSelf` (interface) - missing @example
-- `src/Graph.ts:1001` `MutableDirectedGraphFromSelf` (const) - missing @example
-- `src/Graph.ts:795` `MutableUndirectedGraphFromSelf` (interface) - missing @example
-- `src/Graph.ts:1022` `MutableUndirectedGraphFromSelf` (const) - missing @example
-- `src/Graph.ts:1041` `DirectedGraph` (interface) - missing @example
-- `src/Graph.ts:1054` `UndirectedGraph` (interface) - missing @example
-- `src/Graph.ts:1198` `UndirectedGraph` (const) - missing @example
-- `src/Graph.ts:1067` `MutableDirectedGraph` (interface) - missing @example
-- `src/Graph.ts:1222` `MutableDirectedGraph` (const) - missing @example
-- `src/Graph.ts:1080` `MutableUndirectedGraph` (interface) - missing @example
-- `src/Graph.ts:1246` `MutableUndirectedGraph` (const) - missing @example
+- `src/Graph.ts:282` `NodeIndex` (type) - missing @example
+- `src/Graph.ts:314` `EdgeIndex` (const) - missing @example
+- `src/Graph.ts:327` `EdgeIndex` (type) - missing @example
+- `src/Graph.ts:335` `EdgeIndexFromString` (const) - missing @example
+- `src/Graph.ts:348` `GraphKind` (const) - missing @example
+- `src/Graph.ts:360` `GraphKind` (type) - missing @example
+- `src/Graph.ts:368` `EdgeEncoded` (type) - missing @example
+- `src/Graph.ts:476` `EdgeEncoded` (const) - missing @example
+- `src/Graph.ts:380` `GraphEncoded` (type) - missing @example
+- `src/Graph.ts:678` `GraphEncoded` (const) - missing @example
+- `src/Graph.ts:416` `EdgeEncodedSchema` (interface) - missing @example
+- `src/Graph.ts:433` `GraphEncodedSchema` (interface) - missing @example
+- `src/Graph.ts:453` `isEdge` (const) - missing @example
+- `src/Graph.ts:463` `isGraph` (const) - missing @example
+- `src/Graph.ts:496` `EdgeFromSelf` (interface) - missing @example
+- `src/Graph.ts:536` `EdgeFromSelf` (const) - missing @example
+- `src/Graph.ts:513` `EdgeTransform` (interface) - missing @example
+- `src/Graph.ts:599` `EdgeTransform` (const) - missing @example
+- `src/Graph.ts:525` `Edge` (interface) - missing @example
+- `src/Graph.ts:708` `GraphFromSelf` (interface) - missing @example
+- `src/Graph.ts:926` `GraphFromSelf` (const) - missing @example
+- `src/Graph.ts:726` `DirectedGraphFromSelf` (interface) - missing @example
+- `src/Graph.ts:944` `DirectedGraphFromSelf` (const) - missing @example
+- `src/Graph.ts:744` `UndirectedGraphFromSelf` (interface) - missing @example
+- `src/Graph.ts:965` `UndirectedGraphFromSelf` (const) - missing @example
+- `src/Graph.ts:762` `MutableGraphFromSelf` (interface) - missing @example
+- `src/Graph.ts:986` `MutableGraphFromSelf` (const) - missing @example
+- `src/Graph.ts:780` `MutableDirectedGraphFromSelf` (interface) - missing @example
+- `src/Graph.ts:1004` `MutableDirectedGraphFromSelf` (const) - missing @example
+- `src/Graph.ts:798` `MutableUndirectedGraphFromSelf` (interface) - missing @example
+- `src/Graph.ts:1025` `MutableUndirectedGraphFromSelf` (const) - missing @example
+- `src/Graph.ts:1044` `DirectedGraph` (interface) - missing @example
+- `src/Graph.ts:1057` `UndirectedGraph` (interface) - missing @example
+- `src/Graph.ts:1201` `UndirectedGraph` (const) - missing @example
+- `src/Graph.ts:1070` `MutableDirectedGraph` (interface) - missing @example
+- `src/Graph.ts:1225` `MutableDirectedGraph` (const) - missing @example
+- `src/Graph.ts:1083` `MutableUndirectedGraph` (interface) - missing @example
+- `src/Graph.ts:1249` `MutableUndirectedGraph` (const) - missing @example
 - `src/Int.ts:98` `PosInt` (type) - 1 unsafe example violation(s)
 - `src/Int.ts:137` `PostgresSerialInt` (type) - 1 unsafe example violation(s)
 - `src/Int.ts:180` `NegInt` (type) - 1 unsafe example violation(s)
@@ -698,9 +701,9 @@ Export findings:
 - `src/csv/CsvCodecOptions.ts:113` `CsvCodecOptionsParseOptions` (const) - missing @example
 - `src/csv/CsvError.ts:34` `CsvError` (class) - missing @example
 - `src/csv/CsvError.ts:42` `csvError` (const) - missing @example
-- `src/csv/format/CsvFormatter.ts:102` `formatCsvHeaderRow` (const) - missing @example
-- `src/csv/format/CsvFormatter.ts:128` `formatCsvDataRow` (const) - missing @example
-- `src/csv/format/CsvFormatter.ts:156` `formatCsvDocument` (const) - missing @example
+- `src/csv/format/CsvFormatter.ts:101` `formatCsvHeaderRow` (const) - missing @example
+- `src/csv/format/CsvFormatter.ts:126` `formatCsvDataRow` (const) - missing @example
+- `src/csv/format/CsvFormatter.ts:153` `formatCsvDocument` (const) - missing @example
 - `src/csv/format/index.ts:14` `export * from "./CsvFormatter.ts";` (re-export) - missing @example
 - `src/csv/index.ts:304` `export * from "./CsvCodecOptions.ts";` (re-export) - missing @example
 - `src/csv/index.ts:309` `export * from "./CsvError.ts";` (re-export) - missing @example
@@ -709,7 +712,7 @@ Export findings:
 - `src/csv/index.ts:298` `CsvText` (type) - missing @example
 - `src/csv/parse/CsvParser.ts:98` `ParsedField` (class) - missing summary; missing @example
 - `src/csv/parse/CsvParser.ts:243` `ParsedRow` (class) - missing summary; missing @example
-- `src/csv/parse/CsvParser.ts:381` `parseCsvRows` (const) - missing @example
+- `src/csv/parse/CsvParser.ts:379` `parseCsvRows` (const) - missing @example
 - `src/csv/parse/ParserOptions.ts:60` `HeaderValueInput` (const) - missing @example
 - `src/csv/parse/ParserOptions.ts:72` `HeaderValueInput` (type) - missing @example
 - `src/csv/parse/ParserOptions.ts:80` `ParserOptionsError` (class) - missing @example
@@ -955,9 +958,9 @@ Export findings:
 - `src/http/headers/Csp.ts:483` `ContentSecurityPolicyOption` (const) - missing summary; missing @example
 - `src/http/headers/Csp.ts:493` `ContentSecurityPolicyOption` (type) - missing summary; missing @example
 - `src/http/headers/Csp.ts:499` `ContentSecurityPolicyResponseHeader` (class) - missing summary; missing @example
-- `src/http/headers/Csp.ts:558` `createContentSecurityPolicyOptionHeaderValue` (const) - missing summary; missing @example
-- `src/http/headers/Csp.ts:584` `ContentSecurityPolicyHeader` (const) - missing summary; missing @example
-- `src/http/headers/Csp.ts:652` `ContentSecurityPolicyHeader` (type) - missing summary; missing @example
+- `src/http/headers/Csp.ts:557` `createContentSecurityPolicyOptionHeaderValue` (const) - missing summary; missing @example
+- `src/http/headers/Csp.ts:583` `ContentSecurityPolicyHeader` (const) - missing summary; missing @example
+- `src/http/headers/Csp.ts:651` `ContentSecurityPolicyHeader` (type) - missing summary; missing @example
 - `src/http/headers/ExpectCT.ts:26` `ExpectCTConfig` (class) - missing summary; missing @example
 - `src/http/headers/ExpectCT.ts:41` `ExpectCTEnabled` (const) - missing summary; missing @example
 - `src/http/headers/ExpectCT.ts:51` `ExpectCTEnabled` (type) - missing summary; missing @example
@@ -982,8 +985,8 @@ Export findings:
 - `src/http/headers/FrameGuard.ts:75` `FrameGuardOption` (const) - missing summary; missing @example
 - `src/http/headers/FrameGuard.ts:85` `FrameGuardOption` (type) - missing summary; missing @example
 - `src/http/headers/FrameGuard.ts:91` `FrameGuardResponseHeader` (class) - missing summary; missing @example
-- `src/http/headers/FrameGuard.ts:135` `FrameGuardHeader` (const) - missing summary; missing @example
-- `src/http/headers/FrameGuard.ts:207` `FrameGuardHeader` (type) - missing summary; missing @example
+- `src/http/headers/FrameGuard.ts:136` `FrameGuardHeader` (const) - missing summary; missing @example
+- `src/http/headers/FrameGuard.ts:210` `FrameGuardHeader` (type) - missing summary; missing @example
 - `src/http/headers/NoOpen.ts:28` `NoOpenValue` (const) - missing summary; missing @example
 - `src/http/headers/NoOpen.ts:39` `NoOpenValue` (type) - missing summary; missing @example
 - `src/http/headers/NoOpen.ts:47` `NoOpenOption` (const) - missing summary; missing @example
@@ -1029,8 +1032,8 @@ Export findings:
 - `src/http/headers/ReferrerPolicy.ts:69` `ReferrerPolicyOption` (const) - missing summary; missing @example
 - `src/http/headers/ReferrerPolicy.ts:79` `ReferrerPolicyOption` (type) - missing summary; missing @example
 - `src/http/headers/ReferrerPolicy.ts:85` `ReferrerPolicyResponseHeader` (class) - missing summary; missing @example
-- `src/http/headers/ReferrerPolicy.ts:126` `ReferrerPolicyHeader` (const) - missing summary; missing @example
-- `src/http/headers/ReferrerPolicy.ts:190` `ReferrerPolicyHeader` (type) - missing summary; missing @example
+- `src/http/headers/ReferrerPolicy.ts:125` `ReferrerPolicyHeader` (const) - missing summary; missing @example
+- `src/http/headers/ReferrerPolicy.ts:191` `ReferrerPolicyHeader` (type) - missing summary; missing @example
 - `src/http/headers/SecureHeader.ts:33` `SecureHeader` (const) - missing summary; missing @example
 - `src/http/headers/SecureHeader.ts:44` `SecureHeader` (type) - missing summary; missing @example
 - `src/http/headers/SecureHeaderError.ts:109` `CspError` (class) - missing summary; missing @example
@@ -1057,8 +1060,8 @@ Export findings:
 - `src/http/headers/XSSProtection.ts:74` `XSSProtectionOption` (const) - missing summary; missing @example
 - `src/http/headers/XSSProtection.ts:84` `XSSProtectionOption` (type) - missing summary; missing @example
 - `src/http/headers/XSSProtection.ts:90` `XSSProtectionResponseHeader` (class) - missing summary; missing @example
-- `src/http/headers/XSSProtection.ts:142` `XSSProtectionHeader` (const) - missing summary; missing @example
-- `src/http/headers/XSSProtection.ts:193` `XSSProtectionHeader` (type) - missing summary; missing @example
+- `src/http/headers/XSSProtection.ts:143` `XSSProtectionHeader` (const) - missing summary; missing @example
+- `src/http/headers/XSSProtection.ts:194` `XSSProtectionHeader` (type) - missing summary; missing @example
 - `src/http/headers/_internal/helpers.ts:22` `ArrayOfStrOrStr` (const) - missing summary; missing @example
 - `src/http/headers/_internal/helpers.ts:32` `ArrayOfStrOrStr` (type) - missing summary; missing @example
 - `src/http/headers/_internal/helpers.ts:38` `StringOrUrl` (const) - missing summary; missing @example
@@ -1782,6 +1785,35 @@ Export findings:
 - `src/index.ts:38` `export * from "./Postgres.format.ts";` (re-export) - missing @example
 - `src/index.ts:46` `export * from "./Postgres.sqlstate.ts";` (re-export) - missing @example
 
+### @beep/face-detection
+
+Path: `packages/drivers/face-detection`
+
+Export findings:
+- `src/FaceDetection.models.ts:20` `PositivePixelDimension` (const) - missing @example
+- `src/FaceDetection.models.ts:39` `PositivePixelDimension` (type) - missing @example
+- `src/FaceDetection.models.ts:47` `FaceDetectionConfidence` (const) - missing @example
+- `src/FaceDetection.models.ts:81` `FaceDetectionConfidence` (type) - missing @example
+- `src/FaceDetection.models.ts:89` `FaceDetectionPercentage` (const) - missing @example
+- `src/FaceDetection.models.ts:123` `FaceDetectionPercentage` (type) - missing @example
+- `src/FaceDetection.models.ts:131` `FaceDetectionTopK` (const) - missing @example
+- `src/FaceDetection.models.ts:150` `FaceDetectionTopK` (type) - missing @example
+- `src/FaceDetection.models.ts:216` `FaceDetectionPoint` (class) - missing @example
+- `src/FaceDetection.models.ts:232` `FaceDetectionBox` (class) - missing @example
+- `src/FaceDetection.models.ts:250` `FaceDetectionLandmarks` (class) - missing @example
+- `src/FaceDetection.models.ts:269` `FaceDetection` (class) - missing @example
+- `src/FaceDetection.models.ts:286` `FaceDetectionResult` (class) - missing @example
+- `src/FaceDetection.models.ts:304` `decodeFaceDetectionModelConfig` (const) - missing @example
+- `src/FaceDetection.models.ts:312` `decodeFaceDetectionImageRequest` (const) - missing @example
+- `src/FaceDetection.service.ts:83` `LoadedFaceDetector` (interface) - missing @example
+- `src/FaceDetection.service.ts:93` `FaceDetectionServiceShape` (interface) - missing @example
+- `src/FaceDetection.service.ts:106` `FaceDetectionService` (class) - missing @example
+- `src/FaceDetection.service.ts:539` `makeFaceDetectionService` (const) - missing @example
+- `src/FaceDetection.service.ts:569` `withDetector` (const) - missing @example
+- `src/index.ts:14` `export * from "./FaceDetection.errors.ts";` (re-export) - missing @example
+- `src/index.ts:22` `export * from "./FaceDetection.models.ts";` (re-export) - missing @example
+- `src/index.ts:30` `export * from "./FaceDetection.service.ts";` (re-export) - missing @example
+
 ### @beep/repo-docgen
 
 Path: `packages/tooling/tool/docgen`
@@ -1873,6 +1905,23 @@ Export findings:
 - `src/next/models/AllowedDevOrigin.schema.ts:57` `AllowedDevOrigin` (type) - 1 unsafe example violation(s)
 - `src/next/models/ImageConfig.schema.ts:28` `LoaderValue` (const) - 1 schema annotation/type-alias gap(s)
 
+### @beep/agent-capability-use-cases
+
+Path: `packages/agent-capability/use-cases`
+
+Export findings:
+- `src/processes/ProfessionalRuntime/ProfessionalRuntime.fixtures.ts:55` `RuntimeFixtureInput` (class) - 1 schema annotation/type-alias gap(s)
+- `src/processes/ProfessionalRuntime/ProfessionalRuntime.service.ts:27` `ProfessionalRuntimeSdk` (interface) - 1 unsafe example violation(s)
+- `src/processes/ProfessionalRuntime/ProfessionalRuntime.values.ts:23` `RuntimeCandidateLifecycle` (const) - 2 schema annotation/type-alias gap(s)
+- `src/processes/ProfessionalRuntime/ProfessionalRuntime.values.ts:38` `RuntimeClaimConfidence` (const) - 2 schema annotation/type-alias gap(s)
+- `src/processes/ProfessionalRuntime/ProfessionalRuntime.values.ts:53` `RuntimeApprovalDecision` (const) - 2 schema annotation/type-alias gap(s)
+- `src/processes/ProfessionalRuntime/ProfessionalRuntime.values.ts:68` `RuntimeRequestKind` (const) - 2 schema annotation/type-alias gap(s)
+- `src/processes/ProfessionalRuntime/ProfessionalRuntime.values.ts:83` `RuntimeSourceKind` (const) - 2 schema annotation/type-alias gap(s)
+- `src/processes/ProfessionalRuntime/ProfessionalRuntime.values.ts:98` `RuntimeActivityType` (const) - 2 schema annotation/type-alias gap(s)
+- `src/processes/ProfessionalRuntime/ProfessionalRuntime.values.ts:113` `RuntimeUsageMode` (const) - 2 schema annotation/type-alias gap(s)
+- `src/processes/ProfessionalRuntime/index.ts:80` `export type { ProfessionalRuntimeSdk } from "./ProfessionalRuntime.service.js";` (re-export) - 1 unsafe example violation(s)
+- `src/public.ts:78` `export type { ProfessionalRuntimeSdk } from "./processes/ProfessionalRuntime/ProfessionalRuntime.service.js";` (re-export) - 1 unsafe example violation(s)
+
 ### @beep/ui
 
 Path: `packages/foundation/ui-system/ui`
@@ -1896,11 +1945,6 @@ Module findings:
 - `src/components/card.tsx:1` (none) - missing summary; missing @since
 - `src/components/carousel.tsx:1` (none) - missing summary; missing @since
 - `src/components/checkbox.tsx:1` (none) - missing summary; missing @since
-- `src/components/codegraph/components/SearchBar.tsx:1` (none) - missing summary; missing @since
-- `src/components/codegraph/components/StatsPanel.tsx:1` (none) - missing summary; missing @since
-- `src/components/codegraph/neo4j.ts:1` (none) - missing summary; missing @since
-- `src/components/codegraph/styles/graph-layout.tsx:1` (none) - missing summary; missing @since
-- `src/components/codegraph/styles/graph-styles.tsx:1` (none) - missing summary; missing @since
 - `src/components/collapsible.tsx:1` (none) - missing summary; missing @since
 - `src/components/combobox.tsx:1` (none) - missing summary; missing @since
 - `src/components/command.tsx:1` (none) - missing summary; missing @since
@@ -2055,30 +2099,6 @@ Export findings:
 - `src/components/carousel.tsx:182` `CarouselPrevious` (function) - missing summary; missing @example
 - `src/components/carousel.tsx:42` `useCarousel` (function) - missing summary; missing @example
 - `src/components/checkbox.tsx:11` `Checkbox` (function) - missing summary; missing @example
-- `src/components/codegraph/components/SearchBar.tsx:15` `SearchMode` (const) - missing summary; missing @example
-- `src/components/codegraph/components/SearchBar.tsx:25` `SearchMode` (type) - missing summary; missing @example
-- `src/components/codegraph/components/SearchBar.tsx:31` `SearchBarProps` (class) - missing summary; missing @example; 1 schema annotation/type-alias gap(s)
-- `src/components/codegraph/components/StatsPanel.tsx:32` `StatsPanel` (function) - missing summary; missing @example
-- `src/components/codegraph/neo4j.ts:11` `DeadCodeItem` (class) - missing summary; missing @example
-- `src/components/codegraph/neo4j.ts:25` `GodObjectItem` (class) - missing summary; missing @example
-- `src/components/codegraph/neo4j.ts:40` `GodFileItem` (class) - missing summary; missing @example
-- `src/components/codegraph/neo4j.ts:53` `DuplicateGroupFunction` (class) - missing summary; missing @example; 1 schema annotation/type-alias gap(s)
-- `src/components/codegraph/neo4j.ts:62` `DuplicateGroup` (class) - missing summary; missing @example; 1 schema annotation/type-alias gap(s)
-- `src/components/codegraph/neo4j.ts:72` `HealthStats` (class) - missing summary; missing @example; 1 schema annotation/type-alias gap(s)
-- `src/components/codegraph/neo4j.ts:100` `ViewMode` (const) - missing summary; missing @example
-- `src/components/codegraph/neo4j.ts:110` `ViewMode` (type) - missing summary; missing @example
-- `src/components/codegraph/neo4j.ts:116` `CacheKey` (const) - missing summary; missing @example
-- `src/components/codegraph/neo4j.ts:126` `CacheKey` (type) - missing summary; missing @example
-- `src/components/codegraph/styles/graph-layout.tsx:13` `LayoutName` (const) - missing summary; missing @example
-- `src/components/codegraph/styles/graph-layout.tsx:23` `LayoutName` (type) - missing summary; missing @example
-- `src/components/codegraph/styles/graph-layout.tsx:29` `LayoutBase` (class) - missing summary; missing @example; 1 schema annotation/type-alias gap(s)
-- `src/components/codegraph/styles/graph-layout.tsx:42` `CircleLayout` (class) - missing summary; missing @example
-- `src/components/codegraph/styles/graph-layout.tsx:56` `ConcentricLayout` (class) - missing summary; missing @example
-- `src/components/codegraph/styles/graph-layout.tsx:73` `BreadthFirstLayout` (class) - missing summary; missing @example
-- `src/components/codegraph/styles/graph-layout.tsx:92` `CoseLayout` (class) - missing summary; missing @example
-- `src/components/codegraph/styles/graph-layout.tsx:116` `GraphLayout` (const) - missing summary; missing @example; 1 schema annotation/type-alias gap(s)
-- `src/components/codegraph/styles/graph-styles.tsx:10` `graphStyles` (const) - missing summary; missing @example
-- `src/components/codegraph/styles/graph-styles.tsx:520` `graphStylesFast` (const) - missing @example
 - `src/components/collapsible.tsx:10` `Collapsible` (function) - missing summary; missing @example
 - `src/components/collapsible.tsx:26` `CollapsibleContent` (function) - missing summary; missing @example
 - `src/components/collapsible.tsx:18` `CollapsibleTrigger` (function) - missing summary; missing @example
@@ -2188,7 +2208,7 @@ Export findings:
 - `src/components/dropdown-menu.tsx:163` `DropdownMenuSubContent` (function) - missing summary; missing @example
 - `src/components/dropdown-menu.tsx:135` `DropdownMenuSubTrigger` (function) - missing summary; missing @example
 - `src/components/dropdown-menu.tsx:29` `DropdownMenuTrigger` (function) - missing summary; missing @example
-- `src/components/editor/editor-ui/content-editable.tsx:16` `ContentEditable` (function) - missing @example
+- `src/components/editor/editor-ui/content-editable.tsx:20` `ContentEditable` (function) - missing @example
 - `src/components/editor/themes/editor-theme.ts:13` `editorTheme` (const) - missing @example
 - `src/components/empty.tsx:10` `Empty` (function) - missing summary; missing @example
 - `src/components/empty.tsx:100` `EmptyContent` (function) - missing summary; missing @example
@@ -2196,16 +2216,16 @@ Export findings:
 - `src/components/empty.tsx:27` `EmptyHeader` (function) - missing summary; missing @example
 - `src/components/empty.tsx:56` `EmptyMedia` (function) - missing summary; missing @example
 - `src/components/empty.tsx:75` `EmptyTitle` (function) - missing summary; missing @example
-- `src/components/field.tsx:85` `Field` (function) - missing summary; missing @example
-- `src/components/field.tsx:105` `FieldContent` (function) - missing summary; missing @example
-- `src/components/field.tsx:154` `FieldDescription` (function) - missing summary; missing @example
-- `src/components/field.tsx:204` `FieldError` (function) - missing summary; missing @example
-- `src/components/field.tsx:53` `FieldGroup` (function) - missing summary; missing @example
-- `src/components/field.tsx:119` `FieldLabel` (function) - missing summary; missing @example
-- `src/components/field.tsx:34` `FieldLegend` (function) - missing summary; missing @example
-- `src/components/field.tsx:173` `FieldSeparator` (function) - missing summary; missing @example
-- `src/components/field.tsx:17` `FieldSet` (function) - missing summary; missing @example
-- `src/components/field.tsx:137` `FieldTitle` (function) - missing summary; missing @example
+- `src/components/field.tsx:88` `Field` (function) - missing summary; missing @example
+- `src/components/field.tsx:108` `FieldContent` (function) - missing summary; missing @example
+- `src/components/field.tsx:157` `FieldDescription` (function) - missing summary; missing @example
+- `src/components/field.tsx:208` `FieldError` (function) - missing summary; missing @example
+- `src/components/field.tsx:56` `FieldGroup` (function) - missing summary; missing @example
+- `src/components/field.tsx:122` `FieldLabel` (function) - missing summary; missing @example
+- `src/components/field.tsx:37` `FieldLegend` (function) - missing summary; missing @example
+- `src/components/field.tsx:176` `FieldSeparator` (function) - missing summary; missing @example
+- `src/components/field.tsx:20` `FieldSet` (function) - missing summary; missing @example
+- `src/components/field.tsx:140` `FieldTitle` (function) - missing summary; missing @example
 - `src/components/hover-card.tsx:11` `HoverCard` (function) - missing summary; missing @example
 - `src/components/hover-card.tsx:27` `HoverCardContent` (function) - missing summary; missing @example
 - `src/components/hover-card.tsx:19` `HoverCardTrigger` (function) - missing summary; missing @example
@@ -2348,7 +2368,7 @@ Export findings:
 - `src/components/slider.tsx:13` `Slider` (function) - missing summary; missing @example
 - `src/components/sonner.tsx:12` `Toaster` (const) - missing summary; missing @example
 - `src/components/speech-input.tsx:142` `SpeechInput` (const) - missing summary; missing @example
-- `src/components/speech-input.tsx:399` `SpeechInputCancelButton` (const) - missing summary; missing @example
+- `src/components/speech-input.tsx:404` `SpeechInputCancelButton` (const) - missing summary; missing @example
 - `src/components/speech-input.tsx:355` `SpeechInputPreview` (const) - missing summary; missing @example
 - `src/components/speech-input.tsx:298` `SpeechInputRecordButton` (const) - missing summary; missing @example
 - `src/components/speech-input.tsx:56` `useSpeechInput` (function) - missing summary; missing @example
@@ -2407,10 +2427,10 @@ Export findings:
 - `src/components/tooltip.tsx:34` `TooltipContent` (function) - missing summary; missing @example
 - `src/components/tooltip.tsx:10` `TooltipProvider` (function) - missing summary; missing @example
 - `src/components/tooltip.tsx:26` `TooltipTrigger` (function) - missing summary; missing @example
-- `src/components/tour.tsx:41` `Step` (interface) - missing summary; missing @example
-- `src/components/tour.tsx:60` `Tour` (interface) - missing summary; missing @example
-- `src/components/tour.tsx:69` `TourProvider` (function) - missing summary; missing @example
-- `src/components/tour.tsx:32` `useTour` (function) - missing summary; missing @example
+- `src/components/tour.tsx:42` `Step` (interface) - missing summary; missing @example
+- `src/components/tour.tsx:61` `Tour` (interface) - missing summary; missing @example
+- `src/components/tour.tsx:70` `TourProvider` (function) - missing summary; missing @example
+- `src/components/tour.tsx:33` `useTour` (function) - missing summary; missing @example
 - `src/components/ui/button.stories.tsx:9` `default` (const) - missing summary; missing @example
 - `src/components/ui/button.stories.tsx:39` `Default` (const) - missing summary; missing @example
 - `src/components/ui/button.stories.tsx:54` `Outline` (const) - missing summary; missing @example
@@ -2427,7 +2447,10 @@ Export findings:
 - `src/components/ui/tooltip.tsx:37` `TooltipContent` (function) - missing summary; missing @example
 - `src/components/ui/tooltip.tsx:13` `TooltipProvider` (function) - missing @example
 - `src/components/ui/tooltip.tsx:29` `TooltipTrigger` (function) - missing summary; missing @example
-- `src/hooks/index.ts:13` `export * from "./useNumberInput.ts";` (re-export) - missing @example
+- `src/hooks/index.ts:13` `export * from "./use-scribe.ts";` (re-export) - missing @example
+- `src/hooks/index.ts:18` `export * from "./useNumberInput.ts";` (re-export) - missing @example
+- `src/hooks/use-scribe.ts:140` `useScribe` (function) - missing @example
+- `src/hooks/use-scribe.ts:41` `ScribeStatus` (type) - missing @example
 - `src/hooks/useMobile.ts:32` `useIsMobile` (function) - missing @example
 - `src/hooks/useMobile.ts:24` `resolveIsMobile` (const) - missing @example
 - `src/hooks/useNumberInput.ts:213` `minSafeInteger` (const) - missing @example
@@ -2447,6 +2470,7 @@ Export findings:
 - `src/lib/index.ts:5` `export * from "./url.ts";` (re-export) - missing @example
 - `src/lib/index.ts:10` `export * from "./utils.ts";` (re-export) - missing @example
 - `src/lib/react-invariant.ts:20` `ReactContextInvariantOptions` (class) - missing @example
+- `src/lib/toaster.ts:16` `globalToastManager` (const) - missing @example
 - `src/lib/url.ts:77` `sanitizeAnchorHref` (const) - missing @example
 - `src/lib/utils.ts:20` `cn` (function) - missing @example
 - `src/themes/colors.ts:30` `colors` (const) - missing @example
@@ -2493,23 +2517,6 @@ Export findings:
 - `src/types/component.ts:18` `OverridableComponent` (type) - missing summary; missing @example
 - `src/types/component.ts:33` `ForwardStyledProps` (type) - missing summary; missing @example
 - `src/types/index.ts:5` `export * from "./component";` (re-export) - missing @example
-
-### @beep/agent-capability-use-cases
-
-Path: `packages/agent-capability/use-cases`
-
-Export findings:
-- `src/processes/ProfessionalRuntime/ProfessionalRuntime.fixtures.ts:55` `RuntimeFixtureInput` (class) - 1 schema annotation/type-alias gap(s)
-- `src/processes/ProfessionalRuntime/ProfessionalRuntime.service.ts:27` `ProfessionalRuntimeSdk` (interface) - 1 unsafe example violation(s)
-- `src/processes/ProfessionalRuntime/ProfessionalRuntime.values.ts:23` `RuntimeCandidateLifecycle` (const) - 2 schema annotation/type-alias gap(s)
-- `src/processes/ProfessionalRuntime/ProfessionalRuntime.values.ts:38` `RuntimeClaimConfidence` (const) - 2 schema annotation/type-alias gap(s)
-- `src/processes/ProfessionalRuntime/ProfessionalRuntime.values.ts:53` `RuntimeApprovalDecision` (const) - 2 schema annotation/type-alias gap(s)
-- `src/processes/ProfessionalRuntime/ProfessionalRuntime.values.ts:68` `RuntimeRequestKind` (const) - 2 schema annotation/type-alias gap(s)
-- `src/processes/ProfessionalRuntime/ProfessionalRuntime.values.ts:83` `RuntimeSourceKind` (const) - 2 schema annotation/type-alias gap(s)
-- `src/processes/ProfessionalRuntime/ProfessionalRuntime.values.ts:98` `RuntimeActivityType` (const) - 2 schema annotation/type-alias gap(s)
-- `src/processes/ProfessionalRuntime/ProfessionalRuntime.values.ts:113` `RuntimeUsageMode` (const) - 2 schema annotation/type-alias gap(s)
-- `src/processes/ProfessionalRuntime/index.ts:80` `export type { ProfessionalRuntimeSdk } from "./ProfessionalRuntime.service.js";` (re-export) - 1 unsafe example violation(s)
-- `src/public.ts:78` `export type { ProfessionalRuntimeSdk } from "./processes/ProfessionalRuntime/ProfessionalRuntime.service.js";` (re-export) - 1 unsafe example violation(s)
 
 ### @beep/architecture-lab-ui
 
@@ -2608,26 +2615,26 @@ Export findings:
 - `src/commands/Architecture/OperationPlan.ts:61` `ArchitecturePlanStage` (type) - missing @example
 - `src/commands/Architecture/OperationPlan.ts:69` `ArchitectureSliceRole` (const) - missing @example
 - `src/commands/Architecture/OperationPlan.ts:91` `ArchitectureSliceRole` (type) - missing @example
-- `src/commands/Architecture/OperationPlan.ts:99` `ArchitectureWriterKind` (const) - missing @example
-- `src/commands/Architecture/OperationPlan.ts:117` `ArchitectureWriterKind` (type) - missing @example
-- `src/commands/Architecture/OperationPlan.ts:125` `ArchitectureSliceRolePlan` (class) - missing @example
-- `src/commands/Architecture/OperationPlan.ts:143` `ArchitecturePlanTarget` (class) - missing @example
-- `src/commands/Architecture/OperationPlan.ts:162` `WriteFileOperation` (class) - missing @example
-- `src/commands/Architecture/OperationPlan.ts:182` `EnsureFileOperation` (class) - missing @example
-- `src/commands/Architecture/OperationPlan.ts:200` `EnsureAbsentPathOperation` (class) - missing @example
-- `src/commands/Architecture/OperationPlan.ts:217` `ArchitectureOperation` (const) - missing @example; 1 schema annotation/type-alias gap(s)
-- `src/commands/Architecture/OperationPlan.ts:225` `ArchitectureOperation` (type) - missing @example
-- `src/commands/Architecture/OperationPlan.ts:233` `CanonicalSliceOperationPlan` (class) - missing @example
-- `src/commands/Architecture/OperationPlan.ts:270` `OperationPlanCheckResult` (class) - missing @example
-- `src/commands/Architecture/OperationPlan.ts:288` `OperationPlanApplyResult` (class) - missing @example
-- `src/commands/Architecture/OperationPlan.ts:1184` `makeCanonicalSliceOperationPlan` (const) - missing @example
-- `src/commands/Architecture/OperationPlan.ts:1222` `makeArchitectureOperationPlan` (const) - missing @example
-- `src/commands/Architecture/OperationPlan.ts:1283` `encodeCanonicalSliceOperationPlanJson` (const) - missing @example
-- `src/commands/Architecture/OperationPlan.ts:1291` `decodeCanonicalSliceOperationPlanJson` (const) - missing @example
-- `src/commands/Architecture/OperationPlan.ts:1304` `checkCanonicalSliceOperationPlan` (const) - missing @example
-- `src/commands/Architecture/OperationPlan.ts:1359` `applyCanonicalSliceOperationPlan` (const) - missing @example
-- `src/commands/Architecture/OperationPlan.ts:1649` `architectureCommand` (const) - missing @example
-- `src/commands/Architecture/index.ts:7` `export * from "./OperationPlan.js";` (re-export) - missing @example
+- `src/commands/Architecture/OperationPlan.ts:180` `ArchitectureWriterKind` (const) - missing @example
+- `src/commands/Architecture/OperationPlan.ts:198` `ArchitectureWriterKind` (type) - missing @example
+- `src/commands/Architecture/OperationPlan.ts:394` `ArchitectureSliceRolePlan` (class) - missing @example
+- `src/commands/Architecture/OperationPlan.ts:412` `ArchitecturePlanTarget` (class) - missing @example
+- `src/commands/Architecture/OperationPlan.ts:431` `WriteFileOperation` (class) - missing @example
+- `src/commands/Architecture/OperationPlan.ts:501` `EnsureFileOperation` (class) - missing @example
+- `src/commands/Architecture/OperationPlan.ts:523` `EnsureAbsentPathOperation` (class) - missing @example
+- `src/commands/Architecture/OperationPlan.ts:544` `ArchitectureOperation` (const) - missing @example; 1 schema annotation/type-alias gap(s)
+- `src/commands/Architecture/OperationPlan.ts:557` `ArchitectureOperation` (type) - missing @example
+- `src/commands/Architecture/OperationPlan.ts:595` `CanonicalSliceOperationPlan` (class) - missing @example
+- `src/commands/Architecture/OperationPlan.ts:632` `OperationPlanCheckResult` (class) - missing @example
+- `src/commands/Architecture/OperationPlan.ts:653` `OperationPlanApplyResult` (class) - missing @example
+- `src/commands/Architecture/OperationPlan.ts:2251` `makeCanonicalSliceOperationPlan` (const) - missing @example
+- `src/commands/Architecture/OperationPlan.ts:2296` `makeArchitectureOperationPlan` (const) - missing @example
+- `src/commands/Architecture/OperationPlan.ts:2404` `encodeCanonicalSliceOperationPlanJson` (const) - missing @example
+- `src/commands/Architecture/OperationPlan.ts:2412` `decodeCanonicalSliceOperationPlanJson` (const) - missing @example
+- `src/commands/Architecture/OperationPlan.ts:2458` `checkCanonicalSliceOperationPlan` (const) - missing @example
+- `src/commands/Architecture/OperationPlan.ts:2527` `applyCanonicalSliceOperationPlan` (const) - missing @example
+- `src/commands/Architecture/index.ts:7` `export * from "./Command.js";` (re-export) - missing @example
+- `src/commands/Architecture/index.ts:14` `export * from "./OperationPlan.js";` (re-export) - missing @example
 - `src/commands/CreatePackage/ConfigUpdater.ts:41` `ConfigUpdateResult` (class) - missing @example
 - `src/commands/CreatePackage/ConfigUpdater.ts:58` `ConfigUpdateTarget` (class) - missing @example
 - `src/commands/CreatePackage/ConfigUpdater.ts:76` `ConfigUpdateTargetResult` (class) - missing @example
@@ -2653,7 +2660,7 @@ Export findings:
 - `src/commands/CreatePackage/FileGenerationPlanService.ts:468` `createFileGenerationPlanService` (const) - missing @example
 - `src/commands/CreatePackage/Handler.ts:77` `resolveCreatePackageTemplateDir` (const) - missing @example
 - `src/commands/CreatePackage/Handler.ts:267` `TemplateContext` (class) - missing @example
-- `src/commands/CreatePackage/Handler.ts:544` `createPackageCommand` (const) - missing @example
+- `src/commands/CreatePackage/Handler.ts:554` `createPackageCommand` (const) - missing @example
 - `src/commands/CreatePackage/TemplateService.ts:24` `TemplateSpec` (class) - missing @example
 - `src/commands/CreatePackage/TemplateService.ts:40` `RenderedTemplate` (class) - missing @example
 - `src/commands/CreatePackage/TemplateService.ts:56` `TemplateRenderRequest` (class) - missing @example
@@ -2685,180 +2692,201 @@ Export findings:
 - `src/commands/Docgen/internal/Operations.ts:260` `DocgenPackageAnalysis` (class) - missing @example
 - `src/commands/Docgen/internal/Operations.ts:279` `DocgenGenerationResult` (class) - missing @example
 - `src/commands/Docgen/internal/Operations.ts:299` `DocgenAggregateResult` (class) - missing @example
-- `src/commands/Docgen/internal/Operations.ts:1127` `normalizeDocsOutputPath` (const) - missing @example
-- `src/commands/Docgen/internal/Operations.ts:1138` `loadDocgenConfigDocument` (const) - missing @example
-- `src/commands/Docgen/internal/Operations.ts:1166` `createDocgenConfigDocument` (const) - missing @example
-- `src/commands/Docgen/internal/Operations.ts:1209` `discoverDocgenWorkspacePackages` (const) - missing @example
+- `src/commands/Docgen/internal/Operations.ts:1128` `normalizeDocsOutputPath` (const) - missing @example
+- `src/commands/Docgen/internal/Operations.ts:1139` `loadDocgenConfigDocument` (const) - missing @example
+- `src/commands/Docgen/internal/Operations.ts:1167` `createDocgenConfigDocument` (const) - missing @example
+- `src/commands/Docgen/internal/Operations.ts:1210` `discoverDocgenWorkspacePackages` (const) - missing @example
 - `src/commands/Docgen/internal/Operations.ts:1252` `resolveDocgenWorkspacePackage` (const) - missing @example
 - `src/commands/Docgen/internal/Operations.ts:1304` `analyzePackageDocumentation` (const) - missing @example
 - `src/commands/Docgen/internal/Operations.ts:1348` `generateAnalysisReport` (const) - missing @example
 - `src/commands/Docgen/internal/Operations.ts:1466` `generateAnalysisJson` (const) - missing @example
 - `src/commands/Docgen/internal/Operations.ts:1476` `aggregateGeneratedDocs` (const) - missing @example
-- `src/commands/Docgen/internal/Operations.ts:1626` `runDocgenForPackage` (const) - missing @example
-- `src/commands/Files/Files.command.ts:386` `filesCommand` (const) - missing @example
+- `src/commands/Docgen/internal/Operations.ts:1627` `runDocgenForPackage` (const) - missing @example
+- `src/commands/Files/Files.command.ts:447` `filesCommand` (const) - missing @example
 - `src/commands/Files/Files.errors.ts:54` `formatPlatformError` (const) - missing @example
 - `src/commands/Files/Files.errors.ts:74` `failOnExtensionlessFile` (const) - missing @example
-- `src/commands/Files/Files.schemas.ts:24` `PositiveMediaDimension` (const) - missing @example
-- `src/commands/Files/Files.schemas.ts:52` `PositiveMediaDimension` (type) - missing @example
-- `src/commands/Files/Files.schemas.ts:60` `FileSha256Hash` (const) - missing @example
-- `src/commands/Files/Files.schemas.ts:79` `FileSha256Hash` (type) - missing @example
-- `src/commands/Files/Files.schemas.ts:87` `NonNegativePixelOffset` (const) - missing @example
-- `src/commands/Files/Files.schemas.ts:115` `NonNegativePixelOffset` (type) - missing @example
-- `src/commands/Files/Files.schemas.ts:123` `MediaKind` (const) - missing @example
-- `src/commands/Files/Files.schemas.ts:135` `MediaKind` (type) - missing @example
-- `src/commands/Files/Files.schemas.ts:143` `SupportedMetadataImageExtension` (const) - missing @example
-- `src/commands/Files/Files.schemas.ts:163` `SupportedMetadataImageExtension` (type) - missing @example
-- `src/commands/Files/Files.schemas.ts:171` `NormalizeImageFormatInput` (const) - missing @example
-- `src/commands/Files/Files.schemas.ts:183` `NormalizeImageFormatInput` (type) - missing @example
-- `src/commands/Files/Files.schemas.ts:191` `NormalizeImageFormat` (const) - missing @example
-- `src/commands/Files/Files.schemas.ts:203` `NormalizeImageFormat` (type) - missing @example
-- `src/commands/Files/Files.schemas.ts:211` `NormalizeSkippedReason` (const) - missing @example
-- `src/commands/Files/Files.schemas.ts:231` `NormalizeSkippedReason` (type) - missing @example
-- `src/commands/Files/Files.schemas.ts:239` `CreateCaptionFilesSkippedReason` (const) - missing @example
-- `src/commands/Files/Files.schemas.ts:260` `CreateCaptionFilesSkippedReason` (type) - missing @example
-- `src/commands/Files/Files.schemas.ts:268` `BorderSide` (const) - missing @example
-- `src/commands/Files/Files.schemas.ts:280` `BorderSide` (type) - missing @example
-- `src/commands/Files/Files.schemas.ts:288` `BorderDetectionKind` (const) - missing @example
-- `src/commands/Files/Files.schemas.ts:307` `BorderDetectionKind` (type) - missing @example
-- `src/commands/Files/Files.schemas.ts:315` `DetectBordersSkippedReason` (const) - missing @example
-- `src/commands/Files/Files.schemas.ts:335` `DetectBordersSkippedReason` (type) - missing @example
-- `src/commands/Files/Files.schemas.ts:343` `CandidateAssessmentProfile` (const) - missing @example
-- `src/commands/Files/Files.schemas.ts:355` `CandidateAssessmentProfile` (type) - missing @example
-- `src/commands/Files/Files.schemas.ts:363` `CandidateAssessmentDecision` (const) - missing @example
-- `src/commands/Files/Files.schemas.ts:375` `CandidateAssessmentDecision` (type) - missing @example
-- `src/commands/Files/Files.schemas.ts:383` `CandidateAssessmentReason` (const) - missing @example
-- `src/commands/Files/Files.schemas.ts:399` `CandidateAssessmentReason` (type) - missing @example
-- `src/commands/Files/Files.schemas.ts:407` `ArchivePoorCandidatesSkippedReason` (const) - missing @example
-- `src/commands/Files/Files.schemas.ts:427` `ArchivePoorCandidatesSkippedReason` (type) - missing @example
-- `src/commands/Files/Files.schemas.ts:435` `CandidateRatioThreshold` (const) - missing @example
-- `src/commands/Files/Files.schemas.ts:454` `CandidateRatioThreshold` (type) - missing @example
-- `src/commands/Files/Files.schemas.ts:462` `BorderDetectionPercentage` (const) - missing @example
-- `src/commands/Files/Files.schemas.ts:496` `BorderDetectionPercentage` (type) - missing @example
-- `src/commands/Files/Files.schemas.ts:504` `BorderDetectionMaxScanPercentage` (const) - missing @example
-- `src/commands/Files/Files.schemas.ts:538` `BorderDetectionMaxScanPercentage` (type) - missing @example
-- `src/commands/Files/Files.schemas.ts:546` `BorderDetectionTolerance` (const) - missing @example
-- `src/commands/Files/Files.schemas.ts:580` `BorderDetectionTolerance` (type) - missing @example
-- `src/commands/Files/Files.schemas.ts:588` `RgbChannel` (const) - missing @example
-- `src/commands/Files/Files.schemas.ts:622` `RgbChannel` (type) - missing @example
-- `src/commands/Files/Files.schemas.ts:630` `ImageSizeMetadata` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:647` `FfprobeSideData` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:662` `FfprobeStream` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:680` `FfprobeOutput` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:695` `SafeFilePrefix` (const) - missing @example
-- `src/commands/Files/Files.schemas.ts:741` `SafeFilePrefix` (type) - missing @example
-- `src/commands/Files/Files.schemas.ts:782` `RenamePlanEntry` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:807` `SortAndRenameSummary` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:859` `StripMetadataSummary` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:903` `CreateCaptionFilesOptions` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:921` `CreateCaptionFilesPlanEntry` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:943` `CreateCaptionFilesSkippedEntry` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:965` `CreateCaptionFilesPlan` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:984` `CreateCaptionFilesSummary` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:1004` `NormalizeFilesOptions` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:1029` `NormalizeManifestOptions` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:1048` `NormalizePlanEntry` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:1076` `NormalizeSkippedEntry` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:1100` `NormalizePlan` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:1121` `NormalizeSummary` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:1150` `NormalizeManifestSummary` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:1170` `NormalizeManifest` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:1192` `ArchivePoorCandidatesOptions` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:1219` `ArchivePoorCandidatesManifestOptions` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:1242` `CandidateAssessmentMetrics` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:1260` `ArchivedSidecarEntry` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:1279` `ArchivePoorCandidatesEntry` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:1306` `ArchivePoorCandidatesSkippedEntry` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:1327` `ArchivePoorCandidatesPlan` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:1347` `ArchivePoorCandidatesSummary` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:1373` `ArchivePoorCandidatesManifestSummary` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:1394` `ArchivePoorCandidatesManifest` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:1418` `DetectBordersOptions` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:1438` `CropBordersOptions` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:1458` `RgbColor` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:1475` `DetectBorderSideMeasurement` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:1496` `DetectBordersEntry` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:1519` `DetectBordersSkippedEntry` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:1538` `DetectBordersSummary` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:1557` `DetectBordersReport` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:1577` `CropBordersPlanEntry` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:1603` `CropBordersPlan` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:1622` `CropBordersSummary` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:1643` `SortableFileCollection` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:1659` `RenamePlan` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:1675` `StripMetadataPlan` (class) - missing @example
-- `src/commands/Files/Files.schemas.ts:1693` `decodeImageSizeMetadata` (const) - missing @example
-- `src/commands/Files/Files.schemas.ts:1701` `decodeFfprobeOutputJson` (const) - missing @example
-- `src/commands/Files/Files.schemas.ts:1709` `decodeRotationNumber` (const) - missing @example; 2 schema annotation/type-alias gap(s)
-- `src/commands/Files/Files.schemas.ts:1717` `decodeSafeFilePrefix` (const) - missing @example
-- `src/commands/Files/Files.schemas.ts:1725` `decodeNormalizeMaxLongEdge` (const) - missing @example
-- `src/commands/Files/Files.schemas.ts:1733` `decodeArchivePoorCandidatesOptions` (const) - missing @example
-- `src/commands/Files/Files.schemas.ts:1741` `decodeCreateCaptionFilesOptions` (const) - missing @example
-- `src/commands/Files/Files.schemas.ts:1749` `decodeDetectBordersOptions` (const) - missing @example
-- `src/commands/Files/Files.schemas.ts:1757` `decodeCropBordersOptions` (const) - missing @example
-- `src/commands/Files/Files.schemas.ts:1765` `encodeNormalizeManifest` (const) - missing @example
-- `src/commands/Files/Files.schemas.ts:1773` `encodeArchivePoorCandidatesManifest` (const) - missing @example
-- `src/commands/Files/Files.schemas.ts:1781` `encodeDetectBordersReport` (const) - missing @example
-- `src/commands/Files/Files.service.ts:146` `FilesCommandServiceShape` (interface) - missing @example
-- `src/commands/Files/Files.service.ts:212` `FilesCommandService` (class) - missing @example
-- `src/commands/Files/Files.service.ts:2998` `printFilesIndex` (const) - missing @example
-- `src/commands/Files/Files.service.ts:3607` `FilesCommandServiceLive` (const) - missing @example
-- `src/commands/Files/Files.service.ts:3618` `archivePoorCandidates` (const) - missing @example
-- `src/commands/Files/Files.service.ts:3633` `createCaptionFiles` (const) - missing @example
-- `src/commands/Files/Files.service.ts:3648` `cropBordersFiles` (const) - missing @example
-- `src/commands/Files/Files.service.ts:3663` `detectBordersFiles` (const) - missing @example
-- `src/commands/Files/Files.service.ts:3678` `normalizeFiles` (const) - missing @example
-- `src/commands/Files/Files.service.ts:3696` `sortAndRenameFiles` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:220` `stringEquivalence` (const) - missing @example; 2 schema annotation/type-alias gap(s)
-- `src/commands/Files/Files.utils.ts:228` `isImageFileExtension` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:236` `isVideoFileExtension` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:244` `isSupportedMetadataImageExtension` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:252` `bySizeDescendingThenNameAscending` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:263` `byNameAscending` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:276` `normalizeBareExtension` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:286` `mediaKindFromExtension` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:309` `formatIndex` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:322` `collectText` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:340` `isExifOrientationRotated` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:350` `isQuarterTurnRotation` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:364` `maybeSwapDimensions` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:386` `rotationFromStream` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:407` `targetNameForEntry` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:431` `hasSkippedFiles` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:441` `selectedCanonicalPathSet` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:457` `renderPlanEntry` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:467` `renderStripMetadataPlanEntry` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:478` `renderCreateCaptionFilesPlanEntry` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:489` `renderCreateCaptionFilesSkippedEntry` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:500` `renderNormalizePlanEntry` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:511` `renderNormalizeSkippedEntry` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:522` `normalizeOutputExtension` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:532` `sharpFormatForNormalize` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:544` `normalizeOutputDimensions` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:573` `mediaDimensionsChanged` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:589` `roundCandidateMetric` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:600` `assessImageCandidate` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:644` `renderArchivePoorCandidatesEntry` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:661` `renderArchivePoorCandidatesSkippedEntry` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:672` `rgbToHex` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:683` `classifyBorderSides` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:729` `analyzeSolidBorders` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:746` `renderDetectBordersEntry` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:765` `renderDetectBordersSkippedEntry` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:785` `cropBordersPlanEntryFromDetection` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:823` `renderCropBordersPlanEntry` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:836` `makeStripMetadataTempEntries` (const) - missing @example
-- `src/commands/Files/Files.utils.ts:861` `isSupportedMetadataImageFile` (const) - missing @example
+- `src/commands/Files/Files.progress.ts:24` `FilesConcurrency` (const) - missing @example
+- `src/commands/Files/Files.progress.ts:74` `isFilesProgressEnabled` (const) - missing @example
+- `src/commands/Files/Files.progress.ts:84` `renderFilesProgressBar` (const) - missing @example
+- `src/commands/Files/Files.progress.ts:105` `runFilesProgressAll` (const) - missing @example
+- `src/commands/Files/Files.progress.ts:173` `runFilesProgressForEach` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:25` `PositiveMediaDimension` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:53` `PositiveMediaDimension` (type) - missing @example
+- `src/commands/Files/Files.schemas.ts:61` `FileSha256Hash` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:80` `FileSha256Hash` (type) - missing @example
+- `src/commands/Files/Files.schemas.ts:88` `NonNegativePixelOffset` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:116` `NonNegativePixelOffset` (type) - missing @example
+- `src/commands/Files/Files.schemas.ts:124` `MediaKind` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:136` `MediaKind` (type) - missing @example
+- `src/commands/Files/Files.schemas.ts:144` `SupportedMetadataImageExtension` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:164` `SupportedMetadataImageExtension` (type) - missing @example
+- `src/commands/Files/Files.schemas.ts:172` `NormalizeImageFormatInput` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:184` `NormalizeImageFormatInput` (type) - missing @example
+- `src/commands/Files/Files.schemas.ts:192` `NormalizeImageFormat` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:204` `NormalizeImageFormat` (type) - missing @example
+- `src/commands/Files/Files.schemas.ts:212` `NormalizeSkippedReason` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:232` `NormalizeSkippedReason` (type) - missing @example
+- `src/commands/Files/Files.schemas.ts:240` `CreateCaptionFilesSkippedReason` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:261` `CreateCaptionFilesSkippedReason` (type) - missing @example
+- `src/commands/Files/Files.schemas.ts:269` `BorderSide` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:281` `BorderSide` (type) - missing @example
+- `src/commands/Files/Files.schemas.ts:289` `BorderDetectionKind` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:308` `BorderDetectionKind` (type) - missing @example
+- `src/commands/Files/Files.schemas.ts:316` `DetectBordersSkippedReason` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:336` `DetectBordersSkippedReason` (type) - missing @example
+- `src/commands/Files/Files.schemas.ts:344` `DetectFacesSkippedReason` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:365` `DetectFacesSkippedReason` (type) - missing @example
+- `src/commands/Files/Files.schemas.ts:373` `DetectFacesFlag` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:391` `DetectFacesFlag` (type) - missing @example
+- `src/commands/Files/Files.schemas.ts:399` `CandidateAssessmentProfile` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:411` `CandidateAssessmentProfile` (type) - missing @example
+- `src/commands/Files/Files.schemas.ts:419` `CandidateAssessmentDecision` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:431` `CandidateAssessmentDecision` (type) - missing @example
+- `src/commands/Files/Files.schemas.ts:439` `CandidateAssessmentReason` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:455` `CandidateAssessmentReason` (type) - missing @example
+- `src/commands/Files/Files.schemas.ts:463` `ArchivePoorCandidatesSkippedReason` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:483` `ArchivePoorCandidatesSkippedReason` (type) - missing @example
+- `src/commands/Files/Files.schemas.ts:491` `CandidateRatioThreshold` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:510` `CandidateRatioThreshold` (type) - missing @example
+- `src/commands/Files/Files.schemas.ts:518` `BorderDetectionPercentage` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:552` `BorderDetectionPercentage` (type) - missing @example
+- `src/commands/Files/Files.schemas.ts:560` `BorderDetectionMaxScanPercentage` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:594` `BorderDetectionMaxScanPercentage` (type) - missing @example
+- `src/commands/Files/Files.schemas.ts:602` `BorderDetectionTolerance` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:636` `BorderDetectionTolerance` (type) - missing @example
+- `src/commands/Files/Files.schemas.ts:644` `RgbChannel` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:678` `RgbChannel` (type) - missing @example
+- `src/commands/Files/Files.schemas.ts:686` `ImageSizeMetadata` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:703` `FfprobeSideData` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:718` `FfprobeStream` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:736` `FfprobeOutput` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:751` `SafeFilePrefix` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:797` `SafeFilePrefix` (type) - missing @example
+- `src/commands/Files/Files.schemas.ts:838` `RenamePlanEntry` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:863` `SortAndRenameSummary` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:915` `StripMetadataSummary` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:959` `CreateCaptionFilesOptions` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:977` `CreateCaptionFilesPlanEntry` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:999` `CreateCaptionFilesSkippedEntry` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1021` `CreateCaptionFilesPlan` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1040` `CreateCaptionFilesSummary` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1060` `NormalizeFilesOptions` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1085` `NormalizeManifestOptions` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1104` `NormalizePlanEntry` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1132` `NormalizeSkippedEntry` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1156` `NormalizePlan` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1177` `NormalizeSummary` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1206` `NormalizeManifestSummary` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1226` `NormalizeManifest` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1248` `ArchivePoorCandidatesOptions` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1275` `ArchivePoorCandidatesManifestOptions` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1298` `CandidateAssessmentMetrics` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1316` `ArchivedSidecarEntry` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1335` `ArchivePoorCandidatesEntry` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1362` `ArchivePoorCandidatesSkippedEntry` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1383` `ArchivePoorCandidatesPlan` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1403` `ArchivePoorCandidatesSummary` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1429` `ArchivePoorCandidatesManifestSummary` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1450` `ArchivePoorCandidatesManifest` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1474` `DetectBordersOptions` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1494` `DetectFacesOptions` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1516` `DetectFacesReportOptions` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1537` `CropBordersOptions` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1557` `RgbColor` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1574` `DetectBorderSideMeasurement` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1595` `DetectBordersEntry` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1618` `DetectBordersSkippedEntry` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1637` `DetectBordersSummary` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1656` `DetectBordersReport` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1676` `DetectFacesEntry` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1704` `DetectFacesSkippedEntry` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1723` `DetectFacesSummary` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1745` `DetectFacesReport` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1767` `CropBordersPlanEntry` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1793` `CropBordersPlan` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1812` `CropBordersSummary` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1833` `SortableFileCollection` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1849` `RenamePlan` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1865` `StripMetadataPlan` (class) - missing @example
+- `src/commands/Files/Files.schemas.ts:1883` `decodeImageSizeMetadata` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:1891` `decodeFfprobeOutputJson` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:1899` `decodeRotationNumber` (const) - missing @example; 2 schema annotation/type-alias gap(s)
+- `src/commands/Files/Files.schemas.ts:1907` `decodeSafeFilePrefix` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:1915` `decodeNormalizeMaxLongEdge` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:1923` `decodeArchivePoorCandidatesOptions` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:1931` `decodeCreateCaptionFilesOptions` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:1939` `decodeDetectBordersOptions` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:1946` `decodeDetectFacesOptions` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:1954` `decodeCropBordersOptions` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:1962` `encodeNormalizeManifest` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:1970` `encodeArchivePoorCandidatesManifest` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:1978` `encodeDetectBordersReport` (const) - missing @example
+- `src/commands/Files/Files.schemas.ts:1985` `encodeDetectFacesReport` (const) - missing @example
+- `src/commands/Files/Files.service.ts:207` `FilesCommandServiceShape` (interface) - missing @example
+- `src/commands/Files/Files.service.ts:280` `FilesCommandService` (class) - missing @example
+- `src/commands/Files/Files.service.ts:3595` `printFilesIndex` (const) - missing @example
+- `src/commands/Files/Files.service.ts:4355` `FilesCommandServiceLive` (const) - missing @example
+- `src/commands/Files/Files.service.ts:4366` `archivePoorCandidates` (const) - missing @example
+- `src/commands/Files/Files.service.ts:4381` `createCaptionFiles` (const) - missing @example
+- `src/commands/Files/Files.service.ts:4396` `cropBordersFiles` (const) - missing @example
+- `src/commands/Files/Files.service.ts:4411` `detectBordersFiles` (const) - missing @example
+- `src/commands/Files/Files.service.ts:4426` `detectFacesFiles` (const) - missing @example
+- `src/commands/Files/Files.service.ts:4441` `normalizeFiles` (const) - missing @example
+- `src/commands/Files/Files.service.ts:4459` `sortAndRenameFiles` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:222` `stringEquivalence` (const) - missing @example; 2 schema annotation/type-alias gap(s)
+- `src/commands/Files/Files.utils.ts:230` `isImageFileExtension` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:238` `isVideoFileExtension` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:246` `isSupportedMetadataImageExtension` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:254` `bySizeDescendingThenNameAscending` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:265` `byNameAscending` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:278` `normalizeBareExtension` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:288` `mediaKindFromExtension` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:311` `formatIndex` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:324` `collectText` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:342` `isExifOrientationRotated` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:352` `isQuarterTurnRotation` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:366` `maybeSwapDimensions` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:388` `rotationFromStream` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:409` `targetNameForEntry` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:433` `hasSkippedFiles` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:443` `selectedCanonicalPathSet` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:459` `renderPlanEntry` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:469` `renderStripMetadataPlanEntry` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:480` `renderCreateCaptionFilesPlanEntry` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:491` `renderCreateCaptionFilesSkippedEntry` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:502` `renderNormalizePlanEntry` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:513` `renderNormalizeSkippedEntry` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:524` `normalizeOutputExtension` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:534` `sharpFormatForNormalize` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:546` `normalizeOutputDimensions` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:575` `mediaDimensionsChanged` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:591` `roundCandidateMetric` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:602` `assessImageCandidate` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:646` `renderArchivePoorCandidatesEntry` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:663` `renderArchivePoorCandidatesSkippedEntry` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:674` `rgbToHex` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:685` `classifyBorderSides` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:731` `analyzeSolidBorders` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:748` `renderDetectBordersEntry` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:767` `renderDetectBordersSkippedEntry` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:778` `renderDetectFacesEntry` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:801` `renderDetectFacesSkippedEntry` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:821` `cropBordersPlanEntryFromDetection` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:859` `renderCropBordersPlanEntry` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:872` `makeStripMetadataTempEntries` (const) - missing @example
+- `src/commands/Files/Files.utils.ts:897` `isSupportedMetadataImageFile` (const) - missing @example
 - `src/commands/Files/index.ts:15` `export * from "./Files.command.js";` (re-export) - missing @example
 - `src/commands/Files/index.ts:22` `export * from "./Files.errors.js";` (re-export) - missing @example
-- `src/commands/Files/index.ts:29` `export * from "./Files.schemas.js";` (re-export) - missing @example
-- `src/commands/Files/index.ts:36` `export * from "./Files.service.js";` (re-export) - missing @example
-- `src/commands/Files/index.ts:43` `export * from "./Files.utils.js";` (re-export) - missing @example
+- `src/commands/Files/index.ts:29` `export * from "./Files.progress.js";` (re-export) - missing @example
+- `src/commands/Files/index.ts:36` `export * from "./Files.schemas.js";` (re-export) - missing @example
+- `src/commands/Files/index.ts:43` `export * from "./Files.service.js";` (re-export) - missing @example
+- `src/commands/Files/index.ts:50` `export * from "./Files.utils.js";` (re-export) - missing @example
 - `src/commands/Graphiti/internal/ProxyServices.ts:56` `ContainerHealthState` (const) - 1 schema annotation/type-alias gap(s)
 - `src/commands/Graphiti/internal/ProxyServices.ts:72` `DependencyHealthState` (const) - 1 schema annotation/type-alias gap(s)
-- `src/commands/Quality/Tasks.ts:693` `sqlIntegrationStepForTesting` (const) - missing @example
-- `src/commands/Quality/Tasks.ts:707` `runSqlIntegrationTestLaneForTesting` (const) - missing @example
-- `src/commands/Quality/Tasks.ts:716` `sqlIntegrationConnectionUriFromEnvForTesting` (const) - missing @example
-- `src/commands/Quality/Tasks.ts:850` `rootQualityStepsForTesting` (const) - missing @example
+- `src/commands/Quality/Tasks.ts:699` `sqlIntegrationStepForTesting` (const) - missing @example
+- `src/commands/Quality/Tasks.ts:713` `runSqlIntegrationTestLaneForTesting` (const) - missing @example
+- `src/commands/Quality/Tasks.ts:722` `sqlIntegrationConnectionUriFromEnvForTesting` (const) - missing @example
+- `src/commands/Quality/Tasks.ts:857` `rootQualityStepsForTesting` (const) - missing @example
 - `src/commands/Reuse/index.ts:361` `reuseCommand` (const) - missing @example
 - `src/commands/Reuse/internal/CodexRunner.ts:23` `CodexRunnerStage` (const) - missing @example
 - `src/commands/Reuse/internal/CodexRunner.ts:37` `CodexRunnerStage` (type) - missing @example
@@ -3265,8 +3293,8 @@ Export findings:
 - `src/Sandbox.errors.ts:498` `SandboxError` (namespace) - missing @example
 - `src/Sandbox.observability.ts:138` `SandboxPhaseAttributes` (const) - missing @example
 - `src/Sandbox.observability.ts:150` `SandboxPhaseAttributes` (type) - missing @example
-- `src/Sandbox.process.ts:140` `SandboxProcessShape` (interface) - missing @example
-- `src/Sandbox.process.ts:242` `SandboxProcessLive` (const) - missing @example
+- `src/Sandbox.process.ts:141` `SandboxProcessShape` (interface) - missing @example
+- `src/Sandbox.process.ts:243` `SandboxProcessLive` (const) - missing @example
 - `src/Sandbox.provider.ts:23` `SandboxProviderKind` (const) - missing @example
 - `src/Sandbox.provider.ts:35` `SandboxProviderKind` (type) - missing @example
 - `src/Sandbox.provider.ts:43` `ExecResult` (class) - missing @example
@@ -3404,17 +3432,6 @@ Export findings:
 - `src/services/shacl-validation.ts:46` `ShaclSeverity` (const) - 1 schema annotation/type-alias gap(s)
 - `src/services/sparql-query.ts:42` `SparqlQueryProfile` (const) - 1 schema annotation/type-alias gap(s)
 
-### @beep/opip-web
-
-Path: `apps/opip-web`
-
-Export findings:
-- `src/app/layout.tsx:41` `default` (function) - missing @example
-- `src/app/layout.tsx:29` `metadata` (const) - missing @example
-- `src/app/manifest.ts:16` `default` (function) - missing @example
-- `src/app/page.tsx:17` `default` (function) - missing @example
-- `src/mdx-components.tsx:18` `useMDXComponents` (function) - missing @example
-
 ### @beep/acp
 
 Path: `packages/drivers/acp`
@@ -3459,6 +3476,186 @@ Export findings:
 - `src/Wink/index.ts:92` `export * from "./WinkUtils.ts";` (re-export) - missing @example
 - `src/Wink/index.ts:97` `export * from "./WinkVectorizer.ts";` (re-export) - missing @example
 
+### @beep/runpod
+
+Path: `packages/drivers/runpod`
+
+Export findings:
+- `src/Runpod.config.ts:19` `RUNPOD_API_URL` (const) - missing @example
+- `src/Runpod.config.ts:27` `RUNPOD_DOCS_INDEX_URL` (const) - missing @example
+- `src/Runpod.config.ts:35` `RunpodConfigInput` (class) - missing @example
+- `src/Runpod.config.ts:52` `RunpodDocsConfigInput` (class) - missing @example
+- `src/Runpod.docs.ts:30` `RunpodDocsIndexEntry` (class) - missing @example
+- `src/Runpod.docs.ts:48` `RunpodDocsIndex` (class) - missing @example
+- `src/Runpod.docs.ts:171` `parseRunpodDocsIndex` (const) - missing @example
+- `src/Runpod.docs.ts:267` `RunpodDocs` (class) - missing @example
+- `src/Runpod.errors.ts:27` `RunpodErrorReason` (const) - missing @example
+- `src/Runpod.errors.ts:45` `RunpodErrorReason` (type) - missing @example
+- `src/Runpod.errors.ts:53` `RunpodDocsErrorReason` (const) - missing @example
+- `src/Runpod.errors.ts:71` `RunpodDocsErrorReason` (type) - missing @example
+- `src/Runpod.errors.ts:81` `RunpodError` (class) - missing @example
+- `src/Runpod.errors.ts:163` `RunpodDocsError` (class) - missing @example
+- `src/Runpod.errors.ts:202` `RunpodErrorOptions` (class) - missing @example
+- `src/Runpod.errors.ts:218` `RunpodRawErrorOptions` (class) - missing @example
+- `src/Runpod.errors.ts:237` `RunpodDocsErrorOptions` (class) - missing @example
+- `src/Runpod.service.ts:32` `RunpodQueryScalar` (const) - missing @example
+- `src/Runpod.service.ts:44` `RunpodQueryScalar` (type) - missing @example
+- `src/Runpod.service.ts:55` `RunpodQueryValue` (const) - missing @example
+- `src/Runpod.service.ts:67` `RunpodQueryValue` (type) - missing @example
+- `src/Runpod.service.ts:75` `RunpodRawRequest` (class) - missing @example
+- `src/Runpod.service.ts:95` `RunpodRawResponse` (class) - missing @example
+- `src/Runpod.service.ts:113` `RunpodShape` (interface) - missing @example
+- `src/Runpod.service.ts:805` `Runpod` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:23` `Pods` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:36` `Pods` (type) - missing @example
+- `src/_generated/Runpod.generated.ts:44` `Pod` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:149` `PodUpdateInPlaceInput` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:165` `PodUpdateInput` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:191` `PodCreateInput` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:238` `NetworkVolumes` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:257` `NetworkVolumes` (type) - missing @example
+- `src/_generated/Runpod.generated.ts:265` `NetworkVolume` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:283` `NetworkVolumeCreateInput` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:300` `NetworkVolumeUpdateInput` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:316` `Templates` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:329` `Templates` (type) - missing @example
+- `src/_generated/Runpod.generated.ts:337` `Template` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:369` `TemplateCreateInput` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:397` `TemplateUpdateInPlaceInput` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:416` `TemplateUpdateInput` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:442` `Endpoints` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:455` `Endpoints` (type) - missing @example
+- `src/_generated/Runpod.generated.ts:463` `Endpoint` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:501` `EndpointUpdateInPlaceInput` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:523` `EndpointUpdateInput` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:555` `EndpointCreateInput` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:588` `User` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:600` `User` (type) - missing @example
+- `src/_generated/Runpod.generated.ts:608` `SavingsPlan` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:628` `Machine` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:681` `DataCenter` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:696` `UnauthorizedError` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:711` `CudaVersions` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:723` `CudaVersions` (type) - missing @example
+- `src/_generated/Runpod.generated.ts:731` `GPUTypeId` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:743` `GPUTypeId` (type) - missing @example
+- `src/_generated/Runpod.generated.ts:751` `ContainerRegistryAuth` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:767` `ContainerRegistryAuths` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:780` `ContainerRegistryAuths` (type) - missing @example
+- `src/_generated/Runpod.generated.ts:788` `ContainerRegistryAuthCreateInput` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:807` `BillingRecord` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:828` `BillingRecords` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:850` `BillingRecords` (type) - missing @example
+- `src/_generated/Runpod.generated.ts:858` `NetworkVolumeBillingRecord` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:877` `NetworkVolumeBillingRecords` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:897` `NetworkVolumeBillingRecords` (type) - missing @example
+- `src/_generated/Runpod.generated.ts:905` `RUNPOD_ALLOWED_CUDA_VERSIONS_VALUES` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:926` `RUNPOD_CPU_FLAVOR_IDS_VALUES` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:934` `RUNPOD_CPU_FLAVOR_PRIORITY_VALUES` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:942` `RUNPOD_CUDA_VERSIONS_VALUES` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:950` `RUNPOD_DATA_CENTER_ID_VALUES` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:985` `RUNPOD_DATA_CENTER_IDS_VALUES` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:1020` `RUNPOD_DATA_CENTER_PRIORITY_VALUES` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:1028` `RUNPOD_GPU_TYPE_ID_VALUES` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:1071` `RUNPOD_GPU_TYPE_IDS_VALUES` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:1129` `RUNPOD_GPU_TYPE_PRIORITY_VALUES` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:1137` `RUNPOD_MIN_CUDA_VERSION_VALUES` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:1158` `GetOpenAPIStatus200Response` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:1170` `GetOpenAPIStatus200Response` (type) - missing @example
+- `src/_generated/Runpod.generated.ts:1178` `GetDocsStatus200TextResponse` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:1190` `GetDocsStatus200TextResponse` (type) - missing @example
+- `src/_generated/Runpod.generated.ts:1198` `GetOpenAPIRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1211` `GetDocsRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1224` `ListPodsRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1254` `CreatePodRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1269` `GetPodRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1289` `UpdatePodRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1305` `DeletePodRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1320` `UpdatePodViaPostRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1336` `StartPodRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1351` `StopPodRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1366` `ResetPodRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1381` `RestartPodRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1396` `ListEndpointsRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1412` `CreateEndpointRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1427` `GetEndpointRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1444` `UpdateEndpointRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1460` `DeleteEndpointRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1475` `UpdateEndpointViaPostRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1493` `ListTemplatesRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1510` `CreateTemplateRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1525` `GetTemplateRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1543` `UpdateTemplateRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1559` `DeleteTemplateRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1574` `UpdateTemplateViaPostRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1592` `ListNetworkVolumesRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1605` `CreateNetworkVolumeRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1620` `GetNetworkVolumeRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1635` `UpdateNetworkVolumeRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1651` `DeleteNetworkVolumeRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1666` `UpdateNetworkVolumeViaPostRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1684` `ListContainerRegistryAuthsRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1699` `CreateContainerRegistryAuthRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1716` `GetContainerRegistryAuthRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1733` `DeleteContainerRegistryAuthRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1750` `PodBillingRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1770` `EndpointBillingRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1793` `NetworkVolumeBillingRequest` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1810` `RunpodHttpMethod` (const) - missing @example; 1 schema annotation/type-alias gap(s)
+- `src/_generated/Runpod.generated.ts:1818` `RunpodHttpMethod` (type) - missing @example
+- `src/_generated/Runpod.generated.ts:1826` `RunpodOperationId` (const) - missing @example; 1 schema annotation/type-alias gap(s)
+- `src/_generated/Runpod.generated.ts:1868` `RunpodOperationId` (type) - missing @example
+- `src/_generated/Runpod.generated.ts:1876` `RunpodRequestBodyKind` (const) - missing @example; 1 schema annotation/type-alias gap(s)
+- `src/_generated/Runpod.generated.ts:1884` `RunpodRequestBodyKind` (type) - missing @example
+- `src/_generated/Runpod.generated.ts:1892` `RunpodResponseBodyKind` (const) - missing @example; 1 schema annotation/type-alias gap(s)
+- `src/_generated/Runpod.generated.ts:1900` `RunpodResponseBodyKind` (type) - missing @example
+- `src/_generated/Runpod.generated.ts:1908` `RunpodOperationDescriptor` (class) - missing @example
+- `src/_generated/Runpod.generated.ts:1932` `getOpenAPIOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:1951` `getDocsOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:1970` `listPodsOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2006` `createPodOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2025` `getPodOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2044` `updatePodOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2063` `deletePodOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2082` `updatePodViaPostOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2101` `startPodOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2120` `stopPodOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2139` `resetPodOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2158` `restartPodOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2177` `listEndpointsOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2196` `createEndpointOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2215` `getEndpointOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2234` `updateEndpointOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2253` `deleteEndpointOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2272` `updateEndpointViaPostOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2291` `listTemplatesOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2310` `createTemplateOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2329` `getTemplateOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2348` `updateTemplateOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2367` `deleteTemplateOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2386` `updateTemplateViaPostOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2405` `listNetworkVolumesOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2424` `createNetworkVolumeOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2443` `getNetworkVolumeOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2462` `updateNetworkVolumeOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2481` `deleteNetworkVolumeOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2500` `updateNetworkVolumeViaPostOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2519` `listContainerRegistryAuthsOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2538` `createContainerRegistryAuthOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2557` `getContainerRegistryAuthOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2576` `deleteContainerRegistryAuthOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2595` `podBillingOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2614` `endpointBillingOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2643` `networkVolumeBillingOperation` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2662` `RUNPOD_OPERATION_SPECS` (const) - missing @example
+- `src/_generated/Runpod.generated.ts:2847` `RunpodOperationsShape` (interface) - missing @example
+- `src/index.ts:14` `export * from "./_generated/Runpod.generated.ts";` (re-export) - missing @example
+- `src/index.ts:21` `export * from "./Runpod.config.ts";` (re-export) - missing @example
+- `src/index.ts:28` `export * from "./Runpod.docs.ts";` (re-export) - missing @example
+- `src/index.ts:35` `export * from "./Runpod.errors.ts";` (re-export) - missing @example
+- `src/index.ts:42` `export * from "./Runpod.service.ts";` (re-export) - missing @example
+- `src/index.ts:50` `VERSION` (const) - missing @example
+
 ### @beep/codedank-web
 
 Path: `apps/codedank-web`
@@ -3484,3 +3681,14 @@ Path: `packages/drivers/openai`
 
 Export findings:
 - `src/index.ts:12` `VERSION` (const) - missing summary; missing @example
+
+### @beep/opip-web
+
+Path: `apps/opip-web`
+
+Export findings:
+- `src/app/layout.tsx:41` `default` (function) - missing @example
+- `src/app/layout.tsx:29` `metadata` (const) - missing @example
+- `src/app/manifest.ts:16` `default` (function) - missing @example
+- `src/app/page.tsx:17` `default` (function) - missing @example
+- `src/mdx-components.tsx:18` `useMDXComponents` (function) - missing @example


### PR DESCRIPTION
## Summary

- convert Effect.gen-returning helpers across the touched tooling and package surfaces to `Effect.fn` / `Effect.fnUntraced`
- add the repo-cli `laws effect-fn` check and wire it into the GitHub-quality lint task
- reuse the shared `TSMorphService` for the new law scanner and add command-level coverage for strict CLI failures
- preserve docgen value-level failure result handling while keeping internal error mapping flat
- refresh the JSDoc inventory and record the no-release changeset decision

## Quality Loop

- addressed reviewer findings around docgen semantics, shared TSMorph reuse, command-level tests, quality-task assertions, and JSDoc inventory coverage
- fixed repo-sanity dependency ordering reported by `sherif`
- added an empty changeset so `changeset status --since=origin/main` can pass for this no-release internal refactor

## Verification

- `bunx --bun vitest run test/effect-fn.test.ts test/quality-tasks.test.ts`
- `bun run beep laws effect-fn --check`
- `bun run beep docgen check --package @beep/repo-cli`
- `bun run beep docgen quality --package @beep/repo-cli --score rubric --packet-limit 0 --output /tmp/repo-cli-jsdoc-quality.md`
- `bun run jsdoc:inventory`
- `bun run lint:fix`
- `bun run check`
- `bun run lint`
- `git diff --check`
- `bun run audit:github quality`
