### PR TITLE
chore(repo): surface export catalog to agents

### DIFF
--- a/.claude/skills/repo-symbol-discovery/SKILL.md
+++ b/.claude/skills/repo-symbol-discovery/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: repo-symbol-discovery
+description: >
+  Use when looking for existing exports, canonical symbols, shared helpers,
+  schemas, utilities, models, duplicate helper avoidance, import paths, or
+  repo-level symbol discovery. Trigger on "does this already exist?", symbol
+  lookup, export map, UnknownRecord, canonical export, and reuse questions.
+version: 0.1.0
+status: active
+---
+
+# Repo Symbol Discovery
+
+Use the generated repo export catalog before creating a new helper, schema,
+model, service, utility, or public symbol that may already exist.
+
+## Canonical Lookup
+
+Start with the human-readable catalog:
+
+```sh
+rg -i "<symbol-or-intent>" standards/repo-exports.catalog.md
+```
+
+Use the JSONC catalog when you need structured fields such as package path,
+import specifier, source path, categories, tags, or generated search text:
+
+```sh
+rg -i "<symbol-or-intent>" standards/repo-exports.catalog.jsonc
+```
+
+## What The Catalog Means
+
+- `standards/repo-exports.catalog.jsonc` is the machine-readable repo-level
+  catalog.
+- `standards/repo-exports.catalog.md` is the human and agent-readable view.
+- The catalog is descriptive current-state metadata: it lists legal public
+  export facts.
+- Architecture doctrine still decides canonical boundaries. Use
+  `standards/ARCHITECTURE.md`, `standards/architecture/README.md`, and
+  package-local policy when deciding whether an import path is appropriate for
+  new code.
+
+## Freshness
+
+Refresh generated artifacts after changing package export maps or public
+exports:
+
+```sh
+bun run repo-exports:catalog
+```
+
+Verify tracked artifacts are current:
+
+```sh
+bun run repo-exports:catalog:check
+```
+
+The pre-push hook runs the check for export-relevant pushed changes.
+
+## Duplicate-Avoidance Rule
+
+If a needed concept sounds generic or repo-wide, search first. For example:
+
+```sh
+rg -i "unknown record|UnknownRecord" standards/repo-exports.catalog.md
+```
+
+Prefer importing a discovered canonical export over redefining a local
+equivalent.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -103,6 +103,10 @@ name = "quality-review-fix-loop"
 enabled = true
 
 [[skills.config]]
+name = "repo-symbol-discovery"
+enabled = true
+
+[[skills.config]]
 name = "schema-first-development"
 enabled = true
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,11 @@ Build and maintain features with effect first development.
 - In `packages/**/{test,dtslint}/**/*.{ts,tsx}`, import package source through `@beep/*` package aliases instead of relative paths into any workspace `src/`; keep relatives only for local helpers, fixtures, snapshots, and other non-`src` test files.
 - Keep service boundaries explicit.
 - Keep repo quality commands green.
+- Before recreating a shared helper, schema, utility, model, or known symbol,
+  search the repo export catalog first:
+  `rg -i "<symbol-or-intent>" standards/repo-exports.catalog.{md,jsonc}`.
+- Refresh the repo export catalog with `bun run repo-exports:catalog`; verify it
+  is current with `bun run repo-exports:catalog:check`.
 - Use `bun run beep architecture` for canonical slice, concept, role, and
   architecture proof generation instead of hand-authoring boilerplate.
 - For architecture concepts, use the canonical `--domain-kind` archetypes:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,3 +12,8 @@ Ship reliable code with effect first and schema first patterns.
 - In `packages/**/{test,dtslint}/**/*.{ts,tsx}`, import package source through `@beep/*` package aliases instead of relative paths into any workspace `src/`; keep relatives only for local helpers, fixtures, snapshots, and other non-`src` test files.
 - Apply schema defaults when safe.
 - Keep quality gates passing.
+- Before recreating shared helpers, schemas, utilities, models, or known symbols,
+  search `standards/repo-exports.catalog.md` or
+  `standards/repo-exports.catalog.jsonc`; refresh with
+  `bun run repo-exports:catalog` and verify with
+  `bun run repo-exports:catalog:check`.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -22,6 +22,40 @@ commit-msg:
     commitlint:
       run: bunx commitlint --edit {1}
 
+pre-push:
+  commands:
+    repo-exports-catalog:
+      run: |
+        bash -lc '
+          set -euo pipefail
+
+          base=""
+          if git rev-parse --verify "@{u}" >/dev/null 2>&1; then
+            base="$(git merge-base "@{u}" HEAD)"
+          fi
+          if [ -z "${base}" ] && git rev-parse --verify origin/main >/dev/null 2>&1; then
+            base="$(git merge-base origin/main HEAD)"
+          fi
+          if [ -z "${base}" ]; then
+            base="$(git rev-list --max-parents=0 HEAD | tail -n 1)"
+          fi
+
+          changed="$(git diff --name-only "${base}...HEAD")"
+          relevant_pattern="(^package\\.json$)|(^standards/repo-exports\\.catalog\\.(jsonc|md)$)|(^packages/tooling/tool/cli/support/generate-repo-exports-catalog\\.ts$)|(^((packages|apps)/.+|infra)/package\\.json$)|(^((packages|apps)/.+|infra)/src/.+\\.(ts|tsx)$)"
+
+          if ! printf "%s\n" "${changed}" | rg -q "${relevant_pattern}"; then
+            echo "repo export catalog: no export-relevant pushed changes"
+            exit 0
+          fi
+
+          bun run repo-exports:catalog:check
+
+          if git diff --name-only HEAD -- standards/repo-exports.catalog.jsonc standards/repo-exports.catalog.md | rg -q .; then
+            echo "repo export catalog: generated artifacts have uncommitted changes; commit them before pushing" >&2
+            exit 1
+          fi
+        '
+
 post-merge:
   commands:
     version-sync-check:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -25,30 +25,77 @@ commit-msg:
 pre-push:
   commands:
     repo-exports-catalog:
+      use_stdin: true
       run: |
         bash -lc '
           set -euo pipefail
 
-          base=""
-          if git rev-parse --verify "@{u}" >/dev/null 2>&1; then
-            base="$(git merge-base "@{u}" HEAD)"
-          fi
-          if [ -z "${base}" ] && git rev-parse --verify origin/main >/dev/null 2>&1; then
-            base="$(git merge-base origin/main HEAD)"
-          fi
-          if [ -z "${base}" ]; then
-            base="$(git rev-list --max-parents=0 HEAD | tail -n 1)"
+          relevant_pattern="(^package\\.json$)|(^standards/repo-exports\\.catalog\\.(jsonc|md)$)|(^packages/tooling/tool/cli/support/generate-repo-exports-catalog\\.ts$)|(^((packages|apps)/.+|infra)/package\\.json$)|(^((packages|apps)/.+|infra)/src/.+\\.(ts|tsx)$)"
+          zero_sha="0000000000000000000000000000000000000000"
+          pushed_ref_lines="$(cat || true)"
+          changed_file="$(mktemp)"
+          trap "rm -f \"${changed_file}\"" EXIT
+
+          if [ -n "${pushed_ref_lines}" ]; then
+            while read -r local_ref local_sha remote_ref remote_sha; do
+              remote_ref="${remote_ref:-}"
+              remote_sha="${remote_sha:-${zero_sha}}"
+
+              if [ -z "${local_sha:-}" ] || [ "${local_sha}" = "${zero_sha}" ]; then
+                continue
+              fi
+              if ! git cat-file -e "${local_sha}^{commit}" 2>/dev/null; then
+                continue
+              fi
+
+              head_ref="${local_sha}^{commit}"
+              base=""
+              if [ "${remote_sha}" != "${zero_sha}" ] && git cat-file -e "${remote_sha}^{commit}" 2>/dev/null; then
+                base="${remote_sha}^{commit}"
+              fi
+              remote_branch="${remote_ref#refs/heads/}"
+              if [ -z "${base}" ] && [ "${remote_branch}" != "${remote_ref}" ] && git rev-parse --verify "origin/${remote_branch}" >/dev/null 2>&1; then
+                base="$(git merge-base "origin/${remote_branch}" "${head_ref}" || true)"
+              fi
+              if [ -z "${base}" ] && git rev-parse --verify origin/main >/dev/null 2>&1; then
+                base="$(git merge-base origin/main "${head_ref}" || true)"
+              fi
+              if [ -z "${base}" ]; then
+                base="$(git rev-list --max-parents=0 "${head_ref}" | tail -n 1)"
+              fi
+
+              git diff --name-only "${base}...${head_ref}" >> "${changed_file}"
+            done <<< "${pushed_ref_lines}"
+          else
+            base=""
+            if git rev-parse --verify "@{u}" >/dev/null 2>&1; then
+              base="$(git merge-base "@{u}" HEAD || true)"
+            fi
+            if [ -z "${base}" ] && git rev-parse --verify origin/main >/dev/null 2>&1; then
+              base="$(git merge-base origin/main HEAD || true)"
+            fi
+            if [ -z "${base}" ]; then
+              base="$(git rev-list --max-parents=0 HEAD | tail -n 1)"
+            fi
+
+            git diff --name-only "${base}...HEAD" >> "${changed_file}"
           fi
 
-          changed="$(git diff --name-only "${base}...HEAD")"
-          relevant_pattern="(^package\\.json$)|(^standards/repo-exports\\.catalog\\.(jsonc|md)$)|(^packages/tooling/tool/cli/support/generate-repo-exports-catalog\\.ts$)|(^((packages|apps)/.+|infra)/package\\.json$)|(^((packages|apps)/.+|infra)/src/.+\\.(ts|tsx)$)"
+          changed="$(sort -u "${changed_file}")"
 
           if ! printf "%s\n" "${changed}" | rg -q "${relevant_pattern}"; then
             echo "repo export catalog: no export-relevant pushed changes"
             exit 0
           fi
 
-          bun run repo-exports:catalog:check
+          if ! bun run repo-exports:catalog:check; then
+            if git diff --name-only HEAD -- standards/repo-exports.catalog.jsonc standards/repo-exports.catalog.md | rg -q .; then
+              echo "repo export catalog: generated artifacts have uncommitted changes; commit them before pushing" >&2
+            else
+              echo "repo export catalog: check failed; run \`bun run repo-exports:catalog\` and commit any generated changes" >&2
+            fi
+            exit 1
+          fi
 
           if git diff --name-only HEAD -- standards/repo-exports.catalog.jsonc standards/repo-exports.catalog.md | rg -q .; then
             echo "repo export catalog: generated artifacts have uncommitted changes; commit them before pushing" >&2


### PR DESCRIPTION
## Summary
- add a repo-symbol-discovery skill that points agents at the generated repo export catalog before recreating shared helpers, schemas, utilities, models, or known symbols
- surface the catalog lookup flow in AGENTS.md and CLAUDE.md, and enable the skill for Codex
- add a pre-push guard that runs the repo export catalog check only when pushed commits touch export-relevant files

## Review loop
- targeted quality-review-fix-loop reviewers returned 0 required findings for quality gate, docs/API, reuse/duplication, evolution/versioning, and tooling/agent guidance

## Verification
- bun run lint:fix
- bun run audit:github quality
- bun run repo-exports:catalog:check
- bunx lefthook validate
- bunx lefthook run pre-push --force --file packages/foundation/modeling/schema/src/Record.ts
- typos AGENTS.md CLAUDE.md .claude/skills/repo-symbol-discovery/SKILL.md lefthook.yml .codex/config.toml
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added repo-symbol-discovery skill documentation and usage guidelines
  * Updated contributor guidelines to check existing symbol exports before creating shared helpers or utilities

* **Chores**
  * Enabled repo-symbol-discovery skill in configuration
  * Added pre-push validation to ensure export catalog remains current

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kriegcloud/beep-effect/pull/148)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->