### PR TITLE
[codex] Restrict sensitive Vercel env vars

### DIFF
--- a/infra/src/OpipWeb.ts
+++ b/infra/src/OpipWeb.ts
@@ -572,6 +572,9 @@ const makeBucketBaseline = (
 
 const optionalTeamArgs = (teamId: string | undefined) => (teamId === undefined ? {} : { teamId });
 
+const makeRuntimeEnvironmentVariableTargets = (sensitive: boolean): Array<"production" | "preview"> =>
+  sensitive ? ["production"] : ["production", "preview"];
+
 const makeRuntimeEnvironmentVariable = (
   name: string,
   project: vercel.Project,
@@ -590,7 +593,7 @@ const makeRuntimeEnvironmentVariable = (
           key,
           projectId: project.id,
           sensitive,
-          targets: ["production", "preview"],
+          targets: makeRuntimeEnvironmentVariableTargets(sensitive),
           value,
         },
         opts

--- a/standards/repo-exports.catalog.md
+++ b/standards/repo-exports.catalog.md
@@ -13339,7 +13339,7 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/infra` | `OpipVercelProjectConfig` | class | `infra/src/OpipWeb.ts:252` | Vercel project configuration for `@beep/opip-web`. |
 | `@beep/infra` | `OpipWebPulumiConfigValues` | const | `infra/src/OpipWeb.ts:87` | Optional Pulumi config values before OPIP deploy defaults are applied. |
 | `@beep/infra` | `OpipWebRuntimeSecrets` | type | `infra/src/OpipWeb.ts:308` | Secret runtime values for OPIP deploy targets. |
-| `@beep/infra` | `OpipWebStack` | class | `infra/src/OpipWeb.ts:636` | Import-safe Pulumi component for OPIP production web infrastructure. |
+| `@beep/infra` | `OpipWebStack` | class | `infra/src/OpipWeb.ts:639` | Import-safe Pulumi component for OPIP production web infrastructure. |
 | `@beep/infra` | `OpipWebStackArgs` | class | `infra/src/OpipWeb.ts:326` | Pulumi-facing args for the OPIP web stack. |
 
 ### @beep/codedank-web


### PR DESCRIPTION
## Summary
- restrict sensitive OPIP Vercel runtime environment variables to production deployments only
- keep non-sensitive runtime configuration available to both production and preview deployments
- refresh repo export catalog line references after the infra helper change

## Security rationale
The finding is legitimate. `makeRuntimeEnvironmentVariable` previously assigned every Vercel environment variable to both `production` and `preview`, and the same helper is used for sensitive `SANITY_API_TOKEN` and `CRM_HUBSPOT_SERVICE_KEY` values. Preview code can read injected runtime variables, so production CRM/CMS credentials should not be available there.

## Validation
- `bunx turbo run check --filter=@beep/infra --cache=local:rw`
- `bun run check`
- pre-push `bun run beep quality repo-exports-catalog --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved environment variable handling in deployment configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kriegcloud/beep-effect/pull/156?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->