### PR TITLE
Restore fail-closed default for Redacted schema encoding

### DIFF
--- a/.repos/effect-v4/packages/effect/src/Schema.ts
+++ b/.repos/effect-v4/packages/effect/src/Schema.ts
@@ -8145,9 +8145,9 @@ export interface Redacted<S extends Top> extends
  *   - The default JSON serializer will deserialize into a `Redacted` instance with the label
  *   - The arbitrary generator will produce a `Redacted` instance with the label
  *   - The formatter will return the label
- * - `disallowJsonEncode`: When set to `true`, when attempting to encode a `Redacted` instance
- *   into JSON, it will fail with an error. This is useful when the wrapped schema is
- *   sensitive and should not be exposed in JSON.
+ * - `disallowJsonEncode`: Controls JSON encoding safety for `Redacted` values.
+ *   - `true` or omitted: JSON encoding fails with an error.
+ *   - `false`: JSON encoding is allowed and extracts the underlying value.
  *
  * @category Redacted
  * @since 3.10.0
@@ -8203,7 +8203,7 @@ export function Redacted<S extends Top>(value: S, options?: {
           redact(value),
           {
             decode: Getter.transform((e) => Redacted_.make(e, { label: options?.label })),
-            encode: options?.disallowJsonEncode ?
+            encode: options?.disallowJsonEncode !== false ?
               Getter.forbidden((oe) =>
                 "Cannot serialize Redacted" +
                 (Option_.isSome(oe) && typeof oe.value.label === "string" ? ` with label: "${oe.value.label}"` : "")
@@ -8263,7 +8263,7 @@ export function RedactedFromValue<S extends Top>(value: S, options?: {
       }),
       {
         decode: Getter.transform((t) => Redacted_.make(t, { label: options?.label })),
-        encode: options?.disallowEncode ?
+        encode: options?.disallowEncode !== false ?
           Getter.forbidden((oe) =>
             "Cannot encode Redacted" +
             (Option_.isSome(oe) && typeof oe.value.label === "string" ? ` with label: "${oe.value.label}"` : "")

--- a/.repos/effect-v4/packages/effect/test/schema/toCodec.test.ts
+++ b/.repos/effect-v4/packages/effect/test/schema/toCodec.test.ts
@@ -1129,13 +1129,13 @@ describe("Serializers", () => {
           const asserts = new TestSchema.Asserts(Schema.toCodecJson(schema))
 
           const encoding = asserts.encoding()
-          await encoding.succeed(
+          await encoding.fail(
             Redacted.make(Option.none()),
-            { _tag: "None" }
+            `Cannot serialize Redacted`
           )
-          await encoding.succeed(
+          await encoding.fail(
             Redacted.make(Option.some("a")),
-            { _tag: "Some", value: "a" }
+            `Cannot serialize Redacted`
           )
 
           const decoding = asserts.decoding()
@@ -1193,9 +1193,9 @@ describe("Serializers", () => {
           const asserts = new TestSchema.Asserts(Schema.toCodecJson(schema))
 
           const encoding = asserts.encoding()
-          await encoding.succeed(
+          await encoding.fail(
             Redacted.make("a", { label: "API key" }),
-            "a"
+            `Cannot serialize Redacted with label: "API key"`
           )
         })
       })
@@ -2410,13 +2410,13 @@ Expected "Infinity" | "-Infinity" | "NaN", got "a"`
         const asserts = new TestSchema.Asserts(Schema.toCodecStringTree(schema))
 
         const encoding = asserts.encoding()
-        await encoding.succeed(
+        await encoding.fail(
           Redacted.make(Option.none()),
-          { _tag: "None" }
+          "Cannot serialize Redacted"
         )
-        await encoding.succeed(
+        await encoding.fail(
           Redacted.make(Option.some("a")),
-          { _tag: "Some", value: "a" }
+          "Cannot serialize Redacted"
         )
 
         const decoding = asserts.decoding()


### PR DESCRIPTION
### Motivation
- The Redacted schema is documented to prevent accidental disclosure of sensitive values, but recent changes made JSON/string-tree codecs expose the wrapped secret by default instead of failing safely. 
- The intent of this change is to restore a conservative, fail-closed default for schema encoders so secrets are not emitted unless callers explicitly opt in.

### Description
- Changed `Schema.Redacted` encoding behavior in `.repos/effect-v4/packages/effect/src/Schema.ts` so JSON encoding fails by default and only allows raw-value encoding when `disallowJsonEncode: false` is explicitly provided. 
- Applied the same default-safe rule to `RedactedFromValue` by requiring `disallowEncode: false` to opt into raw-value encoding. 
- Updated the doc comment for the `disallowJsonEncode` option to clarify the new default semantics. 
- Adjusted tests in `.repos/effect-v4/packages/effect/test/schema/toCodec.test.ts` to assert that encoding a `Redacted` value fails by default while decoding behavior remains unchanged.

### Testing
- Ran the targeted test suite with `pnpm test packages/effect/test/schema/toCodec.test.ts` and the updated tests passed. 
- The modified test file exercises both JSON and string-tree codec paths for `Schema.Redacted` and confirms the default encode path now fails while decoding still succeeds.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a105b8d481c832caa185e1744118ca8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security for redacted data by preventing serialization to JSON by default. Encoding is now forbidden unless explicitly permitted, improving data protection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kriegcloud/beep-effect/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->