### PR TITLE
docs(agent-effectiveness): close phase 1 initiative

### DIFF
--- a/initiatives/agent-effectiveness-loop/PLAN.md
+++ b/initiatives/agent-effectiveness-loop/PLAN.md
@@ -13,7 +13,7 @@ Status: complete
 
 ## Phase 1 - Agent-Effectiveness Doctor And Annotation Plan
 
-Status: live-proofed for PR readiness
+Status: complete
 
 Implemented local, no-mutation outputs:
 
@@ -35,9 +35,22 @@ values, draft JSDoc, or code examples.
 Live proof is recorded in
 [history/outputs/phase1-live-proof.md](./history/outputs/phase1-live-proof.md).
 
+Implemented guarded Phoenix sync plumbing:
+
+- `beep agent-effectiveness datasets bundle --json`
+- `beep agent-effectiveness prompts bundle --json`
+- `beep agent-effectiveness experiments bundle --json`
+- `beep agent-effectiveness phoenix sync --json`
+
+This closeout treats the Phoenix driver and sync loop as guarded Phase 1B
+plumbing. Sync defaults to dry-run, requires explicit confirmation before live
+writes, and is not used as live-mutation proof for Phase 1 completion. Closeout
+evidence is recorded in
+[history/outputs/phase1-closeout.md](./history/outputs/phase1-closeout.md).
+
 ## Phase 2 - Phoenix-Native Enrichment
 
-Status: deferred until Phase 1 proof
+Status: deferred after Phase 1 closeout
 
 Candidate areas:
 
@@ -49,7 +62,7 @@ Candidate areas:
 
 ## Phase 3 - Repo Workflow Integration
 
-Status: pending Phase 1 proof
+Status: deferred after Phase 1 closeout
 
 Future implementation may add Phoenix annotation writes, datasets, experiments,
 prompt-management workflows, Phoenix API drivers, or additional AI metrics

--- a/initiatives/agent-effectiveness-loop/README.md
+++ b/initiatives/agent-effectiveness-loop/README.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Phase 1 local doctor and annotation-plan loop live-proofed for PR readiness
+Phase 1 complete
 
 ## Mission
 
@@ -41,23 +41,33 @@ or server configuration.
 
 ## Current Recommendation
 
-Use the implemented no-mutation agent-effectiveness doctor and annotation-plan
-loop as the trust gate before any Phoenix write path. The Phase 1 live proof is
-recorded in [history/outputs/phase1-live-proof.md](./history/outputs/phase1-live-proof.md).
-The synthesis still defers Phoenix writes, datasets, experiments, prompt
-management, and backend drivers until the repo-owned local trust gate and
-privacy-checked annotation schema prove useful.
+Use the implemented agent-effectiveness doctor, annotation-plan loop, and
+guarded Phoenix sync plumbing as the trust gate for repo-owned agent feedback.
+The Phase 1 live proof is recorded in
+[history/outputs/phase1-live-proof.md](./history/outputs/phase1-live-proof.md),
+and the post-merge closeout is recorded in
+[history/outputs/phase1-closeout.md](./history/outputs/phase1-closeout.md).
+
+The merged Phoenix sync path remains confirmation-gated. The Phase 1 closeout
+does not use live Phoenix mutation as proof, and Phase 2/3 enrichment work
+remains deferred.
 
 ## Implemented Phase 1 Commands
 
 - `beep agent-effectiveness doctor --json`
 - `beep agent-effectiveness annotations plan --json`
 - `beep agent-effectiveness annotations check --json`
+- `beep agent-effectiveness datasets bundle --json`
+- `beep agent-effectiveness prompts bundle --json`
+- `beep agent-effectiveness experiments bundle --json`
+- `beep agent-effectiveness phoenix sync --json`
 
-The commands are report-only. They inspect Phoenix reachability/project
-inventory, local AI metrics evidence, and the JSDoc worker-eval report, then
-produce sanitized metadata-only annotation proposals. They do not write to
-Phoenix or mutate agent configuration.
+The doctor and annotation commands are report-only. They inspect Phoenix
+reachability/project inventory, local AI metrics evidence, and the JSDoc
+worker-eval report, then produce sanitized metadata-only annotation proposals.
+The bundle commands produce deterministic Phoenix-ready payloads. The sync
+command defaults to dry-run and requires an explicit confirmation token before
+any Phoenix write.
 
 ## Reading Order
 

--- a/initiatives/agent-effectiveness-loop/SPEC.md
+++ b/initiatives/agent-effectiveness-loop/SPEC.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**Phase 1 local doctor and annotation-plan loop live-proofed for PR readiness**
+**Phase 1 complete**
 
 ## Owner
 
@@ -128,6 +128,18 @@ This slice produces a trust gate and privacy-checked annotation plan before any
 Phoenix mutation, dataset creation, prompt management, experiment creation, or
 backend driver work is allowed.
 
+Phase 1 closeout also landed guarded Phoenix sync plumbing:
+
+- `beep agent-effectiveness datasets bundle --json`
+- `beep agent-effectiveness prompts bundle --json`
+- `beep agent-effectiveness experiments bundle --json`
+- `beep agent-effectiveness phoenix sync --json`
+
+The sync path defaults to dry-run and requires explicit confirmation before live
+Phoenix writes. Phase 1 completion is proven by the no-mutation live proof,
+privacy checks, CI, and review closeout; it does not require live Phoenix
+mutation.
+
 ## Phase 1 Implementation Contract
 
 The Phase 1 implementation is split across:
@@ -158,3 +170,6 @@ Phase 1 live proof is recorded in
 the section level: Phoenix inventory must decode and pass, annotation privacy
 checks must pass, and the overall doctor may remain `warning` when optional
 local AI-metrics evidence is unavailable.
+
+Phase 1 post-merge closeout is recorded in
+`history/outputs/phase1-closeout.md`.

--- a/initiatives/agent-effectiveness-loop/history/outputs/phase1-closeout.md
+++ b/initiatives/agent-effectiveness-loop/history/outputs/phase1-closeout.md
@@ -1,0 +1,37 @@
+# Phase 1 Closeout
+
+## Status
+
+Phase 1 is complete.
+
+## Merge Evidence
+
+- PR #167, `feat(agent-effectiveness): add Phoenix sync loop`, merged on
+  2026-05-20 at `dee0dfd6e87473b38af0ebcf26a1ba3fbc85ed16`.
+- PR #168, `fix(agent-effectiveness): tighten Phoenix sync follow-up`, merged
+  on 2026-05-20 at `c6b9dc987d704d76b8237e24bd39edb92f909ece`.
+
+## Closeout Scope
+
+The closeout covers the Phase 1 doctor, annotation-plan, annotation-check,
+Phoenix bundle, and guarded Phoenix sync surfaces. Sync defaults to dry-run and
+requires explicit confirmation before live Phoenix writes.
+
+No live Phoenix mutation is required as Phase 1 closeout proof. Phoenix-native
+enrichment, live write workflows, prompt management, experiment automation, and
+broader workflow integration remain deferred to separately planned Phase 2/3
+work.
+
+## CI And Review Evidence
+
+The final PR #168 head passed CI on 2026-05-20, including check, lint, repo
+sanity, unit tests, integration tests, docgen, security, SAST, secret scanning,
+Nix shell, Greptile review, CodeRabbit, and Vercel. The build lane was skipped
+by workflow policy.
+
+Local docgen was intentionally skipped during the follow-up loop; CI docgen
+passed on the final follow-up PR.
+
+The actionable PR #168 review threads were resolved before merge. Stale PR #167
+threads for the dataset lookup error handling and nested privacy scanning were
+verified against the merged PR #168 fixes and resolved during closeout.

--- a/initiatives/agent-effectiveness-loop/ops/manifest.json
+++ b/initiatives/agent-effectiveness-loop/ops/manifest.json
@@ -3,7 +3,7 @@
   "initiative": {
     "id": "agent-effectiveness-loop",
     "title": "Agent Effectiveness Loop",
-    "status": "phase1-live-proof-pr-ready",
+    "status": "phase1-complete",
     "created": "2026-05-16",
     "updated": "2026-05-20",
     "packetAnchorDocument": "SPEC.md"
@@ -41,14 +41,19 @@
   },
   "phase1": {
     "id": "doctor-and-annotation-plan",
-    "status": "live-proofed-pr-ready",
+    "status": "complete",
     "commands": [
       "beep agent-effectiveness doctor --json",
       "beep agent-effectiveness annotations plan --json",
-      "beep agent-effectiveness annotations check --json"
+      "beep agent-effectiveness annotations check --json",
+      "beep agent-effectiveness datasets bundle --json",
+      "beep agent-effectiveness prompts bundle --json",
+      "beep agent-effectiveness experiments bundle --json",
+      "beep agent-effectiveness phoenix sync --json"
     ],
-    "mutationPolicy": "local-artifacts-only",
+    "mutationPolicy": "dry-run-default-confirmation-required",
     "proof": "history/outputs/phase1-live-proof.md",
+    "closeout": "history/outputs/phase1-closeout.md",
     "implementationSurfaces": [
       "packages/tooling/library/ai-metrics/src/agent-effectiveness.ts",
       "packages/tooling/tool/cli/src/commands/AgentEffectiveness/index.ts"
@@ -66,10 +71,10 @@
     "https://arize.com/docs/phoenix/tracing/how-to-tracing/feedback-and-annotations/evaluating-phoenix-traces"
   ],
   "nonGoals": [
-    "mutating Phoenix projects, datasets, prompts, annotations, experiments, or server config during Phase 1",
+    "using live Phoenix mutation as required Phase 1 closeout proof",
     "moving AI metrics semantics out of tooling packages",
     "syncing raw transcripts or private paths into research artifacts",
     "graduating worker auto-remediation from read-only evidence"
   ],
-  "nextAction": "Open the Phase 1 draft PR, keep Phoenix mutation paths deferred, then decide separately whether Phase 2 should add Phoenix writes, datasets, experiments, or prompt-management workflows."
+  "nextAction": "Plan Phase 2 separately if Phoenix-native enrichment, live write workflows, prompt management, or experiment automation become the next priority."
 }

--- a/initiatives/agent-effectiveness-loop/ops/manifest.json
+++ b/initiatives/agent-effectiveness-loop/ops/manifest.json
@@ -17,7 +17,7 @@
     "infraPackage": "@beep/infra"
   },
   "livePhoenix": {
-    "access": "read-only",
+    "access": "read-only-default-confirmation-gated-writes-available",
     "projectsUrl": "https://dankserver.tailc7c348.ts.net:8447/projects",
     "graphqlUrl": "https://dankserver.tailc7c348.ts.net:8447/graphql",
     "sanitization": "project names, aggregate counts, feature availability, schema names, attribute names, and hashed identifiers only"


### PR DESCRIPTION
## Summary
- mark the agent-effectiveness loop Phase 1 slice complete
- document the guarded Phase 1B Phoenix bundle/sync plumbing while keeping live mutation outside closeout proof
- add a closeout record with PR #167/#168 merge evidence, CI status, and review-thread cleanup

## Verification
- jq . initiatives/agent-effectiveness-loop/ops/manifest.json
- git diff --check
- bun run changeset:status:since-main
- bun run audit:github repo-sanity

Local docgen was intentionally skipped; CI docgen should cover this docs-only closeout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Phase 1 of agent-effectiveness-loop initiative marked as complete.
  * Updated specifications and planning documents to reflect completion status.
  * Documented guarded Phoenix sync operations, which default to dry-run mode with explicit confirmation required for live writes.
  * Added Phase 1 closeout evidence documentation.

* **Chores**
  * Updated initiative manifest and status configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kriegcloud/beep-effect/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->