### PR TITLE
docs: record jsdoc worker runpod evidence

### DIFF
--- a/initiatives/README.md
+++ b/initiatives/README.md
@@ -27,6 +27,7 @@ actually lives here.
 ## Current Initiatives
 
 - `ai-metrics-stack`
+- `agent-effectiveness-loop` — research bootstrap for Phoenix-backed coding-agent effectiveness evals and diagnostics.
 - `agentic-professional-runtime`
 - `agent-governance-control-plane`
 - `ip-law-knowledge-graph`

--- a/initiatives/agent-effectiveness-loop/PLAN.md
+++ b/initiatives/agent-effectiveness-loop/PLAN.md
@@ -1,0 +1,62 @@
+# Agent Effectiveness Loop Plan
+
+## Phase 0 - Research Bootstrap
+
+Status: complete
+
+- Create the initiative packet and research lane index.
+- Run the Phoenix capability map, live Phoenix state audit, repo eval/metrics
+  audit, and opportunity map as separate artifact-producing lanes.
+- Synthesize the artifacts into a ranked execution plan.
+- Keep all production code, infra, timers, deployment files, and agent configs
+  unchanged during this phase.
+
+## Phase 1 - Agent-Effectiveness Doctor And Annotation Plan
+
+Status: selected
+
+Implement only local, no-mutation outputs:
+
+- `beep agent-effectiveness doctor --json`
+- `beep agent-effectiveness annotations plan --json`
+- `beep agent-effectiveness annotations check --json`
+
+This phase should combine Phoenix health, project inventory, AI-metrics
+forwarder/report state, source coverage, scorecard gaps, labels, benchmarks,
+worker-eval report status, mirror/retention status, and explicit unavailable
+provider/tool/cost metrics into one trust gate.
+
+The annotation plan should render proposed Phoenix annotations from repo-owned
+labels, benchmarks, scorecards, worker-eval status, source coverage, and loop
+health without applying them to Phoenix.
+
+## Phase 2 - Phoenix-Native Enrichment
+
+Status: deferred until Phase 1 proof
+
+Candidate areas:
+
+- datasets and experiments for repo-specific agent tasks;
+- evals on traces and deterministic code evaluators;
+- prompt/config experiment comparison;
+- annotations and failure-mode labels in Phoenix;
+- Phoenix CLI/MCP usage if it improves operator workflows.
+
+## Phase 3 - Repo Workflow Integration
+
+Status: pending Phase 1 proof
+
+Future implementation may add Phoenix annotation writes, datasets, experiments,
+prompt-management workflows, Phoenix API drivers, or additional AI metrics
+projections only after Phase 1 proves the local trust gate and annotation schema
+are useful and private.
+
+## Verification Posture
+
+Every implementation phase must name:
+
+- the repo command or runbook that produces the evidence;
+- the Phoenix project or derived report that receives sanitized output;
+- privacy checks proving no raw transcript or private path leakage;
+- the repo quality commands for any touched package;
+- the rollback or no-op behavior when Phoenix is unavailable.

--- a/initiatives/agent-effectiveness-loop/README.md
+++ b/initiatives/agent-effectiveness-loop/README.md
@@ -1,0 +1,54 @@
+# Agent Effectiveness Loop
+
+## Status
+
+Phase 0 research complete; implementation slice selected
+
+## Mission
+
+Create a repo-specific feedback loop that uses Phoenix, the existing AI metrics
+stack, and read-only worker-eval evidence to improve how coding agents operate
+in this repo.
+
+Phoenix is the primary observability and evaluation surface, but the initiative
+goal is agent effectiveness: better repo guidance, better evals, better
+diagnostics, and better operator workflows for understanding where agents
+struggle.
+
+## Starting Point
+
+This initiative depends on two existing packets:
+
+- `initiatives/ai-metrics-stack` - privacy-safe transcript ingestion, config
+  snapshots, labels, benchmarks, scorecards, OTLP export, and the live Phoenix
+  deployment on dankserver.
+- `initiatives/jsdoc-worker-eval` - read-only JSDoc worker-eval orchestration,
+  hosted/Runpod model evidence, and sanitized Phoenix spans for the
+  `beep-jsdoc-worker-eval` project.
+
+The live Phoenix UI is available on the tailnet at
+`https://dankserver.tailc7c348.ts.net:8447/projects`. Research may inspect it
+read-only and must not mutate projects, datasets, prompts, experiments, traces,
+or server configuration.
+
+## Research Artifacts
+
+- [Phoenix capability map](./research/phoenix-capability-map.md)
+- [Live Phoenix state audit](./research/live-phoenix-state-audit.md)
+- [Repo eval and metrics surface audit](./research/repo-eval-metrics-surface-audit.md)
+- [Agent-effectiveness opportunity map](./research/agent-effectiveness-opportunity-map.md)
+- [Synthesis and ranked execution plan](./research/synthesis-ranked-execution-plan.md)
+
+## Current Recommendation
+
+Implement the no-mutation agent-effectiveness doctor and annotation-plan loop
+first. The synthesis deliberately defers Phoenix writes, datasets, experiments,
+prompt management, and backend drivers until the repo-owned local trust gate
+and privacy-checked annotation schema exist.
+
+## Reading Order
+
+- [SPEC.md](./SPEC.md) - authoritative research and privacy contract
+- [PLAN.md](./PLAN.md) - phased execution plan
+- [ops/manifest.json](./ops/manifest.json) - machine-readable routing metadata
+- [research/README.md](./research/README.md) - research lane index

--- a/initiatives/agent-effectiveness-loop/SPEC.md
+++ b/initiatives/agent-effectiveness-loop/SPEC.md
@@ -1,0 +1,129 @@
+# Agent Effectiveness Loop Specification
+
+## Status
+
+**Phase 0 research complete; implementation slice selected**
+
+## Owner
+
+@beep-team
+
+## Created / Updated
+
+- **Created:** 2026-05-16
+- **Updated:** 2026-05-16
+
+## Mission
+
+Design a repo-specific feedback loop for improving coding-agent effectiveness.
+The loop should use Phoenix capabilities, existing AI metrics artifacts, and
+read-only worker-eval evidence to answer:
+
+- where do coding agents struggle in this repo?
+- which repo guidance, config, prompt, or workflow changes improve outcomes?
+- which evals and scorecards should be repeatable before changing agent
+  configs or graduating worker automation?
+- which operator commands would make those insights easy to collect and review?
+
+Phoenix is a tool in this loop, not the owner of the repo semantics.
+
+## Inputs
+
+Required repo packets:
+
+- `initiatives/ai-metrics-stack/{README.md,SPEC.md,PLAN.md,ops/manifest.json}`
+- `initiatives/ai-metrics-stack/history/outputs/*`
+- `initiatives/jsdoc-worker-eval/{README.md,SPEC.md,PLAN.md,ops/manifest.json}`
+- `initiatives/jsdoc-worker-eval/research/*`
+- `initiatives/jsdoc-worker-eval/history/outputs/*`
+
+Required doctrine:
+
+- `standards/ARCHITECTURE.md`
+- `standards/architecture/07-non-slice-families.md`
+- `standards/architecture/08-testing.md`
+- `standards/architecture/12-observability.md`
+
+Required Phoenix sources:
+
+- Phoenix docs index: <https://arize.com/docs/phoenix/llms.txt>
+- Live read-only Phoenix instance:
+  <https://dankserver.tailc7c348.ts.net:8447/projects>
+
+## Ownership
+
+Agent effectiveness metrics are repo-operational tooling.
+
+- `@beep/repo-ai-metrics` owns developer AI analytics semantics.
+- `@beep/repo-cli` owns operator commands and user-facing workflows.
+- `@beep/observability` owns general runtime OTLP, metrics, logs, traces, and
+  reusable observability helpers.
+- `@beep/infra` owns deployable topology and dankserver automation.
+- Backend-specific `drivers/*` are allowed only when a real Phoenix or
+  alternate-backend API wrapper is needed beyond OTLP/export/install contracts.
+
+The initiative must not move developer AI analytics semantics into shared
+kernel, product slices, generic foundation packages, or runtime observability.
+
+## Privacy Contract
+
+Research artifacts may include sanitized evidence only:
+
+- project names
+- aggregate counts
+- feature availability
+- schema, attribute, and command names
+- hashed identifiers already accepted by the AI metrics privacy contract
+- links to repo artifacts and public documentation
+
+Research artifacts must not include:
+
+- raw prompt, response, transcript, or tool payload text
+- private local paths, home paths, source paths, or archive paths
+- secrets, tokens, 1Password refs with resolved values, or encryption material
+- raw Phoenix span payload bodies
+- unreviewed exception text that could contain private content
+
+Live Phoenix access is read-only. Do not mutate projects, datasets,
+experiments, prompts, annotations, traces, or server configuration during this
+research bootstrap.
+
+## Research Lanes
+
+Phase 0 uses four artifact-producing lanes:
+
+1. **Phoenix capability map** - comprehensive Phoenix feature inventory mapped
+   to coding-agent improvement opportunities.
+2. **Live Phoenix state audit** - read-only evidence from the deployed Phoenix
+   instance and existing projects.
+3. **Repo eval and metrics surface audit** - map existing repo commands,
+   artifacts, privacy rules, and data products.
+4. **Agent-effectiveness opportunity map** - ranked candidate evals,
+   diagnostics, datasets, annotations, scorecards, and future CLI workflows.
+
+Each lane writes one Markdown artifact under `research/`.
+
+## Completion Criteria
+
+Phase 0 is complete when:
+
+- all four research artifacts exist and cite their repo or public-doc sources;
+- live Phoenix evidence is sanitized and read-only;
+- the synthesis ranks first implementation slices by impact, effort, privacy
+  risk, architecture home, and verification burden;
+- the plan chooses one recommended first path instead of only preserving an
+  idea list;
+- no production package, infra, timer, deployment, or agent config behavior is
+  changed during research bootstrap.
+
+## Selected Phase 1 Slice
+
+The selected first implementation slice is local and no-mutation:
+
+- `beep agent-effectiveness doctor --json`
+- `beep agent-effectiveness annotations plan --json`
+- `beep agent-effectiveness annotations check --json`
+
+This slice must produce a trust gate and privacy-checked annotation plan before
+any Phoenix mutation, dataset creation, prompt management, experiment creation,
+or backend driver work is allowed.

--- a/initiatives/agent-effectiveness-loop/ops/manifest.json
+++ b/initiatives/agent-effectiveness-loop/ops/manifest.json
@@ -1,0 +1,71 @@
+{
+  "schemaVersion": "initiative-manifest/v1",
+  "initiative": {
+    "id": "agent-effectiveness-loop",
+    "title": "Agent Effectiveness Loop",
+    "status": "phase0-research-complete-phase1-selected",
+    "created": "2026-05-16",
+    "updated": "2026-05-16",
+    "packetAnchorDocument": "SPEC.md"
+  },
+  "mission": "Design a repo-specific Phoenix-backed feedback loop for improving coding-agent effectiveness.",
+  "ownership": {
+    "family": "tooling",
+    "primaryLibrary": "@beep/repo-ai-metrics",
+    "primaryCli": "@beep/repo-cli",
+    "observabilityPackage": "@beep/observability",
+    "infraPackage": "@beep/infra"
+  },
+  "livePhoenix": {
+    "access": "read-only",
+    "projectsUrl": "https://dankserver.tailc7c348.ts.net:8447/projects",
+    "graphqlUrl": "https://dankserver.tailc7c348.ts.net:8447/graphql",
+    "sanitization": "project names, aggregate counts, feature availability, schema names, attribute names, and hashed identifiers only"
+  },
+  "phase0": {
+    "id": "research-bootstrap-and-ranked-plan",
+    "status": "complete",
+    "outputs": [
+      "research/phoenix-capability-map.md",
+      "research/live-phoenix-state-audit.md",
+      "research/repo-eval-metrics-surface-audit.md",
+      "research/agent-effectiveness-opportunity-map.md",
+      "research/synthesis-ranked-execution-plan.md"
+    ],
+    "researchLanes": [
+      "phoenix-capability-map",
+      "live-phoenix-state-audit",
+      "repo-eval-metrics-surface-audit",
+      "agent-effectiveness-opportunity-map"
+    ]
+  },
+  "phase1": {
+    "id": "doctor-and-annotation-plan",
+    "status": "selected",
+    "commands": [
+      "beep agent-effectiveness doctor --json",
+      "beep agent-effectiveness annotations plan --json",
+      "beep agent-effectiveness annotations check --json"
+    ],
+    "mutationPolicy": "local-artifacts-only"
+  },
+  "inputPackets": [
+    "initiatives/ai-metrics-stack",
+    "initiatives/jsdoc-worker-eval"
+  ],
+  "externalReferences": [
+    "https://arize.com/docs/phoenix/llms.txt",
+    "https://arize.com/docs/phoenix/integrations/developer-tools/coding-agents",
+    "https://arize.com/docs/phoenix/datasets-and-experiments/how-to-experiments/run-experiments",
+    "https://arize.com/docs/phoenix/evaluation/how-to-evals/code-evaluators",
+    "https://arize.com/docs/phoenix/tracing/how-to-tracing/feedback-and-annotations/evaluating-phoenix-traces"
+  ],
+  "nonGoals": [
+    "production code changes during Phase 0",
+    "mutating Phoenix projects, datasets, prompts, annotations, experiments, or server config during Phase 0",
+    "moving AI metrics semantics out of tooling packages",
+    "syncing raw transcripts or private paths into research artifacts",
+    "graduating worker auto-remediation from read-only evidence"
+  ],
+  "nextAction": "Implement the local agent-effectiveness doctor and annotation-plan commands."
+}

--- a/initiatives/agent-effectiveness-loop/research/README.md
+++ b/initiatives/agent-effectiveness-loop/research/README.md
@@ -1,0 +1,24 @@
+# Agent Effectiveness Loop Research
+
+This directory contains the Phase 0 research artifacts for the
+`agent-effectiveness-loop` initiative.
+
+## Lanes
+
+- `phoenix-capability-map.md` - comprehensive Phoenix feature map for
+  coding-agent effectiveness work.
+- `live-phoenix-state-audit.md` - sanitized read-only audit of the deployed
+  dankserver Phoenix instance.
+- `repo-eval-metrics-surface-audit.md` - existing repo eval, metrics, labels,
+  benchmarks, scorecards, and OTLP surfaces.
+- `agent-effectiveness-opportunity-map.md` - candidate evals, diagnostics,
+  scorecards, and CLI workflows.
+- `synthesis-ranked-execution-plan.md` - ranked execution plan synthesized
+  from the four lanes.
+
+## Evidence Rules
+
+Research artifacts may cite public Phoenix docs, repo docs, and sanitized live
+Phoenix observations. They must not include raw transcript text, prompt/output
+text, private local paths, secrets, archive paths, or unreviewed span payload
+bodies.

--- a/initiatives/agent-effectiveness-loop/research/agent-effectiveness-opportunity-map.md
+++ b/initiatives/agent-effectiveness-loop/research/agent-effectiveness-opportunity-map.md
@@ -1,0 +1,727 @@
+# Agent-Effectiveness Opportunity Map
+
+Generated: 2026-05-16
+
+## Scope
+
+This artifact ranks concrete opportunities for improving coding agents in this
+repo by combining Phoenix capability ideas with the existing AI metrics and
+JSDoc worker-eval surfaces.
+
+Phase 0 remains read-only:
+
+- no production package changes;
+- no Phoenix dataset, prompt, experiment, annotation, or trace mutation;
+- no raw prompt, response, transcript, private path, source path, archive path,
+  or secret material in this artifact;
+- Phoenix is treated as an observability/eval surface, while repo semantics stay
+  in repo-owned tooling packages.
+
+## Source Snapshot
+
+Phoenix capability ideas used here:
+
+- OTLP/OpenTelemetry traces for model calls, retrieval, tool use, and custom
+  logic: <https://arize.com/docs/phoenix>
+- evaluations over traces and spans, including LLM, code, and human labels:
+  <https://arize.com/docs/phoenix>
+- datasets and experiments for repeatable comparisons:
+  <https://arize.com/docs/phoenix/datasets-and-experiments/tutorial/defining-the-dataset>
+- server-side dataset evaluators with annotation outputs:
+  <https://arize.com/docs/phoenix/evaluation/server-evals/overview>
+- structured annotations on spans, traces, sessions, and documents:
+  <https://arize.com/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/annotations>
+- TypeScript experiment helpers:
+  <https://arize.com/docs/phoenix/sdk-api-reference/typescript/packages/phoenix-client/experiments>
+- prompt management, playground, and span replay:
+  <https://arize.com/docs/phoenix/prompt-engineering/overview-prompts>
+- Phoenix CLI export of traces, datasets, experiments, and annotations for AI
+  coding workflows:
+  <https://arize.com/docs/phoenix/release-notes/01-2026/01-21-2026-cli-datasets-experiments-annotations>
+
+Repo evidence used here:
+
+- `initiatives/agent-effectiveness-loop/SPEC.md` defines the Phase 0 privacy,
+  ownership, and research-lane contract.
+- `initiatives/ai-metrics-stack/SPEC.md` defines the config-impact scorecard,
+  privacy model, OTLP-first Phoenix posture, and tooling ownership.
+- `initiatives/ai-metrics-stack/history/outputs/p4-scorecards-labels-and-benchmarks.md`
+  proves label queue, benchmark, and weekly report surfaces.
+- `initiatives/ai-metrics-stack/history/outputs/p6-seven-day-proof-and-hardening.md`
+  proves real-source forwarder, redacted OTLP export, Phoenix health, label
+  queue, and baseline weekly report evidence.
+- `initiatives/ai-metrics-stack/history/outputs/p6-proof-runner-isolation-and-runbook.md`
+  proves source coverage, benchmark checks, scorecard readiness gaps, and the
+  daily health checklist.
+- `initiatives/jsdoc-worker-eval/SPEC.md` and
+  `initiatives/jsdoc-worker-eval/research/2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval-10-packet.md`
+  prove read-only worker eval, hosted/local/Runpod model evidence, advisory
+  packet outcomes, and Phoenix OTLP export.
+- `packages/tooling/library/ai-metrics/src/models.ts`,
+  `scorecard.ts`, and `otlp.ts` contain the current schema surfaces for
+  config snapshots, tasks, labels, benchmark cases, benchmark runs,
+  scorecards, and redacted OTLP spans.
+- `packages/tooling/tool/cli/src/commands/AIMetrics/index.ts` exposes current
+  `beep ai-metrics` operator workflows.
+- `packages/tooling/tool/cli/src/commands/Docgen/index.ts` and
+  `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts`
+  expose current read-only JSDoc worker-eval workflows.
+
+Live read-only Phoenix health was checked during this pass:
+
+- endpoint responded `HTTP 200`;
+- `x-phoenix-server-version` was `15.5.0`;
+- no Phoenix data was mutated.
+
+## Classification Legend
+
+Impact:
+
+- High: likely to change agent outcomes, reduce repeated failures, or unblock
+  reliable automation.
+- Medium: improves diagnosis, comparison, or operator workflow but depends on
+  another loop for outcome lift.
+- Low: useful hygiene or visibility with limited direct behavior change.
+
+Effort:
+
+- Small: mostly report/query/CLI wrapper over existing tables or JSON reports.
+- Medium: new repo-owned data projection or Phoenix export path, but no new
+  backend semantics.
+- Large: new durable model, backend API integration, provider enrichment, or
+  human-review workflow.
+
+Privacy risk:
+
+- Low: hashes, counts, low-cardinality labels, command names, and aggregate
+  scores only.
+- Medium: touches human notes, worker drafts, prompt references, or trace
+  selection and needs explicit redaction/review.
+- High: touches raw transcripts, prompt/output content, provider payloads,
+  source paths, or cost/token enrichment from external logs.
+
+Architecture home:
+
+- `@beep/repo-ai-metrics`: developer AI analytics semantics, labels,
+  benchmark records, scorecards, datasets, redacted derived projections.
+- `@beep/repo-cli`: operator commands and user-facing workflows.
+- `@beep/repo-docgen`: deterministic docgen quality semantics, if a future
+  slice needs reusable quality packet APIs outside the CLI.
+- `@beep/observability`: generic Effect/OTLP helpers only.
+- `@beep/infra`: Phoenix/dankserver deployment topology.
+- `packages/drivers/*`: only if a future Phoenix API wrapper is needed beyond
+  OTLP export or CLI shell-out.
+
+## Ranked Opportunity Table
+
+| Rank | Opportunity | Impact | Effort | Privacy Risk | Architecture Home | Verification Evidence |
+|---:|---|---|---|---|---|---|
+| 1 | Agent outcome annotation bridge | High | Medium | Medium | `@beep/repo-ai-metrics`, `@beep/repo-cli` | Existing outcome labels, benchmark runs, scorecards, redacted OTLP spans, Phoenix annotations support |
+| 2 | JSDoc worker-eval Phoenix experiment lane | High | Medium | Medium | `@beep/repo-cli`, possible `@beep/repo-docgen`, `@beep/repo-ai-metrics` | 10-packet Runpod worker eval, hosted Codex baseline, deterministic `beep docgen quality` packets, Phoenix experiments/datasets |
+| 3 | Config snapshot A/B scorecard loop | High | Small | Low | `@beep/repo-ai-metrics`, `@beep/repo-cli` | Existing config snapshots, weekly scorecards, label and benchmark readiness gates |
+| 4 | Agent diagnostics doctor | High | Small | Low | `@beep/repo-cli`, `@beep/repo-ai-metrics` | Current `ai-metrics` health commands, Phoenix health, source coverage, scorecard gaps |
+| 5 | Human review queue for worker drafts | High | Medium | Medium | `@beep/repo-cli`, `@beep/repo-ai-metrics` | Worker report dispositions, policy violation codes, existing label queue pattern |
+| 6 | Failure-mode taxonomy and scorecard | High | Medium | Low | `@beep/repo-ai-metrics`, `@beep/repo-cli` | Current label dimensions plus JSDoc policy violations and scorecard coverage gaps |
+| 7 | Prompt/config experiment registry | Medium-High | Medium | Medium | `@beep/repo-ai-metrics`, `@beep/repo-cli`; Phoenix prompt support optional | Config snapshot diffs, Phoenix prompt/version/playground capabilities |
+| 8 | Trace taxonomy hardening for agent tasks | Medium-High | Medium | Low | `@beep/repo-ai-metrics`, `@beep/observability` | OTLP allowlist, `session.id`, source role/hash attribution, Phoenix root-span caveat |
+| 9 | Source coverage and blind-spot dashboard | Medium | Small | Low | `@beep/repo-ai-metrics`, `@beep/repo-cli` | P6 source coverage shows recent Codex-only collection and all-time Claude/OpenClaw visibility |
+| 10 | Provider/model/tool/cost enrichment | Medium-High | Large | High | `@beep/repo-ai-metrics`, possible provider/gateway driver, `@beep/infra` | Current scorecards explicitly mark these metrics unavailable/not-scored |
+| 11 | Phoenix CLI export/import runbooks | Medium | Small | Medium | `@beep/repo-cli` first; driver only if needed | Phoenix CLI now exports traces/experiments/datasets/annotations; repo mirror/retention patterns exist |
+| 12 | Architecture-doctrine benchmark pack | Medium-High | Medium | Low | `@beep/repo-cli`, `@beep/repo-ai-metrics` | Existing architecture standards, repo quality commands, recurring agent failure classes |
+
+## Top Opportunities
+
+### 1. Agent Outcome Annotation Bridge
+
+Opportunity:
+
+Export repo-owned outcome labels, benchmark results, scorecard readiness, and
+worker-eval packet outcomes as Phoenix annotations on existing redacted spans,
+traces, or sessions.
+
+Why it matters:
+
+Phoenix annotations are the natural feedback primitive for "this agent run was
+good/bad/needs review." The repo already has structured labels and scorecards;
+the missing link is making those labels visible at the exact trace/session level
+where operators inspect agent behavior.
+
+Candidate annotations:
+
+| Annotation | Target | Source | Kind | Optimization |
+|---|---|---|---|---|
+| `agent.outcome.passed` | session or trace | `OutcomeLabel.passed` | human/code | maximize |
+| `agent.outcome.rating` | session or trace | `OutcomeLabel.rating` | human | maximize |
+| `agent.quality_gate` | session or trace | `OutcomeLabel.qualityGate` | human/code | categorical |
+| `agent.interventions` | session or trace | `OutcomeLabel.interventionCount` | human | minimize |
+| `agent.follow_up_fix` | session or trace | `OutcomeLabel.followUpFix` | human | minimize |
+| `benchmark.passed` | trace or session | `BenchmarkRun.passed` | code/human | maximize |
+| `benchmark.quality_gate` | trace or session | `BenchmarkRun.qualityGate` | code/human | categorical |
+| `scorecard.completion_ready` | session/project window | `Scorecard.completionReady` | code | maximize |
+| `scorecard.gap` | session/project window | `Scorecard.coverageGaps` | code | categorical |
+| `worker.policy_violation` | worker packet span | `DocgenQualityWorkerEvalReport.policyViolations` | code | minimize |
+
+Candidate evals:
+
+- annotation completeness: every completion-creditable scorecard row has at
+  least one label and one benchmark annotation;
+- annotation privacy: no annotation value contains raw text, private path,
+  source path, archive path, or secret-shaped content;
+- trace linkage: annotation target can be resolved from hash-only task/session
+  metadata without exposing raw transcript identifiers;
+- reviewer agreement: compare human label and worker recommendation for
+  selected JSDoc packets.
+
+Datasets:
+
+- `agent-outcomes-v1`: one row per labeled `AgentTask`, using task id,
+  config snapshot id, source kind, source role, label dimensions, and hashed
+  parentage only.
+- `config-scorecard-v1`: one row per `Scorecard`, using aggregate counts,
+  scores, readiness, and gap labels.
+- `jsdoc-worker-packets-v1`: one row per selected JSDoc worker packet with
+  package name, finding codes, review disposition, duration, and policy
+  violation codes; no draft body by default.
+
+Scorecard additions:
+
+- `annotationCoverage`: percent of labeled tasks with matching Phoenix
+  annotation evidence.
+- `reviewAgreement`: percent of human-reviewed worker drafts whose final human
+  label agrees with worker disposition.
+- `policyPreservation`: percent of worker candidates with zero policy
+  violation codes.
+
+Prompt/config experiments:
+
+- Compare scorecards before and after changes to `AGENTS.md`, `.codex`, or
+  worker policy snippets.
+- Use Phoenix experiment comparison only after the repo-owned scorecard defines
+  the canonical metric names.
+
+Diagnostics:
+
+- report orphaned labels without trace/session target;
+- report traces with `session.id` but no task/scorecard attribution;
+- report annotations that would violate the OTLP/annotation privacy allowlist.
+
+Future commands:
+
+- `bun run beep agent-effectiveness annotations plan --target phoenix`
+- `bun run beep agent-effectiveness annotations export --format json`
+- `bun run beep agent-effectiveness annotations apply --target phoenix --confirm phoenix-annotation-write`
+- `bun run beep agent-effectiveness annotations check --target phoenix`
+
+Recommendation:
+
+Make the first slice a dry-run JSON export and privacy checker. Defer the
+Phoenix write command until a reviewer can inspect the exact annotation schema.
+
+### 2. JSDoc Worker-Eval Phoenix Experiment Lane
+
+Opportunity:
+
+Promote the existing read-only JSDoc worker-eval evidence into a repeatable
+experiment lane: deterministic quality packets become the dataset, worker
+provider/model/reasoning/prompt variants become experiment runs, and
+deterministic plus human-review checks become evaluators.
+
+Why it matters:
+
+This is the cleanest existing coding-agent eval surface in the repo. It already
+has deterministic inputs, bounded packets, advisory model outputs, policy
+violation codes, hosted Codex evidence, local negative evidence, Runpod
+evidence, and Phoenix OTLP spans.
+
+Candidate datasets:
+
+- `jsdoc-quality-remediation-packets-v1`
+  - inputs: subject id hash/ref, package name, finding codes, required tags,
+    verification command argv, packet metadata;
+  - references: deterministic missing-tag/finding set and expected policy
+    constraints;
+  - metadata: package family, symbol kind, source quality report id,
+    packet selection rank.
+- `jsdoc-worker-model-suitability-v1`
+  - inputs: provider, model, environment class, packet count;
+  - outputs: completed, failed, timed out, duration, policy violation set,
+    cleanup status, Phoenix export status.
+- `jsdoc-human-review-v1`
+  - future human labels only; no source edits or draft bodies until explicitly
+    approved.
+
+Candidate evals:
+
+| Eval | Type | Measurement |
+|---|---|---|
+| `jsdoc.required_tags_present` | code | candidate includes required documentation categories named by deterministic findings |
+| `jsdoc.no_policy_violations` | code | candidate packet reports zero policy violation codes |
+| `jsdoc.worker_completion` | code | completed packets divided by selected packets |
+| `jsdoc.worker_timeout_rate` | code | timed-out packets divided by selected packets |
+| `jsdoc.human_acceptance` | human | accepted candidate drafts divided by reviewed drafts |
+| `jsdoc.prompt_cost_latency` | code | duration and cost once provider metrics exist |
+| `jsdoc.no_runtime_change_claim` | human/code | candidate is documentation-only and does not claim source edits were made |
+
+Annotations:
+
+- `worker.status`: completed, failed, timed-out;
+- `worker.disposition`: candidate, needs-human-review, reject;
+- `worker.policy_violation`: bounded policy code;
+- `worker.duration_ms`: packet duration;
+- `worker.provider` and `worker.model`: low-cardinality selected values;
+- `worker.sample_id`: source report or experiment id.
+
+Scorecards:
+
+- `workerReliability`: completion minus timeout/failure rate;
+- `policySafety`: zero-policy-violation rate;
+- `reviewYield`: human acceptance rate once review labels exist;
+- `costRuntime`: not scored until provider/cost metrics are real.
+
+Prompt/config experiments:
+
+- hosted Codex low reasoning vs medium reasoning;
+- hosted Codex vs Runpod Qwen on the same packet dataset;
+- compact JSDoc policy excerpt variants;
+- packet-only context vs packet plus selected deterministic policy examples;
+- Runpod fallback image vs prebuilt image/cache once cost/runtime reduction is
+  explicitly in scope.
+
+Diagnostics:
+
+- detect policy violation drift by finding code;
+- detect model/environment pairings unsuitable for interactive work;
+- detect provider routes that emit no Phoenix spans when `--otlp` is enabled;
+- detect cleanup failures for billable remote evals.
+
+Future commands:
+
+- `bun run beep docgen quality-worker-eval dataset build --input <quality.json>`
+- `bun run beep docgen quality-worker-eval experiment run --dataset <id>`
+- `bun run beep docgen quality-worker-eval experiment compare --dataset <id>`
+- `bun run beep docgen quality-worker-review queue`
+- `bun run beep docgen quality-worker-review label --packet-id <id>`
+
+Recommendation:
+
+Use the JSDoc worker lane as the first Phoenix experiment candidate after the
+annotation dry-run exists. It is bounded, already read-only, and has a known
+failure signal: `missing-example` policy preservation.
+
+### 3. Config Snapshot A/B Scorecard Loop
+
+Opportunity:
+
+Turn existing config snapshots and weekly scorecards into a deliberate
+experiment workflow for agent config and prompt/guidance changes.
+
+Why it matters:
+
+The AI metrics stack was built to answer whether changes to agent-facing config
+improve coding-agent outcomes. The current scorecard already weights outcome
+more heavily than flow and cost, requires labels plus benchmark runs for
+completion credit, and reports unavailable model/tool/cost fields as gaps.
+
+Candidate evals:
+
+- config snapshot readiness: at least one task, one human label, and one
+  benchmark run;
+- quality gate delta: changed snapshot has higher pass/quality-gate rate than
+  previous snapshot;
+- intervention delta: changed snapshot reduces intervention count;
+- follow-up-fix delta: changed snapshot reduces follow-up fixes;
+- benchmark stability: changed snapshot does not regress curated benchmark
+  checks.
+
+Datasets:
+
+- `agent-config-snapshots-v1`: config snapshot id, included path categories,
+  changed path categories, previous snapshot id, label counts, benchmark counts.
+- `agent-config-benchmark-runs-v1`: benchmark case id, config snapshot id,
+  pass/fail, quality gate, elapsed time, prompt ref/hash only.
+
+Annotations:
+
+- `config.snapshot_id`;
+- `config.changed_agent_guidance`: boolean or bounded category;
+- `config.scorecard_ready`;
+- `config.regression_detected`.
+
+Scorecards:
+
+- keep current total/outcome/flow/cost weights;
+- add a config-experiment view comparing only snapshots that changed
+  agent-facing guidance;
+- keep provider/model/tool/cost as explicit unavailable/not-scored until P7c.
+
+Prompt/config experiments:
+
+- change one guidance surface at a time;
+- run the same curated benchmark case against old/new snapshots;
+- require a scorecard readiness gate before declaring a config change better.
+
+Diagnostics:
+
+- no labels for changed snapshot;
+- no benchmark run for changed snapshot;
+- scorecard compares snapshots with different source windows;
+- actual changed paths do not overlap agent-facing config paths.
+
+Future commands:
+
+- `bun run beep agent-effectiveness config experiment start --label <name>`
+- `bun run beep agent-effectiveness config experiment compare --from <snapshot> --to <snapshot>`
+- `bun run beep agent-effectiveness scorecard config-impact --window 7d`
+
+Recommendation:
+
+This is the lowest-effort, highest-alignment loop. It should become the default
+way to decide whether repo guidance and agent config changes helped.
+
+### 4. Agent Diagnostics Doctor
+
+Opportunity:
+
+Add a read-only diagnostic command that summarizes whether the feedback loop is
+healthy enough to trust before anyone interprets scorecards or Phoenix views.
+
+Why it matters:
+
+The repo already has many partial health signals: Phoenix health/version,
+source coverage, forwarder status, label queue, benchmark case list, scorecard
+gaps, OTLP export status, mirror status, retention status, and worker eval
+cleanup. Operators need one "can I trust this loop today?" command.
+
+Candidate checks:
+
+- Phoenix endpoint reachable and version header present;
+- redacted OTLP export produced session/turn spans for latest run;
+- latest forwarder status has nonzero derived turns;
+- source coverage reports candidates and included counts by source kind;
+- no source kind is silently starved by global file limits;
+- scorecard readiness has labels and benchmarks for the relevant config;
+- `model_call_metrics_unavailable_not_scored`, tool, token, and cost gaps are
+  explicit;
+- JSDoc worker report has no failed/timed-out packets for selected sample;
+- Runpod cleanup completed for remote worker runs;
+- Graphiti memory lookup is not required for scorecard interpretation.
+
+Datasets:
+
+- `agent-loop-health-snapshots-v1`: one row per diagnostic run with bounded
+  statuses and counts.
+
+Annotations:
+
+- `loop.health`: ok, degraded, blocked;
+- `loop.blocker`: bounded code such as `no_labels`, `no_benchmark_runs`,
+  `phoenix_unreachable`, `otlp_missing`, `worker_cleanup_failed`.
+
+Scorecards:
+
+- `loopTrust`: binary readiness gate before ranking agent config changes;
+- `coverageTrust`: source coverage adequacy by source kind.
+
+Future commands:
+
+- `bun run beep agent-effectiveness doctor`
+- `bun run beep agent-effectiveness doctor --json`
+- `bun run beep agent-effectiveness doctor --include-phoenix`
+- `bun run beep agent-effectiveness doctor --include-worker-eval <report.json>`
+
+Recommendation:
+
+Implement this before any Phoenix mutation. It turns the existing evidence
+surfaces into a repeatable operator guardrail and should be almost entirely
+read-only.
+
+### 5. Human Review Queue For Worker Drafts
+
+Opportunity:
+
+Create a human review queue for worker-eval candidates, separate from source
+editing. Human acceptance labels become the graduation signal for future
+write-mode remediation.
+
+Why it matters:
+
+The JSDoc worker evidence is promising but explicitly not enough for automatic
+source edits. A review queue lets the repo learn which worker outputs are
+actually acceptable without changing source files.
+
+Candidate evals:
+
+- candidate accepted without edits;
+- candidate accepted after human edit;
+- candidate rejected for policy reason;
+- candidate rejected for repo-style reason;
+- candidate failed deterministic verification;
+- candidate would have changed runtime behavior.
+
+Datasets:
+
+- `worker-draft-review-v1`: packet metadata, model/provider, disposition,
+  policy codes, human acceptance label, verification result.
+
+Annotations:
+
+- `review.accepted`;
+- `review.rejection_reason`;
+- `review.requires_policy_update`;
+- `review.verification_passed`.
+
+Scorecards:
+
+- `humanAcceptanceRate`;
+- `verificationPassRate`;
+- `policyViolationEscapeRate`;
+- `meanReviewTime`.
+
+Prompt/config experiments:
+
+- compare worker policy snippets by acceptance rate;
+- compare model/reasoning variants by accepted-without-edit rate;
+- compare packet selection strategies by review yield.
+
+Future commands:
+
+- `bun run beep docgen quality-worker-review queue --input <worker-report.json>`
+- `bun run beep docgen quality-worker-review label --packet-id <id> --accepted`
+- `bun run beep docgen quality-worker-review report --json`
+
+Recommendation:
+
+Do this before any auto-remediation plan. It supplies the precision and
+policy-preservation evidence the worker-eval packet says is missing.
+
+## Cross-Cutting Candidate Datasets
+
+| Dataset | Source | Privacy Posture | First Use |
+|---|---|---|---|
+| `agent-outcomes-v1` | outcome labels plus `AgentTask` rows | low; hash ids and bounded labels | Phoenix annotations and config-impact scorecards |
+| `agent-config-snapshots-v1` | config snapshot artifacts and scorecards | low; path categories and hashes, not file content | config A/B comparisons |
+| `agent-loop-health-v1` | doctor output | low; statuses and counts | trust gate for scorecard interpretation |
+| `jsdoc-quality-remediation-packets-v1` | deterministic quality reports | medium; must exclude prompt/draft text by default | worker experiments |
+| `jsdoc-worker-model-suitability-v1` | worker eval reports | medium; include model/env/runtime, exclude draft bodies by default | model/provider selection |
+| `worker-draft-review-v1` | future human labels | medium; human notes need redaction | remediation graduation |
+| `source-coverage-v1` | source discovery and forwarder coverage | low; counts and source kinds only | source starvation diagnostics |
+| `provider-enrichment-v1` | future gateway/provider metrics | high | cost/token/tool scorecards after P7c |
+
+## Cross-Cutting Candidate Evals
+
+| Eval | Input | Output | Type | Impact | Privacy Risk |
+|---|---|---|---|---|---|
+| `privacy.no_raw_text` | report/export/annotation payload | pass/fail with bounded reason | code | High | Low |
+| `privacy.no_private_paths` | report/export/annotation payload | pass/fail with bounded reason | code | High | Low |
+| `scorecard.completion_ready` | scorecard row | pass/fail | code | High | Low |
+| `config.improved_outcome` | two config snapshots | delta score | code/human | High | Low |
+| `worker.completed` | worker packet result | pass/fail | code | Medium | Low |
+| `worker.no_policy_violation` | worker packet result | pass/fail/code set | code | High | Low |
+| `worker.human_acceptance` | reviewed candidate | accepted/rejected | human | High | Medium |
+| `trace.has_session_id` | Phoenix/repo span export | pass/fail | code | Medium | Low |
+| `trace.has_repo_attribution` | OTLP span attributes | pass/fail | code | Medium | Low |
+| `source.coverage_not_starved` | forwarder coverage | pass/fail by source kind | code | Medium | Low |
+| `benchmark.no_regression` | benchmark runs | pass/fail/delta | code/human | High | Low |
+| `provider.cost_available` | future provider rows | available/not scored | code | Medium | High |
+
+## Annotation Schema Candidates
+
+Start with a repo-owned JSON schema and only later map it to Phoenix writes.
+
+Required fields:
+
+- `annotation.name`: bounded dotted name;
+- `annotation.targetKind`: trace, span, session, dataset_example,
+  experiment_run;
+- `annotation.targetRef`: hash-only local reference until Phoenix ids are
+  resolved;
+- `annotation.kind`: human, llm, code;
+- `annotation.score`: optional numeric score;
+- `annotation.label`: optional bounded label;
+- `annotation.explanation`: optional redacted bounded note;
+- `annotation.optimization`: maximize, minimize, none;
+- `annotation.source`: label, benchmark, scorecard, worker-eval, doctor;
+- `annotation.privacyChecked`: boolean.
+
+Initial allowlist:
+
+- `agent.outcome.passed`
+- `agent.outcome.rating`
+- `agent.quality_gate`
+- `agent.interventions`
+- `agent.follow_up_fix`
+- `benchmark.passed`
+- `benchmark.quality_gate`
+- `scorecard.completion_ready`
+- `scorecard.gap`
+- `worker.status`
+- `worker.disposition`
+- `worker.policy_violation`
+- `worker.duration_ms`
+- `loop.health`
+- `loop.blocker`
+- `source.coverage`
+
+Blocked by default:
+
+- raw worker draft text;
+- raw prompt or response text;
+- raw transcript ids;
+- private paths;
+- source paths;
+- archive paths;
+- unredacted human notes;
+- provider payloads;
+- token/cost data until the P7c privacy design is accepted.
+
+## Scorecard Candidates
+
+### Agent Config Impact
+
+Existing spine:
+
+- task count;
+- label count;
+- benchmark run count;
+- completion readiness;
+- total, outcome, flow, and cost scores;
+- coverage gaps.
+
+Additions:
+
+- annotation coverage;
+- source coverage adequacy;
+- benchmark regression count;
+- worker review agreement once review labels exist.
+
+### Worker Model Suitability
+
+Metrics:
+
+- selected packet count;
+- completion rate;
+- timeout/failure rate;
+- policy violation rate;
+- human acceptance rate;
+- mean duration;
+- cleanup success for remote workers;
+- Phoenix export success.
+
+Decision gate:
+
+- keep read-only until human acceptance, policy preservation, runtime, and cost
+  thresholds are defined and met.
+
+### Loop Trust
+
+Metrics:
+
+- Phoenix health;
+- latest forwarder status freshness;
+- derived turn count;
+- OTLP span count;
+- source coverage;
+- label queue availability;
+- benchmark case availability;
+- scorecard readiness;
+- mirror status if the target is dankserver.
+
+Decision gate:
+
+- do not interpret config-impact deltas when loop trust is blocked.
+
+## Prompt And Config Experiments
+
+Candidate experiments:
+
+| Experiment | Variant Axis | Primary Metric | Dataset | Risk |
+|---|---|---|---|---|
+| JSDoc policy prompt | compact excerpt variants | policy violation rate, human acceptance | `jsdoc-quality-remediation-packets-v1` | Medium |
+| Worker model/reasoning | provider/model/reasoning effort | completion, policy safety, runtime | `jsdoc-worker-model-suitability-v1` | Medium |
+| Agent guidance update | `AGENTS.md` or `.codex` change | config-impact scorecard delta | `agent-config-snapshots-v1` | Low |
+| Source window policy | recent-only vs broader coverage | loop trust and source coverage | `source-coverage-v1` | Low |
+| Runpod runtime strategy | fallback image vs cached image | duration, cleanup, cost | worker model suitability | Medium |
+| Review rubric | acceptance rubric variants | reviewer agreement | `worker-draft-review-v1` | Medium |
+
+Rules:
+
+- one config/prompt axis per experiment;
+- require snapshot ids before and after;
+- require at least one label and one benchmark for completion credit;
+- keep prompt bodies as repo-local artifacts or Phoenix prompt versions only
+  after privacy review;
+- publish only hashes, refs, bounded labels, and aggregate scores in research.
+
+## Diagnostics Map
+
+| Diagnostic | Failure Found | Existing Evidence Surface | Future Command |
+|---|---|---|---|
+| Phoenix health | endpoint down or version missing | curl health, Phoenix version header | `agent-effectiveness doctor --include-phoenix` |
+| OTLP export | spans not emitted or malformed | `ai-metrics otlp export`, span counts | `agent-effectiveness traces check` |
+| Trace linkage | spans cannot link to task/session/scorecard | OTLP attributes, `session.id` | `agent-effectiveness traces link-check` |
+| Source starvation | global limits hide non-Codex sources | source coverage counts | `agent-effectiveness sources coverage` |
+| Scorecard readiness | no labels or benchmarks | scorecard gaps | `agent-effectiveness scorecard check` |
+| Worker policy drift | candidate violates JSDoc policy | worker policy violation codes | `docgen quality-worker-eval compare` |
+| Worker cleanup | billable remote pod left running | Runpod wrapper cleanup metadata | `docgen quality-worker-eval-runpod doctor` |
+| Privacy leakage | raw text/path/secret in derived payload | privacy check and redaction rules | `agent-effectiveness privacy check` |
+| Provider blind spot | model/tool/token/cost missing | scorecard explicit not-scored gaps | `agent-effectiveness enrichment gaps` |
+| Graph/memory dependency | memory lookup unavailable or timed out | session-start Graphiti status | `agent-effectiveness memory doctor` |
+
+## Possible Future `@beep/repo-cli` Commands
+
+Prefer `beep agent-effectiveness` as the operator group if the loop grows
+beyond AI metrics and docgen. Keep narrower commands under `beep ai-metrics`
+or `beep docgen` when they are plainly owned by those domains.
+
+| Command | Purpose | Writes? | Home |
+|---|---|---:|---|
+| `beep agent-effectiveness doctor` | summarize loop trust across Phoenix, source coverage, labels, benchmarks, worker reports | no | `@beep/repo-cli` |
+| `beep agent-effectiveness dataset build` | build sanitized dataset JSON from existing derived tables/reports | local output only | `@beep/repo-cli`, `@beep/repo-ai-metrics` |
+| `beep agent-effectiveness eval run` | run code/human-ready evals over a named sanitized dataset | local output only | `@beep/repo-cli` |
+| `beep agent-effectiveness annotations plan` | render proposed Phoenix annotations without applying | local output only | `@beep/repo-cli`, `@beep/repo-ai-metrics` |
+| `beep agent-effectiveness annotations apply` | apply reviewed annotations to Phoenix | yes, confirmed | `@beep/repo-cli`; driver if direct API is needed |
+| `beep agent-effectiveness scorecard weekly` | render agent-effectiveness scorecard on top of existing AI metrics rows | local output only | `@beep/repo-ai-metrics` |
+| `beep agent-effectiveness config experiment compare` | compare two config snapshots with labels and benchmarks | no | `@beep/repo-cli` |
+| `beep agent-effectiveness traces check` | verify trace/span linkage and allowlisted attributes | no | `@beep/repo-ai-metrics` |
+| `beep docgen quality-worker-review queue` | create review queue from worker candidates | local output only | `@beep/repo-cli` |
+| `beep docgen quality-worker-review label` | record human acceptance/rejection for a worker candidate | yes, local derived store | `@beep/repo-cli`, `@beep/repo-ai-metrics` |
+| `beep ai-metrics enrichment gaps` | report provider/model/tool/token/cost blind spots | no | existing AI metrics command group |
+
+## Recommended First Slice
+
+Start with a no-mutation loop:
+
+1. `agent-effectiveness doctor --json`
+2. `agent-effectiveness annotations plan --from-ai-metrics --from-worker-eval`
+3. `agent-effectiveness dataset build --kind jsdoc-worker-packets`
+4. `docgen quality-worker-review queue --input <worker-report.json>`
+
+Acceptance evidence:
+
+- all outputs are JSON/Markdown artifacts only;
+- privacy checker proves no raw text, private path, source path, archive path,
+  or secret material;
+- annotations are planned but not applied;
+- JSDoc worker datasets exclude draft bodies by default;
+- scorecard readiness and explicit not-scored gaps are visible in the doctor
+  output;
+- the artifact can be run against the existing 10-packet worker report and P6
+  AI metrics data without Phoenix mutation.
+
+Why this first:
+
+- it uses already-proven repo surfaces;
+- it avoids new production or Phoenix writes;
+- it gives operators one trust gate before interpreting Phoenix or scorecards;
+- it creates the review evidence required before any future auto-remediation.
+
+## Deferred Until After A Read-Only Proof
+
+- Direct Phoenix writes for annotations, datasets, experiments, or prompts.
+- Storing worker draft text in Phoenix.
+- Auto-remediation or source-file write mode.
+- Provider/gateway enrichment that touches raw provider payloads, costs, token
+  counts, or model-call details.
+- New backend drivers before a direct Phoenix API need is proven.
+- Moving agent-effectiveness semantics into shared kernel, product slices, or
+  generic observability packages.

--- a/initiatives/agent-effectiveness-loop/research/live-phoenix-state-audit.md
+++ b/initiatives/agent-effectiveness-loop/research/live-phoenix-state-audit.md
@@ -1,0 +1,138 @@
+# Live Phoenix State Audit
+
+## Scope
+
+Audit date: 2026-05-16.
+
+Live target: `https://dankserver.tailc7c348.ts.net:8447`.
+
+This audit used read-only HTTP header probes, GraphQL read queries, and GraphQL
+schema introspection only. No Phoenix mutation operations were executed.
+
+## Repo Contract
+
+- The initiative README identifies Phoenix as the primary observability and
+  evaluation surface for the agent-effectiveness loop, with the live tailnet UI
+  at `/projects` and explicit read-only access for research
+  (`initiatives/agent-effectiveness-loop/README.md:9-16`,
+  `initiatives/agent-effectiveness-loop/README.md:29-32`).
+- The specification allows only sanitized research evidence: project names,
+  aggregate counts, feature availability, schema/attribute/command names, hashed
+  identifiers already accepted by the AI metrics privacy contract, and links to
+  repo/public docs. It forbids raw prompt, response, transcript, tool payload,
+  private path, secret, raw span payload, and unreviewed exception text
+  (`initiatives/agent-effectiveness-loop/SPEC.md:68-89`).
+- The manifest declares read-only live Phoenix access, the projects URL, the
+  GraphQL URL, and the sanitization boundary for this lane
+  (`initiatives/agent-effectiveness-loop/ops/manifest.json:19-24`).
+- Phase 0 explicitly requires research artifacts to cite sources, keep live
+  Phoenix evidence sanitized/read-only, and avoid production, infra, timer,
+  deployment, or agent-config changes
+  (`initiatives/agent-effectiveness-loop/SPEC.md:106-117`).
+- The deployed stack config pins Phoenix to `arizephoenix/phoenix:15.5.0` on
+  tailnet HTTPS port `8447`, with the `dankserver.tailc7c348.ts.net` FQDN
+  (`infra/Pulumi.beep-ai-metrics-dankserver.yaml:5-7`,
+  `infra/Pulumi.beep-ai-metrics-dankserver.yaml:13`).
+
+## Live Availability
+
+| Probe | Sanitized result |
+| --- | --- |
+| `HEAD /` | HTTP 200 over HTTP/2; `x-phoenix-server-version: 15.5.0` |
+| `HEAD /projects` | HTTP 200 over HTTP/2; `x-phoenix-server-version: 15.5.0` |
+| GraphQL smoke query | `__typename` returned `Query` |
+| GraphQL `serverStatus` | `insufficientStorage: false` |
+
+The live version header matches the pinned stack image version.
+
+## Aggregate State
+
+GraphQL aggregate counts:
+
+| Surface | Count |
+| --- | ---: |
+| Projects | 2 |
+| Datasets | 0 |
+| Prompts | 0 |
+| Custom evaluators | 0 |
+
+First-page read queries for datasets, prompts, evaluators, and annotation
+configs returned empty edge lists.
+
+## Projects
+
+| Project | Has traces | Records | Traces | Annotation names |
+| --- | --- | ---: | ---: | --- |
+| `default` | yes | 10,305,782 | 343 | trace/span/session names empty |
+| `beep-jsdoc-worker-eval` | yes | 118 | 4 | trace/span/session names empty |
+
+The `beep-jsdoc-worker-eval` project is expected from the worker-eval packet:
+that packet documents opt-in Phoenix export with the same tailnet base URL and
+project name, and notes sanitized spans for that run
+(`initiatives/jsdoc-worker-eval/README.md:37-46`,
+`initiatives/jsdoc-worker-eval/README.md:88-89`).
+
+## Feature Availability
+
+Observed GraphQL query fields include:
+
+- project inventory and lookup: `projects`, `projectCount`,
+  `projectsLastUpdatedAt`, `getProjectByName`
+- trace lookup: `getTraceByOtelId`, `getSpanByOtelId`,
+  `getProjectSessionById`
+- dataset inventory: `datasets`, `datasetCount`, `datasetLabels`,
+  `datasetSplits`
+- prompt inventory: `prompts`, `promptCount`, `promptLabels`
+- evaluator inventory: `evaluators`, `evaluatorCount`, `builtInEvaluators`,
+  `classificationEvaluatorConfigs`
+- annotation config inventory: `annotationConfigs`
+- trace retention and health: `defaultProjectTraceRetentionPolicy`,
+  `projectTraceRetentionPolicies`, `serverStatus`
+- model/provider surfaces: `modelProviders`, `generativeModels`,
+  `playgroundModels`
+
+Observed mutation schema names show Phoenix supports project, dataset, prompt,
+evaluator, annotation, experiment, trace, API-key, and user administration
+workflows. These schema names were observed by introspection only; none were
+called.
+
+Observed project attributes useful for sanitized future audits include:
+
+- `name`, `hasTraces`, `recordCount`, `traceCount`
+- `traceAnnotationsNames`, `spanAnnotationNames`,
+  `sessionAnnotationNames`, `documentEvaluationNames`
+- `spans`, `sessions`, `trace`
+- `spanCountTimeSeries`, `traceCountTimeSeries`,
+  `traceCountByStatusTimeSeries`
+- `tokenCountTotal`, `tokenCountPrompt`, `tokenCountCompletion`
+- `costSummary`, `latencyMsQuantile`, `spanLatencyMsQuantile`
+
+Built-in evaluator names currently available through GraphQL:
+
+- `contains`
+- `exact_match`
+- `regex`
+- `levenshtein_distance`
+- `json_distance`
+
+## Audit Readout
+
+Phoenix is live and queryable on the expected tailnet URL, reports version
+`15.5.0`, and has two trace-bearing projects. The live state is trace-heavy but
+not yet enriched with Phoenix-native datasets, prompts, custom evaluators, or
+annotation configs.
+
+For the agent-effectiveness loop, the immediate read-only opportunity is to use
+existing project-level aggregate counts and annotation-name inventories as
+health signals while keeping raw traces out of research artifacts. Any future
+dataset, prompt, evaluator, annotation, or experiment work should be a separate
+implementation phase because the current Phase 0 contract forbids mutating
+Phoenix state.
+
+## Sanitization Notes
+
+Included evidence is limited to project names, aggregate counts, feature
+availability, schema/attribute names, version headers, and repo-relative source
+citations. This artifact intentionally excludes raw prompts, outputs,
+transcript text, tool payloads, raw span payloads, private paths, secrets,
+resolved credential references, trace IDs, span IDs, and exception text.

--- a/initiatives/agent-effectiveness-loop/research/phoenix-capability-map.md
+++ b/initiatives/agent-effectiveness-loop/research/phoenix-capability-map.md
@@ -1,0 +1,237 @@
+# Phoenix Capability Map
+
+## Scope
+
+This artifact maps Phoenix capabilities from official Phoenix documentation to
+coding-agent effectiveness opportunities for this repo. It is intentionally
+public-doc sourced and sanitized: it does not include private trace payloads,
+prompt text, response text, home paths, source paths, secrets, or private
+Phoenix instance URLs.
+
+Primary source index: <https://arize.com/docs/phoenix/llms.txt>
+
+## Executive Read
+
+Phoenix is an open-source AI observability and evaluation platform built on
+OpenTelemetry and OpenInference. Its strongest fit for this initiative is not
+"more dashboards"; it is a repeatable evidence loop for coding-agent behavior:
+trace agent runs, organize them by project/session, label failure modes, turn
+good and bad cases into datasets, run deterministic and LLM-as-judge evals, and
+compare prompt/config/workflow changes before changing agent defaults.
+
+For this repo, the highest-leverage Phoenix paths are:
+
+- Use tracing, sessions, and annotations to explain where coding agents spend
+  time, fail, loop, or recover.
+- Use datasets, experiments, and server-side evaluators to turn recurring repo
+  tasks into a regression harness.
+- Use client-side TypeScript/Python evals for repo-specific checks that are too
+  semantic for unit tests but too important for informal review.
+- Use CLI/MCP/skills as operator and assistant access paths, while keeping
+  mutation permissions constrained during research.
+- Use production controls, retention, RBAC, secrets, and self-hosting posture to
+  preserve the repo's privacy boundary.
+
+## Capability Matrix
+
+| Phoenix capability | Official source URLs | What Phoenix provides | Coding-agent improvement path for this repo | Adoption notes |
+| --- | --- | --- | --- | --- |
+| Tracing over OpenTelemetry and OpenInference | <https://arize.com/docs/phoenix>, <https://arize.com/docs/phoenix/tracing/llm-traces>, <https://arize.com/docs/phoenix/tracing/how-to-tracing/setup-tracing> | Trace capture for model calls, retrieval, tool use, custom logic, latency, token usage, exceptions, prompts, tool schemas, and function calls. Phoenix accepts OTLP and supports Python, TypeScript, and Java instrumentation. | Make coding-agent runs inspectable as execution traces: root agent task, tool calls, shell commands, model calls, retries, subagent work, and error recovery. This can reveal which repo workflows confuse agents and where guidance or automation should change. | Treat Phoenix as the evidence surface, not the repo semantics owner. Use sanitized attributes and existing privacy rules before exporting spans. |
+| Projects | <https://arize.com/docs/phoenix/tracing/llm-traces/projects>, <https://arize.com/docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-projects> | Projects separate traces by environment, application, initiative, experiment, or team and provide dedicated evaluation spaces. | Create separate project boundaries for agent research lanes, worker evals, prompt/config experiments, and production-like telemetry so unrelated traces do not pollute the same metrics. | Project naming should be stable and non-sensitive. Avoid raw task text in project names. |
+| Sessions | <https://arize.com/docs/phoenix/tracing/llm-traces/sessions>, <https://arize.com/docs/phoenix/tracing/how-to-tracing/setup-tracing/setup-sessions> | Sessions group related traces across multi-turn conversations, expose a chat-like view, and aggregate token usage and latency per conversation. | Model a coding-agent thread as a session so later review can inspect the full task arc: user request, investigation, edits, verification, interruptions, and final status. | Use hashed or generated session identifiers rather than private thread titles. |
+| Metadata and span customization | <https://arize.com/docs/phoenix/tracing/how-to-tracing/add-metadata>, <https://arize.com/docs/phoenix/tracing/how-to-tracing/add-metadata/customize-spans>, <https://arize.com/docs/phoenix/tracing/how-to-tracing/advanced/modifying-spans>, <https://arize.com/docs/phoenix/tracing/how-to-tracing/advanced/masking-span-attributes> | Custom attributes, tags, session IDs, user IDs, prompt template metadata, span processors, suppression, and masking controls. | Add sanitized repo-relevant dimensions such as task class, package family, verification command class, model/provider family, tool category, and outcome label. This enables queryable patterns without exposing raw code or prompts. | Define an allowlist before instrumentation. Prefer coarse labels over raw payload capture. |
+| Annotations and feedback | <https://arize.com/docs/phoenix/tracing/llm-traces/how-to-annotate-traces>, <https://arize.com/docs/phoenix/tracing/how-to-tracing/feedback-and-annotations>, <https://arize.com/docs/phoenix/tracing/how-to-tracing/feedback-and-annotations/capture-feedback> | Human, end-user, LLM, and code annotations with labels, scores, explanations, metadata, and identifiers attached to spans. Annotations can be added from UI, client, or REST API. | Establish a controlled label set for coding-agent outcomes: completed, blocked, wrong-package, privacy-risk, verification-missing, compile-fail, review-fix, over-broad-edit, and similar failure modes. Attach labels to spans or sessions to build longitudinal evidence. | For Phase 0, read-only. Future write flows need explicit configs and privacy review. |
+| Evals on traces | <https://arize.com/docs/phoenix/tracing/how-to-tracing/feedback-and-annotations/evaluating-phoenix-traces>, <https://arize.com/docs/phoenix/tracing/how-to-tracing/feedback-and-annotations/llm-evaluations>, <https://arize.com/docs/phoenix/evaluation/how-to-evals/using-evals-with-phoenix> | Export trace datasets from Phoenix, run code or LLM evals, and log results back as annotations. Eval results are treated as automated annotations. | Mine sanitized traces for agent failure modes, run repeatable evals against those traces, and log pass/fail or rubric scores back to Phoenix. This is the bridge from observability to a measurable agent-improvement loop. | Never evaluate raw private prompts externally. If using LLM judges, feed sanitized summaries or approved derived fields. |
+| Client-side LLM evals | <https://arize.com/docs/phoenix/evaluation/llm-evals>, <https://arize.com/docs/phoenix/evaluation/how-to-evals>, <https://arize.com/docs/phoenix/evaluation/how-to-evals/custom-llm-evaluators>, <https://arize.com/docs/phoenix/evaluation/how-to-evals/configuring-the-llm> | Python and TypeScript eval SDKs, model adapters, LLM-as-judge evaluators, structured output via tool calling, built-in explanations, rate-limit handling, retries, batching, dynamic concurrency, and evaluator tracing. | Build rubrics for semantic behaviors that repo tests cannot catch: whether the agent followed architecture doctrine, stayed within scope, gave a truthful final status, preserved user changes, selected the right package owner, and named missing verification honestly. | Judge prompts are themselves code-like artifacts. Version and test them. Prefer small rubrics with auditable explanations. |
+| Client-side code evals | <https://arize.com/docs/phoenix/evaluation/how-to-evals/code-evaluators>, <https://arize.com/docs/phoenix/evaluation/how-to-evals/batch-evaluations>, <https://arize.com/docs/phoenix/evaluation/pre-built-metrics> | Deterministic evaluators in Python or TypeScript using functions, score objects, exact match, regex, Levenshtein, JSON distance, precision/recall, and custom heuristics. Batch dataframe evaluation is available in Python. | Encode cheap, deterministic checks for agent artifacts: required sections present, no forbidden private patterns, exact command summaries included, diff only touches assigned files, source URLs present, or expected labels emitted. | Put deterministic checks before LLM judges. They are cheaper, faster, and easier to trust in CI-style loops. |
+| Server-side evals | <https://arize.com/docs/phoenix/evaluation/server-evals/overview>, <https://arize.com/docs/phoenix/evaluation/server-evals/input-mapping>, <https://arize.com/docs/phoenix/evaluation/server-evals/pre-built-metrics>, <https://arize.com/docs/phoenix/evaluation/server-evals/llm-evaluators> | UI-configured dataset evaluators that run server-side on every Playground experiment. Supports built-in code evaluators and Phoenix-managed LLM evaluators with reusable input mapping. | Attach standard evals to repo-agent datasets so every prompt/model/workflow experiment gets the same scoring suite without each operator reconfiguring evals locally. | Current docs scope automatic server evals to Playground experiments on datasets; programmatic experiments should pass evaluators explicitly. |
+| Datasets | <https://arize.com/docs/phoenix/datasets-and-experiments/overview-datasets>, <https://arize.com/docs/phoenix/datasets-and-experiments/how-to-datasets/creating-datasets>, <https://arize.com/docs/phoenix/datasets-and-experiments/how-to-datasets/updating-datasets>, <https://arize.com/docs/phoenix/datasets-and-experiments/how-to-datasets/exporting-datasets> | Versioned collections of examples with inputs, optional references, metadata, CSV/Pandas/object upload, trace-to-dataset curation, stable IDs with diff updates, CSV export, fine-tuning JSONL, and OpenAI Evals JSONL export. | Curate golden datasets for recurring coding-agent tasks: docs-only research, package-local fixes, JSDoc compliance, review-thread resolution, schema modeling, and verification reporting. Use stable hashed IDs so datasets can update without losing experiment links. | Dataset examples must be sanitized and reviewed. Do not store raw private prompts, responses, paths, or source snippets unless explicitly allowed by the initiative privacy contract. |
+| Experiments | <https://arize.com/docs/phoenix/datasets-and-experiments/overview-datasets>, <https://arize.com/docs/phoenix/datasets-and-experiments/how-to-experiments/run-experiments>, <https://arize.com/docs/phoenix/datasets-and-experiments/how-to-experiments/using-evaluators>, <https://arize.com/docs/phoenix/datasets-and-experiments/how-to-experiments/repetitions>, <https://arize.com/docs/phoenix/datasets-and-experiments/how-to-experiments/splits> | Run task functions against datasets, compare outputs and eval results, attach evaluators, run repetitions for probabilistic systems, and use splits for hard examples, train/validation/test, or focused evaluation. | Compare prompt/config/model changes against the same agent task set before changing repo guidance. Repetitions are especially useful for agentic variability; splits can isolate hard tasks like architecture-boundary decisions or review cleanup. | Use small, high-signal datasets first. Experiments should answer one decision at a time. |
+| Background experiments | <https://arize.com/docs/phoenix/datasets-and-experiments/how-to-experiments/run-experiments-in-background> | Playground experiments can keep running after the browser is closed and survive server restarts. | Useful for longer repo-agent benchmarks that should not depend on an operator keeping a browser open. | Keep Phase 0 research read-only; use this later if an approved dataset/experiment workflow exists. |
+| Prompt management | <https://arize.com/docs/phoenix/prompt-engineering/overview-prompts>, <https://arize.com/docs/phoenix/prompt-engineering/overview-prompts/prompt-management>, <https://arize.com/docs/phoenix/prompt-engineering/how-to-prompts/create-a-prompt>, <https://arize.com/docs/phoenix/prompt-engineering/how-to-prompts/tag-a-prompt> | Prompt creation, storage, modification, version history, tags such as production/staging/development, and audit trail for prompt changes. | Treat repo-agent system prompts, evaluator rubrics, and operator prompts as versioned experimental artifacts. Tags can represent approved repo guidance versus candidate variants. | Phoenix docs warn that client libraries for prompts are early; do not make production agent behavior depend on remote prompt fetch without caching/fallback. |
+| Prompt Playground | <https://arize.com/docs/phoenix/prompt-engineering/overview-prompts/prompt-playground>, <https://arize.com/docs/phoenix/prompt-engineering/how-to-prompts/test-a-prompt>, <https://arize.com/docs/phoenix/prompt-engineering/how-to-prompts/configure-ai-providers> | Interactive prompt IDE for prompt text, models, invocation parameters, tools, output formats, datasets, traces, and experiments. Playground runs are recorded as traces and experiments. | Let operators test candidate guidance and evaluator prompts against golden repo-agent examples before putting them into agent config or docs. | Playground is excellent for research and comparison; production repo guidance should still land in version-controlled artifacts. |
+| Span replay | <https://arize.com/docs/phoenix/prompt-engineering/overview-prompts/span-replay> | Load stored LLM spans into Playground and replay them with changed prompt text, model parameters, or providers. | For a failed agent decision, replay only the relevant LLM step with a safer prompt or model to see whether the failure is prompt-sensitive, model-sensitive, or caused by missing repo context. | Replay requires care because span inputs may contain private data. Use sanitized or approved spans only. |
+| Prompts in code and provider tools | <https://arize.com/docs/phoenix/prompt-engineering/overview-prompts/prompts-in-code>, <https://arize.com/docs/phoenix/prompt-engineering/how-to-prompts/using-a-prompt>, <https://arize.com/docs/phoenix/prompt-engineering/how-to-prompts/use-provider-tools> | Python and TypeScript clients can create/update prompts, pull by name/version/tag, format variables, and support tool calling, response formats, and provider-hosted tools. | Possible future path for repo-local tooling that fetches evaluator prompts or operator prompt templates while keeping tags aligned to approved versions. | For coding agents, remote prompt dependency is a reliability risk. Prefer local checked-in prompts unless Phoenix prompt management adds clear value. |
+| Metrics dashboard | <https://arize.com/docs/phoenix/tracing/llm-traces/metrics> | Per-project metrics dashboard for trace latency/errors, latency quantiles, annotation score time series, cost over time, top models by cost/tokens, token usage, LLM invocations/errors, and tool calls/errors. | Track whether agent changes actually reduce latency, error rate, tool-call failures, and cost per successful task. Annotation score time series can show whether guidance changes improve outcomes over time. | Phoenix project metrics are good for operator review; custom repo scorecards may still belong in repo-owned analytics. |
+| Cost tracking | <https://arize.com/docs/phoenix/tracing/how-to-tracing/cost-tracking> | Automatic token-based cost calculation from OpenInference token/model attributes, built-in model pricing, custom model pricing, and rollups at trace, span, session, experiment, and project levels. | Identify expensive failure patterns such as long loops, repeated failed tool calls, high-reasoning spans, or model choices that do not improve task success. Tie cost to outcome labels rather than optimizing cost alone. | Ensure instrumentation emits token counts and model/provider names. Configure custom prices for non-built-in or local model providers. |
+| Export, query, and import trace data | <https://arize.com/docs/phoenix/tracing/how-to-tracing/importing-and-exporting-traces>, <https://arize.com/docs/phoenix/tracing/how-to-tracing/importing-and-exporting-traces/extract-data-from-spans>, <https://arize.com/docs/phoenix/tracing/how-to-tracing/importing-and-exporting-traces/exporting-annotated-spans>, <https://arize.com/docs/phoenix/tracing/how-to-tracing/importing-and-exporting-traces/importing-existing-traces> | Span dataframe export, query DSL, filtering by metadata and eval results, joining parent/child spans, annotated-span export, and loading saved OpenInference trace datasets. | Build sanitized offline reports and regression datasets from Phoenix without giving broad UI access. Query only needed fields and export derived metrics or approved annotations. | Export paths are powerful privacy choke points. Make the export schema explicit and reviewed. |
+| ATIF agent trajectory import | <https://arize.com/docs/phoenix/tracing/how-to-tracing/importing-and-exporting-traces/importing-atif-trajectories> | Upload ATIF-compatible agent trajectories from tools such as Harbor, Claude Code, OpenHands, and other frameworks. Converter builds AGENT/LLM/TOOL span hierarchies, supports subagent nesting, and merges continuations. | Import sanitized coding-agent trajectories from offline runs to visualize parent/subagent delegation and long-context continuations without requiring live instrumentation first. | Strong fit for read-only research if ATIF export can be sanitized before upload. |
+| Phoenix CLI for coding assistants | <https://arize.com/docs/phoenix/integrations/developer-tools/coding-agents>, <https://arize.com/docs/phoenix/tracing/how-to-tracing/importing-and-exporting-traces/retrieve-traces-via-cli> | `@arizeai/phoenix-cli` exposes `px` commands for projects, traces, sessions, formatting, annotations, recent-trace retrieval, and assistant-friendly output. | Give operators and agents a terminal-native, scriptable way to fetch recent traces, failed traces, sessions, and annotations for debugging and report generation. | Prefer read-only CLI usage initially. Store endpoint/project/API key in local env, never committed config. |
+| Phoenix MCP servers | <https://arize.com/docs/phoenix/integrations/developer-tools/coding-agents>, <https://arize.com/docs/phoenix/integrations/phoenix-mcp-server> | Docs MCP searches Phoenix docs. Phoenix MCP connects assistants to projects, traces, spans, sessions, annotation configs, prompts, datasets, experiments, and annotations. | Docs MCP helps agents use Phoenix APIs correctly. Phoenix MCP can support operator workflows like trace triage, prompt lookup, and experiment review from inside coding assistants. | Direct Phoenix MCP can mutate prompts/datasets in some flows. Use read-only discipline or limited credentials until write workflows are approved. |
+| Phoenix skills | <https://arize.com/docs/phoenix/integrations/developer-tools/coding-agents> | Installable skills via `npx skills add Arize-ai/phoenix`; advertised skills include `phoenix-cli`, `phoenix-evals`, and `phoenix-tracing`, with support for agents including Claude Code, Cursor, Windsurf, Codex, GitHub Copilot, Cline, OpenCode, and Gemini CLI. | Add reusable agent instructions for Phoenix CLI, evals, and tracing once this initiative chooses an approved workflow. This can reduce repeated setup mistakes across agents. | Do not install or alter agent config during Phase 0 unless explicitly requested. Capture candidate skill usage in a later implementation plan. |
+| MCP tracing in Python and TypeScript | <https://arize.com/docs/phoenix/integrations/python/mcp-tracing>, <https://arize.com/docs/phoenix/integrations/typescript/mcp/mcp-tracing-typescript> | OpenInference instrumentation for MCP clients and servers, including client-to-server interactions under one trace hierarchy. | If repo tooling exposes MCP servers or coding agents consume MCP tools, trace MCP boundaries to see which tool calls drive success, retries, slowdowns, or errors. | Useful for future tool-level diagnostics. Keep payload masking strict. |
+| TypeScript SDK availability | <https://arize.com/docs/phoenix/tracing/how-to-tracing/setup-tracing>, <https://arize.com/docs/phoenix/evaluation/how-to-evals>, <https://arize.com/docs/phoenix/datasets-and-experiments/how-to-experiments/run-experiments>, <https://arize.com/docs/phoenix/integrations/developer-tools/coding-agents> | TypeScript packages include `@arizeai/phoenix-otel`, `@arizeai/phoenix-client`, `@arizeai/phoenix-evals`, `@arizeai/phoenix-cli`, and `@arizeai/phoenix-mcp`; docs state installed packages ship docs/source in `node_modules`. | This repo can keep most future automation in TypeScript/Bun/Node workflows where it already has repo tooling, using installed package docs as version-matched references. | Verify actual installed package APIs before implementation. Phoenix docs note some client prompt features are early. |
+| Python SDK availability | <https://arize.com/docs/phoenix/tracing/how-to-tracing/setup-tracing>, <https://arize.com/docs/phoenix/evaluation/how-to-evals>, <https://arize.com/docs/phoenix/tracing/how-to-tracing/importing-and-exporting-traces/extract-data-from-spans>, <https://arize.com/docs/phoenix/datasets-and-experiments/how-to-datasets/creating-datasets> | Python SDKs cover tracing setup through `phoenix.otel`, Phoenix client APIs, dataframe export/query workflows, dataset creation, evals, and batch dataframe evaluation. | Python is useful for analysis notebooks, dataframe-heavy export/review, and batch evaluation pipelines. TypeScript should still be preferred for repo-integrated CLI commands when parity exists. | If Python is used, keep generated reports sanitized and avoid notebook-only state as the sole evidence path. |
+| Production and self-hosting | <https://arize.com/docs/phoenix/self-hosting>, <https://arize.com/docs/phoenix/production-guide>, <https://arize.com/docs/phoenix/self-hosting/configuration>, <https://arize.com/docs/phoenix/environments> | Phoenix can run in Cloud, container, notebook, terminal, Docker, Kubernetes, Helm, AWS, and Railway. Self-hosting is full-featured and keeps data in your infrastructure. Production guidance covers batch processing, gRPC transport, memory/disk scaling, PostgreSQL, and backups. | Keep sensitive agent telemetry inside the controlled Phoenix deployment. Use production guidance to keep ingestion reliable if agent traces become a routine repo operation. | Pin container versions in production, plan backups and restore drills, and prefer gRPC/batch processing for sustained ingest. |
+| Security, auth, retention, and secrets | <https://arize.com/docs/phoenix/settings/access-control-rbac>, <https://arize.com/docs/phoenix/settings/api-keys>, <https://arize.com/docs/phoenix/settings/data-retention>, <https://arize.com/docs/phoenix/settings/secrets>, <https://arize.com/docs/phoenix/self-hosting> | RBAC roles include admin, member, and viewer; API keys include system keys, user keys, and admin secret; retention can purge traces by time or count; secrets store encrypted provider credentials when `PHOENIX_SECRET` is configured. | Use viewer/read-only access for research agents, system keys for approved automation, explicit retention for trace-heavy projects, and admin-managed secrets for Playground/eval provider credentials. | A viewer role is the safest default for audits. Production secrets need `PHOENIX_SECRET`; retention defaults should be reviewed before large-scale trace ingestion. |
+
+## Repo-Specific Capability Clusters
+
+### 1. Observe Coding-Agent Work
+
+Phoenix tracing, projects, sessions, metrics, and cost tracking can make agent
+work inspectable without relying on anecdotal final answers. The useful unit is
+not just "model call"; it is the full coding loop: task intake, repo search,
+tool selection, edits, tests, review handling, and final report.
+
+Candidate repo benefits:
+
+- identify slow or expensive task families;
+- detect repeated failed tool-call patterns;
+- compare model/provider choices by outcome and cost;
+- distinguish repo-guidance failures from model/tool/runtime failures;
+- review long-running agent sessions without reading raw transcripts.
+
+### 2. Label and Score Outcomes
+
+Annotations are the central bridge from raw observability to agent improvement.
+Phoenix supports human, LLM, and code annotations with labels, scores, and
+metadata. For this repo, the first useful annotation taxonomy should be small,
+operational, and privacy-safe.
+
+Candidate labels:
+
+- `completed`
+- `blocked`
+- `verification-missing`
+- `wrong-architecture-home`
+- `over-broad-edit`
+- `user-change-risk`
+- `private-data-risk`
+- `review-thread-incomplete`
+- `test-failure-fixed`
+- `test-failure-unresolved`
+
+These labels can later become scorecard dimensions, dataset filters, and eval
+targets.
+
+### 3. Turn Repeated Work Into Datasets
+
+Phoenix datasets and experiments are the strongest path from "interesting trace"
+to "repeatable proof." The repo can curate sanitized examples for recurring
+agent jobs and use experiments to compare candidate changes.
+
+Good first datasets should be narrow:
+
+- docs-only research artifact tasks;
+- JSDoc/schema compliance review tasks;
+- package-boundary classification tasks;
+- review-feedback triage tasks;
+- final-answer truthfulness and verification-reporting tasks.
+
+Each example should include only sanitized input fields, expected behavior,
+allowed source references, metadata labels, and an expected outcome rubric.
+
+### 4. Evaluate Agent Changes Before Shipping Them
+
+Client-side code evals should handle deterministic gates such as file-scope
+limits, required citations, forbidden private patterns, required verification
+fields, or exact JSON/report shape. LLM evals should handle semantic judgments
+such as "did the agent respect architecture doctrine?" or "does the final answer
+truthfully describe the verification state?"
+
+Server-side dataset evaluators are attractive once Phoenix datasets exist
+because they run automatically on Playground experiments. For programmatic repo
+experiments, pass evaluators explicitly to the Phoenix client APIs.
+
+### 5. Improve Operator Workflows
+
+Phoenix CLI, Docs MCP, Phoenix MCP, and Phoenix skills give coding agents and
+operators direct ways to fetch recent traces, inspect sessions, look up docs,
+and review experiments. The safest order is:
+
+1. CLI read-only retrieval for traces/sessions.
+2. Docs MCP for version-independent documentation lookup.
+3. Skills for consistent Phoenix operating instructions.
+4. Direct Phoenix MCP only after credentials and mutation boundaries are clear.
+
+### 6. Preserve Privacy and Reliability
+
+Phoenix is compatible with this initiative only if it stays inside the privacy
+contract. Self-hosting, RBAC, API keys, retention policies, secrets management,
+span masking, and sanitized export schemas are not optional implementation
+details; they are part of the capability map.
+
+Required guardrails for future implementation:
+
+- no raw prompt/response/transcript/tool payloads in research artifacts;
+- no private local paths or private service URLs in reports;
+- allowlisted span attributes only;
+- read-only credentials for research agents;
+- retention policies before large trace ingestion;
+- tested backup/restore posture for any production dependency;
+- local fallback/no-op behavior when Phoenix is unavailable.
+
+## Recommended First Uses
+
+1. Build a sanitized trace review report that uses Phoenix CLI/export data and
+   repo-owned labels, without mutating Phoenix.
+2. Define a tiny annotation taxonomy for coding-agent outcomes and map it to
+   existing scorecard language.
+3. Create one sanitized dataset for a recurring agent task class and pair it
+   with deterministic code evals before adding LLM judges.
+4. Use experiments to compare one prompt/config/workflow change against that
+   dataset.
+5. Consider Phoenix MCP and skills only after the read-only CLI workflow proves
+   useful.
+
+## Source URLs
+
+- Phoenix documentation index: <https://arize.com/docs/phoenix/llms.txt>
+- Phoenix overview: <https://arize.com/docs/phoenix>
+- Tracing overview: <https://arize.com/docs/phoenix/tracing/llm-traces>
+- Projects: <https://arize.com/docs/phoenix/tracing/llm-traces/projects>
+- Sessions: <https://arize.com/docs/phoenix/tracing/llm-traces/sessions>
+- Annotations: <https://arize.com/docs/phoenix/tracing/llm-traces/how-to-annotate-traces>
+- Tracing setup: <https://arize.com/docs/phoenix/tracing/how-to-tracing/setup-tracing>
+- Trace annotations and feedback: <https://arize.com/docs/phoenix/tracing/how-to-tracing/feedback-and-annotations>
+- Evals on traces: <https://arize.com/docs/phoenix/tracing/how-to-tracing/feedback-and-annotations/evaluating-phoenix-traces>
+- Log evaluation results: <https://arize.com/docs/phoenix/tracing/how-to-tracing/feedback-and-annotations/llm-evaluations>
+- Metrics dashboard: <https://arize.com/docs/phoenix/tracing/llm-traces/metrics>
+- Cost tracking: <https://arize.com/docs/phoenix/tracing/how-to-tracing/cost-tracking>
+- Importing and exporting traces: <https://arize.com/docs/phoenix/tracing/how-to-tracing/importing-and-exporting-traces>
+- Export data and query spans: <https://arize.com/docs/phoenix/tracing/how-to-tracing/importing-and-exporting-traces/extract-data-from-spans>
+- Exporting annotated spans: <https://arize.com/docs/phoenix/tracing/how-to-tracing/importing-and-exporting-traces/exporting-annotated-spans>
+- Import existing traces: <https://arize.com/docs/phoenix/tracing/how-to-tracing/importing-and-exporting-traces/importing-existing-traces>
+- Import ATIF trajectories: <https://arize.com/docs/phoenix/tracing/how-to-tracing/importing-and-exporting-traces/importing-atif-trajectories>
+- Retrieve traces via CLI: <https://arize.com/docs/phoenix/tracing/how-to-tracing/importing-and-exporting-traces/retrieve-traces-via-cli>
+- Evaluation overview: <https://arize.com/docs/phoenix/evaluation/llm-evals>
+- Client-side evals: <https://arize.com/docs/phoenix/evaluation/how-to-evals>
+- Code evaluators: <https://arize.com/docs/phoenix/evaluation/how-to-evals/code-evaluators>
+- Batch evaluations: <https://arize.com/docs/phoenix/evaluation/how-to-evals/batch-evaluations>
+- Using evals with Phoenix: <https://arize.com/docs/phoenix/evaluation/how-to-evals/using-evals-with-phoenix>
+- Server evals: <https://arize.com/docs/phoenix/evaluation/server-evals/overview>
+- Server eval input mapping: <https://arize.com/docs/phoenix/evaluation/server-evals/input-mapping>
+- Server eval pre-built metrics: <https://arize.com/docs/phoenix/evaluation/server-evals/pre-built-metrics>
+- Datasets and experiments overview: <https://arize.com/docs/phoenix/datasets-and-experiments/overview-datasets>
+- Creating datasets: <https://arize.com/docs/phoenix/datasets-and-experiments/how-to-datasets/creating-datasets>
+- Updating datasets: <https://arize.com/docs/phoenix/datasets-and-experiments/how-to-datasets/updating-datasets>
+- Exporting datasets: <https://arize.com/docs/phoenix/datasets-and-experiments/how-to-datasets/exporting-datasets>
+- Run experiments: <https://arize.com/docs/phoenix/datasets-and-experiments/how-to-experiments/run-experiments>
+- Using evaluators in experiments: <https://arize.com/docs/phoenix/datasets-and-experiments/how-to-experiments/using-evaluators>
+- Dataset evaluators: <https://arize.com/docs/phoenix/datasets-and-experiments/how-to-experiments/how-to-dataset-evaluators>
+- Repetitions: <https://arize.com/docs/phoenix/datasets-and-experiments/how-to-experiments/repetitions>
+- Splits: <https://arize.com/docs/phoenix/datasets-and-experiments/how-to-experiments/splits>
+- Background experiments: <https://arize.com/docs/phoenix/datasets-and-experiments/how-to-experiments/run-experiments-in-background>
+- Prompts overview: <https://arize.com/docs/phoenix/prompt-engineering/overview-prompts>
+- Prompt management: <https://arize.com/docs/phoenix/prompt-engineering/overview-prompts/prompt-management>
+- Prompt playground: <https://arize.com/docs/phoenix/prompt-engineering/overview-prompts/prompt-playground>
+- Span replay: <https://arize.com/docs/phoenix/prompt-engineering/overview-prompts/span-replay>
+- Prompts in code: <https://arize.com/docs/phoenix/prompt-engineering/overview-prompts/prompts-in-code>
+- Create a prompt: <https://arize.com/docs/phoenix/prompt-engineering/how-to-prompts/create-a-prompt>
+- Test a prompt: <https://arize.com/docs/phoenix/prompt-engineering/how-to-prompts/test-a-prompt>
+- Tag a prompt: <https://arize.com/docs/phoenix/prompt-engineering/how-to-prompts/tag-a-prompt>
+- Use a prompt: <https://arize.com/docs/phoenix/prompt-engineering/how-to-prompts/using-a-prompt>
+- Use provider tools: <https://arize.com/docs/phoenix/prompt-engineering/how-to-prompts/use-provider-tools>
+- Coding agents: <https://arize.com/docs/phoenix/integrations/developer-tools/coding-agents>
+- Phoenix MCP server: <https://arize.com/docs/phoenix/integrations/phoenix-mcp-server>
+- TypeScript MCP tracing: <https://arize.com/docs/phoenix/integrations/typescript/mcp/mcp-tracing-typescript>
+- Python MCP tracing: <https://arize.com/docs/phoenix/integrations/python/mcp-tracing>
+- Self-hosting: <https://arize.com/docs/phoenix/self-hosting>
+- Production guide: <https://arize.com/docs/phoenix/production-guide>
+- Environments: <https://arize.com/docs/phoenix/environments>
+- Self-hosting configuration: <https://arize.com/docs/phoenix/self-hosting/configuration>
+- Access control: <https://arize.com/docs/phoenix/settings/access-control-rbac>
+- API keys: <https://arize.com/docs/phoenix/settings/api-keys>
+- Data retention: <https://arize.com/docs/phoenix/settings/data-retention>
+- Secrets: <https://arize.com/docs/phoenix/settings/secrets>

--- a/initiatives/agent-effectiveness-loop/research/repo-eval-metrics-surface-audit.md
+++ b/initiatives/agent-effectiveness-loop/research/repo-eval-metrics-surface-audit.md
@@ -1,0 +1,245 @@
+# Repo Eval And Metrics Surface Audit
+
+## Status
+
+Phase 0 research artifact for `agent-effectiveness-loop`.
+
+This audit maps the repo-local eval and metrics surfaces that already exist,
+the work that the existing packets still classify as planned/follow-up, and the
+surfaces that must not be disturbed while agent-effectiveness planning happens.
+It is intentionally docs-only: no production code, infra, timer, deployment, or
+agent config behavior was changed for this artifact.
+
+## Scope And Evidence
+
+Primary packets inspected:
+
+- `initiatives/agent-effectiveness-loop/{README.md,SPEC.md,PLAN.md,ops/manifest.json}`
+- `initiatives/ai-metrics-stack/{README.md,SPEC.md,PLAN.md,ops/manifest.json}`
+- `initiatives/ai-metrics-stack/history/outputs/*.md`
+- `initiatives/jsdoc-worker-eval/{README.md,SPEC.md,PLAN.md,ops/manifest.json}`
+- `initiatives/jsdoc-worker-eval/research/*.md`
+- `initiatives/jsdoc-worker-eval/history/outputs/*.json`
+
+Primary code surfaces inspected:
+
+- `packages/tooling/library/ai-metrics`
+- `packages/tooling/tool/cli/src/commands/AIMetrics/index.ts`
+- `packages/tooling/tool/cli/src/commands/Docgen/index.ts`
+- `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts`
+- `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerRunpodEval.ts`
+- `packages/foundation/capability/observability`
+- `packages/drivers/duckdb`
+- `infra/src/AIMetrics.ts`
+- `infra/test/AIMetrics.test.ts`
+- `standards/ARCHITECTURE.md`
+- `standards/architecture/07-non-slice-families.md`
+- `standards/architecture/12-observability.md`
+
+Commands used for discovery:
+
+```sh
+rg --files initiatives | rg "(agent-effectiveness-loop|ai-metrics-stack|jsdoc-worker-eval|metrics|eval)"
+rg --files packages infra standards | rg "(repo-ai-metrics|AIMetrics|ai-metrics|quality-worker-eval|forwarder|otlp|mirror|retention)"
+rg -n "label|benchmark|weekly|forwarder|OTLP|mirror|retention|follow-up|must not" initiatives/ai-metrics-stack packages/tooling
+```
+
+## Executive Classification
+
+Existing:
+
+- `@beep/repo-ai-metrics` exists at `packages/tooling/library/ai-metrics` as a
+  private tooling library with schema-first models and helpers for source
+  discovery, ingest, encrypted raw archive, derived DuckDB/Parquet storage,
+  config snapshots, forwarder runs, OTLP projection/export, labels,
+  benchmarks, weekly scorecards, mirror bundles, retention, and install specs.
+- `beep ai-metrics` exists in `@beep/repo-cli` at
+  `packages/tooling/tool/cli/src/commands/AIMetrics/index.ts` and exposes the
+  operator workflows the AI-metrics packet names.
+- `beep docgen quality-worker-eval` and
+  `beep docgen quality-worker-eval-runpod` exist in `@beep/repo-cli` and are
+  intentionally read-only eval surfaces.
+- Phoenix is the default UI and OTLP target for the AI-metrics stack, with
+  deployment owned by `@beep/infra`.
+
+Planned/follow-up:
+
+- AI-metrics P7e closeout remains the packeted V1 completion gate until a final
+  seven-day report and confirmed sanitized derived mirror are recorded.
+- P7c provider/model/tool/token/cost enrichment and P7d dashboard/backend
+  expansion are follow-up capabilities, not blockers for V1.
+- Server-owned collection is a future topology target requiring transcript
+  access/sync and privacy design.
+- `jsdoc-worker-eval` auto-remediation, human draft acceptance rubrics, and
+  repeated remote Qwen cost reductions are follow-up initiatives, not current
+  write-mode permission.
+
+Must not be disturbed:
+
+- Do not change the active AI-metrics proof runner, timer cadence, source
+  window, proof data root, or privacy contract while the existing packet still
+  treats P6/P7e closeout as active.
+- Do not mutate Phoenix projects, datasets, prompts, annotations, traces,
+  experiments, or server config during this research bootstrap.
+- Do not sync raw transcripts, local paths, source paths, archive paths,
+  prompt/output text, decrypted bodies, or secret values into reports, mirrors,
+  OTLP spans, or research artifacts.
+- Do not move developer AI analytics semantics into `@beep/observability`,
+  `shared/*`, product slices, generic foundation packages, or backend drivers.
+- Do not treat worker-eval output as source of truth or make it blocking
+  enforcement.
+
+## Surface Inventory
+
+| Surface | Exists | Planned / Follow-Up | Must Not Disturb | Evidence |
+|---|---|---|---|---|
+| `@beep/repo-ai-metrics` | Yes. `package.json`, `README.md`, and `src/index.ts` export archive, compose, config snapshot, derived storage, forwarder, ingest, install, mirror, models, OTLP, privacy, retention, scorecard, shell, and source-discovery modules. | Provider/gateway enrichment and dashboard expansion remain later P7 work. | Keep developer AI analytics semantics here; do not promote them into shared kernel, product slices, or `@beep/observability`. | `packages/tooling/library/ai-metrics/package.json`; `packages/tooling/library/ai-metrics/README.md`; `packages/tooling/library/ai-metrics/src/index.ts`; `initiatives/ai-metrics-stack/SPEC.md` |
+| `beep ai-metrics` CLI | Yes. Root command exposes ingest, source discovery, config snapshots, privacy checks, install workflows, forwarder, OTLP export, labels, benchmarks, reports, mirror, retention, and archive drill. | Future agent-effectiveness workflows should bind to this CLI where they reuse existing data products. | Do not add commands that bypass privacy, confirmation, or dry-run gates. | `packages/tooling/tool/cli/src/commands/AIMetrics/index.ts`; `packages/tooling/tool/cli/test/ai-metrics-command.test.ts` |
+| Forwarder | Yes. `forwarder run` writes encrypted raw archive objects, derived DuckDB rows, Parquet exports, config snapshots, and optional OTLP status. `forwarder timer` renders workstation systemd units with bounded budgets. | Server-owned collection remains future topology work. | Do not re-render or alter active proof runner/timer behavior unless the owning AI-metrics closeout explicitly calls for it. | `packages/tooling/library/ai-metrics/src/forwarder.ts`; `packages/tooling/library/ai-metrics/test/ingest.test.ts`; `initiatives/ai-metrics-stack/history/outputs/p6-proof-runner-isolation-and-runbook.md` |
+| OTLP export | Yes. `otlp export` projects redacted derived DuckDB rows into allowlisted trace spans. `forwarder run --otlp` performs additive export after storage succeeds. | Backend-specific APIs are still deferred until a real non-OTLP need exists. | Preserve the attribute allowlist and hash-only identifiers. OTLP must not carry raw prompts, output text, local paths, or secret-shaped data. | `packages/tooling/library/ai-metrics/src/otlp.ts`; `packages/tooling/tool/cli/test/ai-metrics-command.test.ts`; `initiatives/ai-metrics-stack/history/outputs/p3-otlp-and-backend-stack.md` |
+| Labels | Yes. `label queue` lists deploy-safe unlabeled tasks and `label add` records structured human outcome labels with rating, pass/fail, quality gate, intervention count, follow-up flag, and redacted note. | More labels may be added only from explicit human outcome judgment. | Do not fabricate labels from model output or worker-eval suggestions. | `packages/tooling/library/ai-metrics/src/scorecard.ts`; `packages/tooling/tool/cli/src/commands/AIMetrics/index.ts`; `initiatives/ai-metrics-stack/history/outputs/p4-scorecards-labels-and-benchmarks.md` |
+| Benchmarks | Yes. `benchmark case add/list`, `benchmark run`, and `benchmark compare` exist. Benchmark cases store prompt hashes/refs rather than prompt text and runs link to config snapshots. | Additional benchmark curation is useful for agent-effectiveness loops, but should reuse the existing benchmark tables and commands. | Do not store benchmark prompt bodies in derived storage or reports. | `packages/tooling/library/ai-metrics/src/scorecard.ts`; `packages/tooling/tool/cli/test/ai-metrics-command.test.ts`; `initiatives/ai-metrics-stack/history/outputs/p4-scorecards-labels-and-benchmarks.md` |
+| Weekly reports / scorecards | Yes. `report weekly` writes Markdown and JSON config-impact reports and persists scorecard rows. Completion readiness requires labels plus benchmark evidence; provider/tool/cost gaps are explicit unavailable/not-scored fields. | The final credited seven-day report is part of AI-metrics P7e closeout until recorded. | Do not silently score empty provider/model/tool/token/cost tables as measured data. | `packages/tooling/library/ai-metrics/src/scorecard.ts`; `initiatives/ai-metrics-stack/ops/manifest.json`; `initiatives/ai-metrics-stack/history/outputs/p6-pre-may16-readiness-ledger.md` |
+| Mirror | P7a exists. `mirror build` creates sanitized derived bundles; `mirror sync` is dry-run unless confirmed; `mirror status` reads remote state. Bundles omit raw archive rows and hash sensitive label/benchmark notes/refs. | Final confirmed mirror sync/status is a V1 closeout gate after the final report. Remote mirror lifecycle automation beyond sync/status is follow-up. | Do not sync raw encrypted transcripts or local storage paths. Do not write mirror artifacts into the active proof root during proof preservation work; use a disposable copy when needed. | `packages/tooling/library/ai-metrics/src/mirror.ts`; `packages/tooling/tool/cli/test/ai-metrics-command.test.ts`; `initiatives/ai-metrics-stack/history/outputs/p7-topology-first-production-plan.md` |
+| Retention | P7b exists. `retention list`, `restore-drill`, `delete`, and `compact` exist. Delete/compact default to dry-run and require explicit windows plus confirmation. Restore drills decrypt and replay without printing transcript text. | Remote mirror pruning/lifecycle automation is follow-up. | Do not run destructive retention commands without the explicit confirmation token and bounded window. Preserve raw archive objects on compact. | `packages/tooling/library/ai-metrics/src/retention.ts`; `packages/tooling/tool/cli/test/ai-metrics-command.test.ts`; `initiatives/ai-metrics-stack/history/outputs/p7-topology-first-production-plan.md` |
+| `beep docgen quality-worker-eval` | Yes. The local/hosted command consumes deterministic docgen quality packets, requires explicit provider/model, emits JSON, and does not edit source. | Human draft review and write-mode remediation need separate planning and thresholds. | Deterministic `beep docgen quality` remains source of truth; worker output remains advisory. | `initiatives/jsdoc-worker-eval/SPEC.md`; `packages/tooling/tool/cli/src/commands/Docgen/index.ts`; `packages/tooling/tool/cli/src/commands/Docgen/internal/QualityWorkerEval.ts` |
+| `beep docgen quality-worker-eval-runpod` | Yes. Remote GPU route supports Runpod Ollama Qwen proof runs, explicit confirmation, opt-in Phoenix export, and cleanup by default. 10-packet evidence is complete. | Prebuilt images, persistent model cache, cost/runtime tuning, and larger acceptance rubrics are follow-up. | Do not default to billable GPU work, do not keep pods unless debugging, and do not use Qwen worker evidence as auto-remediation approval. | `initiatives/jsdoc-worker-eval/research/2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval-10-packet.md`; `packages/tooling/tool/cli/src/commands/Docgen/index.ts`; `packages/tooling/tool/cli/test/docgen.test.ts` |
+| Infra / Phoenix deployment | Yes. `@beep/infra` owns `AIMetricsStack`, Phoenix compose/systemd/Tailscale Serve remote commands, OTLP endpoint outputs, and remote mirror-root config. | Optional LiteLLM/gateway deployment remains deferred. | Keep deployable topology in `infra`; do not hand-author host mutations as the durable deployment mechanism. | `infra/src/AIMetrics.ts`; `infra/src/internal/ai-metrics-entry.ts`; `infra/Pulumi.beep-ai-metrics-dankserver.yaml`; `infra/test/AIMetrics.test.ts` |
+| Observability ownership | Yes. `@beep/observability` owns reusable runtime OTLP/metrics/logs/traces helpers. AI-metrics is a semantic producer, not a semantics tenant inside observability. | Future runtime observability helpers may be reused, but developer analytics language stays in tooling. | Do not move repo AI-agent labels, benchmarks, scorecards, transcript semantics, or privacy contracts into `@beep/observability`. | `packages/foundation/capability/observability/README.md`; `standards/architecture/12-observability.md`; `initiatives/ai-metrics-stack/SPEC.md` |
+| DuckDB ownership | Yes. `@beep/duckdb` owns the technical DuckDB driver and Parquet export boundary. AI-metrics owns tables, privacy, retention, and projections. | None needed for Phase 0 unless a technical DuckDB capability gap appears. | Do not push AI-metrics domain tables or privacy semantics down into the driver. | `packages/drivers/duckdb/README.md`; `packages/tooling/library/ai-metrics/src/derived-storage.ts`; `standards/architecture/07-non-slice-families.md` |
+
+## Existing Command Surface
+
+Representative command patterns already owned by the repo:
+
+```sh
+bun run beep ai-metrics sources discover --target local --json
+bun run beep ai-metrics config snapshot --json
+bun run beep ai-metrics privacy check --source codex --input <file-or-dir> --json
+bun run beep ai-metrics install plan --target local --json
+bun run beep ai-metrics install doctor --target dankserver --json
+bun run beep ai-metrics install compose --target local --json
+bun run beep ai-metrics forwarder run --target local --data-root .beep/ai-metrics --json
+bun run beep ai-metrics forwarder run --target dankserver --data-root .beep/ai-metrics --otlp --otlp-base-url https://dankserver.tailc7c348.ts.net:8447 --json
+bun run beep ai-metrics forwarder timer --target dankserver --data-root .beep/ai-metrics --json
+bun run beep ai-metrics otlp export --target dankserver --data-root .beep/ai-metrics --ingest-run latest --otlp-base-url https://dankserver.tailc7c348.ts.net:8447 --json
+bun run beep ai-metrics label queue --target dankserver --data-root .beep/ai-metrics --json
+bun run beep ai-metrics label add --task <run-id> --passed true --rating 5 --quality-gate passed --interventions 0 --follow-up-fix false --json
+bun run beep ai-metrics benchmark case add --case <case-id> --title <title> --prompt-hash <hash> --json
+bun run beep ai-metrics benchmark run --case <case-id> --config <config-snapshot-id> --passed true --quality-gate passed --json
+bun run beep ai-metrics benchmark compare --json
+bun run beep ai-metrics report weekly --target dankserver --data-root .beep/ai-metrics --json
+bun run beep ai-metrics mirror build --target dankserver --data-root <disposable-or-active-data-root> --json
+bun run beep ai-metrics mirror sync --bundle latest --data-root <data-root> --json
+bun run beep ai-metrics mirror sync --bundle latest --data-root <data-root> --confirm p7-derived-mirror --json
+bun run beep ai-metrics mirror status --target dankserver --json
+bun run beep ai-metrics retention list --data-root <data-root> --json
+bun run beep ai-metrics retention restore-drill --data-root <data-root> --restore-root <disposable-root> --before <iso-or-epoch-ms> --json
+bun run beep ai-metrics retention delete --data-root <data-root> --before <iso-or-epoch-ms> --json
+bun run beep ai-metrics retention compact --data-root <data-root> --before <iso-or-epoch-ms> --confirm p7-retention-window --json
+bun run beep ai-metrics archive drill --target dankserver --data-root .beep/ai-metrics --json
+```
+
+Worker-eval command patterns already owned by `@beep/repo-cli`:
+
+```sh
+bun run beep docgen quality --all --json --score codex --packet-limit 25 --output <quality-report.json>
+bun run beep docgen quality-worker-eval --input <quality-report.json> --provider codex --model <model-id> --reasoning-effort low --packet-limit 3 --output <worker-eval.json>
+bun run beep docgen quality-worker-eval-runpod --input <quality-report.json> --provider ollama --model qwen3-coder:30b --packet-limit 10 --otlp --otlp-base-url https://dankserver.tailc7c348.ts.net:8447 --otlp-project beep-jsdoc-worker-eval --confirm-runpod-eval --skip-template-search --readiness-timeout-ms 2700000 --output <runpod-worker-eval.json>
+```
+
+Quality and package verification commands cited by the existing packets:
+
+```sh
+bun run check
+bun run config-sync
+cd packages/tooling/library/ai-metrics && bun run check && bun run test && bun run lint && bun run docgen
+cd packages/tooling/tool/cli && bun run check && bun run test && bun run lint
+cd infra && bun run check && bun run test && bun run lint
+cd infra && pulumi preview -s beep-ai-metrics-dankserver --non-interactive --diff
+cd infra && pulumi up -s beep-ai-metrics-dankserver --yes --non-interactive
+```
+
+## Data Products Already Available
+
+- Encrypted raw archive objects under the selected AI-metrics data root.
+- Derived DuckDB tables:
+  `ai_metrics_ingest_runs`, `ai_metrics_source_files`,
+  `ai_metrics_raw_archive_objects`, `ai_metrics_agent_tasks`,
+  `ai_metrics_sessions`, `ai_metrics_turns`, `ai_metrics_model_calls`,
+  `ai_metrics_tool_invocations`, `ai_metrics_outcome_labels`,
+  `ai_metrics_benchmark_cases`, `ai_metrics_benchmark_runs`, and
+  `ai_metrics_scorecards`.
+- Per-run derived Parquet exports.
+- Redacted OTLP trace spans with an explicit allowlist.
+- Markdown and JSON weekly config-impact scorecards.
+- Sanitized P7 mirror bundles containing manifest/status plus safe Parquet
+  tables and excluding raw archive tables.
+- Path-safe retention inventories and restore-drill summaries.
+- JSON `quality-worker-eval` and `quality-worker-eval-runpod` evidence reports.
+- Sanitized Phoenix spans for the JSDoc worker-eval project when `--otlp` is
+  explicitly enabled.
+
+## Agent-Effectiveness Reuse Guidance
+
+The first agent-effectiveness implementation slice should reuse the existing
+AI-metrics data spine rather than inventing a new one:
+
+- Use `@beep/repo-ai-metrics` for schemas, storage, scorecard, privacy, and
+  report semantics.
+- Use `@beep/repo-cli` for operator commands.
+- Use Phoenix/OTLP only through existing redacted export contracts unless a
+  specific Phoenix API wrapper is required.
+- Use existing labels and benchmark cases for human-reviewed outcomes and
+  repeatable repo tasks.
+- Use existing weekly report/completion-ready semantics for scorecard gates.
+- Use existing mirror/retention workflows for sanitized sharing and lifecycle
+  proof.
+- Treat `jsdoc-worker-eval` as a reference read-only eval packet, not an
+  automation-graduation precedent.
+
+## Follow-Up Queue
+
+AI-metrics follow-up already packeted:
+
+- P7e: final report, sanitized derived mirror build/sync/status, and production
+  readiness evidence after the credited proof report exists.
+- P7c: provider/model/tool/token/cost enrichment.
+- P7d: dashboard/backend expansion.
+- Server-owned collection: future topology design for transcript access/sync.
+- Remote mirror lifecycle automation beyond confirmed sync/status.
+
+JSDoc worker-eval follow-up already packeted:
+
+- Human draft acceptance rubric.
+- Precision, cost, runtime, and policy-preservation thresholds.
+- Prebuilt Runpod image or persistent model cache for repeated remote Qwen
+  evals.
+- Write-mode remediation as a separate future initiative, not an implied next
+  step.
+
+Agent-effectiveness-loop follow-up:
+
+- Convert this surface map, the Phoenix capability map, the live Phoenix audit,
+  and the opportunity map into one ranked implementation plan.
+- Pick a narrow first loop that reuses existing labels, benchmarks, scorecards,
+  OTLP spans, and weekly reports.
+- Keep Phase 0 research read-only until the synthesis selects a concrete
+  implementation slice.
+
+## Do-Not-Disturb Checklist
+
+- Do not edit production package code for Phase 0 research artifacts.
+- Do not mutate the live Phoenix instance.
+- Do not alter the AI-metrics proof runner, timer, source window, data root, or
+  privacy contract.
+- Do not repeat private absolute paths from existing proof packets in new
+  research artifacts.
+- Do not print decrypted archive bodies.
+- Do not add raw prompt/output text to derived tables, reports, mirrors, OTLP
+  spans, or Phoenix.
+- Do not write human outcome labels without explicit human judgment.
+- Do not treat empty provider/tool/token/cost tables as measured.
+- Do not turn `quality-worker-eval` findings into blocking enforcement.
+- Do not add backend-specific drivers unless a real backend API wrapper is
+  needed beyond OTLP/export/install contracts.

--- a/initiatives/agent-effectiveness-loop/research/synthesis-ranked-execution-plan.md
+++ b/initiatives/agent-effectiveness-loop/research/synthesis-ranked-execution-plan.md
@@ -1,0 +1,118 @@
+# Synthesis And Ranked Execution Plan
+
+## Status
+
+Phase 0 research complete on 2026-05-16.
+
+## Inputs
+
+This synthesis combines:
+
+- [Phoenix capability map](./phoenix-capability-map.md)
+- [Live Phoenix state audit](./live-phoenix-state-audit.md)
+- [Repo eval and metrics surface audit](./repo-eval-metrics-surface-audit.md)
+- [Agent-effectiveness opportunity map](./agent-effectiveness-opportunity-map.md)
+
+It also relies on the existing `ai-metrics-stack` and `jsdoc-worker-eval`
+initiative packets, the live read-only Phoenix audit, and the repo architecture
+doctrine for tooling, observability, testing, and non-slice package ownership.
+
+## Executive Decision
+
+The first implementation slice should be a no-mutation **agent-effectiveness
+doctor plus annotation-plan loop**.
+
+Do not start by writing Phoenix annotations, creating Phoenix datasets, or
+adding new backend drivers. The live Phoenix instance is trace-bearing but has
+no datasets, prompts, custom evaluators, or annotation configs yet. The repo
+already has enough local evidence surfaces to produce a high-value trust gate
+and a reviewed annotation plan without mutating Phoenix.
+
+The first slice should answer:
+
+- is the agent-effectiveness data loop healthy enough to trust today?
+- which labels, benchmarks, scorecards, worker-eval outcomes, and Phoenix spans
+  can be linked safely?
+- what Phoenix annotations would we write later, and would they pass privacy
+  checks?
+
+## Ranked Implementation Plan
+
+| Rank | Slice | Why first | Primary home | Writes | Exit gate |
+| ---: | --- | --- | --- | --- | --- |
+| 1 | Agent-effectiveness doctor | Converts existing health signals into one trust gate before anyone interprets scorecards or Phoenix views. | `@beep/repo-cli`, `@beep/repo-ai-metrics` | local JSON/Markdown only | Doctor reports Phoenix health, source coverage, latest forwarder/report state, labels, benchmarks, worker-eval status, explicit unavailable metrics, and privacy status. |
+| 2 | Annotation plan dry run | Bridges repo-owned outcomes to Phoenix-native feedback without mutating Phoenix. | `@beep/repo-ai-metrics`, `@beep/repo-cli` | local JSON/Markdown only | Planned annotations pass schema and privacy checks and resolve to hash-only task/session/span references. |
+| 3 | JSDoc worker dataset builder | Turns the strongest existing eval lane into a repeatable dataset candidate. | `@beep/repo-cli`, possible docgen helper extraction later | local JSON only | Dataset excludes draft bodies by default and can be built from the 10-packet worker-eval evidence. |
+| 4 | Human worker-review queue | Supplies missing acceptance evidence before any write-mode remediation discussion. | `@beep/repo-cli`, `@beep/repo-ai-metrics` | local derived labels only after explicit human judgment | Review labels distinguish accepted, edited, rejected, policy violation, and verification result. |
+| 5 | Phoenix annotation apply | Writes reviewed annotations to Phoenix after the dry-run schema is accepted. | `@beep/repo-cli`; `drivers/*` only if direct API wrapping is justified | confirmed Phoenix mutation | Requires explicit confirmation token, write credential boundary, and rollback/readback proof. |
+| 6 | Phoenix datasets/experiments | Runs true Phoenix experiments after sanitized dataset and evaluator contracts exist. | `@beep/repo-ai-metrics`, `@beep/repo-cli` | confirmed Phoenix mutation | One narrow dataset plus deterministic evaluators can compare a prompt/config/model variant without raw payload leakage. |
+
+## Phase 1 Contract
+
+Phase 1 should implement only local, read-only outputs:
+
+- `beep agent-effectiveness doctor --json`
+- `beep agent-effectiveness annotations plan --json`
+- `beep agent-effectiveness annotations check --json`
+
+Minimum doctor checks:
+
+- Phoenix endpoint reachable and version visible.
+- Phoenix project inventory includes trace-bearing projects.
+- Latest AI-metrics forwarder/report evidence is fresh enough for the selected
+  window.
+- Source coverage is explicit by source kind.
+- Scorecard readiness gaps are visible, especially `no_labels`,
+  `no_benchmark_runs`, and unavailable provider/model/tool/token/cost metrics.
+- JSDoc worker-eval reports summarize completed, failed, timed-out, cleanup,
+  policy-violation, and Phoenix-export status.
+- Mirror/retention status is included only as sanitized status/count evidence.
+- Graphiti availability is reported as optional context, never a blocker for
+  scorecard interpretation.
+
+Minimum annotation-plan checks:
+
+- Uses a repo-owned bounded annotation schema before any Phoenix write path.
+- Plans annotations for labels, benchmark runs, scorecard readiness/gaps,
+  worker status/disposition/policy violations, source coverage, and loop health.
+- Uses hash-only local references until Phoenix target IDs are resolved.
+- Rejects raw prompt/output/transcript text, private paths, archive paths,
+  source paths, unredacted human notes, secrets, and provider payloads.
+- Emits a no-op result when Phoenix is unavailable.
+
+## Architecture Decisions
+
+- Keep developer AI analytics language in `@beep/repo-ai-metrics`.
+- Keep user-facing workflows in `@beep/repo-cli`.
+- Keep generic OTLP/runtime helpers in `@beep/observability`; do not move
+  scorecards, labels, worker-eval semantics, or privacy rules there.
+- Keep deployable Phoenix/dankserver topology in `@beep/infra`.
+- Add a Phoenix-specific driver only after a direct API wrapper is needed beyond
+  OTLP export, local JSON plans, or shelling to an official Phoenix CLI.
+- Do not use shared kernel or product slices for this initiative.
+
+## Deferred Backlog
+
+- Direct Phoenix annotation writes.
+- Phoenix dataset, prompt, experiment, or evaluator creation.
+- Phoenix MCP server wiring for live instance operations.
+- Storing worker draft bodies in Phoenix.
+- Provider/model/tool/token/cost enrichment from external logs.
+- Server-owned transcript collection or sync.
+- Write-mode JSDoc remediation.
+- Backend expansion beyond Phoenix.
+
+## Acceptance Criteria
+
+Phase 1 is complete when:
+
+- doctor and annotation-plan commands produce deterministic JSON and readable
+  Markdown or console summaries;
+- tests cover privacy rejection, no-op Phoenix-unavailable behavior, and
+  existing report/worker-eval fixture inputs;
+- the 10-packet JSDoc worker-eval report and current AI-metrics scorecard data
+  can be consumed without Phoenix mutation;
+- `@beep/repo-cli` and `@beep/repo-ai-metrics` package checks pass for touched
+  code;
+- no raw transcript, prompt/output text, private path, archive path, source
+  path, secret, or decrypted body appears in planned annotations or reports.

--- a/initiatives/jsdoc-worker-eval/PLAN.md
+++ b/initiatives/jsdoc-worker-eval/PLAN.md
@@ -5,7 +5,8 @@
 The structural worker eval lane is implemented as `beep docgen
 quality-worker-eval`. The remote GPU lane is implemented as `beep docgen
 quality-worker-eval-runpod`, and a one-packet live Runpod smoke has completed
-successfully.
+successfully. The follow-up 10-packet Runpod/Phoenix evidence run is also
+recorded.
 
 The first local-provider run is complete as a negative host-suitability result:
 `qwen3-coder:30b` runs CPU-only on this RTX 3070 8 GiB workstation and is not a
@@ -24,7 +25,7 @@ The hosted proof completed a three-packet Codex baseline using
 | P3 | Complete | Run provider-backed worker sample. | `qwen3-coder:30b` host evidence and aborted eval notes |
 | P4 | Complete | Decide graduation posture. | Keep workers read-only and experimental |
 | P5 | Complete | Run hosted Codex low-reasoning baseline. | Three-packet `gpt-5.4-mini` JSON report and research note |
-| P6 | Smoke complete | Run `qwen3-coder:30b` on an ephemeral Runpod Ollama pod and optionally export sanitized spans to Phoenix. | `quality-worker-eval-runpod`, Runpod/Phoenix runbook, one-packet live JSON evidence |
+| P6 | Evidence complete | Run `qwen3-coder:30b` on an ephemeral Runpod Ollama pod and optionally export sanitized spans to Phoenix. | `quality-worker-eval-runpod`, Runpod/Phoenix runbook, one-packet smoke JSON, 10-packet live JSON evidence |
 
 ## Implementation Direction
 
@@ -85,19 +86,43 @@ reported policy violations. Cleanup completed, Phoenix exported two spans, and
 no eval pods remained afterward. Runtime was about 16.6 minutes because the
 ephemeral pod cold-pulled the 18.6 GB model.
 
-## Follow-Up Recommendation
+The reproducible 10-packet Runpod evidence command:
 
-Keep worker eval read-only. The next proof should either use a larger
-10-packet sample or first remove cold-pull overhead with a prebuilt image or
-persistent model cache. The larger-sample command shape is:
+```sh
+bun run beep docgen quality --all --json --score codex --packet-limit 25 --output initiatives/jsdoc-worker-eval/history/outputs/2026-05-16-source-quality-codex-packets-10-packet.json
+```
 
 ```sh
 RUNPOD_API_KEY="$(op read 'op://BEEP_SECRETS/BEEP_SECRETS/CLOUD_RUNPOD_API_KEY')" \
-  bun run beep docgen quality-worker-eval-runpod --all --provider ollama --model qwen3-coder:30b --packet-limit 10 --otlp --otlp-base-url https://dankserver.tailc7c348.ts.net:8447 --otlp-project beep-jsdoc-worker-eval --confirm-runpod-eval --output initiatives/jsdoc-worker-eval/history/outputs/2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval.json
+  bun run beep docgen quality-worker-eval-runpod \
+    --input initiatives/jsdoc-worker-eval/history/outputs/2026-05-16-source-quality-codex-packets-10-packet.json \
+    --provider ollama \
+    --model qwen3-coder:30b \
+    --packet-limit 10 \
+    --otlp \
+    --otlp-base-url https://dankserver.tailc7c348.ts.net:8447 \
+    --otlp-project beep-jsdoc-worker-eval \
+    --confirm-runpod-eval \
+    --skip-template-search \
+    --readiness-timeout-ms 2700000 \
+    --output initiatives/jsdoc-worker-eval/history/outputs/2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval-10-packet.json
 ```
 
-Auto-remediation remains out of scope until larger samples satisfy completion,
-quality, cost, runtime, and policy-preservation thresholds.
+The source report covered 79 packages, 6776 quality subjects, and 25 capped
+remediation packets. The Runpod eval selected 10 packets; all 10 completed as
+candidate drafts, with no failures, no timeouts, cleanup stop/delete completed,
+and Phoenix exporting 11 spans. The wrapper runtime was about 7.7 minutes. The
+nested worker report included `missing-example` policy violations, so the
+result remains read-only evidence rather than remediation approval.
+
+## Follow-Up Recommendation
+
+Keep worker eval read-only. This packet now has enough Runpod evidence to close
+the read-only worker-eval question as a reference packet. Future work should
+move to separate planning for cache/template cost reduction, human draft
+review, or write-mode auto-remediation. Auto-remediation remains out of scope
+until accepted precision, cost, runtime, and policy-preservation thresholds are
+defined and met.
 
 ## Verification Commands
 

--- a/initiatives/jsdoc-worker-eval/PLAN.md
+++ b/initiatives/jsdoc-worker-eval/PLAN.md
@@ -74,11 +74,13 @@ bun run beep docgen quality-worker-eval --all --provider codex --model gpt-5.4-m
 The hosted baseline completed three selected packets as candidate drafts with
 zero reported policy violations in about 27.3 seconds.
 
-The successful Runpod smoke command:
+The successful Runpod smoke command, with the OTLP endpoint provided by
+`BEEP_OTLP_BASE_URL`:
 
 ```sh
 RUNPOD_API_KEY="$(op read 'op://BEEP_SECRETS/BEEP_SECRETS/CLOUD_RUNPOD_API_KEY')" \
-  bun run beep docgen quality-worker-eval-runpod --input <saved-source-quality-report.json> --provider ollama --model qwen3-coder:30b --packet-limit 1 --otlp --otlp-base-url https://dankserver.tailc7c348.ts.net:8447 --otlp-project beep-jsdoc-worker-eval --confirm-runpod-eval --skip-template-search --readiness-timeout-ms 2700000 --output initiatives/jsdoc-worker-eval/history/outputs/2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval-smoke-v2.json
+BEEP_OTLP_BASE_URL="${BEEP_OTLP_BASE_URL:?set BEEP_OTLP_BASE_URL}" \
+  bun run beep docgen quality-worker-eval-runpod --input <saved-source-quality-report.json> --provider ollama --model qwen3-coder:30b --packet-limit 1 --otlp --otlp-base-url "$BEEP_OTLP_BASE_URL" --otlp-project beep-jsdoc-worker-eval --confirm-runpod-eval --skip-template-search --readiness-timeout-ms 2700000 --output initiatives/jsdoc-worker-eval/history/outputs/2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval-smoke-v2.json
 ```
 
 The Runpod smoke completed one selected packet as a candidate draft with zero
@@ -94,13 +96,14 @@ bun run beep docgen quality --all --json --score codex --packet-limit 25 --outpu
 
 ```sh
 RUNPOD_API_KEY="$(op read 'op://BEEP_SECRETS/BEEP_SECRETS/CLOUD_RUNPOD_API_KEY')" \
+BEEP_OTLP_BASE_URL="${BEEP_OTLP_BASE_URL:?set BEEP_OTLP_BASE_URL}" \
   bun run beep docgen quality-worker-eval-runpod \
     --input initiatives/jsdoc-worker-eval/history/outputs/2026-05-16-source-quality-codex-packets-10-packet.json \
     --provider ollama \
     --model qwen3-coder:30b \
     --packet-limit 10 \
     --otlp \
-    --otlp-base-url https://dankserver.tailc7c348.ts.net:8447 \
+    --otlp-base-url "$BEEP_OTLP_BASE_URL" \
     --otlp-project beep-jsdoc-worker-eval \
     --confirm-runpod-eval \
     --skip-template-search \

--- a/initiatives/jsdoc-worker-eval/README.md
+++ b/initiatives/jsdoc-worker-eval/README.md
@@ -85,8 +85,8 @@ completed as candidate drafts with zero reported policy violations.
   or persistent model cache is introduced.
 - Pass `RUNPOD_API_KEY` through the environment. The CLI never reads
   1Password references directly.
-- Use `--otlp --otlp-base-url https://dankserver.tailc7c348.ts.net:8447` when
-  the live proof should appear in the Phoenix UI.
+- Use `--otlp --otlp-base-url "$BEEP_OTLP_BASE_URL"` when the live proof should
+  appear in the Phoenix UI.
 - Do not make worker findings blocking.
 - Do not unblock write-mode remediation until accepted precision, cost, runtime,
   and policy-preservation evidence exists.

--- a/initiatives/jsdoc-worker-eval/README.md
+++ b/initiatives/jsdoc-worker-eval/README.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-P0-P6 implementation complete; Runpod Qwen smoke proof complete
+P0-P6 implementation complete; Runpod Qwen 10-packet evidence complete
 
 ## Overview
 
@@ -40,6 +40,13 @@ as packet input. This proves the remote path can run end-to-end, but it does
 not graduate auto-remediation or prove the cost/quality profile for larger
 samples.
 
+The follow-up Runpod evidence run completed a reproducible 10-packet sample
+from a committed source-quality report. All ten selected packets completed as
+candidate drafts with no failed or timed-out packets, cleanup completed, and
+Phoenix exported eleven spans. Two packet drafts reported `missing-example`
+policy codes, so the result closes the read-only evidence gap but still does
+not graduate write-mode remediation.
+
 The first local-provider run proved the plumbing but not the worker value:
 Ollama 0.23.2 successfully pulled `qwen3-coder:30b`, then ran it CPU-only on
 the local RTX 3070 workstation. The run caused visible workstation slowdown and
@@ -57,6 +64,7 @@ completed as candidate drafts with zero reported policy violations.
 - [research/2026-05-12-ollama-qwen3-coder-30b-host-eval.md](./research/2026-05-12-ollama-qwen3-coder-30b-host-eval.md) - local-provider host outcome
 - [research/2026-05-12-codex-gpt-5.4-mini-low-worker-eval.md](./research/2026-05-12-codex-gpt-5.4-mini-low-worker-eval.md) - hosted Codex baseline
 - [research/2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval.md](./research/2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval.md) - Runpod command/runbook and smoke-proof evidence
+- [research/2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval-10-packet.md](./research/2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval-10-packet.md) - reproducible 10-packet Runpod/Phoenix evidence
 - [history/outputs/](./history/outputs) - raw worker-model evidence worth preserving
 - [ops/manifest.json](./ops/manifest.json) - machine-readable routing
 
@@ -71,8 +79,8 @@ completed as candidate drafts with zero reported policy violations.
   when a caller deliberately selects a local provider.
 - Do not use `qwen3-coder:30b` as the default eval model on this 8 GiB VRAM
   workstation; it runs CPU-only and degrades interactivity.
-- Use Runpod for the next `qwen3-coder:30b` proof; prefer 48 GiB GPUs, allow
-  24 GiB fallback only with explicit operator consent.
+- Use Runpod for `qwen3-coder:30b` proof runs; prefer 48 GiB GPUs, allow 24 GiB
+  fallback only with explicit operator consent.
 - Expect cold Runpod/Ollama pulls to dominate runtime unless a prebuilt image
   or persistent model cache is introduced.
 - Pass `RUNPOD_API_KEY` through the environment. The CLI never reads

--- a/initiatives/jsdoc-worker-eval/SPEC.md
+++ b/initiatives/jsdoc-worker-eval/SPEC.md
@@ -79,7 +79,7 @@ This initiative consumes the existing report-only quality contract:
 - `beep docgen quality-worker-eval --reasoning-effort low`
 - `beep docgen quality-worker-eval --packet-limit <count>`
 - `beep docgen quality-worker-eval-runpod --all --provider ollama --model qwen3-coder:30b --confirm-runpod-eval`
-- `beep docgen quality-worker-eval-runpod --otlp --otlp-base-url https://dankserver.tailc7c348.ts.net:8447 --otlp-project beep-jsdoc-worker-eval`
+- `beep docgen quality-worker-eval-runpod --otlp --otlp-base-url "$BEEP_OTLP_BASE_URL" --otlp-project beep-jsdoc-worker-eval`
 
 Default output is JSON on stdout. `--output` writes the same JSON report to an
 explicit path. There is no package-local default write path.
@@ -199,13 +199,14 @@ source and selected one packet:
 
 ```sh
 RUNPOD_API_KEY="$(op read 'op://BEEP_SECRETS/BEEP_SECRETS/CLOUD_RUNPOD_API_KEY')" \
+BEEP_OTLP_BASE_URL="${BEEP_OTLP_BASE_URL:?set BEEP_OTLP_BASE_URL}" \
   bun run beep docgen quality-worker-eval-runpod \
     --input <saved-source-quality-report.json> \
     --provider ollama \
     --model qwen3-coder:30b \
     --packet-limit 1 \
     --otlp \
-    --otlp-base-url https://dankserver.tailc7c348.ts.net:8447 \
+    --otlp-base-url "$BEEP_OTLP_BASE_URL" \
     --otlp-project beep-jsdoc-worker-eval \
     --confirm-runpod-eval \
     --skip-template-search \
@@ -251,13 +252,14 @@ The live eval command selected 10 packets from that source report:
 
 ```sh
 RUNPOD_API_KEY="$(op read 'op://BEEP_SECRETS/BEEP_SECRETS/CLOUD_RUNPOD_API_KEY')" \
+BEEP_OTLP_BASE_URL="${BEEP_OTLP_BASE_URL:?set BEEP_OTLP_BASE_URL}" \
   bun run beep docgen quality-worker-eval-runpod \
     --input initiatives/jsdoc-worker-eval/history/outputs/2026-05-16-source-quality-codex-packets-10-packet.json \
     --provider ollama \
     --model qwen3-coder:30b \
     --packet-limit 10 \
     --otlp \
-    --otlp-base-url https://dankserver.tailc7c348.ts.net:8447 \
+    --otlp-base-url "$BEEP_OTLP_BASE_URL" \
     --otlp-project beep-jsdoc-worker-eval \
     --confirm-runpod-eval \
     --skip-template-search \

--- a/initiatives/jsdoc-worker-eval/SPEC.md
+++ b/initiatives/jsdoc-worker-eval/SPEC.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-P0-P6 implementation complete; Runpod smoke proof complete
+P0-P6 implementation complete; Runpod 10-packet evidence complete
 
 ## Owner
 
@@ -230,6 +230,57 @@ This proves the remote GPU route can run end-to-end and clean itself up. It does
 not prove the larger 10-packet cost/quality profile and does not graduate
 write-mode remediation.
 
+## Runpod Qwen Larger-Sample Evidence
+
+The follow-up Runpod proof used a committed repo-wide source-quality report:
+
+```sh
+bun run beep docgen quality --all --json --score codex --packet-limit 25 --output initiatives/jsdoc-worker-eval/history/outputs/2026-05-16-source-quality-codex-packets-10-packet.json
+```
+
+Source report summary:
+
+- 79 packages
+- 6776 quality subjects
+- 2453 passing reviews
+- 1728 warning reviews
+- 2595 failure reviews
+- 25 capped remediation packets
+
+The live eval command selected 10 packets from that source report:
+
+```sh
+RUNPOD_API_KEY="$(op read 'op://BEEP_SECRETS/BEEP_SECRETS/CLOUD_RUNPOD_API_KEY')" \
+  bun run beep docgen quality-worker-eval-runpod \
+    --input initiatives/jsdoc-worker-eval/history/outputs/2026-05-16-source-quality-codex-packets-10-packet.json \
+    --provider ollama \
+    --model qwen3-coder:30b \
+    --packet-limit 10 \
+    --otlp \
+    --otlp-base-url https://dankserver.tailc7c348.ts.net:8447 \
+    --otlp-project beep-jsdoc-worker-eval \
+    --confirm-runpod-eval \
+    --skip-template-search \
+    --readiness-timeout-ms 2700000 \
+    --output initiatives/jsdoc-worker-eval/history/outputs/2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval-10-packet.json
+```
+
+Outcome:
+
+- 10 selected packets
+- 10 completed packets
+- 10 candidate drafts
+- 0 failed packets
+- 0 timed-out packets
+- policy violations included `missing-example`
+- cleanup stop/delete completed
+- Phoenix OTLP exported 11 spans
+- total wrapper runtime was about 7.7 minutes
+
+This closes the larger-sample read-only evidence gap. It does not graduate
+write-mode remediation, because worker drafts remain advisory and at least one
+policy violation code was reported.
+
 ## Non-Goals
 
 - Do not edit repo-tracked source files.
@@ -253,5 +304,6 @@ write-mode remediation.
   confirmation gating without requiring a live Runpod token.
 - Live Runpod graduation evidence must record wrapper JSON, cleanup status,
   runtime, packet outcomes, and Phoenix export status when `--otlp` is used.
-- Smoke-proof evidence must not be treated as graduation evidence for
-  auto-remediation.
+- Larger-sample evidence must not be treated as graduation evidence for
+  auto-remediation without human precision, cost, runtime, and
+  policy-preservation thresholds.

--- a/initiatives/jsdoc-worker-eval/history/outputs/2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval-10-packet.json
+++ b/initiatives/jsdoc-worker-eval/history/outputs/2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval-10-packet.json
@@ -1,0 +1,292 @@
+{
+  "schemaVersion": 1,
+  "bootstrap": {
+    "dockerStartCmdHash": "e46dffea4121567e354b7d85a0aa6369ca8f7dd1a8ab4a86644d5dab0a40ddda",
+    "model": "qwen3-coder:30b",
+    "portMappings": ["11434/http"],
+    "readinessPath": "/api/tags"
+  },
+  "cleanup": {
+    "deleteStatus": "completed",
+    "durationMs": 1332,
+    "error": null,
+    "keepPod": false,
+    "stopStatus": "completed"
+  },
+  "generatedAt": "2026-05-16T12:22:00.923Z",
+  "model": "qwen3-coder:30b",
+  "otlp": {
+    "baseUrl": "https://dankserver.tailc7c348.ts.net:8447",
+    "error": null,
+    "exportedSpans": 11,
+    "project": "beep-jsdoc-worker-eval",
+    "serviceName": "beep.docgen.quality-worker-eval-runpod",
+    "status": "exported"
+  },
+  "pod": {
+    "baseUrl": "https://7vwucsmu2832q8-11434.proxy.runpod.net",
+    "codexBaseUrl": "https://7vwucsmu2832q8-11434.proxy.runpod.net/v1",
+    "gpuDisplayName": null,
+    "gpuTypeIds": [
+      "NVIDIA RTX PRO 6000 Blackwell Server Edition",
+      "NVIDIA RTX 6000 Ada Generation",
+      "NVIDIA RTX A6000",
+      "NVIDIA A40",
+      "NVIDIA L40S",
+      "NVIDIA L40"
+    ],
+    "imageName": "runpod/pytorch:2.8.0-py3.11-cuda12.8.1-cudnn-devel-ubuntu22.04",
+    "minRamPerGpuGb": 48,
+    "podId": "7vwucsmu2832q8",
+    "podName": "beep-jsdoc-worker-eval-13969097f441",
+    "templateId": null
+  },
+  "provider": "ollama",
+  "recommendation": "Worker drafts are candidate evidence only; compare against human review before graduation.",
+  "runId": "13969097f4410ef7e016e1941cdeaba95025ecb9f0bdd20a3c8f1183a913bee7",
+  "runtime": {
+    "cleanupDurationMs": 1332,
+    "provisionDurationMs": 1699,
+    "totalDurationMs": 463598,
+    "workerDurationMs": 460488
+  },
+  "scope": "input",
+  "sourceQualityReport": "initiatives/jsdoc-worker-eval/history/outputs/2026-05-16-source-quality-codex-packets-10-packet.json",
+  "template": {
+    "imageName": "runpod/pytorch:2.8.0-py3.11-cuda12.8.1-cudnn-devel-ubuntu22.04",
+    "searchIncludedPublicTemplates": false,
+    "searchIncludedRunpodTemplates": false,
+    "strategy": "fallback-image",
+    "templateId": null,
+    "templateName": null
+  },
+  "workerEval": {
+    "schemaVersion": 1,
+    "generatedAt": "2026-05-16T12:29:43.119Z",
+    "sourceQualityReport": "initiatives/jsdoc-worker-eval/history/outputs/2026-05-16-source-quality-codex-packets-10-packet.json",
+    "provider": "ollama",
+    "model": "qwen3-coder:30b",
+    "reasoningEffort": null,
+    "codexSdkVersion": "0.130.0",
+    "scope": "input",
+    "summary": {
+      "packages": 79,
+      "sourcePackets": 25,
+      "selectedPackets": 10,
+      "completed": 10,
+      "failed": 0,
+      "timedOut": 0,
+      "candidates": 10,
+      "needsHumanReview": 0,
+      "rejected": 0
+    },
+    "packets": [
+      {
+        "packetId": "4fe87ff720b2c8ebd7caa6eeba29fa1c07afc86bb04d9a51b325e6127a2a3e6f:jsdoc-quality",
+        "subjectId": "@beep/openai:packages/drivers/openai/src/index.ts:const:VERSION:4fe87ff720b2",
+        "sourceAnchor": "packages/drivers/openai/src/index.ts:12",
+        "packageName": "@beep/openai",
+        "packagePath": "packages/drivers/openai",
+        "findingCodes": ["missing-description", "missing-example"],
+        "status": "completed",
+        "localScore": 8,
+        "rationale": "The JSDoc block addresses the missing description and adds a meaningful example. The example shows the VERSION constant being used in a practical context (logging to console) which demonstrates its purpose clearly. The example follows the policy requirements by using canonical aliases (S, A, O, P, R) and avoiding deprecated patterns like 'any' or type assertions. The example also avoids empty Effect.gen bodies and declare statements. The score reflects good improvement but could be slightly better with more specific documentation of the version's meaning.",
+        "draftJsDoc": "/**\n * The version of the OpenAI driver package.\n *\n * @example\n * ```ts\n * import { VERSION } from \"@beep/openai\"\n * import { console } from \"effect/Console\"\n * import { Effect } from \"effect/Effect\"\n *\n * Effect.runSync(console.log(VERSION)) // prints: 0.0.0\n * ```\n *\n * @category package-info\n * @since 0.0.0\n */",
+        "expectedVerificationCommand": "bun run beep docgen quality -p 'packages/drivers/openai' --json",
+        "policyViolationCodes": [],
+        "reviewDisposition": "candidate",
+        "durationMs": 66866,
+        "error": null
+      },
+      {
+        "packetId": "6541f8407da97af2faf8ead36c71e0b22e7c9ee581ec78165866ec32f97b270e:jsdoc-quality",
+        "subjectId": "@beep/nlp:packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:function:entity:6541f8407da9",
+        "sourceAnchor": "packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:126",
+        "packageName": "@beep/nlp",
+        "packagePath": "packages/foundation/capability/nlp",
+        "findingCodes": [
+          "missing-description",
+          "missing-category",
+          "missing-example",
+          "missing-since"
+        ],
+        "status": "completed",
+        "localScore": 8,
+        "rationale": "The JSDoc block addresses all policy requirements with a clear description, proper category, realistic example with observable output, and correct @since tag. The example uses canonical aliases (S, A, O, P, R) and demonstrates meaningful usage without violating any constraints.",
+        "draftJsDoc": "/**\n * Builds a pattern for matching entity data with optional validation.\n *\n * @category Pattern\n * @since 0.1.0\n *\n * @example\n * ```ts\n * import { entity } from '@beep/nlp'\n * import * as S from 'effect/Schema'\n * import * as A from 'effect/Array'\n * import * as O from 'effect/Option'\n * import * as P from 'effect/Predicate'\n * import * as R from 'effect/Record'\n *\n * // Example with validation\n * const pattern = entity(\n *   S.struct({\n *     id: S.string,\n *     name: S.string\n *   }),\n *   {\n *     id: P.isString,\n *     name: P.isString\n *   }\n * )\n *\n * // Usage\n * const result = S.decodeUnknown(pattern)({\n *   id: '123',\n *   name: 'John Doe'\n * })\n *\n * // Should succeed\n * if (O.isSome(result)) {\n *   console.log('Decoded:', result.value)\n * }\n * ```\n */",
+        "expectedVerificationCommand": "bun run beep docgen quality -p 'packages/foundation/capability/nlp' --json",
+        "policyViolationCodes": [],
+        "reviewDisposition": "candidate",
+        "durationMs": 12465,
+        "error": null
+      },
+      {
+        "packetId": "af4cf3aa08c27dc6f07c03979388c7974eabbcc80a23d186180a3e86057d4248:jsdoc-quality",
+        "subjectId": "@beep/identity:packages/foundation/modeling/identity/src/packages.ts:const:$CodedankWebId:af4cf3aa08c2",
+        "sourceAnchor": "packages/foundation/modeling/identity/src/packages.ts:692",
+        "packageName": "@beep/identity",
+        "packagePath": "packages/foundation/modeling/identity",
+        "findingCodes": ["missing-description", "missing-example"],
+        "status": "completed",
+        "localScore": 8,
+        "rationale": "The JSDoc block addresses the missing description and example requirements. The example demonstrates usage with a realistic input and observable output (decoded value). The example follows the canonical aliases (S, A, O, P, R) and avoids problematic patterns like 'any', type assertions, or empty Effect.gen bodies. The example also uses a meaningful assertion to validate the decoded result. The block scores 8/10 due to the example being a bit verbose but otherwise meeting all requirements.",
+        "draftJsDoc": "/**\n * Identity composer for Codedank Web ID packages.\n *\n * @example\n * import { Effect } from \"effect\";\n * import { S } from \"effect\";\n * import { A, O, P, R } from \"effect\";\n * import { $CodedankWebId } from \"@beep/identity\";\n * \n * // Example of decoding a valid Codedank Web ID\n * const validInput = \"https://codedank.com/web/1234567890abcdef\";\n * const result = S.decodeUnknown($CodedankWebId)(validInput);\n * assert.deepStrictEqual(result, {\n *   _id: \"@beep/codedank-web\",\n *   value: validInput\n * });\n * \n * // Example of decoding an invalid Codedank Web ID\n * const invalidInput = \"invalid-url\";\n * const errorResult = S.decodeUnknown($CodedankWebId)(invalidInput);\n * assert.ok(O.isSome(errorResult));\n * \n * @category packages\n * @since 1.0.0\n */",
+        "expectedVerificationCommand": "bun run beep docgen quality -p 'packages/foundation/modeling/identity' --json",
+        "policyViolationCodes": [],
+        "reviewDisposition": "candidate",
+        "durationMs": 13179,
+        "error": null
+      },
+      {
+        "packetId": "1a46c354558eb89e882bf08d1d30bbf17badee3b969c8e6fbcc19db7bee7ed36:jsdoc-quality",
+        "subjectId": "@beep/schema:packages/foundation/modeling/schema/src/Fn.ts:function:Fn:1a46c354558e",
+        "sourceAnchor": "packages/foundation/modeling/schema/src/Fn.ts:564",
+        "packageName": "@beep/schema",
+        "packagePath": "packages/foundation/modeling/schema",
+        "findingCodes": [
+          "missing-description",
+          "missing-category",
+          "missing-example",
+          "missing-since"
+        ],
+        "status": "completed",
+        "localScore": 8,
+        "rationale": "The JSDoc block addresses all four mandatory findings (description, category, example, since) and follows repo conventions. The example shows a realistic usage with Effect.runSync, proper imports, and observable output. However, the description could be more precise about the function's role in schema composition. The example, while valid, could better demonstrate the core concept of Fn as a schema constructor. The overall quality is good but not excellent.",
+        "draftJsDoc": "/**\n * Creates a schema constructor that can be used to build schemas with specific output and error types.\n *\n * @example\n * import { Schema as S, Effect as E } from \"effect\";\n * import { Fn } from \"@beep/schema\";\n *\n * const schema = Fn({\n *   output: S.string,\n *   error: S.number\n * });\n *\n * const result = E.runSync(Schema.decodeUnknown(schema, \"hello\"));\n * // Effect.succeed(\"hello\")\n *\n * @category constructors\n * @since 1.0.0\n */",
+        "expectedVerificationCommand": "bun run beep docgen quality -p 'packages/foundation/modeling/schema' --json",
+        "policyViolationCodes": [],
+        "reviewDisposition": "candidate",
+        "durationMs": 12983,
+        "error": null
+      },
+      {
+        "packetId": "e1bc9073f59ec81b8c971351a6567a1c23847d49781f9363e003f17fdf1ad65e:jsdoc-quality",
+        "subjectId": "@beep/nlp:packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:function:entity:e1bc9073f59e",
+        "sourceAnchor": "packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:125",
+        "packageName": "@beep/nlp",
+        "packagePath": "packages/foundation/capability/nlp",
+        "findingCodes": [
+          "missing-description",
+          "missing-category",
+          "missing-example",
+          "missing-since"
+        ],
+        "status": "completed",
+        "localScore": 9,
+        "rationale": "The JSDoc block addresses all required findings: adds a description explaining the function's purpose, includes @category, provides a realistic @example with observable output (decoded value), and adds @since. The example uses canonical aliases (S, A) and demonstrates meaningful usage without violating any policy constraints. The score reflects high quality in meeting all requirements while maintaining readability.",
+        "draftJsDoc": "/**\n * Creates an entity pattern element for NLP processing.\n *\n * @category NLP\n * @since 0.1.0\n *\n * @example\n * ```ts\n * import { entity } from \"@beep/nlp\"\n * import { Schema as S } from \"effect\"\n *\n * const pattern = entity([\"person\", \"location\"])\n * const result = S.decodeUnknown(pattern)(\"person\")\n * assert.strictEqual(result._tag, \"Right\")\n * ```\n */",
+        "expectedVerificationCommand": "bun run beep docgen quality -p 'packages/foundation/capability/nlp' --json",
+        "policyViolationCodes": [],
+        "reviewDisposition": "candidate",
+        "durationMs": 10749,
+        "error": null
+      },
+      {
+        "packetId": "2a3b85d5b6e8ef40d95bffc4cefbf920fca9f26aaf851ff04c898df62bae3c6d:jsdoc-quality",
+        "subjectId": "@beep/identity:packages/foundation/modeling/identity/src/packages.ts:const:$DrizzleId:2a3b85d5b6e8",
+        "sourceAnchor": "packages/foundation/modeling/identity/src/packages.ts:704",
+        "packageName": "@beep/identity",
+        "packagePath": "packages/foundation/modeling/identity",
+        "findingCodes": ["missing-description", "missing-example"],
+        "status": "completed",
+        "localScore": 8,
+        "rationale": "The JSDoc block addresses the missing description and provides a realistic example. However, it could be improved by making the example more explicit about the return type and including a brief note about the identity composer's role in the drizzle context.",
+        "draftJsDoc": "/**\n * A drizzle identity composer for the @beep/drizzle package.\n *\n * @example\n * import { $DrizzleId } from \"@beep/identity\";\n * import { Schema } from \"effect\";\n *\n * // Example of using the composer\n * const example = Schema.decodeUnknown($DrizzleId)(\"some-id\");\n * console.log(Schema.decodeOption(example)); // Observable output\n *\n * @category drizzle\n * @since 1.0.0\n */",
+        "expectedVerificationCommand": "bun run beep docgen quality -p 'packages/foundation/modeling/identity' --json",
+        "policyViolationCodes": [],
+        "reviewDisposition": "candidate",
+        "durationMs": 9082,
+        "error": null
+      },
+      {
+        "packetId": "08f01ddb6ce91dfea37369e834faba5af534cfe18da958e5812975115b9830b2:jsdoc-quality",
+        "subjectId": "@beep/schema:packages/foundation/modeling/schema/src/Fn.ts:function:ThunkOf:08f01ddb6ce9",
+        "sourceAnchor": "packages/foundation/modeling/schema/src/Fn.ts:455",
+        "packageName": "@beep/schema",
+        "packagePath": "packages/foundation/modeling/schema",
+        "findingCodes": [
+          "missing-description",
+          "missing-category",
+          "missing-example",
+          "missing-since"
+        ],
+        "status": "completed",
+        "localScore": 8,
+        "rationale": "The JSDoc block addresses all policy requirements with a comprehensive example showing Effect execution, proper tagging with @category and @since, and a clear description. The example uses canonical aliases (S, A, O, P, R) and demonstrates meaningful input/output. The score reflects high quality while acknowledging the example could be slightly more elaborate.",
+        "draftJsDoc": "/**\n * Creates a schema for a thunk that returns a value of type `Output` or throws an error of type `Error`.\n *\n * @example\n * ```ts\n * import { Schema as S, Effect as E, Array as A, Option as O, Predicate as P, Record as R } from 'effect'\n * import { ThunkOf } from '@beep/schema'\n *\n * const thunkSchema = ThunkOf(S.number, S.string)\n * const thunk = () => 42\n * const result = E.runSync(E.try({\n *   try: () => thunkSchema.decodeUnknown(thunk),\n *   catch: (e) => e\n * }))\n * // Effect<never, string, number>\n * ```\n *\n * @category schema\n * @since 1.0.0\n */",
+        "expectedVerificationCommand": "bun run beep docgen quality -p 'packages/foundation/modeling/schema' --json",
+        "policyViolationCodes": ["missing-example", "missing-example"],
+        "reviewDisposition": "candidate",
+        "durationMs": 9441,
+        "error": null
+      },
+      {
+        "packetId": "9b28951d80fa03e74fecd7d35b8735f9fbc28dffdbc7e2f3791d35024f304f21:jsdoc-quality",
+        "subjectId": "@beep/nlp:packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:function:literal:9b28951d80fa",
+        "sourceAnchor": "packages/foundation/capability/nlp/src/Core/PatternBuilders.ts:151",
+        "packageName": "@beep/nlp",
+        "packagePath": "packages/foundation/capability/nlp",
+        "findingCodes": [
+          "missing-description",
+          "missing-category",
+          "missing-example",
+          "missing-since"
+        ],
+        "status": "completed",
+        "localScore": 7,
+        "rationale": "The JSDoc block has several issues that need to be addressed:\n\n1. Missing description: The function lacks a clear explanation of its purpose\n2. Missing category: No @category tag following repo conventions\n3. Missing since: No @since tag indicating version\n4. Example needs improvement: The example should be more realistic and show meaningful output\n\nThe proposed replacement addresses these by:\n- Adding a clear description explaining the function's purpose\n- Including @category with proper repo convention\n- Adding @since tag with version\n- Providing a realistic example that demonstrates actual usage with observable output\n\nThe score of 7 reflects that while the replacement fixes the main issues, it could be improved with more specific use cases and better demonstration of the function's capabilities.",
+        "draftJsDoc": "/**\n * Creates a literal pattern for matching exact strings.\n *\n * @category Pattern\n * @since 0.1.0\n *\n * @example\n * import { literal } from '@beep/nlp'\n * import * as S from 'effect/Schema'\n *\n * const schema = S.parseSync(S.String, literal('hello'))\n * // => 'hello'\n */",
+        "expectedVerificationCommand": "bun run beep docgen quality -p 'packages/foundation/capability/nlp' --json",
+        "policyViolationCodes": ["missing-example", "missing-example"],
+        "reviewDisposition": "candidate",
+        "durationMs": 10862,
+        "error": null
+      },
+      {
+        "packetId": "4d752ded789c1a3688303ed50bbab84d46e6fc8e9d55fc579cc84909f629e4b3:jsdoc-quality",
+        "subjectId": "@beep/identity:packages/foundation/modeling/identity/src/packages.ts:const:$DuckdbId:4d752ded789c",
+        "sourceAnchor": "packages/foundation/modeling/identity/src/packages.ts:710",
+        "packageName": "@beep/identity",
+        "packagePath": "packages/foundation/modeling/identity",
+        "findingCodes": ["missing-description", "missing-example"],
+        "status": "completed",
+        "localScore": 8,
+        "rationale": "The JSDoc block addresses the missing description and includes a realistic example with observable output. However, it could be improved by explicitly mentioning the identity composer pattern and adding more context about the DuckdbId's role in the identity system. The example is good but could be slightly more elaborate to better demonstrate the practical usage.",
+        "draftJsDoc": "/**\n * Identity composer for DuckDB identifiers.\n *\n * @example\n * import { Identity } from \"@beep/identity\";\n * import { S } from \"effect\";\n *\n * const schema = Identity.schema($DuckdbId);\n * const decoded = S.decodeUnknown(schema)(\"duckdb://my_table\");\n * console.log(decoded); // { _id: \"duckdb://my_table\" }\n */",
+        "expectedVerificationCommand": "bun run beep docgen quality -p 'packages/foundation/modeling/identity' --json",
+        "policyViolationCodes": [],
+        "reviewDisposition": "candidate",
+        "durationMs": 9039,
+        "error": null
+      },
+      {
+        "packetId": "9ea3e9b0622ffd7ca3cf42ce98a719ef7ae0fad598b8a1d6d57d8b8a657643e3:jsdoc-quality",
+        "subjectId": "@beep/schema:packages/foundation/modeling/schema/src/Fn.ts:function:ThunkOf:9ea3e9b0622f",
+        "sourceAnchor": "packages/foundation/modeling/schema/src/Fn.ts:451",
+        "packageName": "@beep/schema",
+        "packagePath": "packages/foundation/modeling/schema",
+        "findingCodes": [
+          "missing-description",
+          "missing-category",
+          "missing-example",
+          "missing-since"
+        ],
+        "status": "completed",
+        "localScore": 9,
+        "rationale": "The JSDoc block now includes all required tags (@category, @example, @since) with appropriate content. The example shows a realistic usage with observable output (decoded value) and uses canonical aliases. The description explains the symbol's purpose. Only one minor improvement could be made to make the example even more illustrative, but overall this meets the policy requirements.",
+        "draftJsDoc": "/**\n * Creates a schema that represents a thunk (zero-argument function) returning a value of the specified output schema.\n *\n * @category schema\n * @since 1.0.0\n * @example\n * ```ts\n * import { Schema } from \"@effect/schema\"\n * import { ThunkOf } from \"@beep/schema\"\n *\n * const schema = ThunkOf(Schema.string)\n *\n * // $ExpectType Schema<() => string>\n * type _A = typeof schema\n *\n * const decoded = Schema.decodeUnknown(schema)(() => \"hello\")\n *\n * // $ExpectType Effect<never, ParseError, () => string>\n * type _B = typeof decoded\n *\n * // decoded will succeed\n * const result = Schema.decodeUnknown(schema)(() => \"hello\")\n * // const result: Effect<never, ParseError, () => string> = Schema.decodeUnknown(schema)(() => \"hello\")\n * ```\n */",
+        "expectedVerificationCommand": "bun run beep docgen quality -p 'packages/foundation/modeling/schema' --json",
+        "policyViolationCodes": [],
+        "reviewDisposition": "candidate",
+        "durationMs": 10618,
+        "error": null
+      }
+    ],
+    "policyViolations": ["missing-example"],
+    "runtime": {
+      "totalDurationMs": 165297,
+      "packetTimeoutMs": 180000
+    },
+    "recommendation": "Worker drafts are candidate evidence only; compare against human review before graduation."
+  }
+}

--- a/initiatives/jsdoc-worker-eval/ops/manifest.json
+++ b/initiatives/jsdoc-worker-eval/ops/manifest.json
@@ -59,7 +59,7 @@
     },
     {
       "id": "2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval",
-      "report": "research/2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval.md",
+      "report": "research/2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval-10-packet.md",
       "raw": "history/outputs/2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval-10-packet.json",
       "sourceRaw": "history/outputs/2026-05-16-source-quality-codex-packets-10-packet.json",
       "smokeRaw": "history/outputs/2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval-smoke-v2.json",

--- a/initiatives/jsdoc-worker-eval/ops/manifest.json
+++ b/initiatives/jsdoc-worker-eval/ops/manifest.json
@@ -3,7 +3,7 @@
   "initiative": {
     "id": "jsdoc-worker-eval",
     "title": "JSDoc Worker Eval",
-    "status": "p0-p6-implemented-runpod-smoke-proof-complete",
+    "status": "p0-p6-implemented-runpod-10-packet-evidence-complete",
     "created": "2026-05-12",
     "updated": "2026-05-16",
     "packetAnchorDocument": "SPEC.md"
@@ -60,9 +60,11 @@
     {
       "id": "2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval",
       "report": "research/2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval.md",
-      "expectedRaw": "history/outputs/2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval.json",
+      "raw": "history/outputs/2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval-10-packet.json",
+      "sourceRaw": "history/outputs/2026-05-16-source-quality-codex-packets-10-packet.json",
       "smokeRaw": "history/outputs/2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval-smoke-v2.json",
-      "result": "smoke-proof-complete"
+      "largerSampleReport": "research/2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval-10-packet.md",
+      "result": "larger-sample-evidence-complete"
     }
   ],
   "phaseStatus": [
@@ -98,7 +100,7 @@
     },
     {
       "id": "P6",
-      "status": "smoke-proof-complete",
+      "status": "evidence-complete",
       "title": "Runpod Ollama Qwen3-Coder remote GPU worker eval"
     }
   ],
@@ -108,5 +110,5 @@
     "Qwen-specific architecture doctrine",
     "auto-remediation write mode"
   ],
-  "nextAction": "Decide whether to run a larger 10-packet Runpod sample now or first remove cold-pull overhead with a repo-owned image/template or persistent model cache."
+  "nextAction": "Treat jsdoc-worker-eval as read-only evidence-complete. Plan cache/template cost reduction, human draft review, or write-mode auto-remediation as separate follow-up initiatives."
 }

--- a/initiatives/jsdoc-worker-eval/research/2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval-10-packet.md
+++ b/initiatives/jsdoc-worker-eval/research/2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval-10-packet.md
@@ -32,13 +32,14 @@ Summary:
 
 ```sh
 RUNPOD_API_KEY="$(op read 'op://BEEP_SECRETS/BEEP_SECRETS/CLOUD_RUNPOD_API_KEY')" \
+BEEP_OTLP_BASE_URL="${BEEP_OTLP_BASE_URL:?set BEEP_OTLP_BASE_URL}" \
   bun run beep docgen quality-worker-eval-runpod \
     --input initiatives/jsdoc-worker-eval/history/outputs/2026-05-16-source-quality-codex-packets-10-packet.json \
     --provider ollama \
     --model qwen3-coder:30b \
     --packet-limit 10 \
     --otlp \
-    --otlp-base-url https://dankserver.tailc7c348.ts.net:8447 \
+    --otlp-base-url "$BEEP_OTLP_BASE_URL" \
     --otlp-project beep-jsdoc-worker-eval \
     --confirm-runpod-eval \
     --skip-template-search \

--- a/initiatives/jsdoc-worker-eval/research/2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval-10-packet.md
+++ b/initiatives/jsdoc-worker-eval/research/2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval-10-packet.md
@@ -1,0 +1,101 @@
+# Runpod Ollama Qwen3-Coder 30B 10-Packet Worker Eval
+
+## Status
+
+Larger-sample read-only evidence complete; auto-remediation still blocked.
+
+## Purpose
+
+Close the remaining `jsdoc-worker-eval` evidence gap by running the already
+implemented Runpod/Codex SDK worker path on a reproducible 10-packet sample.
+This run does not edit source files and does not make worker judgment the source
+of truth.
+
+## Source Quality Report
+
+Command:
+
+```sh
+bun run beep docgen quality --all --json --score codex --packet-limit 25 --output initiatives/jsdoc-worker-eval/history/outputs/2026-05-16-source-quality-codex-packets-10-packet.json
+```
+
+Summary:
+
+- Packages: 79
+- Quality subjects: 6776
+- Passing reviews: 2453
+- Warning reviews: 1728
+- Failure reviews: 2595
+- Remediation packets: 25
+
+## Eval Command
+
+```sh
+RUNPOD_API_KEY="$(op read 'op://BEEP_SECRETS/BEEP_SECRETS/CLOUD_RUNPOD_API_KEY')" \
+  bun run beep docgen quality-worker-eval-runpod \
+    --input initiatives/jsdoc-worker-eval/history/outputs/2026-05-16-source-quality-codex-packets-10-packet.json \
+    --provider ollama \
+    --model qwen3-coder:30b \
+    --packet-limit 10 \
+    --otlp \
+    --otlp-base-url https://dankserver.tailc7c348.ts.net:8447 \
+    --otlp-project beep-jsdoc-worker-eval \
+    --confirm-runpod-eval \
+    --skip-template-search \
+    --readiness-timeout-ms 2700000 \
+    --output initiatives/jsdoc-worker-eval/history/outputs/2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval-10-packet.json
+```
+
+Runpod strategy:
+
+- Provider: Ollama through the Codex SDK.
+- Model: `qwen3-coder:30b`.
+- Template strategy: fallback image.
+- Image: `runpod/pytorch:2.8.0-py3.11-cuda12.8.1-cudnn-devel-ubuntu22.04`.
+- GPU policy: 48 GiB minimum; no 24 GiB fallback.
+- Template search: skipped.
+- Cleanup: stop and delete by default.
+
+## Outcome
+
+- Selected packets: 10
+- Completed packets: 10
+- Candidate drafts: 10
+- Failed packets: 0
+- Timed-out packets: 0
+- Needs human review: 0
+- Rejected packets: 0
+- Policy violations: `missing-example`
+- Phoenix export: 11 spans to project `beep-jsdoc-worker-eval`
+- Cleanup: stop completed, delete completed
+- Cleanup verification: `runpodctl pod get 7vwucsmu2832q8` returned 404
+  `pod not found`
+- Total wrapper runtime: 463598 ms
+- Worker duration: 460488 ms
+- Provision duration: 1699 ms
+- Cleanup duration: 1332 ms
+
+The selected packets covered `@beep/openai`, `@beep/nlp`, `@beep/identity`,
+and `@beep/schema`.
+
+## Interpretation
+
+The larger sample proves the remote Qwen worker path can process a 10-packet
+queue, export sanitized Phoenix spans, and clean up the ephemeral pod. It also
+shows that worker output still needs policy review: two candidate drafts
+reported duplicate `missing-example` policy codes, and the aggregate worker
+policy violation set contains `missing-example`.
+
+This is sufficient to close the read-only worker-eval evidence gap. It is not
+sufficient to allow automatic source edits.
+
+## Recommendation
+
+Keep `jsdoc-worker-eval` as a reference packet and keep worker runs advisory.
+Future work should be planned separately:
+
+- prebuilt Runpod image or persistent model cache if repeated remote Qwen evals
+  need lower latency or lower cost
+- human review/eval rubric for candidate draft acceptance
+- write-mode remediation only after explicit precision, cost, runtime, and
+  policy-preservation thresholds are defined

--- a/initiatives/jsdoc-worker-eval/research/2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval.md
+++ b/initiatives/jsdoc-worker-eval/research/2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval.md
@@ -14,13 +14,14 @@ read-only worker eval. It does not graduate auto-remediation.
 
 ```sh
 RUNPOD_API_KEY="$(op read 'op://BEEP_SECRETS/BEEP_SECRETS/CLOUD_RUNPOD_API_KEY')" \
+BEEP_OTLP_BASE_URL="${BEEP_OTLP_BASE_URL:?set BEEP_OTLP_BASE_URL}" \
   bun run beep docgen quality-worker-eval-runpod \
     --all \
     --provider ollama \
     --model qwen3-coder:30b \
     --packet-limit 10 \
     --otlp \
-    --otlp-base-url https://dankserver.tailc7c348.ts.net:8447 \
+    --otlp-base-url "$BEEP_OTLP_BASE_URL" \
     --otlp-project beep-jsdoc-worker-eval \
     --confirm-runpod-eval \
     --output initiatives/jsdoc-worker-eval/history/outputs/2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval.json
@@ -69,13 +70,14 @@ Command:
 
 ```sh
 RUNPOD_API_KEY="$(op read 'op://BEEP_SECRETS/BEEP_SECRETS/CLOUD_RUNPOD_API_KEY')" \
+BEEP_OTLP_BASE_URL="${BEEP_OTLP_BASE_URL:?set BEEP_OTLP_BASE_URL}" \
   bun run beep docgen quality-worker-eval-runpod \
     --input <saved-source-quality-report.json> \
     --provider ollama \
     --model qwen3-coder:30b \
     --packet-limit 1 \
     --otlp \
-    --otlp-base-url https://dankserver.tailc7c348.ts.net:8447 \
+    --otlp-base-url "$BEEP_OTLP_BASE_URL" \
     --otlp-project beep-jsdoc-worker-eval \
     --confirm-runpod-eval \
     --skip-template-search \

--- a/initiatives/jsdoc-worker-eval/research/README.md
+++ b/initiatives/jsdoc-worker-eval/research/README.md
@@ -5,6 +5,7 @@ Curated provider-backed evaluation reports live here.
 - [2026-05-12 Ollama Qwen3-Coder 30B host eval](./2026-05-12-ollama-qwen3-coder-30b-host-eval.md)
 - [2026-05-12 Codex GPT-5.4 Mini low worker eval](./2026-05-12-codex-gpt-5.4-mini-low-worker-eval.md)
 - [2026-05-16 Runpod Ollama Qwen3-Coder 30B worker eval](./2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval.md)
+- [2026-05-16 Runpod Ollama Qwen3-Coder 30B 10-packet worker eval](./2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval-10-packet.md)
 
 Reports should record:
 


### PR DESCRIPTION
## Summary

- records the reproducible 10-packet Runpod/Ollama Qwen3-Coder worker-eval evidence
- updates the jsdoc-worker-eval packet status, plan, spec, and manifest to mark read-only Runpod evidence complete
- preserves auto-remediation as out of scope until separate human-review/write-mode gates are planned

## Verification

- `jq empty initiatives/jsdoc-worker-eval/ops/manifest.json initiatives/jsdoc-worker-eval/history/outputs/2026-05-16-source-quality-codex-packets-10-packet.json initiatives/jsdoc-worker-eval/history/outputs/2026-05-16-runpod-ollama-qwen3-coder-30b-worker-eval-10-packet.json`
- `git diff --check main...HEAD`
- `bun run repo-exports:catalog:check`
- `bun run --filter @beep/repo-cli check`
- `bun run --filter @beep/repo-cli lint`
- `bun run --filter @beep/repo-cli test -- test/docgen.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated initiative plans, specifications, and research documentation with evaluation results and recommendations.

* **Chores**
  * Updated status tracking and manifest to reflect completed evaluation evidence and deferred follow-up work to separate initiatives.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kriegcloud/beep-effect/pull/153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->