### PR TITLE
feat(repo-cli): harden Yeet proof workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,11 @@ Build and maintain features with effect first development.
   `rg -i "<symbol-or-intent>" standards/repo-exports.catalog.{md,jsonc}`.
 - Refresh the repo export catalog with `bun run repo-exports:catalog`; verify it
   is current with `bun run repo-exports:catalog:check`.
+- Yeet workflow hardening is in proof mode: use `bun run beep yeet repair`,
+  `bun run beep yeet verify`, and `bun run beep yeet publish --message "..."`
+  for proving the path, but do not treat Yeet as the canonical replacement for
+  manual quality lanes until its dedicated proof PR is green in GitHub Actions
+  and the Yeet agent skill is added.
 - Use `bun run beep architecture` for canonical slice, concept, role, and
   architecture proof generation instead of hand-authoring boilerplate.
 - For architecture concepts, use the canonical `--domain-kind` archetypes:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,11 @@ Ship reliable code with effect first and schema first patterns.
   `standards/repo-exports.catalog.jsonc`; refresh with
   `bun run repo-exports:catalog` and verify with
   `bun run repo-exports:catalog:check`.
+- Yeet workflow hardening is in proof mode: use `bun run beep yeet repair`,
+  `bun run beep yeet verify`, and `bun run beep yeet publish --message "..."`
+  for proving the path, but do not treat Yeet as the canonical replacement for
+  manual quality lanes until its dedicated proof PR is green in GitHub Actions
+  and the Yeet agent skill is added.
 
 ## Prompt-cache discipline
 Claude Code auto-caches the stable conversation prefix (system prompt, tool

--- a/packages/tooling/tool/cli/README.md
+++ b/packages/tooling/tool/cli/README.md
@@ -417,9 +417,10 @@ bun run beep yeet publish --message "feat(repo-cli): harden yeet proof"
 
 `repair` is the only mode that runs deterministic write steps. It currently
 runs affected lint fixes, local docgen, `repo-exports:catalog`, and then affected
-feedback. `verify` is read-only and runs affected feedback followed by
-`quality github-checks pre-push`, the shared proof surface that mirrors the
-all-up local GitHub Actions proof. `publish` does not run repair steps: it
+feedback. Affected test feedback is scoped to unit and type-test lanes; the
+integration lane is reserved for the full proof. `verify` is read-only and runs
+affected feedback followed by `quality github-checks pre-push`, the shared proof
+surface that mirrors the all-up local GitHub Actions proof. `publish` does not run repair steps: it
 requires reviewed staged changes, commits them, runs the same `pre-push` proof
 against the new local commit, and pushes only after that proof passes. Bare
 `yeet --message ...` remains a publish alias.

--- a/packages/tooling/tool/cli/README.md
+++ b/packages/tooling/tool/cli/README.md
@@ -403,6 +403,32 @@ bun run beep quality repo-exports-catalog --check
 bun run beep quality changeset-graph
 ```
 
+### `yeet`
+
+Run the repo-native agent workflow candidate for repair, verification, and
+publishing. Yeet is not considered the canonical replacement for manual quality
+lanes until the dedicated proof PR passes GitHub Actions end to end.
+
+```bash
+bun run beep yeet repair
+bun run beep yeet verify
+bun run beep yeet publish --message "feat(repo-cli): harden yeet proof"
+```
+
+`repair` is the only mode that runs deterministic write steps. It currently
+runs affected lint fixes, local docgen, `repo-exports:catalog`, and then affected
+feedback. `verify` is read-only and runs affected feedback followed by
+`quality github-checks pre-push`, the shared proof surface that mirrors the
+all-up local GitHub Actions proof. `publish` does not run repair steps: it
+requires reviewed staged changes, commits them, runs the same `pre-push` proof
+against the new local commit, and pushes only after that proof passes. Bare
+`yeet --message ...` remains a publish alias.
+
+If `yeet verify` or `yeet publish` passes locally but the proof PR fails in
+GitHub Actions, treat that as a Yeet/quality parity bug or environment drift
+unless the failure is clearly an external outage. The custom Yeet agent skill
+should be added only after this proof loop is green.
+
 ### `ci`
 
 Render CI helper output from checked-in repo automation.

--- a/packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts
@@ -7,7 +7,6 @@
 
 import { $RepoCliId } from "@beep/identity/packages";
 import { findRepoRoot, jsonStringifyPretty } from "@beep/repo-utils";
-import { LiteralKit } from "@beep/schema";
 import { A, Str, thunkFalse } from "@beep/utils";
 import { Console, Effect, FileSystem, flow, Order, Path, pipe, Stream } from "effect";
 import { dual } from "effect/Function";
@@ -20,6 +19,7 @@ import { ChildProcess } from "effect/unstable/process";
 import { XMLParser } from "fast-xml-parser";
 import { parse } from "jsonc-parser";
 import { printLines } from "../../internal/cli/Printer.js";
+import { GITHUB_CHECK_MODE_VALUES, GithubCheckMode as GithubCheckModeSchema } from "../../internal/repo-run/index.js";
 import { runChangesetGraphCheck } from "./ChangesetGraph.js";
 import { configStringEqualsSync } from "./internal/Config.js";
 import { writeJSDocDocumentationInventory } from "./internal/JSDocDocumentationInventory.js";
@@ -29,6 +29,7 @@ import { QualityScriptCommandError } from "./Quality.errors.js";
 import { QualityTaskStep } from "./Tasks.js";
 import type { ChildProcessSpawner } from "effect/unstable/process";
 import type { ParseError } from "jsonc-parser";
+import type { GithubCheckMode as GithubCheckModeType } from "../../internal/repo-run/index.js";
 
 /**
  * Public quality script command error export.
@@ -40,7 +41,6 @@ export { QualityScriptCommandError } from "./Quality.errors.js";
 
 const $I = $RepoCliId.create("commands/Quality/ScriptCommands");
 
-const GITHUB_CHECK_MODES = ["quality", "repo-sanity", "secrets", "security", "sast", "nix", "pre-push"] as const;
 const ignoredTestDirectoryNames = ["node_modules", "dist", "coverage", "tmp"] as const;
 const ignoredTestPathSegments = ["/test/fixtures/"] as const;
 const dtslintSearchRoots = ["apps", "packages", "tooling"] as const;
@@ -138,11 +138,7 @@ type TsgoDiagnosticOutput = {
  * @category models
  * @since 0.0.0
  */
-export const GithubCheckMode = LiteralKit(GITHUB_CHECK_MODES).pipe(
-  $I.annoteSchema("GithubCheckMode", {
-    description: "GitHub verification mode handled by the repo-cli quality command group.",
-  })
-);
+export const GithubCheckMode = GithubCheckModeSchema;
 
 /**
  * GitHub check mode handled by `beep quality github-checks`.
@@ -155,7 +151,7 @@ export const GithubCheckMode = LiteralKit(GITHUB_CHECK_MODES).pipe(
  * @category models
  * @since 0.0.0
  */
-export type GithubCheckMode = typeof GithubCheckMode.Type;
+export type GithubCheckMode = GithubCheckModeType;
 
 const commandText = (command: string, args: ReadonlyArray<string>) => A.join([command, ...args], " ");
 
@@ -1640,7 +1636,7 @@ const runQualityProgram = <A, R>(
 const githubChecksCommand = Command.make(
   "github-checks",
   {
-    mode: Argument.choice("mode", GITHUB_CHECK_MODES).pipe(Argument.withDescription("GitHub check mode to run")),
+    mode: Argument.choice("mode", GITHUB_CHECK_MODE_VALUES).pipe(Argument.withDescription("GitHub check mode to run")),
   },
   ({ mode }) => runQualityProgram(runGithubChecks(mode))
 ).pipe(Command.withDescription("Run repository GitHub verification lanes"));

--- a/packages/tooling/tool/cli/src/commands/Quality/Tasks.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/Tasks.ts
@@ -17,6 +17,7 @@ import * as P from "effect/Predicate";
 import * as R from "effect/Record";
 import * as S from "effect/Schema";
 import { ChildProcess } from "effect/unstable/process";
+import { GITHUB_CHECK_MODE_VALUES } from "../../internal/repo-run/index.js";
 import { configStringEqualsSync, configStringOption } from "./internal/Config.js";
 import { QualityTaskConfigurationError, QualityTaskFailed, QualityTaskGroupFailed } from "./Quality.errors.js";
 import type { DomainError, NoSuchFileError } from "@beep/repo-utils";
@@ -53,7 +54,6 @@ const LINT_POLICY_SUBCOMMANDS = [
   "tooling-schema-first",
 ] as const;
 const AUDIT_MODE_NAMES = ["packages", "github"] as const;
-const GITHUB_CHECK_MODES = ["quality", "repo-sanity", "secrets", "security", "sast", "nix", "pre-push"] as const;
 
 /**
  * Canonical quality task name.
@@ -247,7 +247,8 @@ const isLintPolicySubcommand = (value: string | undefined): boolean =>
 const isRootAuditMode = (value: string): value is RootAuditMode =>
   A.contains(AUDIT_MODE_NAMES as ReadonlyArray<string>, value);
 
-const isGithubCheckMode = (value: string): boolean => A.contains(GITHUB_CHECK_MODES as ReadonlyArray<string>, value);
+const isGithubCheckMode = (value: string): boolean =>
+  A.contains(GITHUB_CHECK_MODE_VALUES as ReadonlyArray<string>, value);
 
 const stripPassthroughDelimiter = (args: ReadonlyArray<string>): ReadonlyArray<string> =>
   pipe(

--- a/packages/tooling/tool/cli/src/commands/Quality/Tasks.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/Tasks.ts
@@ -17,7 +17,7 @@ import * as P from "effect/Predicate";
 import * as R from "effect/Record";
 import * as S from "effect/Schema";
 import { ChildProcess } from "effect/unstable/process";
-import { GITHUB_CHECK_MODE_VALUES } from "../../internal/repo-run/index.js";
+import { GithubCheckMode } from "../../internal/repo-run/index.js";
 import { configStringEqualsSync, configStringOption } from "./internal/Config.js";
 import { QualityTaskConfigurationError, QualityTaskFailed, QualityTaskGroupFailed } from "./Quality.errors.js";
 import type { DomainError, NoSuchFileError } from "@beep/repo-utils";
@@ -247,8 +247,7 @@ const isLintPolicySubcommand = (value: string | undefined): boolean =>
 const isRootAuditMode = (value: string): value is RootAuditMode =>
   A.contains(AUDIT_MODE_NAMES as ReadonlyArray<string>, value);
 
-const isGithubCheckMode = (value: string): boolean =>
-  A.contains(GITHUB_CHECK_MODE_VALUES as ReadonlyArray<string>, value);
+const isGithubCheckMode = S.is(GithubCheckMode);
 
 const stripPassthroughDelimiter = (args: ReadonlyArray<string>): ReadonlyArray<string> =>
   pipe(

--- a/packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts
@@ -8,9 +8,76 @@
 import { Command, Flag } from "effect/unstable/cli";
 import { runYeet, YeetRunOptions } from "./internal/Handler.js";
 import { DEFAULT_YEET_PACKET_DIR } from "./internal/Planner.js";
+import type { YeetRunMode } from "./internal/Planner.js";
+
+const baseFlag = Flag.string("base").pipe(
+  Flag.withDescription("Base ref for affected feedback planning"),
+  Flag.withDefault("origin/main")
+);
+
+const headFlag = Flag.string("head").pipe(
+  Flag.withDescription("Head ref for affected feedback planning"),
+  Flag.withDefault("HEAD")
+);
+
+const jsonFlag = Flag.boolean("json").pipe(Flag.withDescription("Render plan output as JSON"));
+
+const packetDirFlag = Flag.string("packet-dir").pipe(
+  Flag.withDescription("Ignored directory for yeet run context, logs, and packets"),
+  Flag.withDefault(DEFAULT_YEET_PACKET_DIR)
+);
+
+const planFlag = Flag.boolean("plan").pipe(Flag.withDescription("Print the yeet plan without running commands"));
+
+const messageFlag = Flag.string("message").pipe(
+  Flag.withDescription("Conventional commit message required before publish"),
+  Flag.withDefault("")
+);
+
+const sharedFlags = {
+  base: baseFlag,
+  head: headFlag,
+  json: jsonFlag,
+  packetDir: packetDirFlag,
+  plan: planFlag,
+} as const;
+
+const publishFlags = {
+  ...sharedFlags,
+  message: messageFlag,
+} as const;
+
+type SharedOptions = {
+  readonly base: string;
+  readonly head: string;
+  readonly json: boolean;
+  readonly packetDir: string;
+  readonly plan: boolean;
+};
+
+const runYeetMode = (mode: YeetRunMode, options: SharedOptions & { readonly message?: string }) =>
+  runYeet(
+    YeetRunOptions.make({
+      ...options,
+      message: options.message ?? "",
+      mode,
+    })
+  );
+
+const yeetVerifyCommand = Command.make("verify", sharedFlags, (options) => runYeetMode("verify", options)).pipe(
+  Command.withDescription("Run read-only affected feedback and the canonical pre-push proof")
+);
+
+const yeetRepairCommand = Command.make("repair", sharedFlags, (options) => runYeetMode("repair", options)).pipe(
+  Command.withDescription("Run deterministic fixers and artifact generators, then affected feedback")
+);
+
+const yeetPublishCommand = Command.make("publish", publishFlags, (options) => runYeetMode("publish", options)).pipe(
+  Command.withDescription("Commit reviewed staged changes, prove the commit, then push")
+);
 
 /**
- * Command that runs fast quality feedback, canonical full proof, then commits and pushes reviewed staged changes.
+ * Command that repairs, verifies, or publishes repository work through Yeet.
  *
  * @example
  * ```ts
@@ -21,29 +88,7 @@ import { DEFAULT_YEET_PACKET_DIR } from "./internal/Planner.js";
  * @category cli-commands
  * @since 0.0.0
  */
-export const yeetCommand = Command.make(
-  "yeet",
-  {
-    base: Flag.string("base").pipe(
-      Flag.withDescription("Base ref for affected feedback planning"),
-      Flag.withDefault("origin/main")
-    ),
-    head: Flag.string("head").pipe(
-      Flag.withDescription("Head ref for affected feedback planning"),
-      Flag.withDefault("HEAD")
-    ),
-    json: Flag.boolean("json").pipe(Flag.withDescription("Render plan output as JSON")),
-    message: Flag.string("message").pipe(
-      Flag.withDescription("Conventional commit message required before publish"),
-      Flag.withDefault("")
-    ),
-    packetDir: Flag.string("packet-dir").pipe(
-      Flag.withDescription("Ignored directory for yeet run context, logs, and packets"),
-      Flag.withDefault(DEFAULT_YEET_PACKET_DIR)
-    ),
-    plan: Flag.boolean("plan").pipe(
-      Flag.withDescription("Print the yeet plan without running quality or git commands")
-    ),
-  },
-  (options) => runYeet(YeetRunOptions.make(options))
-).pipe(Command.withDescription("Run repo quality feedback, full proof, then commit and push reviewed staged changes"));
+export const yeetCommand = Command.make("yeet", publishFlags, (options) => runYeetMode("publish", options)).pipe(
+  Command.withDescription("Repair, verify, or publish repository work with canonical quality proof"),
+  Command.withSubcommands([yeetVerifyCommand, yeetRepairCommand, yeetPublishCommand])
+);

--- a/packages/tooling/tool/cli/src/commands/Yeet/index.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/index.ts
@@ -13,6 +13,13 @@
  */
 export { YeetRunOptions, YeetRunResult } from "./internal/Handler.js";
 /**
+ * Public yeet execution mode model.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export { YeetRunMode } from "./internal/Planner.js";
+/**
  * Yeet quality issue index models and parsers.
  *
  * @category models

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts
@@ -25,7 +25,13 @@ import {
 } from "../../../internal/repo-run/index.js";
 import { YeetCommandError } from "../Yeet.errors.js";
 import { renderPackageQualityPacketMarkdown } from "./PacketRenderer.js";
-import { buildYeetRunPlan, DEFAULT_YEET_PACKET_DIR, emptyTurboPlanSnapshot, YEET_FEEDBACK_TASKS } from "./Planner.js";
+import {
+  buildYeetRunPlanWithMode,
+  DEFAULT_YEET_PACKET_DIR,
+  emptyTurboPlanSnapshot,
+  YEET_FEEDBACK_TASKS,
+  YeetRunMode,
+} from "./Planner.js";
 import { buildQualityIssueIndex, qualityIssuesFromStepResult } from "./QualityIssueIndex.js";
 import type { ChildProcessSpawner } from "effect/unstable/process";
 import type { RepoPlanStep, RepoRunPlan, RepoStepRunResult } from "../../../internal/repo-run/index.js";
@@ -134,7 +140,7 @@ const decodeTurboQueryLsDocument = S.decodeUnknownEffect(S.fromJsonString(TurboQ
  * ```ts
  * import { YeetRunOptions } from "@beep/repo-cli/commands/Yeet"
  *
- * const options = YeetRunOptions.make({ base: "origin/main", head: "HEAD", json: false, message: "", packetDir: ".beep/yeet", plan: true })
+ * const options = YeetRunOptions.make({ base: "origin/main", head: "HEAD", json: false, message: "", mode: "verify", packetDir: ".beep/yeet", plan: true })
  * console.log(options.base)
  * ```
  * @category models
@@ -146,6 +152,7 @@ export class YeetRunOptions extends S.Class<YeetRunOptions>($I`YeetRunOptions`)(
     head: S.String,
     json: S.Boolean,
     message: S.String,
+    mode: YeetRunMode,
     packetDir: S.String,
     plan: S.Boolean,
   },
@@ -269,6 +276,35 @@ const runGitOutput = Effect.fn("Yeet.runGitOutput")(function* (
     });
   }
   return Str.trim(result.output);
+});
+
+const originRefPrefix = "origin/" as const;
+
+const originBranchFromBase = (base: string): O.Option<string> =>
+  pipe(
+    O.some(base),
+    O.filter(Str.startsWith(originRefPrefix)),
+    O.map(Str.replace(originRefPrefix, "")),
+    O.filter(Str.isNonEmpty)
+  );
+
+const refreshBaseRef = Effect.fn("Yeet.refreshBaseRef")(function* (
+  repoRoot: string,
+  base: string
+): Effect.fn.Return<void, YeetCommandError, ChildProcessSpawner.ChildProcessSpawner> {
+  const originBranch = originBranchFromBase(base);
+  if (O.isSome(originBranch)) {
+    yield* runGitOutput(repoRoot, [
+      "fetch",
+      "--quiet",
+      "--no-tags",
+      "origin",
+      `${originBranch.value}:refs/remotes/origin/${originBranch.value}`,
+    ]);
+    return;
+  }
+
+  yield* runGitOutput(repoRoot, ["rev-parse", "--verify", base]);
 });
 
 const runGitPathList = Effect.fn("Yeet.runGitPathList")(function* (
@@ -613,6 +649,7 @@ export const hydrateYeetRunContext = Effect.fn("Yeet.hydrateYeetRunContext")(fun
 > {
   const repoRoot = yield* findRepoRoot().pipe(Effect.mapError(YeetCommandError.new("Failed to locate repo root.")));
   const branch = yield* runGitOutput(repoRoot, ["rev-parse", "--abbrev-ref", "HEAD"]);
+  yield* refreshBaseRef(repoRoot, options.base);
   const turbo = yield* collectTurboPlanSnapshot(repoRoot, options);
 
   return RepoRunContext.make({
@@ -756,12 +793,12 @@ const emptyPlanResult = Effect.fn("Yeet.emptyPlanResult")(function* (
 
 const validateRequiredMessage = (options: YeetRunOptions): Effect.Effect<O.Option<string>, YeetCommandError> => {
   const message = optionFromNonEmpty(options.message);
-  if (options.plan || O.isSome(message)) {
+  if (options.plan || options.mode !== "publish" || O.isSome(message)) {
     return Effect.succeed(message);
   }
   return Effect.fail(
     YeetCommandError.make({
-      message: "yeet requires --message with a conventional commit message unless --plan is used.",
+      message: "yeet publish requires --message with a conventional commit message unless --plan is used.",
       exitCode: 1,
     })
   );
@@ -823,7 +860,8 @@ const failWithIssueArtifacts = Effect.fn("Yeet.failWithIssueArtifacts")(function
 
 const runPlanExecution = Effect.fn("Yeet.runPlanExecution")(function* (
   plan: RepoRunPlan,
-  message: string
+  mode: YeetRunMode,
+  message: O.Option<string>
 ): Effect.fn.Return<
   YeetRunResult,
   YeetCommandError,
@@ -831,9 +869,9 @@ const runPlanExecution = Effect.fn("Yeet.runPlanExecution")(function* (
 > {
   const prepareSteps = A.filter(plan.steps, (step) => step.phase === "prepare");
   const feedbackSteps = A.filter(plan.steps, (step) => step.phase === "feedback");
+  const commitSteps = A.filter(plan.steps, (step) => step.phase === "commit");
   const fullSteps = A.filter(plan.steps, (step) => step.phase === "full");
   const publishSteps = A.filter(plan.steps, (step) => step.phase === "publish");
-  const publishIntent = yield* collectPublishIntent(plan.context);
 
   const prepareResults = yield* runPhase(plan.context, prepareSteps);
   if (A.some(prepareResults, (result) => result.exitCode !== 0)) {
@@ -845,13 +883,33 @@ const runPlanExecution = Effect.fn("Yeet.runPlanExecution")(function* (
     return yield* failWithIssueArtifacts(plan.context, feedbackSteps, feedbackResults, "yeet feedback phase failed.");
   }
 
-  const fullResults = yield* runPhase(plan.context, fullSteps);
-  if (A.some(fullResults, (result) => result.exitCode !== 0)) {
-    return yield* failWithIssueArtifacts(plan.context, fullSteps, fullResults, "yeet final full proof failed.");
+  if (mode === "repair") {
+    return yield* emptyPlanResult(plan.context);
   }
 
-  yield* validateCommitMessage(plan.context, message);
+  if (mode === "verify") {
+    const verifyResults = yield* runPhase(plan.context, fullSteps);
+    if (A.some(verifyResults, (result) => result.exitCode !== 0)) {
+      return yield* failWithIssueArtifacts(plan.context, fullSteps, verifyResults, "yeet verification proof failed.");
+    }
+    return yield* emptyPlanResult(plan.context);
+  }
+
+  const publishIntent = yield* collectPublishIntent(plan.context);
+  const commitMessage = O.getOrElse(message, () => "");
+  yield* validateCommitMessage(plan.context, commitMessage);
   yield* stageReviewedPublishIntent(plan.context, publishIntent);
+
+  const commitResults = yield* runPhase(plan.context, commitSteps);
+  if (A.some(commitResults, (result) => result.exitCode !== 0)) {
+    return yield* failWithIssueArtifacts(plan.context, commitSteps, commitResults, "yeet commit phase failed.");
+  }
+
+  const fullResults = yield* runPhase(plan.context, fullSteps);
+  if (A.some(fullResults, (result) => result.exitCode !== 0)) {
+    return yield* failWithIssueArtifacts(plan.context, fullSteps, fullResults, "yeet publish proof failed.");
+  }
+
   const publishResults = yield* runPhase(plan.context, publishSteps);
   if (A.some(publishResults, (result) => result.exitCode !== 0)) {
     return yield* failWithIssueArtifacts(plan.context, publishSteps, publishResults, "yeet publish phase failed.");
@@ -901,25 +959,30 @@ export const runYeet = Effect.fn("Yeet.runYeet")(function* (
 > {
   const message = yield* validateRequiredMessage(options);
   const context = yield* hydrateYeetRunContext(options);
-  const plan = buildYeetRunPlan(context, message);
+  const plan = buildYeetRunPlanWithMode(context, message, options.mode);
   if (options.plan) {
     yield* renderPlan(plan, options.json);
     return yield* emptyPlanResult(context);
   }
 
-  return yield* runPlanExecution(
-    plan,
-    O.getOrElse(message, () => "")
-  );
+  return yield* runPlanExecution(plan, options.mode, message);
 });
 
 /**
  * Build a plan for tests without reading repository state.
  *
+ * @param context - Hydrated test context.
+ * @param message - Optional publish commit message.
+ * @param mode - Yeet mode to plan.
+ * @returns Ordered Yeet run plan.
  * @category testing
  * @since 0.0.0
  */
-export const buildYeetRunPlanForTesting = buildYeetRunPlan;
+export const buildYeetRunPlanForTesting = (
+  context: RepoRunContext,
+  message: O.Option<string>,
+  mode: YeetRunMode = "publish"
+): RepoRunPlan => buildYeetRunPlanWithMode(context, message, mode);
 
 /**
  * Construct baseline yeet options for focused tests.
@@ -935,6 +998,7 @@ export const defaultYeetRunOptions = (overrides: Partial<YeetRunOptions> = {}): 
     head: "HEAD",
     json: false,
     message: "",
+    mode: "publish",
     packetDir: DEFAULT_YEET_PACKET_DIR,
     plan: false,
     ...overrides,

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts
@@ -31,6 +31,7 @@ import {
   emptyTurboPlanSnapshot,
   YEET_FEEDBACK_TASKS,
   YeetRunMode,
+  YeetRunPlanModeOptions,
 } from "./Planner.js";
 import { buildQualityIssueIndex, qualityIssuesFromStepResult } from "./QualityIssueIndex.js";
 import type { ChildProcessSpawner } from "effect/unstable/process";
@@ -959,7 +960,7 @@ export const runYeet = Effect.fn("Yeet.runYeet")(function* (
 > {
   const message = yield* validateRequiredMessage(options);
   const context = yield* hydrateYeetRunContext(options);
-  const plan = buildYeetRunPlanWithMode(context, message, options.mode);
+  const plan = buildYeetRunPlanWithMode(context, message, YeetRunPlanModeOptions.make({ mode: options.mode }));
   if (options.plan) {
     yield* renderPlan(plan, options.json);
     return yield* emptyPlanResult(context);
@@ -971,18 +972,21 @@ export const runYeet = Effect.fn("Yeet.runYeet")(function* (
 /**
  * Build a plan for tests without reading repository state.
  *
- * @param context - Hydrated test context.
- * @param message - Optional publish commit message.
- * @param mode - Yeet mode to plan.
+ * @param options - Hydrated test context, optional message, and optional mode.
  * @returns Ordered Yeet run plan.
  * @category testing
  * @since 0.0.0
  */
-export const buildYeetRunPlanForTesting = (
-  context: RepoRunContext,
-  message: O.Option<string>,
-  mode: YeetRunMode = "publish"
-): RepoRunPlan => buildYeetRunPlanWithMode(context, message, mode);
+export const buildYeetRunPlanForTesting = (options: {
+  readonly context: RepoRunContext;
+  readonly message: O.Option<string>;
+  readonly mode?: YeetRunMode;
+}): RepoRunPlan =>
+  buildYeetRunPlanWithMode(
+    options.context,
+    options.message,
+    YeetRunPlanModeOptions.make({ mode: options.mode ?? "publish" })
+  );
 
 /**
  * Construct baseline yeet options for focused tests.

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts
@@ -416,6 +416,24 @@ const stageReviewedPublishIntent = Effect.fn("Yeet.stageReviewedPublishIntent")(
   }
 });
 
+const validatePostCommitProofDidNotChangeWorktree = Effect.fn("Yeet.validatePostCommitProofDidNotChangeWorktree")(
+  function* (
+    context: RepoRunContext
+  ): Effect.fn.Return<void, YeetCommandError, ChildProcessSpawner.ChildProcessSpawner> {
+    const stagedPaths = yield* collectStagedPublishPaths(context.repoRoot);
+    const unstagedPaths = yield* collectUnstagedTrackedPaths(context.repoRoot);
+    const untrackedPaths = yield* collectUntrackedPaths(context.repoRoot);
+    const changedPaths = sortedUniquePaths([...stagedPaths, ...unstagedPaths, ...untrackedPaths]);
+
+    if (!A.isReadonlyArrayEmpty(changedPaths)) {
+      return yield* publishScopeError(
+        "yeet publish stopped because the full proof changed files after the local commit. Regenerate them, then amend or reset the commit that has not yet been pushed before retrying.",
+        changedPaths
+      );
+    }
+  }
+);
+
 const isEscapedQuote = (output: string, index: number): boolean => {
   let backslashCount = 0;
   for (let cursor = index - 1; cursor >= 0 && output[cursor] === "\\"; cursor -= 1) {
@@ -859,6 +877,61 @@ const failWithIssueArtifacts = Effect.fn("Yeet.failWithIssueArtifacts")(function
   );
 });
 
+const runVerifyMode = Effect.fn("Yeet.runVerifyMode")(function* (
+  context: RepoRunContext,
+  fullSteps: ReadonlyArray<RepoPlanStep>
+): Effect.fn.Return<
+  YeetRunResult,
+  YeetCommandError,
+  FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+> {
+  const verifyResults = yield* runPhase(context, fullSteps);
+  if (A.some(verifyResults, (result) => result.exitCode !== 0)) {
+    return yield* failWithIssueArtifacts(context, fullSteps, verifyResults, "yeet verification proof failed.");
+  }
+  return yield* emptyPlanResult(context);
+});
+
+const runPublishMode = Effect.fn("Yeet.runPublishMode")(function* (
+  plan: RepoRunPlan,
+  message: O.Option<string>,
+  commitSteps: ReadonlyArray<RepoPlanStep>,
+  fullSteps: ReadonlyArray<RepoPlanStep>,
+  publishSteps: ReadonlyArray<RepoPlanStep>
+): Effect.fn.Return<
+  YeetRunResult,
+  YeetCommandError,
+  FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+> {
+  const publishIntent = yield* collectPublishIntent(plan.context);
+  const commitMessage = O.getOrElse(message, () => "");
+  yield* validateCommitMessage(plan.context, commitMessage);
+  yield* stageReviewedPublishIntent(plan.context, publishIntent);
+
+  const commitResults = yield* runPhase(plan.context, commitSteps);
+  if (A.some(commitResults, (result) => result.exitCode !== 0)) {
+    return yield* failWithIssueArtifacts(plan.context, commitSteps, commitResults, "yeet commit phase failed.");
+  }
+
+  const fullResults = yield* runPhase(plan.context, fullSteps);
+  if (A.some(fullResults, (result) => result.exitCode !== 0)) {
+    return yield* failWithIssueArtifacts(
+      plan.context,
+      fullSteps,
+      fullResults,
+      "yeet publish proof failed after creating the local commit. Fix the issue, then amend or reset the commit that has not yet been pushed before retrying."
+    );
+  }
+  yield* validatePostCommitProofDidNotChangeWorktree(plan.context);
+
+  const publishResults = yield* runPhase(plan.context, publishSteps);
+  if (A.some(publishResults, (result) => result.exitCode !== 0)) {
+    return yield* failWithIssueArtifacts(plan.context, publishSteps, publishResults, "yeet publish phase failed.");
+  }
+
+  return yield* publishResult(plan.context);
+});
+
 const runPlanExecution = Effect.fn("Yeet.runPlanExecution")(function* (
   plan: RepoRunPlan,
   mode: YeetRunMode,
@@ -884,39 +957,11 @@ const runPlanExecution = Effect.fn("Yeet.runPlanExecution")(function* (
     return yield* failWithIssueArtifacts(plan.context, feedbackSteps, feedbackResults, "yeet feedback phase failed.");
   }
 
-  if (mode === "repair") {
-    return yield* emptyPlanResult(plan.context);
-  }
-
-  if (mode === "verify") {
-    const verifyResults = yield* runPhase(plan.context, fullSteps);
-    if (A.some(verifyResults, (result) => result.exitCode !== 0)) {
-      return yield* failWithIssueArtifacts(plan.context, fullSteps, verifyResults, "yeet verification proof failed.");
-    }
-    return yield* emptyPlanResult(plan.context);
-  }
-
-  const publishIntent = yield* collectPublishIntent(plan.context);
-  const commitMessage = O.getOrElse(message, () => "");
-  yield* validateCommitMessage(plan.context, commitMessage);
-  yield* stageReviewedPublishIntent(plan.context, publishIntent);
-
-  const commitResults = yield* runPhase(plan.context, commitSteps);
-  if (A.some(commitResults, (result) => result.exitCode !== 0)) {
-    return yield* failWithIssueArtifacts(plan.context, commitSteps, commitResults, "yeet commit phase failed.");
-  }
-
-  const fullResults = yield* runPhase(plan.context, fullSteps);
-  if (A.some(fullResults, (result) => result.exitCode !== 0)) {
-    return yield* failWithIssueArtifacts(plan.context, fullSteps, fullResults, "yeet publish proof failed.");
-  }
-
-  const publishResults = yield* runPhase(plan.context, publishSteps);
-  if (A.some(publishResults, (result) => result.exitCode !== 0)) {
-    return yield* failWithIssueArtifacts(plan.context, publishSteps, publishResults, "yeet publish phase failed.");
-  }
-
-  return yield* publishResult(plan.context);
+  return yield* YeetRunMode.$match(mode, {
+    repair: () => emptyPlanResult(plan.context),
+    verify: () => runVerifyMode(plan.context, fullSteps),
+    publish: () => runPublishMode(plan, message, commitSteps, fullSteps, publishSteps),
+  });
 });
 
 const renderPlan = Effect.fn("Yeet.renderPlan")(function* (

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts
@@ -15,6 +15,7 @@ import * as S from "effect/Schema";
 import {
   byRepoPlanStepAscending,
   enforceConservativeResume,
+  RepoPlanPhase,
   RepoPlanStep,
   RepoRunPlan,
   repoProofStepDefinition,
@@ -220,6 +221,7 @@ const feedbackFilterArgs = (context: RepoRunContext, feedbackTask: YeetFeedbackT
   );
 
 const feedbackRunArgs = (feedbackTask: YeetFeedbackTask, filters: ReadonlyArray<string>): ReadonlyArray<string> =>
+  // Feedback tests stay on unit/type lanes; repair is generator-only, and verify/publish run integration in full proof.
   feedbackTask === "test"
     ? ["--unit", "--types", ...filters, ...sharedFeedbackTurboArgs]
     : [...filters, ...sharedFeedbackTurboArgs];
@@ -378,20 +380,14 @@ export const yeetPlanPhases = (plan: RepoRunPlan): ReadonlyArray<RepoPlanStep["p
     A.map((step) => step.phase),
     A.dedupe,
     A.sort(
-      Order.mapInput(Order.Number, (phase) => {
-        if (phase === "prepare") {
-          return 0;
-        }
-        if (phase === "feedback") {
-          return 1;
-        }
-        if (phase === "commit") {
-          return 2;
-        }
-        if (phase === "full") {
-          return 3;
-        }
-        return 4;
-      })
+      Order.mapInput(Order.Number, (phase: RepoPlanStep["phase"]) =>
+        RepoPlanPhase.$match(phase, {
+          prepare: () => 0,
+          feedback: () => 1,
+          commit: () => 2,
+          full: () => 3,
+          publish: () => 4,
+        })
+      )
     )
   );

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts
@@ -11,6 +11,7 @@ import { Order } from "effect";
 import * as A from "effect/Array";
 import { dual, pipe } from "effect/Function";
 import * as O from "effect/Option";
+import * as S from "effect/Schema";
 import {
   byRepoPlanStepAscending,
   enforceConservativeResume,
@@ -39,6 +40,8 @@ export const DEFAULT_YEET_PACKET_DIR = ".beep/yeet" as const;
  */
 export const YEET_FEEDBACK_TASKS = ["build", "check", "lint", "test"] as const;
 
+type YeetFeedbackTask = (typeof YEET_FEEDBACK_TASKS)[number];
+
 /**
  * Yeet execution modes.
  *
@@ -64,6 +67,27 @@ export const YeetRunMode = LiteralKit(["repair", "verify", "publish"]).pipe(
  * @since 0.0.0
  */
 export type YeetRunMode = typeof YeetRunMode.Type;
+
+/**
+ * Options for building a Yeet run plan in a specific mode.
+ *
+ * @example
+ * ```ts
+ * import { YeetRunPlanModeOptions } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(YeetRunPlanModeOptions.make({ mode: "verify" }).mode)
+ * ```
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetRunPlanModeOptions extends S.Class<YeetRunPlanModeOptions>($I`YeetRunPlanModeOptions`)(
+  {
+    mode: YeetRunMode,
+  },
+  $I.annote("YeetRunPlanModeOptions", {
+    description: "Options for building a Yeet run plan in a specific mode.",
+  })
+) {}
 
 const sharedFeedbackTurboArgs = ["--continue=dependencies-successful", "--summarize", "--ui=stream"] as const;
 
@@ -185,7 +209,7 @@ const packageNameForFeedbackTask =
       O.filter((packageName) => task.task === feedbackTask && packageName !== "//")
     );
 
-const feedbackFilterArgs = (context: RepoRunContext, feedbackTask: string): ReadonlyArray<string> =>
+const feedbackFilterArgs = (context: RepoRunContext, feedbackTask: YeetFeedbackTask): ReadonlyArray<string> =>
   pipe(
     context.turbo.tasks,
     A.map(packageNameForFeedbackTask(feedbackTask)),
@@ -195,12 +219,17 @@ const feedbackFilterArgs = (context: RepoRunContext, feedbackTask: string): Read
     A.map((packageName) => `--filter=${packageName}`)
   );
 
+const feedbackRunArgs = (feedbackTask: YeetFeedbackTask, filters: ReadonlyArray<string>): ReadonlyArray<string> =>
+  feedbackTask === "test"
+    ? ["--unit", "--types", ...filters, ...sharedFeedbackTurboArgs]
+    : [...filters, ...sharedFeedbackTurboArgs];
+
 const feedbackStep = (
   context: RepoRunContext,
   id: string,
   label: string,
   script: string,
-  task: string
+  task: YeetFeedbackTask
 ): O.Option<RepoPlanStep> => {
   const filters = feedbackFilterArgs(context, task);
   if (A.isReadonlyArrayEmpty(filters)) {
@@ -214,7 +243,7 @@ const feedbackStep = (
       label,
       "feedback",
       script,
-      ["--", ...filters, ...sharedFeedbackTurboArgs],
+      ["--", ...feedbackRunArgs(task, filters)],
       "readonly",
       "repo",
       O.some(task)
@@ -261,11 +290,16 @@ const stepsForMode = (
  *
  * @param context - Hydrated run context.
  * @param message - Optional conventional commit message; required by publish execution.
- * @param mode - Yeet execution mode.
+ * @param options - Mode selector used to choose repair, verify, or publish steps.
  * @returns Ordered repository run plan.
  * @example
  * ```ts
- * import { buildYeetRunPlanWithMode, RepoRunContext, TurboPlanSnapshot } from "@beep/repo-cli/test/Yeet"
+ * import {
+ *   buildYeetRunPlanWithMode,
+ *   RepoRunContext,
+ *   TurboPlanSnapshot,
+ *   YeetRunPlanModeOptions
+ * } from "@beep/repo-cli/test/Yeet"
  * import * as O from "effect/Option"
  *
  * const context = RepoRunContext.make({
@@ -278,20 +312,22 @@ const stepsForMode = (
  *   repoRoot: "/repo",
  *   turbo: TurboPlanSnapshot.make({ graphHealthStatus: "ok", graphHealthWarnings: [], tasks: [] })
  * })
- * console.log(buildYeetRunPlanWithMode(context, O.none(), "verify").steps)
+ * console.log(buildYeetRunPlanWithMode(context, O.none(), YeetRunPlanModeOptions.make({ mode: "verify" })).steps)
  * ```
  * @category workflows
  * @since 0.0.0
  */
-export const buildYeetRunPlanWithMode = (
-  context: RepoRunContext,
-  message: O.Option<string>,
-  mode: YeetRunMode
-): RepoRunPlan =>
-  RepoRunPlan.make({
-    context,
-    steps: pipe(stepsForMode(context, message, mode), A.sort(byRepoPlanStepAscending)),
-  });
+export const buildYeetRunPlanWithMode: {
+  (context: RepoRunContext, message: O.Option<string>, options: YeetRunPlanModeOptions): RepoRunPlan;
+  (message: O.Option<string>, options: YeetRunPlanModeOptions): (context: RepoRunContext) => RepoRunPlan;
+} = dual(
+  3,
+  (context: RepoRunContext, message: O.Option<string>, options: YeetRunPlanModeOptions): RepoRunPlan =>
+    RepoRunPlan.make({
+      context,
+      steps: pipe(stepsForMode(context, message, options.mode), A.sort(byRepoPlanStepAscending)),
+    })
+);
 
 /**
  * Build the publish-mode yeet run plan.
@@ -325,7 +361,7 @@ export const buildYeetRunPlan: {
 } = dual(
   2,
   (context: RepoRunContext, message: O.Option<string>): RepoRunPlan =>
-    buildYeetRunPlanWithMode(context, message, "publish")
+    buildYeetRunPlanWithMode(context, message, YeetRunPlanModeOptions.make({ mode: "publish" }))
 );
 
 /**

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts
@@ -5,6 +5,8 @@
  * @since 0.0.0
  */
 
+import { $RepoCliId } from "@beep/identity/packages";
+import { LiteralKit } from "@beep/schema";
 import { Order } from "effect";
 import * as A from "effect/Array";
 import { dual, pipe } from "effect/Function";
@@ -14,9 +16,12 @@ import {
   enforceConservativeResume,
   RepoPlanStep,
   RepoRunPlan,
+  repoProofStepDefinition,
   TurboPlanSnapshot,
 } from "../../../internal/repo-run/index.js";
 import type { RepoRunContext, TurboPlanTask } from "../../../internal/repo-run/index.js";
+
+const $I = $RepoCliId.create("commands/Yeet/internal/Planner");
 
 /**
  * Default ignored directory for yeet run artifacts.
@@ -33,6 +38,32 @@ export const DEFAULT_YEET_PACKET_DIR = ".beep/yeet" as const;
  * @since 0.0.0
  */
 export const YEET_FEEDBACK_TASKS = ["build", "check", "lint", "test"] as const;
+
+/**
+ * Yeet execution modes.
+ *
+ * @example
+ * ```ts
+ * import { YeetRunMode } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(YeetRunMode.is.verify("verify"))
+ * ```
+ * @category models
+ * @since 0.0.0
+ */
+export const YeetRunMode = LiteralKit(["repair", "verify", "publish"]).pipe(
+  $I.annoteSchema("YeetRunMode", {
+    description: "Execution mode selected for a yeet repository run.",
+  })
+);
+
+/**
+ * Yeet execution modes.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export type YeetRunMode = typeof YeetRunMode.Type;
 
 const sharedFeedbackTurboArgs = ["--continue=dependencies-successful", "--summarize", "--ui=stream"] as const;
 
@@ -66,11 +97,17 @@ const bunRunStep = (
     })
   );
 
-const gitStep = (context: RepoRunContext, id: string, label: string, args: ReadonlyArray<string>): RepoPlanStep =>
+const gitStep = (
+  context: RepoRunContext,
+  id: string,
+  label: string,
+  phase: RepoPlanStep["phase"],
+  args: ReadonlyArray<string>
+): RepoPlanStep =>
   RepoPlanStep.make({
     id,
     label,
-    phase: "publish",
+    phase,
     command: "git",
     args: [...args],
     cwd: context.repoRoot,
@@ -104,6 +141,41 @@ const affectedEnv = (context: RepoRunContext): Record<string, string | undefined
   TURBO_SCM_BASE: context.base,
   TURBO_SCM_HEAD: context.head,
 });
+
+const repairSteps = (context: RepoRunContext): ReadonlyArray<RepoPlanStep> => [
+  bunRunStep(
+    context,
+    "prepare:01-lint-fix",
+    "prepare:lint:fix",
+    "prepare",
+    "lint:fix",
+    ["--", ...affectedArgs()],
+    "write",
+    "repo",
+    O.none(),
+    O.some(affectedEnv(context))
+  ),
+  bunRunStep(
+    context,
+    "prepare:02-docgen-local",
+    "prepare:docgen:local",
+    "prepare",
+    "docgen:local",
+    [],
+    "write",
+    "repo"
+  ),
+  bunRunStep(
+    context,
+    "prepare:03-repo-exports-catalog",
+    "prepare:repo-exports:catalog",
+    "prepare",
+    "repo-exports:catalog",
+    [],
+    "write",
+    "repo"
+  ),
+];
 
 const packageNameForFeedbackTask =
   (feedbackTask: string) =>
@@ -150,8 +222,79 @@ const feedbackStep = (
   );
 };
 
+const feedbackSteps = (context: RepoRunContext): ReadonlyArray<RepoPlanStep> =>
+  A.getSomes([
+    feedbackStep(context, "feedback:01-build", "feedback:build", "build", "build"),
+    feedbackStep(context, "feedback:02-check", "feedback:check", "check", "check"),
+    feedbackStep(context, "feedback:03-lint", "feedback:lint", "lint", "lint"),
+    feedbackStep(context, "feedback:04-test", "feedback:test", "test", "test"),
+  ]);
+
+const proofStep = (context: RepoRunContext): RepoPlanStep => {
+  const proof = repoProofStepDefinition("pre-push");
+  return bunRunStep(context, proof.id, proof.label, "full", "beep", proof.args, "readonly", "repo");
+};
+
+const commitStep = (context: RepoRunContext, message: O.Option<string>): RepoPlanStep =>
+  gitStep(context, "commit:01-git-commit", "commit:git:commit", "commit", [
+    "commit",
+    "-m",
+    O.getOrElse(message, () => "<required-conventional-commit-message>"),
+  ]);
+
+const pushStep = (context: RepoRunContext): RepoPlanStep =>
+  gitStep(context, "publish:01-git-push", "publish:git:push", "publish", ["push"]);
+
+const stepsForMode = (
+  context: RepoRunContext,
+  message: O.Option<string>,
+  mode: YeetRunMode
+): ReadonlyArray<RepoPlanStep> =>
+  YeetRunMode.$match(mode, {
+    repair: () => [...repairSteps(context), ...feedbackSteps(context)],
+    verify: () => [...feedbackSteps(context), proofStep(context)],
+    publish: () => [...feedbackSteps(context), commitStep(context, message), proofStep(context), pushStep(context)],
+  });
+
 /**
- * Build the v1 yeet run plan.
+ * Build a yeet run plan for a specific mode.
+ *
+ * @param context - Hydrated run context.
+ * @param message - Optional conventional commit message; required by publish execution.
+ * @param mode - Yeet execution mode.
+ * @returns Ordered repository run plan.
+ * @example
+ * ```ts
+ * import { buildYeetRunPlanWithMode, RepoRunContext, TurboPlanSnapshot } from "@beep/repo-cli/test/Yeet"
+ * import * as O from "effect/Option"
+ *
+ * const context = RepoRunContext.make({
+ *   base: "origin/main",
+ *   branch: "repo-cli-yeet",
+ *   cwd: "/repo",
+ *   head: "HEAD",
+ *   originalArgv: [],
+ *   packetDir: ".beep/yeet",
+ *   repoRoot: "/repo",
+ *   turbo: TurboPlanSnapshot.make({ graphHealthStatus: "ok", graphHealthWarnings: [], tasks: [] })
+ * })
+ * console.log(buildYeetRunPlanWithMode(context, O.none(), "verify").steps)
+ * ```
+ * @category workflows
+ * @since 0.0.0
+ */
+export const buildYeetRunPlanWithMode = (
+  context: RepoRunContext,
+  message: O.Option<string>,
+  mode: YeetRunMode
+): RepoRunPlan =>
+  RepoRunPlan.make({
+    context,
+    steps: pipe(stepsForMode(context, message, mode), A.sort(byRepoPlanStepAscending)),
+  });
+
+/**
+ * Build the publish-mode yeet run plan.
  *
  * @param context - Hydrated run context.
  * @param message - Optional conventional commit message; omitted only for plan mode.
@@ -179,66 +322,11 @@ const feedbackStep = (
 export const buildYeetRunPlan: {
   (context: RepoRunContext, message: O.Option<string>): RepoRunPlan;
   (message: O.Option<string>): (context: RepoRunContext) => RepoRunPlan;
-} = dual(2, (context: RepoRunContext, message: O.Option<string>): RepoRunPlan => {
-  const commitMessage = O.getOrElse(message, () => "<required-conventional-commit-message>");
-  const steps = [
-    bunRunStep(
-      context,
-      "prepare:01-lint-fix",
-      "prepare:lint:fix",
-      "prepare",
-      "lint:fix",
-      ["--", ...affectedArgs()],
-      "write",
-      "repo",
-      O.none(),
-      O.some(affectedEnv(context))
-    ),
-    bunRunStep(
-      context,
-      "prepare:02-docgen-local",
-      "prepare:docgen:local",
-      "prepare",
-      "docgen:local",
-      [],
-      "write",
-      "repo"
-    ),
-    ...A.getSomes([
-      feedbackStep(context, "feedback:01-build", "feedback:build", "build", "build"),
-      feedbackStep(context, "feedback:02-check", "feedback:check", "check", "check"),
-      feedbackStep(context, "feedback:03-lint", "feedback:lint", "lint", "lint"),
-      feedbackStep(context, "feedback:04-test", "feedback:test", "test", "test"),
-    ]),
-    bunRunStep(
-      context,
-      "full:01-quality",
-      "full:quality",
-      "full",
-      "beep",
-      ["quality", "github-checks", "quality"],
-      "readonly",
-      "repo"
-    ),
-    gitStep(context, "publish:01-commit", "publish:git:commit", ["commit", "-m", commitMessage]),
-    bunRunStep(
-      context,
-      "publish:02-secrets",
-      "publish:secrets",
-      "publish",
-      "beep",
-      ["quality", "github-checks", "secrets"],
-      "readonly",
-      "repo"
-    ),
-    gitStep(context, "publish:03-push", "publish:git:push", ["push"]),
-  ];
-
-  return RepoRunPlan.make({
-    context,
-    steps: pipe(steps, A.sort(byRepoPlanStepAscending)),
-  });
-});
+} = dual(
+  2,
+  (context: RepoRunContext, message: O.Option<string>): RepoRunPlan =>
+    buildYeetRunPlanWithMode(context, message, "publish")
+);
 
 /**
  * Return plan phases in execution order.
@@ -261,10 +349,13 @@ export const yeetPlanPhases = (plan: RepoRunPlan): ReadonlyArray<RepoPlanStep["p
         if (phase === "feedback") {
           return 1;
         }
-        if (phase === "full") {
+        if (phase === "commit") {
           return 2;
         }
-        return 3;
+        if (phase === "full") {
+          return 3;
+        }
+        return 4;
       })
     )
   );

--- a/packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts
+++ b/packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts
@@ -28,7 +28,7 @@ const $I = $RepoCliId.create("internal/repo-run/RepoRun.models");
  * @category models
  * @since 0.0.0
  */
-export const RepoPlanPhase = LiteralKit(["prepare", "feedback", "full", "publish"]).pipe(
+export const RepoPlanPhase = LiteralKit(["prepare", "feedback", "commit", "full", "publish"]).pipe(
   $I.annoteSchema("RepoPlanPhase", {
     description: "Named phase in a repository run plan.",
   })
@@ -361,8 +361,9 @@ const phaseOrderValue = (phase: RepoPlanPhase): number =>
   RepoPlanPhase.$match(phase, {
     prepare: () => 0,
     feedback: () => 1,
-    full: () => 2,
-    publish: () => 3,
+    commit: () => 2,
+    full: () => 3,
+    publish: () => 4,
   });
 
 /**

--- a/packages/tooling/tool/cli/src/internal/repo-run/RepoRun.proofs.ts
+++ b/packages/tooling/tool/cli/src/internal/repo-run/RepoRun.proofs.ts
@@ -1,0 +1,136 @@
+/**
+ * Shared repository proof-surface definitions for repo-cli orchestration.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { LiteralKit } from "@beep/schema";
+import * as S from "effect/Schema";
+
+const $I = $RepoCliId.create("internal/repo-run/RepoRun.proofs");
+
+/**
+ * GitHub check mode handled by `beep quality github-checks`.
+ *
+ * @example
+ * ```ts
+ * import { GithubCheckMode } from "@beep/repo-cli/internal/repo-run"
+ *
+ * console.log(GithubCheckMode.is["pre-push"]("pre-push"))
+ * ```
+ * @category models
+ * @since 0.0.0
+ */
+export const GITHUB_CHECK_MODE_VALUES = [
+  "quality",
+  "repo-sanity",
+  "secrets",
+  "security",
+  "sast",
+  "nix",
+  "pre-push",
+] as const;
+
+/**
+ * GitHub check mode handled by `beep quality github-checks`.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const GithubCheckMode = LiteralKit(GITHUB_CHECK_MODE_VALUES).pipe(
+  $I.annoteSchema("GithubCheckMode", {
+    description: "GitHub verification mode handled by the repo-cli quality command group.",
+  })
+);
+
+/**
+ * GitHub check mode handled by `beep quality github-checks`.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export type GithubCheckMode = typeof GithubCheckMode.Type;
+
+/**
+ * Named proof surfaces that orchestration commands may require.
+ *
+ * @example
+ * ```ts
+ * import { RepoProofSurface } from "@beep/repo-cli/internal/repo-run"
+ *
+ * console.log(RepoProofSurface.is["pre-push"]("pre-push"))
+ * ```
+ * @category models
+ * @since 0.0.0
+ */
+export const RepoProofSurface = LiteralKit(["quality", "pre-push"]).pipe(
+  $I.annoteSchema("RepoProofSurface", {
+    description: "Named repository proof surface backed by a GitHub checks mode.",
+  })
+);
+
+/**
+ * Named proof surfaces that orchestration commands may require.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export type RepoProofSurface = typeof RepoProofSurface.Type;
+
+/**
+ * Planned command metadata for a repository proof surface.
+ *
+ * @example
+ * ```ts
+ * import { repoProofStepDefinition } from "@beep/repo-cli/internal/repo-run"
+ *
+ * console.log(repoProofStepDefinition("pre-push").args)
+ * ```
+ * @category models
+ * @since 0.0.0
+ */
+export class RepoProofStepDefinition extends S.Class<RepoProofStepDefinition>($I`RepoProofStepDefinition`)(
+  {
+    surface: RepoProofSurface,
+    id: S.String,
+    label: S.String,
+    args: S.Array(S.String),
+  },
+  $I.annote("RepoProofStepDefinition", {
+    description: "Planned command metadata for a repository proof surface.",
+  })
+) {}
+
+/**
+ * Return the `beep` command metadata that proves a repository proof surface.
+ *
+ * @param surface - Proof surface to run.
+ * @returns Command metadata for a `bun run beep ...` plan step.
+ * @example
+ * ```ts
+ * import { repoProofStepDefinition } from "@beep/repo-cli/internal/repo-run"
+ *
+ * console.log(repoProofStepDefinition("quality").label)
+ * ```
+ * @category constructors
+ * @since 0.0.0
+ */
+export const repoProofStepDefinition = (surface: RepoProofSurface): RepoProofStepDefinition =>
+  RepoProofSurface.$match(surface, {
+    quality: () =>
+      RepoProofStepDefinition.make({
+        surface,
+        id: "full:01-quality",
+        label: "full:quality",
+        args: ["quality", "github-checks", "quality"],
+      }),
+    "pre-push": () =>
+      RepoProofStepDefinition.make({
+        surface,
+        id: "full:01-pre-push",
+        label: "full:pre-push",
+        args: ["quality", "github-checks", "pre-push"],
+      }),
+  });

--- a/packages/tooling/tool/cli/src/internal/repo-run/index.ts
+++ b/packages/tooling/tool/cli/src/internal/repo-run/index.ts
@@ -7,3 +7,4 @@
 
 export * from "./RepoRun.executor.js";
 export * from "./RepoRun.models.js";
+export * from "./RepoRun.proofs.js";

--- a/packages/tooling/tool/cli/test/yeet.test.ts
+++ b/packages/tooling/tool/cli/test/yeet.test.ts
@@ -11,6 +11,7 @@ import {
   RepoRunContext,
   RepoStepRunResult,
   renderPackageQualityPacketMarkdown,
+  repoProofStepDefinition,
   TurboPlanSnapshot,
   TurboPlanTask,
   TurboWorkspacePackage,
@@ -120,8 +121,67 @@ const findStep = (steps: ReadonlyArray<RepoPlanStep>, label: string): RepoPlanSt
   );
 
 describe("yeet planner", () => {
-  it("builds the feedback-then-full v1 flow in publish-safe order", () => {
+  it("builds publish as feedback, commit, pre-push proof, then push", () => {
     const plan = buildYeetRunPlanForTesting(context, O.some("feat(repo-cli): add yeet"));
+
+    expect(
+      pipe(
+        plan.steps,
+        A.map((step) => step.label)
+      )
+    ).toEqual([
+      "feedback:build",
+      "feedback:check",
+      "feedback:lint",
+      "feedback:test",
+      "commit:git:commit",
+      "full:pre-push",
+      "publish:git:push",
+    ]);
+    expect(
+      pipe(
+        plan.steps,
+        A.map((step) => step.phase),
+        A.dedupe
+      )
+    ).toEqual(["feedback", "commit", "full", "publish"]);
+
+    const commit = findStep(plan.steps, "commit:git:commit");
+    const proof = findStep(plan.steps, "full:pre-push");
+    const push = findStep(plan.steps, "publish:git:push");
+
+    expect(commit.args).toEqual(["commit", "-m", "feat(repo-cli): add yeet"]);
+    expect(proof.args).toEqual(["run", "beep", "quality", "github-checks", "pre-push"]);
+    expect(proof.mutability).toBe("readonly");
+    expect(push.args).toEqual(["push"]);
+    expect(
+      pipe(
+        plan.steps,
+        A.map((step) => step.args)
+      )
+    ).not.toContainEqual(["add", "-A"]);
+  });
+
+  it("builds verify as read-only feedback plus the canonical pre-push proof", () => {
+    const plan = buildYeetRunPlanForTesting(context, O.none(), "verify");
+
+    expect(
+      pipe(
+        plan.steps,
+        A.map((step) => step.label)
+      )
+    ).toEqual(["feedback:build", "feedback:check", "feedback:lint", "feedback:test", "full:pre-push"]);
+    expect(
+      pipe(
+        plan.steps,
+        A.map((step) => step.mutability),
+        A.dedupe
+      )
+    ).toEqual(["readonly"]);
+  });
+
+  it("builds repair as deterministic generators plus affected feedback", () => {
+    const plan = buildYeetRunPlanForTesting(context, O.none(), "repair");
 
     expect(
       pipe(
@@ -131,37 +191,20 @@ describe("yeet planner", () => {
     ).toEqual([
       "prepare:lint:fix",
       "prepare:docgen:local",
+      "prepare:repo-exports:catalog",
       "feedback:build",
       "feedback:check",
       "feedback:lint",
       "feedback:test",
-      "full:quality",
-      "publish:git:commit",
-      "publish:secrets",
-      "publish:git:push",
     ]);
-    expect(
-      pipe(
-        plan.steps,
-        A.map((step) => step.phase),
-        A.dedupe
-      )
-    ).toEqual(["prepare", "feedback", "full", "publish"]);
+    expect(findStep(plan.steps, "prepare:repo-exports:catalog").args).toEqual(["run", "repo-exports:catalog"]);
+  });
 
-    const commit = findStep(plan.steps, "publish:git:commit");
-    const secrets = findStep(plan.steps, "publish:secrets");
-    const push = findStep(plan.steps, "publish:git:push");
+  it("uses the shared pre-push proof definition for Yeet parity", () => {
+    const proof = repoProofStepDefinition("pre-push");
 
-    expect(commit.args).toEqual(["commit", "-m", "feat(repo-cli): add yeet"]);
-    expect(secrets.args).toEqual(["run", "beep", "quality", "github-checks", "secrets"]);
-    expect(secrets.mutability).toBe("readonly");
-    expect(push.args).toEqual(["push"]);
-    expect(
-      pipe(
-        plan.steps,
-        A.map((step) => step.args)
-      )
-    ).not.toContainEqual(["add", "-A"]);
+    expect(proof.args).toEqual(["quality", "github-checks", "pre-push"]);
+    expect(proof.label).toBe("full:pre-push");
   });
 
   it("threads task-aware affected filters into feedback runs", () => {
@@ -189,7 +232,7 @@ describe("yeet planner", () => {
   });
 
   it("uses Turbo SCM environment for write-mode affected prepare steps", () => {
-    const plan = buildYeetRunPlanForTesting(context, O.some("feat(repo-cli): add yeet"));
+    const plan = buildYeetRunPlanForTesting(context, O.none(), "repair");
     const step = findStep(plan.steps, "prepare:lint:fix");
 
     expect(step.args).toEqual([
@@ -236,14 +279,7 @@ describe("yeet planner", () => {
         plan.steps,
         A.map((step) => step.label)
       )
-    ).toEqual([
-      "prepare:lint:fix",
-      "prepare:docgen:local",
-      "full:quality",
-      "publish:git:commit",
-      "publish:secrets",
-      "publish:git:push",
-    ]);
+    ).toEqual(["commit:git:commit", "full:pre-push", "publish:git:push"]);
   });
 
   it("filters publish paths against the reviewed staged intent", () => {
@@ -318,16 +354,14 @@ describe("yeet planner", () => {
   it("does not enable fingerprint resume until runtime skip execution exists", () => {
     const plan = buildYeetRunPlanForTesting(context, O.some("feat(repo-cli): add yeet"));
 
-    expect(findStep(plan.steps, "prepare:lint:fix").resume).toBe("never");
-    expect(findStep(plan.steps, "prepare:docgen:local").resume).toBe("never");
     expect(findStep(plan.steps, "feedback:check").resume).toBe("never");
-    expect(findStep(plan.steps, "full:quality").resume).toBe("never");
-    expect(findStep(plan.steps, "publish:git:commit").resume).toBe("never");
+    expect(findStep(plan.steps, "full:pre-push").resume).toBe("never");
+    expect(findStep(plan.steps, "commit:git:commit").resume).toBe("never");
   });
 
   it("quotes command text without changing argv", () => {
     const plan = buildYeetRunPlanForTesting(context, O.some("feat(repo-cli): add yeet"));
-    const commit = findStep(plan.steps, "publish:git:commit");
+    const commit = findStep(plan.steps, "commit:git:commit");
 
     expect(commit.args).toEqual(["commit", "-m", "feat(repo-cli): add yeet"]);
     expect(commandTextForStep(commit)).toBe("git commit -m 'feat(repo-cli): add yeet'");
@@ -488,11 +522,11 @@ describe("yeet quality issue index", () => {
       ]
     );
     const step = RepoPlanStep.make({
-      id: "full:quality",
-      label: "full:quality",
+      id: "full:pre-push",
+      label: "full:pre-push",
       phase: "full",
       command: "bun",
-      args: ["run", "beep", "quality", "github-checks", "quality"],
+      args: ["run", "beep", "quality", "github-checks", "pre-push"],
       cwd: "/repo",
       scope: "repo",
       mutability: "readonly",
@@ -503,7 +537,7 @@ describe("yeet quality issue index", () => {
       step,
       RepoStepRunResult.make({
         stepId: step.id,
-        commandText: "bun run beep quality github-checks quality",
+        commandText: "bun run beep quality github-checks pre-push",
         exitCode: 1,
         output: "packages/foundation/modeling/schema/src/example.ts:3:1 - error TS2322: nope",
       })

--- a/packages/tooling/tool/cli/test/yeet.test.ts
+++ b/packages/tooling/tool/cli/test/yeet.test.ts
@@ -122,7 +122,7 @@ const findStep = (steps: ReadonlyArray<RepoPlanStep>, label: string): RepoPlanSt
 
 describe("yeet planner", () => {
   it("builds publish as feedback, commit, pre-push proof, then push", () => {
-    const plan = buildYeetRunPlanForTesting(context, O.some("feat(repo-cli): add yeet"));
+    const plan = buildYeetRunPlanForTesting({ context, message: O.some("feat(repo-cli): add yeet") });
 
     expect(
       pipe(
@@ -163,7 +163,7 @@ describe("yeet planner", () => {
   });
 
   it("builds verify as read-only feedback plus the canonical pre-push proof", () => {
-    const plan = buildYeetRunPlanForTesting(context, O.none(), "verify");
+    const plan = buildYeetRunPlanForTesting({ context, message: O.none(), mode: "verify" });
 
     expect(
       pipe(
@@ -181,7 +181,7 @@ describe("yeet planner", () => {
   });
 
   it("builds repair as deterministic generators plus affected feedback", () => {
-    const plan = buildYeetRunPlanForTesting(context, O.none(), "repair");
+    const plan = buildYeetRunPlanForTesting({ context, message: O.none(), mode: "repair" });
 
     expect(
       pipe(
@@ -215,7 +215,10 @@ describe("yeet planner", () => {
       turboTask("lint"),
       turboTask("test"),
     ]);
-    const plan = buildYeetRunPlanForTesting(scopedContext, O.some("feat(repo-cli): add yeet"));
+    const plan = buildYeetRunPlanForTesting({
+      context: scopedContext,
+      message: O.some("feat(repo-cli): add yeet"),
+    });
 
     expect(findStep(plan.steps, "feedback:check").args).toEqual([
       "run",
@@ -229,10 +232,21 @@ describe("yeet planner", () => {
     ]);
     expect(findStep(plan.steps, "feedback:check").args).not.toContain("--affected");
     expect(findStep(plan.steps, "feedback:check").scope).toBe("repo");
+    expect(findStep(plan.steps, "feedback:test").args).toEqual([
+      "run",
+      "test",
+      "--",
+      "--unit",
+      "--types",
+      "--filter=@beep/repo-cli",
+      "--continue=dependencies-successful",
+      "--summarize",
+      "--ui=stream",
+    ]);
   });
 
   it("uses Turbo SCM environment for write-mode affected prepare steps", () => {
-    const plan = buildYeetRunPlanForTesting(context, O.none(), "repair");
+    const plan = buildYeetRunPlanForTesting({ context, message: O.none(), mode: "repair" });
     const step = findStep(plan.steps, "prepare:lint:fix");
 
     expect(step.args).toEqual([
@@ -251,10 +265,10 @@ describe("yeet planner", () => {
   });
 
   it("omits feedback steps whose task has no affected packages", () => {
-    const plan = buildYeetRunPlanForTesting(
-      contextWithTasks([turboTask("build"), turboTask("lint")]),
-      O.some("feat(repo-cli): add yeet")
-    );
+    const plan = buildYeetRunPlanForTesting({
+      context: contextWithTasks([turboTask("build"), turboTask("lint")]),
+      message: O.some("feat(repo-cli): add yeet"),
+    });
 
     expect(
       pipe(
@@ -266,7 +280,10 @@ describe("yeet planner", () => {
   });
 
   it("keeps feedback as a no-op instead of falling back to all packages", () => {
-    const plan = buildYeetRunPlanForTesting(contextWithTasks([]), O.some("feat(repo-cli): add yeet"));
+    const plan = buildYeetRunPlanForTesting({
+      context: contextWithTasks([]),
+      message: O.some("feat(repo-cli): add yeet"),
+    });
 
     expect(
       pipe(
@@ -352,7 +369,7 @@ describe("yeet planner", () => {
   });
 
   it("does not enable fingerprint resume until runtime skip execution exists", () => {
-    const plan = buildYeetRunPlanForTesting(context, O.some("feat(repo-cli): add yeet"));
+    const plan = buildYeetRunPlanForTesting({ context, message: O.some("feat(repo-cli): add yeet") });
 
     expect(findStep(plan.steps, "feedback:check").resume).toBe("never");
     expect(findStep(plan.steps, "full:pre-push").resume).toBe("never");
@@ -360,7 +377,7 @@ describe("yeet planner", () => {
   });
 
   it("quotes command text without changing argv", () => {
-    const plan = buildYeetRunPlanForTesting(context, O.some("feat(repo-cli): add yeet"));
+    const plan = buildYeetRunPlanForTesting({ context, message: O.some("feat(repo-cli): add yeet") });
     const commit = findStep(plan.steps, "commit:git:commit");
 
     expect(commit.args).toEqual(["commit", "-m", "feat(repo-cli): add yeet"]);

--- a/standards/repo-exports.catalog.md
+++ b/standards/repo-exports.catalog.md
@@ -21,8 +21,8 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | packagesWithoutPublicExports | 6 |
 | missingWorkspaceMetadata | 4 |
 | importSpecifiers | 1053 |
-| publicExportEntries | 13863 |
-| uniquePackageSymbols | 6146 |
+| publicExportEntries | 13877 |
+| uniquePackageSymbols | 6152 |
 
 ## Seed Discovery Proof
 
@@ -52,7 +52,7 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | 13 | `@beep/discord` | `packages/drivers/discord` | has-public-exports | 5 | 27 | 8 |
 | 14 | `@beep/face-detection` | `packages/drivers/face-detection` | has-public-exports | 5 | 72 | 20 |
 | 15 | `@beep/architecture-lab-client` | `packages/architecture-lab/client` | has-public-exports | 2 | 6 | 6 |
-| 16 | `@beep/repo-cli` | `packages/tooling/tool/cli` | has-public-exports | 147 | 1668 | 601 |
+| 16 | `@beep/repo-cli` | `packages/tooling/tool/cli` | has-public-exports | 147 | 1682 | 607 |
 | 17 | `@beep/ai-sync` | `packages/tooling/library/ai-sync` | has-public-exports | 11 | 180 | 57 |
 | 18 | `@beep/shared-server` | `packages/shared/server` | has-public-exports | 2 | 2 | 1 |
 | 19 | `@beep/nlp-mcp` | `packages/drivers/nlp-mcp` | has-public-exports | 10 | 75 | 63 |
@@ -809,14 +809,14 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli` | `lawsCommand` | const | `packages/tooling/tool/cli/src/commands/Laws/Laws.command.ts:439` | Laws command group. |
 | `@beep/repo-cli` | `lintCommand` | const | `packages/tooling/tool/cli/src/commands/Lint/Lint.command.ts:556` | Lint command group. |
 | `@beep/repo-cli` | `purgeCommand` | const | `packages/tooling/tool/cli/src/commands/Purge/Purge.command.ts:249` | CLI command to purge workspace/root build artifacts. |
-| `@beep/repo-cli` | `qualityCommand` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1729` | Quality command group for repo operational checks. |
+| `@beep/repo-cli` | `qualityCommand` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1725` | Quality command group for repo operational checks. |
 | `@beep/repo-cli` | `reuseCommand` | const | `packages/tooling/tool/cli/src/commands/Reuse/Reuse.command.ts:672` | Reuse-discovery command group. |
 | `@beep/repo-cli` | `rootCommand` | const | `packages/tooling/tool/cli/src/commands/Root.ts:46` | Top-level CLI command that registers all subcommands. |
 | `@beep/repo-cli` | `syncDataToTsCommand` | const | `packages/tooling/tool/cli/src/commands/SyncDataToTs/SyncDataToTs.command.ts:446` | CLI command for syncing official upstream datasets into checked-in TypeScript modules. |
 | `@beep/repo-cli` | `topoSortCommand` | const | `packages/tooling/tool/cli/src/commands/TopoSort/TopoSort.command.ts:33` | CLI command that builds the workspace dependency graph and prints package names |
 | `@beep/repo-cli` | `tsconfigSyncCommand` | const | `packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.command.ts:1846` | CLI command for synchronizing root and workspace tsconfig state. |
 | `@beep/repo-cli` | `versionSyncCommand` | const | `packages/tooling/tool/cli/src/commands/VersionSync/VersionSync.command.ts:54` | CLI command for synchronizing version pins across the monorepo. |
-| `@beep/repo-cli` | `yeetCommand` | const | `packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts:24` | Command that runs fast quality feedback, canonical full proof, then commits and pushes reviewed staged changes. |
+| `@beep/repo-cli` | `yeetCommand` | const | `packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts:91` | Command that repairs, verifies, or publishes repository work through Yeet. |
 | `@beep/repo-cli/commands/AgentEffectiveness` | `agentEffectivenessCommand` | const | `packages/tooling/tool/cli/src/commands/AgentEffectiveness/AgentEffectiveness.command.ts:657` | Agent-effectiveness root command. |
 | `@beep/repo-cli/commands/AgentEffectiveness/AgentEffectiveness.command` | `agentEffectivenessCommand` | const | `packages/tooling/tool/cli/src/commands/AgentEffectiveness/AgentEffectiveness.command.ts:657` | Agent-effectiveness root command. |
 | `@beep/repo-cli/commands/AgentEffectiveness/index` | `agentEffectivenessCommand` | const | `packages/tooling/tool/cli/src/commands/AgentEffectiveness/AgentEffectiveness.command.ts:657` | Agent-effectiveness root command. |
@@ -1840,7 +1840,7 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/commands/Purge/Purge.command` | `purgeCommand` | const | `packages/tooling/tool/cli/src/commands/Purge/Purge.command.ts:249` | CLI command to purge workspace/root build artifacts. |
 | `@beep/repo-cli/commands/Purge/Purge.command` | `PurgeSummary` | class | `packages/tooling/tool/cli/src/commands/Purge/Purge.command.ts:127` | Summary statistics returned after a purge run. |
 | `@beep/repo-cli/commands/Quality` | `ChangesetGraphError` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:43` | Failure raised while validating changeset package references. |
-| `@beep/repo-cli/commands/Quality` | `qualityCommand` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1729` | Quality command group for repo operational checks. |
+| `@beep/repo-cli/commands/Quality` | `qualityCommand` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1725` | Quality command group for repo operational checks. |
 | `@beep/repo-cli/commands/Quality` | `QualityScriptCommandError` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:88` | Typed failure for repo operational commands. |
 | `@beep/repo-cli/commands/Quality` | `QualityTaskConfigurationError` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:245` | Error raised when a quality task cannot resolve its required configuration. |
 | `@beep/repo-cli/commands/Quality` | `QualityTaskFailed` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:144` | Error raised when a quality task subprocess exits unsuccessfully. |
@@ -1854,36 +1854,36 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/commands/Quality/ChangesetGraph` | `makeChangesetGraphSummary` | const | `packages/tooling/tool/cli/src/commands/Quality/ChangesetGraph.ts:449` | Build a changeset graph summary from already-collected inputs. |
 | `@beep/repo-cli/commands/Quality/ChangesetGraph` | `runChangesetGraphCheck` | const | `packages/tooling/tool/cli/src/commands/Quality/ChangesetGraph.ts:464` | Run the non-mutating changeset package graph guard. |
 | `@beep/repo-cli/commands/Quality/index` | `ChangesetGraphError` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:43` | Failure raised while validating changeset package references. |
-| `@beep/repo-cli/commands/Quality/index` | `qualityCommand` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1729` | Quality command group for repo operational checks. |
+| `@beep/repo-cli/commands/Quality/index` | `qualityCommand` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1725` | Quality command group for repo operational checks. |
 | `@beep/repo-cli/commands/Quality/index` | `QualityScriptCommandError` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:88` | Typed failure for repo operational commands. |
 | `@beep/repo-cli/commands/Quality/index` | `QualityTaskConfigurationError` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:245` | Error raised when a quality task cannot resolve its required configuration. |
 | `@beep/repo-cli/commands/Quality/index` | `QualityTaskFailed` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:144` | Error raised when a quality task subprocess exits unsuccessfully. |
 | `@beep/repo-cli/commands/Quality/index` | `QualityTaskGroupFailed` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:198` | Error raised when a bounded quality task group completes with failed steps. |
 | `@beep/repo-cli/commands/Quality/index` | `UnexpectedQualityTaskFailure` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:277` | Error raised when an unexpected quality task cause reaches the command boundary. |
-| `@beep/repo-cli/commands/Quality/Quality.command` | `collectEffectTsgoDiagnosticLines` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:869` | Collect Effect tsgo diagnostics from command output regardless of process exit code. |
+| `@beep/repo-cli/commands/Quality/Quality.command` | `collectEffectTsgoDiagnosticLines` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:865` | Collect Effect tsgo diagnostics from command output regardless of process exit code. |
 | `@beep/repo-cli/commands/Quality/Quality.command` | `GithubCheckMode` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:141` | GitHub check mode handled by `beep quality github-checks`. |
-| `@beep/repo-cli/commands/Quality/Quality.command` | `GithubCheckMode` | type | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:158` | GitHub check mode handled by `beep quality github-checks`. |
-| `@beep/repo-cli/commands/Quality/Quality.command` | `qualityCommand` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1729` | Quality command group for repo operational checks. |
+| `@beep/repo-cli/commands/Quality/Quality.command` | `GithubCheckMode` | type | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:154` | GitHub check mode handled by `beep quality github-checks`. |
+| `@beep/repo-cli/commands/Quality/Quality.command` | `qualityCommand` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1725` | Quality command group for repo operational checks. |
 | `@beep/repo-cli/commands/Quality/Quality.command` | `QualityScriptCommandError` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:88` | Typed failure for repo operational commands. |
-| `@beep/repo-cli/commands/Quality/Quality.command` | `runBunAudit` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:361` | Run Bun's high-severity package audit with OSV ignores mirrored from config. |
-| `@beep/repo-cli/commands/Quality/Quality.command` | `runDtslintTsgoChecks` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1206` | Run repo-wide tsgo diagnostics for dtslint files. |
-| `@beep/repo-cli/commands/Quality/Quality.command` | `runGithubChecks` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:621` | Run a GitHub checks mode from the repository root. |
-| `@beep/repo-cli/commands/Quality/Quality.command` | `runJSDocInventory` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1526` | Run the JSDoc inventory generator now owned by repo-cli. |
-| `@beep/repo-cli/commands/Quality/Quality.command` | `runJSDocModuleTagsCheck` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1449` | Verify tracked fileoverview comments do not use the legacy `@module` tag. |
-| `@beep/repo-cli/commands/Quality/Quality.command` | `runJSDocQuality` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1617` | Run the repo-wide JSDoc quality gate. |
-| `@beep/repo-cli/commands/Quality/Quality.command` | `runRepoExportsCatalog` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1561` | Run the repo export catalog generator now owned by repo-cli. |
-| `@beep/repo-cli/commands/Quality/Quality.command` | `runTestTsgoChecks` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1252` | Run repo-wide Effect diagnostics for test files. |
-| `@beep/repo-cli/commands/Quality/Quality.command` | `runTsgoRulesCheck` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1015` | Check that the root tsgo Effect diagnostics configuration enables every installed rule as an error. |
-| `@beep/repo-cli/commands/Quality/Quality.command` | `runTsgoSmokeCheck` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1348` | Verify that tsgo reports the Effect diagnostic expected by this repo. |
+| `@beep/repo-cli/commands/Quality/Quality.command` | `runBunAudit` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:357` | Run Bun's high-severity package audit with OSV ignores mirrored from config. |
+| `@beep/repo-cli/commands/Quality/Quality.command` | `runDtslintTsgoChecks` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1202` | Run repo-wide tsgo diagnostics for dtslint files. |
+| `@beep/repo-cli/commands/Quality/Quality.command` | `runGithubChecks` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:617` | Run a GitHub checks mode from the repository root. |
+| `@beep/repo-cli/commands/Quality/Quality.command` | `runJSDocInventory` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1522` | Run the JSDoc inventory generator now owned by repo-cli. |
+| `@beep/repo-cli/commands/Quality/Quality.command` | `runJSDocModuleTagsCheck` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1445` | Verify tracked fileoverview comments do not use the legacy `@module` tag. |
+| `@beep/repo-cli/commands/Quality/Quality.command` | `runJSDocQuality` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1613` | Run the repo-wide JSDoc quality gate. |
+| `@beep/repo-cli/commands/Quality/Quality.command` | `runRepoExportsCatalog` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1557` | Run the repo export catalog generator now owned by repo-cli. |
+| `@beep/repo-cli/commands/Quality/Quality.command` | `runTestTsgoChecks` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1248` | Run repo-wide Effect diagnostics for test files. |
+| `@beep/repo-cli/commands/Quality/Quality.command` | `runTsgoRulesCheck` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1011` | Check that the root tsgo Effect diagnostics configuration enables every installed rule as an error. |
+| `@beep/repo-cli/commands/Quality/Quality.command` | `runTsgoSmokeCheck` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1344` | Verify that tsgo reports the Effect diagnostic expected by this repo. |
 | `@beep/repo-cli/commands/Quality/Quality.errors` | `ChangesetGraphError` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:43` | Failure raised while validating changeset package references. |
 | `@beep/repo-cli/commands/Quality/Quality.errors` | `QualityScriptCommandError` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:88` | Typed failure for repo operational commands. |
 | `@beep/repo-cli/commands/Quality/Quality.errors` | `QualityTaskConfigurationError` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:245` | Error raised when a quality task cannot resolve its required configuration. |
 | `@beep/repo-cli/commands/Quality/Quality.errors` | `QualityTaskFailed` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:144` | Error raised when a quality task subprocess exits unsuccessfully. |
 | `@beep/repo-cli/commands/Quality/Quality.errors` | `QualityTaskGroupFailed` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:198` | Error raised when a bounded quality task group completes with failed steps. |
 | `@beep/repo-cli/commands/Quality/Quality.errors` | `UnexpectedQualityTaskFailure` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:277` | Error raised when an unexpected quality task cause reaches the command boundary. |
-| `@beep/repo-cli/commands/Quality/Tasks` | `collectStepOutput` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1203` | Run a subprocess and capture all output. Exposed for focused unit tests. |
+| `@beep/repo-cli/commands/Quality/Tasks` | `collectStepOutput` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1204` | Run a subprocess and capture all output. Exposed for focused unit tests. |
 | `@beep/repo-cli/commands/Quality/Tasks` | `PackageTaskProfile` | class | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:103` | Package-local script profile used by the quality task adapter. |
-| `@beep/repo-cli/commands/Quality/Tasks` | `parseQualityTaskInvocation` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1097` | Parse a raw argv vector into a quality task invocation when the first token is |
+| `@beep/repo-cli/commands/Quality/Tasks` | `parseQualityTaskInvocation` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1098` | Parse a raw argv vector into a quality task invocation when the first token is |
 | `@beep/repo-cli/commands/Quality/Tasks` | `QualityTaskConfigurationError` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:245` | Error raised when a quality task cannot resolve its required configuration. |
 | `@beep/repo-cli/commands/Quality/Tasks` | `QualityTaskFailed` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:144` | Error raised when a quality task subprocess exits unsuccessfully. |
 | `@beep/repo-cli/commands/Quality/Tasks` | `QualityTaskGroupFailed` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:198` | Error raised when a bounded quality task group completes with failed steps. |
@@ -1891,13 +1891,13 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/commands/Quality/Tasks` | `QualityTaskName` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:69` | Canonical quality task name. |
 | `@beep/repo-cli/commands/Quality/Tasks` | `QualityTaskName` | type | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:86` | Canonical quality task name. |
 | `@beep/repo-cli/commands/Quality/Tasks` | `QualityTaskStep` | class | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:130` | Planned subprocess invocation. |
-| `@beep/repo-cli/commands/Quality/Tasks` | `rootQualityStepsForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:994` | Build root quality task subprocess steps. Exposed for focused unit tests. |
-| `@beep/repo-cli/commands/Quality/Tasks` | `runQualityTask` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1141` | Run a parsed quality task in either repo-root or package-local mode. |
-| `@beep/repo-cli/commands/Quality/Tasks` | `runQualityTaskIfRequested` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1171` | Run a quality task directly from a raw argv vector. |
-| `@beep/repo-cli/commands/Quality/Tasks` | `runQualityTaskStepGroupForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1220` | Run a bounded quality task group. Exposed for focused unit tests. |
-| `@beep/repo-cli/commands/Quality/Tasks` | `runSqlIntegrationTestLaneForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:804` | Run the SQL integration lane with an injected resource and child command. |
-| `@beep/repo-cli/commands/Quality/Tasks` | `sqlIntegrationConnectionUriFromEnvForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:818` | Resolve the SQL integration database connection URI from environment variables. |
-| `@beep/repo-cli/commands/Quality/Tasks` | `sqlIntegrationStepForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:785` | Build the SQL integration test subprocess step. Exposed for focused unit tests. |
+| `@beep/repo-cli/commands/Quality/Tasks` | `rootQualityStepsForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:995` | Build root quality task subprocess steps. Exposed for focused unit tests. |
+| `@beep/repo-cli/commands/Quality/Tasks` | `runQualityTask` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1142` | Run a parsed quality task in either repo-root or package-local mode. |
+| `@beep/repo-cli/commands/Quality/Tasks` | `runQualityTaskIfRequested` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1172` | Run a quality task directly from a raw argv vector. |
+| `@beep/repo-cli/commands/Quality/Tasks` | `runQualityTaskStepGroupForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1221` | Run a bounded quality task group. Exposed for focused unit tests. |
+| `@beep/repo-cli/commands/Quality/Tasks` | `runSqlIntegrationTestLaneForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:805` | Run the SQL integration lane with an injected resource and child command. |
+| `@beep/repo-cli/commands/Quality/Tasks` | `sqlIntegrationConnectionUriFromEnvForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:819` | Resolve the SQL integration database connection URI from environment variables. |
+| `@beep/repo-cli/commands/Quality/Tasks` | `sqlIntegrationStepForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:786` | Build the SQL integration test subprocess step. Exposed for focused unit tests. |
 | `@beep/repo-cli/commands/Quality/Tasks` | `UnexpectedQualityTaskFailure` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:277` | Error raised when an unexpected quality task cause reaches the command boundary. |
 | `@beep/repo-cli/commands/Reuse` | `buildCloneDocument` | const | `packages/tooling/tool/cli/src/commands/Reuse/internal/CloneBaseline.ts:116` | Build a sorted, deterministic baseline document from clone candidates. |
 | `@beep/repo-cli/commands/Reuse` | `CloneBaselineDocument` | class | `packages/tooling/tool/cli/src/commands/Reuse/internal/CloneBaseline.ts:67` | Committed baseline of acknowledged structural-clone clusters for the ratchet. |
@@ -2101,10 +2101,12 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/commands/Yeet` | `QualityIssueRouting` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/QualityIssueIndex.ts:138` | Specialist routing hint for one issue. |
 | `@beep/repo-cli/commands/Yeet` | `QualityIssueSeverity` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/QualityIssueIndex.ts:85` | Blocking level assigned to a normalized yeet quality finding. |
 | `@beep/repo-cli/commands/Yeet` | `QualityIssueSeverity` | type | `packages/tooling/tool/cli/src/commands/Yeet/internal/QualityIssueIndex.ts:97` | Type-level union of yeet quality severity literals. |
-| `@beep/repo-cli/commands/Yeet` | `yeetCommand` | const | `packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts:24` | Command that runs fast quality feedback, canonical full proof, then commits and pushes reviewed staged changes. |
+| `@beep/repo-cli/commands/Yeet` | `yeetCommand` | const | `packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts:91` | Command that repairs, verifies, or publishes repository work through Yeet. |
 | `@beep/repo-cli/commands/Yeet` | `YeetCommandError` | class | `packages/tooling/tool/cli/src/commands/Yeet/Yeet.errors.ts:40` | Operational error raised by the yeet command. |
-| `@beep/repo-cli/commands/Yeet` | `YeetRunOptions` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:143` | Runtime options accepted by the yeet handler. |
-| `@beep/repo-cli/commands/Yeet` | `YeetRunResult` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:170` | Result returned by a yeet execution attempt. |
+| `@beep/repo-cli/commands/Yeet` | `YeetRunMode` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:54` | Yeet execution modes. |
+| `@beep/repo-cli/commands/Yeet` | `YeetRunMode` | type | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:66` | Yeet execution modes. |
+| `@beep/repo-cli/commands/Yeet` | `YeetRunOptions` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:149` | Runtime options accepted by the yeet handler. |
+| `@beep/repo-cli/commands/Yeet` | `YeetRunResult` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:177` | Result returned by a yeet execution attempt. |
 | `@beep/repo-cli/commands/Yeet/index` | `PackageQualityReport` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/QualityIssueIndex.ts:224` | Package-level issue report rendered into a quality packet. |
 | `@beep/repo-cli/commands/Yeet/index` | `QualityIssue` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/QualityIssueIndex.ts:170` | One normalized quality issue. |
 | `@beep/repo-cli/commands/Yeet/index` | `QualityIssueCategory` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/QualityIssueIndex.ts:44` | Classification domain for normalized yeet quality findings. |
@@ -2115,11 +2117,13 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/commands/Yeet/index` | `QualityIssueRouting` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/QualityIssueIndex.ts:138` | Specialist routing hint for one issue. |
 | `@beep/repo-cli/commands/Yeet/index` | `QualityIssueSeverity` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/QualityIssueIndex.ts:85` | Blocking level assigned to a normalized yeet quality finding. |
 | `@beep/repo-cli/commands/Yeet/index` | `QualityIssueSeverity` | type | `packages/tooling/tool/cli/src/commands/Yeet/internal/QualityIssueIndex.ts:97` | Type-level union of yeet quality severity literals. |
-| `@beep/repo-cli/commands/Yeet/index` | `yeetCommand` | const | `packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts:24` | Command that runs fast quality feedback, canonical full proof, then commits and pushes reviewed staged changes. |
+| `@beep/repo-cli/commands/Yeet/index` | `yeetCommand` | const | `packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts:91` | Command that repairs, verifies, or publishes repository work through Yeet. |
 | `@beep/repo-cli/commands/Yeet/index` | `YeetCommandError` | class | `packages/tooling/tool/cli/src/commands/Yeet/Yeet.errors.ts:40` | Operational error raised by the yeet command. |
-| `@beep/repo-cli/commands/Yeet/index` | `YeetRunOptions` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:143` | Runtime options accepted by the yeet handler. |
-| `@beep/repo-cli/commands/Yeet/index` | `YeetRunResult` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:170` | Result returned by a yeet execution attempt. |
-| `@beep/repo-cli/commands/Yeet/Yeet.command` | `yeetCommand` | const | `packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts:24` | Command that runs fast quality feedback, canonical full proof, then commits and pushes reviewed staged changes. |
+| `@beep/repo-cli/commands/Yeet/index` | `YeetRunMode` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:54` | Yeet execution modes. |
+| `@beep/repo-cli/commands/Yeet/index` | `YeetRunMode` | type | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:66` | Yeet execution modes. |
+| `@beep/repo-cli/commands/Yeet/index` | `YeetRunOptions` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:149` | Runtime options accepted by the yeet handler. |
+| `@beep/repo-cli/commands/Yeet/index` | `YeetRunResult` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:177` | Result returned by a yeet execution attempt. |
+| `@beep/repo-cli/commands/Yeet/Yeet.command` | `yeetCommand` | const | `packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts:91` | Command that repairs, verifies, or publishes repository work through Yeet. |
 | `@beep/repo-cli/commands/Yeet/Yeet.errors` | `YeetCommandError` | class | `packages/tooling/tool/cli/src/commands/Yeet/Yeet.errors.ts:40` | Operational error raised by the yeet command. |
 | `@beep/repo-cli/test/CreatePackage` | `checkConfigNeedsUpdate` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:671` | Check whether config entries already exist (for dry-run output). |
 | `@beep/repo-cli/test/CreatePackage` | `checkConfigNeedsUpdateForTargets` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:589` | Batch read-only drift checker for root config updates. |
@@ -2295,17 +2299,17 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/test/Quality` | `ChangesetGraphPackageReference` | class | `packages/tooling/tool/cli/src/commands/Quality/ChangesetGraph.ts:72` | A package name referenced by a changeset file. |
 | `@beep/repo-cli/test/Quality` | `ChangesetGraphSummary` | class | `packages/tooling/tool/cli/src/commands/Quality/ChangesetGraph.ts:102` | Summary emitted by the changeset package graph guard. |
 | `@beep/repo-cli/test/Quality` | `changesetPackageReferencesFromText` | const | `packages/tooling/tool/cli/src/commands/Quality/ChangesetGraph.ts:309` | Parse package references from one changeset Markdown document. |
-| `@beep/repo-cli/test/Quality` | `collectEffectTsgoDiagnosticLines` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:869` | Collect Effect tsgo diagnostics from command output regardless of process exit code. |
-| `@beep/repo-cli/test/Quality` | `collectStepOutput` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1203` | Run a subprocess and capture all output. Exposed for focused unit tests. |
+| `@beep/repo-cli/test/Quality` | `collectEffectTsgoDiagnosticLines` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:865` | Collect Effect tsgo diagnostics from command output regardless of process exit code. |
+| `@beep/repo-cli/test/Quality` | `collectStepOutput` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1204` | Run a subprocess and capture all output. Exposed for focused unit tests. |
 | `@beep/repo-cli/test/Quality` | `findMissingChangesetPackageReferences` | const | `packages/tooling/tool/cli/src/commands/Quality/ChangesetGraph.ts:402` | Find changeset package references that are not in the workspace graph. |
 | `@beep/repo-cli/test/Quality` | `GithubCheckMode` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:141` | GitHub check mode handled by `beep quality github-checks`. |
-| `@beep/repo-cli/test/Quality` | `GithubCheckMode` | type | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:158` | GitHub check mode handled by `beep quality github-checks`. |
+| `@beep/repo-cli/test/Quality` | `GithubCheckMode` | type | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:154` | GitHub check mode handled by `beep quality github-checks`. |
 | `@beep/repo-cli/test/Quality` | `JSDocDocumentationInventoryOptions` | class | `packages/tooling/tool/cli/src/commands/Quality/internal/JSDocDocumentationInventory.ts:140` | Options for building or writing the JSDoc documentation inventory. |
 | `@beep/repo-cli/test/Quality` | `JSDocDocumentationInventoryWriteResult` | class | `packages/tooling/tool/cli/src/commands/Quality/internal/JSDocDocumentationInventory.ts:160` | Result returned after writing JSDoc inventory artifacts. |
 | `@beep/repo-cli/test/Quality` | `makeChangesetGraphSummary` | const | `packages/tooling/tool/cli/src/commands/Quality/ChangesetGraph.ts:449` | Build a changeset graph summary from already-collected inputs. |
 | `@beep/repo-cli/test/Quality` | `PackageTaskProfile` | class | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:103` | Package-local script profile used by the quality task adapter. |
-| `@beep/repo-cli/test/Quality` | `parseQualityTaskInvocation` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1097` | Parse a raw argv vector into a quality task invocation when the first token is |
-| `@beep/repo-cli/test/Quality` | `qualityCommand` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1729` | Quality command group for repo operational checks. |
+| `@beep/repo-cli/test/Quality` | `parseQualityTaskInvocation` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1098` | Parse a raw argv vector into a quality task invocation when the first token is |
+| `@beep/repo-cli/test/Quality` | `qualityCommand` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1725` | Quality command group for repo operational checks. |
 | `@beep/repo-cli/test/Quality` | `QualityScriptCommandError` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:88` | Typed failure for repo operational commands. |
 | `@beep/repo-cli/test/Quality` | `QualityTaskConfigurationError` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:245` | Error raised when a quality task cannot resolve its required configuration. |
 | `@beep/repo-cli/test/Quality` | `QualityTaskFailed` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:144` | Error raised when a quality task subprocess exits unsuccessfully. |
@@ -2316,24 +2320,24 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/test/Quality` | `QualityTaskStep` | class | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:130` | Planned subprocess invocation. |
 | `@beep/repo-cli/test/Quality` | `RepoExportsCatalogOptions` | class | `packages/tooling/tool/cli/src/commands/Quality/internal/RepoExportsCatalog.ts:119` | Options for building, writing, or checking the repo export catalog. |
 | `@beep/repo-cli/test/Quality` | `RepoExportsCatalogWriteResult` | class | `packages/tooling/tool/cli/src/commands/Quality/internal/RepoExportsCatalog.ts:137` | Result returned after writing or checking repo export catalog artifacts. |
-| `@beep/repo-cli/test/Quality` | `rootQualityStepsForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:994` | Build root quality task subprocess steps. Exposed for focused unit tests. |
-| `@beep/repo-cli/test/Quality` | `runBunAudit` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:361` | Run Bun's high-severity package audit with OSV ignores mirrored from config. |
+| `@beep/repo-cli/test/Quality` | `rootQualityStepsForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:995` | Build root quality task subprocess steps. Exposed for focused unit tests. |
+| `@beep/repo-cli/test/Quality` | `runBunAudit` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:357` | Run Bun's high-severity package audit with OSV ignores mirrored from config. |
 | `@beep/repo-cli/test/Quality` | `runChangesetGraphCheck` | const | `packages/tooling/tool/cli/src/commands/Quality/ChangesetGraph.ts:464` | Run the non-mutating changeset package graph guard. |
-| `@beep/repo-cli/test/Quality` | `runDtslintTsgoChecks` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1206` | Run repo-wide tsgo diagnostics for dtslint files. |
-| `@beep/repo-cli/test/Quality` | `runGithubChecks` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:621` | Run a GitHub checks mode from the repository root. |
-| `@beep/repo-cli/test/Quality` | `runJSDocInventory` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1526` | Run the JSDoc inventory generator now owned by repo-cli. |
-| `@beep/repo-cli/test/Quality` | `runJSDocModuleTagsCheck` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1449` | Verify tracked fileoverview comments do not use the legacy `@module` tag. |
-| `@beep/repo-cli/test/Quality` | `runJSDocQuality` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1617` | Run the repo-wide JSDoc quality gate. |
-| `@beep/repo-cli/test/Quality` | `runQualityTask` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1141` | Run a parsed quality task in either repo-root or package-local mode. |
-| `@beep/repo-cli/test/Quality` | `runQualityTaskIfRequested` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1171` | Run a quality task directly from a raw argv vector. |
-| `@beep/repo-cli/test/Quality` | `runQualityTaskStepGroupForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1220` | Run a bounded quality task group. Exposed for focused unit tests. |
-| `@beep/repo-cli/test/Quality` | `runRepoExportsCatalog` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1561` | Run the repo export catalog generator now owned by repo-cli. |
-| `@beep/repo-cli/test/Quality` | `runSqlIntegrationTestLaneForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:804` | Run the SQL integration lane with an injected resource and child command. |
-| `@beep/repo-cli/test/Quality` | `runTestTsgoChecks` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1252` | Run repo-wide Effect diagnostics for test files. |
-| `@beep/repo-cli/test/Quality` | `runTsgoRulesCheck` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1015` | Check that the root tsgo Effect diagnostics configuration enables every installed rule as an error. |
-| `@beep/repo-cli/test/Quality` | `runTsgoSmokeCheck` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1348` | Verify that tsgo reports the Effect diagnostic expected by this repo. |
-| `@beep/repo-cli/test/Quality` | `sqlIntegrationConnectionUriFromEnvForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:818` | Resolve the SQL integration database connection URI from environment variables. |
-| `@beep/repo-cli/test/Quality` | `sqlIntegrationStepForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:785` | Build the SQL integration test subprocess step. Exposed for focused unit tests. |
+| `@beep/repo-cli/test/Quality` | `runDtslintTsgoChecks` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1202` | Run repo-wide tsgo diagnostics for dtslint files. |
+| `@beep/repo-cli/test/Quality` | `runGithubChecks` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:617` | Run a GitHub checks mode from the repository root. |
+| `@beep/repo-cli/test/Quality` | `runJSDocInventory` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1522` | Run the JSDoc inventory generator now owned by repo-cli. |
+| `@beep/repo-cli/test/Quality` | `runJSDocModuleTagsCheck` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1445` | Verify tracked fileoverview comments do not use the legacy `@module` tag. |
+| `@beep/repo-cli/test/Quality` | `runJSDocQuality` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1613` | Run the repo-wide JSDoc quality gate. |
+| `@beep/repo-cli/test/Quality` | `runQualityTask` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1142` | Run a parsed quality task in either repo-root or package-local mode. |
+| `@beep/repo-cli/test/Quality` | `runQualityTaskIfRequested` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1172` | Run a quality task directly from a raw argv vector. |
+| `@beep/repo-cli/test/Quality` | `runQualityTaskStepGroupForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1221` | Run a bounded quality task group. Exposed for focused unit tests. |
+| `@beep/repo-cli/test/Quality` | `runRepoExportsCatalog` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1557` | Run the repo export catalog generator now owned by repo-cli. |
+| `@beep/repo-cli/test/Quality` | `runSqlIntegrationTestLaneForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:805` | Run the SQL integration lane with an injected resource and child command. |
+| `@beep/repo-cli/test/Quality` | `runTestTsgoChecks` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1248` | Run repo-wide Effect diagnostics for test files. |
+| `@beep/repo-cli/test/Quality` | `runTsgoRulesCheck` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1011` | Check that the root tsgo Effect diagnostics configuration enables every installed rule as an error. |
+| `@beep/repo-cli/test/Quality` | `runTsgoSmokeCheck` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1344` | Verify that tsgo reports the Effect diagnostic expected by this repo. |
+| `@beep/repo-cli/test/Quality` | `sqlIntegrationConnectionUriFromEnvForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:819` | Resolve the SQL integration database connection URI from environment variables. |
+| `@beep/repo-cli/test/Quality` | `sqlIntegrationStepForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:786` | Build the SQL integration test subprocess step. Exposed for focused unit tests. |
 | `@beep/repo-cli/test/Quality` | `UnexpectedQualityTaskFailure` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:277` | Error raised when an unexpected quality task cause reaches the command boundary. |
 | `@beep/repo-cli/test/Quality` | `writeJSDocDocumentationInventory` | const | `packages/tooling/tool/cli/src/commands/Quality/internal/JSDocDocumentationInventory.ts:995` | Write JSDoc inventory JSONC and Markdown artifacts. |
 | `@beep/repo-cli/test/Quality` | `writeOrCheckRepoExportsCatalog` | const | `packages/tooling/tool/cli/src/commands/Quality/internal/RepoExportsCatalog.ts:698` | Write or freshness-check repo export catalog JSONC and Markdown artifacts. |
@@ -2409,22 +2413,26 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/test/VersionSync` | `VersionSyncResolution` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:382` | Resolver output consumed by reporting and write-mode services. |
 | `@beep/repo-cli/test/VersionSync` | `VersionSyncUpdateLocation` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:366` | YAML location to update in write mode. |
 | `@beep/repo-cli/test/Yeet` | `buildQualityIssueIndex` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/QualityIssueIndex.ts:716` | Build a schema-first issue index from normalized issues. |
-| `@beep/repo-cli/test/Yeet` | `buildYeetRunPlan` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:179` | Build the v1 yeet run plan. |
-| `@beep/repo-cli/test/Yeet` | `buildYeetRunPlanForTesting` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:922` | Build a plan for tests without reading repository state. |
-| `@beep/repo-cli/test/Yeet` | `byRepoPlanStepAscending` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:374` | Order repository plan steps by phase, then identifier. |
-| `@beep/repo-cli/test/Yeet` | `commandTextForStep` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:416` | Render a planned step as a shell-like command string. |
-| `@beep/repo-cli/test/Yeet` | `decodeTurboPlanTasksFromQueryJsonForTesting` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:558` | Decode Turbo query JSON into Yeet Turbo plan task metadata for focused tests. |
-| `@beep/repo-cli/test/Yeet` | `DEFAULT_YEET_PACKET_DIR` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:27` | Default ignored directory for yeet run artifacts. |
-| `@beep/repo-cli/test/Yeet` | `defaultYeetRunOptions` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:932` | Construct baseline yeet options for focused tests. |
-| `@beep/repo-cli/test/Yeet` | `emptyTurboPlanSnapshot` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:96` | Create an empty Turbo metadata snapshot. |
-| `@beep/repo-cli/test/Yeet` | `enforceConservativeResume` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:455` | Ensure a step's resume field follows v1 safety rules. |
+| `@beep/repo-cli/test/Yeet` | `buildYeetRunPlan` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:322` | Build the publish-mode yeet run plan. |
+| `@beep/repo-cli/test/Yeet` | `buildYeetRunPlanForTesting` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:981` | Build a plan for tests without reading repository state. |
+| `@beep/repo-cli/test/Yeet` | `buildYeetRunPlanWithMode` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:286` | Build a yeet run plan for a specific mode. |
+| `@beep/repo-cli/test/Yeet` | `byRepoPlanStepAscending` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:375` | Order repository plan steps by phase, then identifier. |
+| `@beep/repo-cli/test/Yeet` | `commandTextForStep` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:417` | Render a planned step as a shell-like command string. |
+| `@beep/repo-cli/test/Yeet` | `decodeTurboPlanTasksFromQueryJsonForTesting` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:594` | Decode Turbo query JSON into Yeet Turbo plan task metadata for focused tests. |
+| `@beep/repo-cli/test/Yeet` | `DEFAULT_YEET_PACKET_DIR` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:32` | Default ignored directory for yeet run artifacts. |
+| `@beep/repo-cli/test/Yeet` | `defaultYeetRunOptions` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:995` | Construct baseline yeet options for focused tests. |
+| `@beep/repo-cli/test/Yeet` | `emptyTurboPlanSnapshot` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:133` | Create an empty Turbo metadata snapshot. |
+| `@beep/repo-cli/test/Yeet` | `enforceConservativeResume` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:456` | Ensure a step's resume field follows v1 safety rules. |
 | `@beep/repo-cli/test/Yeet` | `executeRepoPlanStep` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.executor.ts:162` | Execute a planned repository step and optionally persist its raw output. |
-| `@beep/repo-cli/test/Yeet` | `gitPathListFromNulOutputForTesting` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:242` | Parse NUL-delimited Git path output for Yeet publish-safety tests. |
-| `@beep/repo-cli/test/Yeet` | `hydrateYeetRunContext` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:607` | Hydrate a shared yeet run context from repository state. |
-| `@beep/repo-cli/test/Yeet` | `isConservativeResumeCandidate` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:444` | Determine whether a planned step may use conservative resume metadata. |
-| `@beep/repo-cli/test/Yeet` | `jsonObjectTextFromMixedOutputForTesting` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:439` | Extract the last decodable JSON object from mixed command output for tests. |
+| `@beep/repo-cli/test/Yeet` | `GITHUB_CHECK_MODE_VALUES` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.proofs.ts:26` | GitHub check mode handled by `beep quality github-checks`. |
+| `@beep/repo-cli/test/Yeet` | `GithubCheckMode` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.proofs.ts:42` | GitHub check mode handled by `beep quality github-checks`. |
+| `@beep/repo-cli/test/Yeet` | `GithubCheckMode` | type | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.proofs.ts:54` | GitHub check mode handled by `beep quality github-checks`. |
+| `@beep/repo-cli/test/Yeet` | `gitPathListFromNulOutputForTesting` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:249` | Parse NUL-delimited Git path output for Yeet publish-safety tests. |
+| `@beep/repo-cli/test/Yeet` | `hydrateYeetRunContext` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:643` | Hydrate a shared yeet run context from repository state. |
+| `@beep/repo-cli/test/Yeet` | `isConservativeResumeCandidate` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:445` | Determine whether a planned step may use conservative resume metadata. |
+| `@beep/repo-cli/test/Yeet` | `jsonObjectTextFromMixedOutputForTesting` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:475` | Extract the last decodable JSON object from mixed command output for tests. |
 | `@beep/repo-cli/test/Yeet` | `PackageQualityReport` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/QualityIssueIndex.ts:224` | Package-level issue report rendered into a quality packet. |
-| `@beep/repo-cli/test/Yeet` | `publishPathsOutsideIntentForTesting` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:250` | Return observed paths that are not part of the reviewed Yeet publish intent. |
+| `@beep/repo-cli/test/Yeet` | `publishPathsOutsideIntentForTesting` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:257` | Return observed paths that are not part of the reviewed Yeet publish intent. |
 | `@beep/repo-cli/test/Yeet` | `QualityIssue` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/QualityIssueIndex.ts:170` | One normalized quality issue. |
 | `@beep/repo-cli/test/Yeet` | `QualityIssueCategory` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/QualityIssueIndex.ts:44` | Classification domain for normalized yeet quality findings. |
 | `@beep/repo-cli/test/Yeet` | `QualityIssueCategory` | type | `packages/tooling/tool/cli/src/commands/Yeet/internal/QualityIssueIndex.ts:71` | Type-level union of normalized yeet quality finding categories. |
@@ -2448,22 +2456,28 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/test/Yeet` | `RepoPlanStepResume` | type | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:121` | Conservative resume eligibility for a planned step. |
 | `@beep/repo-cli/test/Yeet` | `RepoPlanStepScope` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:83` | Step scope classification. |
 | `@beep/repo-cli/test/Yeet` | `RepoPlanStepScope` | type | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:95` | Step scope classification. |
+| `@beep/repo-cli/test/Yeet` | `repoProofStepDefinition` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.proofs.ts:120` | Return the `beep` command metadata that proves a repository proof surface. |
+| `@beep/repo-cli/test/Yeet` | `RepoProofStepDefinition` | class | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.proofs.ts:94` | Planned command metadata for a repository proof surface. |
+| `@beep/repo-cli/test/Yeet` | `RepoProofSurface` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.proofs.ts:68` | Named proof surfaces that orchestration commands may require. |
+| `@beep/repo-cli/test/Yeet` | `RepoProofSurface` | type | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.proofs.ts:80` | Named proof surfaces that orchestration commands may require. |
 | `@beep/repo-cli/test/Yeet` | `RepoRunContext` | class | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:249` | Shared run context hydrated before planning. |
 | `@beep/repo-cli/test/Yeet` | `RepoRunPlan` | class | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:323` | Repository run plan. |
 | `@beep/repo-cli/test/Yeet` | `RepoStepRunResult` | class | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:346` | Captured subprocess result for a planned step. |
 | `@beep/repo-cli/test/Yeet` | `resolveLocalRepoBinary` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.executor.ts:203` | Resolve a local node_modules binary when present. |
 | `@beep/repo-cli/test/Yeet` | `runRepoCommandCapture` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.executor.ts:92` | Execute a command and capture combined output. |
-| `@beep/repo-cli/test/Yeet` | `runYeet` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:895` | Run yeet with the provided options. |
+| `@beep/repo-cli/test/Yeet` | `runYeet` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:953` | Run yeet with the provided options. |
 | `@beep/repo-cli/test/Yeet` | `TurboPlanSnapshot` | class | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:214` | Turbo snapshot stored in the shared run context. |
 | `@beep/repo-cli/test/Yeet` | `TurboPlanTask` | class | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:162` | Turbo task metadata captured from dry-runs or summaries. |
-| `@beep/repo-cli/test/Yeet` | `turboTaskForStep` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:472` | Lookup Turbo metadata for a planned step, if available. |
+| `@beep/repo-cli/test/Yeet` | `turboTaskForStep` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:473` | Lookup Turbo metadata for a planned step, if available. |
 | `@beep/repo-cli/test/Yeet` | `TurboWorkspacePackage` | class | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:191` | Workspace package metadata captured from Turbo graph queries. |
-| `@beep/repo-cli/test/Yeet` | `YEET_FEEDBACK_TASKS` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:35` | Turbo tasks used by the Yeet feedback phase. |
-| `@beep/repo-cli/test/Yeet` | `yeetCommand` | const | `packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts:24` | Command that runs fast quality feedback, canonical full proof, then commits and pushes reviewed staged changes. |
+| `@beep/repo-cli/test/Yeet` | `YEET_FEEDBACK_TASKS` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:40` | Turbo tasks used by the Yeet feedback phase. |
+| `@beep/repo-cli/test/Yeet` | `yeetCommand` | const | `packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts:91` | Command that repairs, verifies, or publishes repository work through Yeet. |
 | `@beep/repo-cli/test/Yeet` | `YeetCommandError` | class | `packages/tooling/tool/cli/src/commands/Yeet/Yeet.errors.ts:40` | Operational error raised by the yeet command. |
-| `@beep/repo-cli/test/Yeet` | `yeetPlanPhases` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:251` | Return plan phases in execution order. |
-| `@beep/repo-cli/test/Yeet` | `YeetRunOptions` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:143` | Runtime options accepted by the yeet handler. |
-| `@beep/repo-cli/test/Yeet` | `YeetRunResult` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:170` | Result returned by a yeet execution attempt. |
+| `@beep/repo-cli/test/Yeet` | `yeetPlanPhases` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:339` | Return plan phases in execution order. |
+| `@beep/repo-cli/test/Yeet` | `YeetRunMode` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:54` | Yeet execution modes. |
+| `@beep/repo-cli/test/Yeet` | `YeetRunMode` | type | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:66` | Yeet execution modes. |
+| `@beep/repo-cli/test/Yeet` | `YeetRunOptions` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:149` | Runtime options accepted by the yeet handler. |
+| `@beep/repo-cli/test/Yeet` | `YeetRunResult` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:177` | Result returned by a yeet execution attempt. |
 
 ### @beep/ai-sync
 

--- a/standards/repo-exports.catalog.md
+++ b/standards/repo-exports.catalog.md
@@ -21,8 +21,8 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | packagesWithoutPublicExports | 6 |
 | missingWorkspaceMetadata | 4 |
 | importSpecifiers | 1053 |
-| publicExportEntries | 13877 |
-| uniquePackageSymbols | 6152 |
+| publicExportEntries | 13878 |
+| uniquePackageSymbols | 6153 |
 
 ## Seed Discovery Proof
 
@@ -52,7 +52,7 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | 13 | `@beep/discord` | `packages/drivers/discord` | has-public-exports | 5 | 27 | 8 |
 | 14 | `@beep/face-detection` | `packages/drivers/face-detection` | has-public-exports | 5 | 72 | 20 |
 | 15 | `@beep/architecture-lab-client` | `packages/architecture-lab/client` | has-public-exports | 2 | 6 | 6 |
-| 16 | `@beep/repo-cli` | `packages/tooling/tool/cli` | has-public-exports | 147 | 1682 | 607 |
+| 16 | `@beep/repo-cli` | `packages/tooling/tool/cli` | has-public-exports | 147 | 1683 | 608 |
 | 17 | `@beep/ai-sync` | `packages/tooling/library/ai-sync` | has-public-exports | 11 | 180 | 57 |
 | 18 | `@beep/shared-server` | `packages/shared/server` | has-public-exports | 2 | 2 | 1 |
 | 19 | `@beep/nlp-mcp` | `packages/drivers/nlp-mcp` | has-public-exports | 10 | 75 | 63 |
@@ -2103,10 +2103,10 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/commands/Yeet` | `QualityIssueSeverity` | type | `packages/tooling/tool/cli/src/commands/Yeet/internal/QualityIssueIndex.ts:97` | Type-level union of yeet quality severity literals. |
 | `@beep/repo-cli/commands/Yeet` | `yeetCommand` | const | `packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts:91` | Command that repairs, verifies, or publishes repository work through Yeet. |
 | `@beep/repo-cli/commands/Yeet` | `YeetCommandError` | class | `packages/tooling/tool/cli/src/commands/Yeet/Yeet.errors.ts:40` | Operational error raised by the yeet command. |
-| `@beep/repo-cli/commands/Yeet` | `YeetRunMode` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:54` | Yeet execution modes. |
-| `@beep/repo-cli/commands/Yeet` | `YeetRunMode` | type | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:66` | Yeet execution modes. |
-| `@beep/repo-cli/commands/Yeet` | `YeetRunOptions` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:149` | Runtime options accepted by the yeet handler. |
-| `@beep/repo-cli/commands/Yeet` | `YeetRunResult` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:177` | Result returned by a yeet execution attempt. |
+| `@beep/repo-cli/commands/Yeet` | `YeetRunMode` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:57` | Yeet execution modes. |
+| `@beep/repo-cli/commands/Yeet` | `YeetRunMode` | type | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:69` | Yeet execution modes. |
+| `@beep/repo-cli/commands/Yeet` | `YeetRunOptions` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:150` | Runtime options accepted by the yeet handler. |
+| `@beep/repo-cli/commands/Yeet` | `YeetRunResult` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:178` | Result returned by a yeet execution attempt. |
 | `@beep/repo-cli/commands/Yeet/index` | `PackageQualityReport` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/QualityIssueIndex.ts:224` | Package-level issue report rendered into a quality packet. |
 | `@beep/repo-cli/commands/Yeet/index` | `QualityIssue` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/QualityIssueIndex.ts:170` | One normalized quality issue. |
 | `@beep/repo-cli/commands/Yeet/index` | `QualityIssueCategory` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/QualityIssueIndex.ts:44` | Classification domain for normalized yeet quality findings. |
@@ -2119,10 +2119,10 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/commands/Yeet/index` | `QualityIssueSeverity` | type | `packages/tooling/tool/cli/src/commands/Yeet/internal/QualityIssueIndex.ts:97` | Type-level union of yeet quality severity literals. |
 | `@beep/repo-cli/commands/Yeet/index` | `yeetCommand` | const | `packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts:91` | Command that repairs, verifies, or publishes repository work through Yeet. |
 | `@beep/repo-cli/commands/Yeet/index` | `YeetCommandError` | class | `packages/tooling/tool/cli/src/commands/Yeet/Yeet.errors.ts:40` | Operational error raised by the yeet command. |
-| `@beep/repo-cli/commands/Yeet/index` | `YeetRunMode` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:54` | Yeet execution modes. |
-| `@beep/repo-cli/commands/Yeet/index` | `YeetRunMode` | type | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:66` | Yeet execution modes. |
-| `@beep/repo-cli/commands/Yeet/index` | `YeetRunOptions` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:149` | Runtime options accepted by the yeet handler. |
-| `@beep/repo-cli/commands/Yeet/index` | `YeetRunResult` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:177` | Result returned by a yeet execution attempt. |
+| `@beep/repo-cli/commands/Yeet/index` | `YeetRunMode` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:57` | Yeet execution modes. |
+| `@beep/repo-cli/commands/Yeet/index` | `YeetRunMode` | type | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:69` | Yeet execution modes. |
+| `@beep/repo-cli/commands/Yeet/index` | `YeetRunOptions` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:150` | Runtime options accepted by the yeet handler. |
+| `@beep/repo-cli/commands/Yeet/index` | `YeetRunResult` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:178` | Result returned by a yeet execution attempt. |
 | `@beep/repo-cli/commands/Yeet/Yeet.command` | `yeetCommand` | const | `packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts:91` | Command that repairs, verifies, or publishes repository work through Yeet. |
 | `@beep/repo-cli/commands/Yeet/Yeet.errors` | `YeetCommandError` | class | `packages/tooling/tool/cli/src/commands/Yeet/Yeet.errors.ts:40` | Operational error raised by the yeet command. |
 | `@beep/repo-cli/test/CreatePackage` | `checkConfigNeedsUpdate` | const | `packages/tooling/tool/cli/src/commands/CreatePackage/ConfigUpdater.ts:671` | Check whether config entries already exist (for dry-run output). |
@@ -2413,26 +2413,26 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/test/VersionSync` | `VersionSyncResolution` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:382` | Resolver output consumed by reporting and write-mode services. |
 | `@beep/repo-cli/test/VersionSync` | `VersionSyncUpdateLocation` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:366` | YAML location to update in write mode. |
 | `@beep/repo-cli/test/Yeet` | `buildQualityIssueIndex` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/QualityIssueIndex.ts:716` | Build a schema-first issue index from normalized issues. |
-| `@beep/repo-cli/test/Yeet` | `buildYeetRunPlan` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:322` | Build the publish-mode yeet run plan. |
-| `@beep/repo-cli/test/Yeet` | `buildYeetRunPlanForTesting` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:981` | Build a plan for tests without reading repository state. |
-| `@beep/repo-cli/test/Yeet` | `buildYeetRunPlanWithMode` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:286` | Build a yeet run plan for a specific mode. |
+| `@beep/repo-cli/test/Yeet` | `buildYeetRunPlan` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:358` | Build the publish-mode yeet run plan. |
+| `@beep/repo-cli/test/Yeet` | `buildYeetRunPlanForTesting` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:980` | Build a plan for tests without reading repository state. |
+| `@beep/repo-cli/test/Yeet` | `buildYeetRunPlanWithMode` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:320` | Build a yeet run plan for a specific mode. |
 | `@beep/repo-cli/test/Yeet` | `byRepoPlanStepAscending` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:375` | Order repository plan steps by phase, then identifier. |
 | `@beep/repo-cli/test/Yeet` | `commandTextForStep` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:417` | Render a planned step as a shell-like command string. |
-| `@beep/repo-cli/test/Yeet` | `decodeTurboPlanTasksFromQueryJsonForTesting` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:594` | Decode Turbo query JSON into Yeet Turbo plan task metadata for focused tests. |
-| `@beep/repo-cli/test/Yeet` | `DEFAULT_YEET_PACKET_DIR` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:32` | Default ignored directory for yeet run artifacts. |
-| `@beep/repo-cli/test/Yeet` | `defaultYeetRunOptions` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:995` | Construct baseline yeet options for focused tests. |
-| `@beep/repo-cli/test/Yeet` | `emptyTurboPlanSnapshot` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:133` | Create an empty Turbo metadata snapshot. |
+| `@beep/repo-cli/test/Yeet` | `decodeTurboPlanTasksFromQueryJsonForTesting` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:595` | Decode Turbo query JSON into Yeet Turbo plan task metadata for focused tests. |
+| `@beep/repo-cli/test/Yeet` | `DEFAULT_YEET_PACKET_DIR` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:33` | Default ignored directory for yeet run artifacts. |
+| `@beep/repo-cli/test/Yeet` | `defaultYeetRunOptions` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:999` | Construct baseline yeet options for focused tests. |
+| `@beep/repo-cli/test/Yeet` | `emptyTurboPlanSnapshot` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:157` | Create an empty Turbo metadata snapshot. |
 | `@beep/repo-cli/test/Yeet` | `enforceConservativeResume` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:456` | Ensure a step's resume field follows v1 safety rules. |
 | `@beep/repo-cli/test/Yeet` | `executeRepoPlanStep` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.executor.ts:162` | Execute a planned repository step and optionally persist its raw output. |
 | `@beep/repo-cli/test/Yeet` | `GITHUB_CHECK_MODE_VALUES` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.proofs.ts:26` | GitHub check mode handled by `beep quality github-checks`. |
 | `@beep/repo-cli/test/Yeet` | `GithubCheckMode` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.proofs.ts:42` | GitHub check mode handled by `beep quality github-checks`. |
 | `@beep/repo-cli/test/Yeet` | `GithubCheckMode` | type | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.proofs.ts:54` | GitHub check mode handled by `beep quality github-checks`. |
-| `@beep/repo-cli/test/Yeet` | `gitPathListFromNulOutputForTesting` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:249` | Parse NUL-delimited Git path output for Yeet publish-safety tests. |
-| `@beep/repo-cli/test/Yeet` | `hydrateYeetRunContext` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:643` | Hydrate a shared yeet run context from repository state. |
+| `@beep/repo-cli/test/Yeet` | `gitPathListFromNulOutputForTesting` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:250` | Parse NUL-delimited Git path output for Yeet publish-safety tests. |
+| `@beep/repo-cli/test/Yeet` | `hydrateYeetRunContext` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:644` | Hydrate a shared yeet run context from repository state. |
 | `@beep/repo-cli/test/Yeet` | `isConservativeResumeCandidate` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:445` | Determine whether a planned step may use conservative resume metadata. |
-| `@beep/repo-cli/test/Yeet` | `jsonObjectTextFromMixedOutputForTesting` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:475` | Extract the last decodable JSON object from mixed command output for tests. |
+| `@beep/repo-cli/test/Yeet` | `jsonObjectTextFromMixedOutputForTesting` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:476` | Extract the last decodable JSON object from mixed command output for tests. |
 | `@beep/repo-cli/test/Yeet` | `PackageQualityReport` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/QualityIssueIndex.ts:224` | Package-level issue report rendered into a quality packet. |
-| `@beep/repo-cli/test/Yeet` | `publishPathsOutsideIntentForTesting` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:257` | Return observed paths that are not part of the reviewed Yeet publish intent. |
+| `@beep/repo-cli/test/Yeet` | `publishPathsOutsideIntentForTesting` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:258` | Return observed paths that are not part of the reviewed Yeet publish intent. |
 | `@beep/repo-cli/test/Yeet` | `QualityIssue` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/QualityIssueIndex.ts:170` | One normalized quality issue. |
 | `@beep/repo-cli/test/Yeet` | `QualityIssueCategory` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/QualityIssueIndex.ts:44` | Classification domain for normalized yeet quality findings. |
 | `@beep/repo-cli/test/Yeet` | `QualityIssueCategory` | type | `packages/tooling/tool/cli/src/commands/Yeet/internal/QualityIssueIndex.ts:71` | Type-level union of normalized yeet quality finding categories. |
@@ -2465,19 +2465,20 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/test/Yeet` | `RepoStepRunResult` | class | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:346` | Captured subprocess result for a planned step. |
 | `@beep/repo-cli/test/Yeet` | `resolveLocalRepoBinary` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.executor.ts:203` | Resolve a local node_modules binary when present. |
 | `@beep/repo-cli/test/Yeet` | `runRepoCommandCapture` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.executor.ts:92` | Execute a command and capture combined output. |
-| `@beep/repo-cli/test/Yeet` | `runYeet` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:953` | Run yeet with the provided options. |
+| `@beep/repo-cli/test/Yeet` | `runYeet` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:954` | Run yeet with the provided options. |
 | `@beep/repo-cli/test/Yeet` | `TurboPlanSnapshot` | class | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:214` | Turbo snapshot stored in the shared run context. |
 | `@beep/repo-cli/test/Yeet` | `TurboPlanTask` | class | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:162` | Turbo task metadata captured from dry-runs or summaries. |
 | `@beep/repo-cli/test/Yeet` | `turboTaskForStep` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:473` | Lookup Turbo metadata for a planned step, if available. |
 | `@beep/repo-cli/test/Yeet` | `TurboWorkspacePackage` | class | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:191` | Workspace package metadata captured from Turbo graph queries. |
-| `@beep/repo-cli/test/Yeet` | `YEET_FEEDBACK_TASKS` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:40` | Turbo tasks used by the Yeet feedback phase. |
+| `@beep/repo-cli/test/Yeet` | `YEET_FEEDBACK_TASKS` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:41` | Turbo tasks used by the Yeet feedback phase. |
 | `@beep/repo-cli/test/Yeet` | `yeetCommand` | const | `packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts:91` | Command that repairs, verifies, or publishes repository work through Yeet. |
 | `@beep/repo-cli/test/Yeet` | `YeetCommandError` | class | `packages/tooling/tool/cli/src/commands/Yeet/Yeet.errors.ts:40` | Operational error raised by the yeet command. |
-| `@beep/repo-cli/test/Yeet` | `yeetPlanPhases` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:339` | Return plan phases in execution order. |
-| `@beep/repo-cli/test/Yeet` | `YeetRunMode` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:54` | Yeet execution modes. |
-| `@beep/repo-cli/test/Yeet` | `YeetRunMode` | type | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:66` | Yeet execution modes. |
-| `@beep/repo-cli/test/Yeet` | `YeetRunOptions` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:149` | Runtime options accepted by the yeet handler. |
-| `@beep/repo-cli/test/Yeet` | `YeetRunResult` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:177` | Result returned by a yeet execution attempt. |
+| `@beep/repo-cli/test/Yeet` | `yeetPlanPhases` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:375` | Return plan phases in execution order. |
+| `@beep/repo-cli/test/Yeet` | `YeetRunMode` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:57` | Yeet execution modes. |
+| `@beep/repo-cli/test/Yeet` | `YeetRunMode` | type | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:69` | Yeet execution modes. |
+| `@beep/repo-cli/test/Yeet` | `YeetRunOptions` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:150` | Runtime options accepted by the yeet handler. |
+| `@beep/repo-cli/test/Yeet` | `YeetRunPlanModeOptions` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:83` | Options for building a Yeet run plan in a specific mode. |
+| `@beep/repo-cli/test/Yeet` | `YeetRunResult` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:178` | Result returned by a yeet execution attempt. |
 
 ### @beep/ai-sync
 

--- a/standards/repo-exports.catalog.md
+++ b/standards/repo-exports.catalog.md
@@ -1881,9 +1881,9 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/commands/Quality/Quality.errors` | `QualityTaskFailed` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:144` | Error raised when a quality task subprocess exits unsuccessfully. |
 | `@beep/repo-cli/commands/Quality/Quality.errors` | `QualityTaskGroupFailed` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:198` | Error raised when a bounded quality task group completes with failed steps. |
 | `@beep/repo-cli/commands/Quality/Quality.errors` | `UnexpectedQualityTaskFailure` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:277` | Error raised when an unexpected quality task cause reaches the command boundary. |
-| `@beep/repo-cli/commands/Quality/Tasks` | `collectStepOutput` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1204` | Run a subprocess and capture all output. Exposed for focused unit tests. |
+| `@beep/repo-cli/commands/Quality/Tasks` | `collectStepOutput` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1203` | Run a subprocess and capture all output. Exposed for focused unit tests. |
 | `@beep/repo-cli/commands/Quality/Tasks` | `PackageTaskProfile` | class | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:103` | Package-local script profile used by the quality task adapter. |
-| `@beep/repo-cli/commands/Quality/Tasks` | `parseQualityTaskInvocation` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1098` | Parse a raw argv vector into a quality task invocation when the first token is |
+| `@beep/repo-cli/commands/Quality/Tasks` | `parseQualityTaskInvocation` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1097` | Parse a raw argv vector into a quality task invocation when the first token is |
 | `@beep/repo-cli/commands/Quality/Tasks` | `QualityTaskConfigurationError` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:245` | Error raised when a quality task cannot resolve its required configuration. |
 | `@beep/repo-cli/commands/Quality/Tasks` | `QualityTaskFailed` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:144` | Error raised when a quality task subprocess exits unsuccessfully. |
 | `@beep/repo-cli/commands/Quality/Tasks` | `QualityTaskGroupFailed` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:198` | Error raised when a bounded quality task group completes with failed steps. |
@@ -1891,13 +1891,13 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/commands/Quality/Tasks` | `QualityTaskName` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:69` | Canonical quality task name. |
 | `@beep/repo-cli/commands/Quality/Tasks` | `QualityTaskName` | type | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:86` | Canonical quality task name. |
 | `@beep/repo-cli/commands/Quality/Tasks` | `QualityTaskStep` | class | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:130` | Planned subprocess invocation. |
-| `@beep/repo-cli/commands/Quality/Tasks` | `rootQualityStepsForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:995` | Build root quality task subprocess steps. Exposed for focused unit tests. |
-| `@beep/repo-cli/commands/Quality/Tasks` | `runQualityTask` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1142` | Run a parsed quality task in either repo-root or package-local mode. |
-| `@beep/repo-cli/commands/Quality/Tasks` | `runQualityTaskIfRequested` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1172` | Run a quality task directly from a raw argv vector. |
-| `@beep/repo-cli/commands/Quality/Tasks` | `runQualityTaskStepGroupForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1221` | Run a bounded quality task group. Exposed for focused unit tests. |
-| `@beep/repo-cli/commands/Quality/Tasks` | `runSqlIntegrationTestLaneForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:805` | Run the SQL integration lane with an injected resource and child command. |
-| `@beep/repo-cli/commands/Quality/Tasks` | `sqlIntegrationConnectionUriFromEnvForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:819` | Resolve the SQL integration database connection URI from environment variables. |
-| `@beep/repo-cli/commands/Quality/Tasks` | `sqlIntegrationStepForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:786` | Build the SQL integration test subprocess step. Exposed for focused unit tests. |
+| `@beep/repo-cli/commands/Quality/Tasks` | `rootQualityStepsForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:994` | Build root quality task subprocess steps. Exposed for focused unit tests. |
+| `@beep/repo-cli/commands/Quality/Tasks` | `runQualityTask` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1141` | Run a parsed quality task in either repo-root or package-local mode. |
+| `@beep/repo-cli/commands/Quality/Tasks` | `runQualityTaskIfRequested` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1171` | Run a quality task directly from a raw argv vector. |
+| `@beep/repo-cli/commands/Quality/Tasks` | `runQualityTaskStepGroupForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1220` | Run a bounded quality task group. Exposed for focused unit tests. |
+| `@beep/repo-cli/commands/Quality/Tasks` | `runSqlIntegrationTestLaneForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:804` | Run the SQL integration lane with an injected resource and child command. |
+| `@beep/repo-cli/commands/Quality/Tasks` | `sqlIntegrationConnectionUriFromEnvForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:818` | Resolve the SQL integration database connection URI from environment variables. |
+| `@beep/repo-cli/commands/Quality/Tasks` | `sqlIntegrationStepForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:785` | Build the SQL integration test subprocess step. Exposed for focused unit tests. |
 | `@beep/repo-cli/commands/Quality/Tasks` | `UnexpectedQualityTaskFailure` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:277` | Error raised when an unexpected quality task cause reaches the command boundary. |
 | `@beep/repo-cli/commands/Reuse` | `buildCloneDocument` | const | `packages/tooling/tool/cli/src/commands/Reuse/internal/CloneBaseline.ts:116` | Build a sorted, deterministic baseline document from clone candidates. |
 | `@beep/repo-cli/commands/Reuse` | `CloneBaselineDocument` | class | `packages/tooling/tool/cli/src/commands/Reuse/internal/CloneBaseline.ts:67` | Committed baseline of acknowledged structural-clone clusters for the ratchet. |
@@ -2103,8 +2103,8 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/commands/Yeet` | `QualityIssueSeverity` | type | `packages/tooling/tool/cli/src/commands/Yeet/internal/QualityIssueIndex.ts:97` | Type-level union of yeet quality severity literals. |
 | `@beep/repo-cli/commands/Yeet` | `yeetCommand` | const | `packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts:91` | Command that repairs, verifies, or publishes repository work through Yeet. |
 | `@beep/repo-cli/commands/Yeet` | `YeetCommandError` | class | `packages/tooling/tool/cli/src/commands/Yeet/Yeet.errors.ts:40` | Operational error raised by the yeet command. |
-| `@beep/repo-cli/commands/Yeet` | `YeetRunMode` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:57` | Yeet execution modes. |
-| `@beep/repo-cli/commands/Yeet` | `YeetRunMode` | type | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:69` | Yeet execution modes. |
+| `@beep/repo-cli/commands/Yeet` | `YeetRunMode` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:58` | Yeet execution modes. |
+| `@beep/repo-cli/commands/Yeet` | `YeetRunMode` | type | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:70` | Yeet execution modes. |
 | `@beep/repo-cli/commands/Yeet` | `YeetRunOptions` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:150` | Runtime options accepted by the yeet handler. |
 | `@beep/repo-cli/commands/Yeet` | `YeetRunResult` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:178` | Result returned by a yeet execution attempt. |
 | `@beep/repo-cli/commands/Yeet/index` | `PackageQualityReport` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/QualityIssueIndex.ts:224` | Package-level issue report rendered into a quality packet. |
@@ -2119,8 +2119,8 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/commands/Yeet/index` | `QualityIssueSeverity` | type | `packages/tooling/tool/cli/src/commands/Yeet/internal/QualityIssueIndex.ts:97` | Type-level union of yeet quality severity literals. |
 | `@beep/repo-cli/commands/Yeet/index` | `yeetCommand` | const | `packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts:91` | Command that repairs, verifies, or publishes repository work through Yeet. |
 | `@beep/repo-cli/commands/Yeet/index` | `YeetCommandError` | class | `packages/tooling/tool/cli/src/commands/Yeet/Yeet.errors.ts:40` | Operational error raised by the yeet command. |
-| `@beep/repo-cli/commands/Yeet/index` | `YeetRunMode` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:57` | Yeet execution modes. |
-| `@beep/repo-cli/commands/Yeet/index` | `YeetRunMode` | type | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:69` | Yeet execution modes. |
+| `@beep/repo-cli/commands/Yeet/index` | `YeetRunMode` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:58` | Yeet execution modes. |
+| `@beep/repo-cli/commands/Yeet/index` | `YeetRunMode` | type | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:70` | Yeet execution modes. |
 | `@beep/repo-cli/commands/Yeet/index` | `YeetRunOptions` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:150` | Runtime options accepted by the yeet handler. |
 | `@beep/repo-cli/commands/Yeet/index` | `YeetRunResult` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:178` | Result returned by a yeet execution attempt. |
 | `@beep/repo-cli/commands/Yeet/Yeet.command` | `yeetCommand` | const | `packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts:91` | Command that repairs, verifies, or publishes repository work through Yeet. |
@@ -2300,7 +2300,7 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/test/Quality` | `ChangesetGraphSummary` | class | `packages/tooling/tool/cli/src/commands/Quality/ChangesetGraph.ts:102` | Summary emitted by the changeset package graph guard. |
 | `@beep/repo-cli/test/Quality` | `changesetPackageReferencesFromText` | const | `packages/tooling/tool/cli/src/commands/Quality/ChangesetGraph.ts:309` | Parse package references from one changeset Markdown document. |
 | `@beep/repo-cli/test/Quality` | `collectEffectTsgoDiagnosticLines` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:865` | Collect Effect tsgo diagnostics from command output regardless of process exit code. |
-| `@beep/repo-cli/test/Quality` | `collectStepOutput` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1204` | Run a subprocess and capture all output. Exposed for focused unit tests. |
+| `@beep/repo-cli/test/Quality` | `collectStepOutput` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1203` | Run a subprocess and capture all output. Exposed for focused unit tests. |
 | `@beep/repo-cli/test/Quality` | `findMissingChangesetPackageReferences` | const | `packages/tooling/tool/cli/src/commands/Quality/ChangesetGraph.ts:402` | Find changeset package references that are not in the workspace graph. |
 | `@beep/repo-cli/test/Quality` | `GithubCheckMode` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:141` | GitHub check mode handled by `beep quality github-checks`. |
 | `@beep/repo-cli/test/Quality` | `GithubCheckMode` | type | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:154` | GitHub check mode handled by `beep quality github-checks`. |
@@ -2308,7 +2308,7 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/test/Quality` | `JSDocDocumentationInventoryWriteResult` | class | `packages/tooling/tool/cli/src/commands/Quality/internal/JSDocDocumentationInventory.ts:160` | Result returned after writing JSDoc inventory artifacts. |
 | `@beep/repo-cli/test/Quality` | `makeChangesetGraphSummary` | const | `packages/tooling/tool/cli/src/commands/Quality/ChangesetGraph.ts:449` | Build a changeset graph summary from already-collected inputs. |
 | `@beep/repo-cli/test/Quality` | `PackageTaskProfile` | class | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:103` | Package-local script profile used by the quality task adapter. |
-| `@beep/repo-cli/test/Quality` | `parseQualityTaskInvocation` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1098` | Parse a raw argv vector into a quality task invocation when the first token is |
+| `@beep/repo-cli/test/Quality` | `parseQualityTaskInvocation` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1097` | Parse a raw argv vector into a quality task invocation when the first token is |
 | `@beep/repo-cli/test/Quality` | `qualityCommand` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1725` | Quality command group for repo operational checks. |
 | `@beep/repo-cli/test/Quality` | `QualityScriptCommandError` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:88` | Typed failure for repo operational commands. |
 | `@beep/repo-cli/test/Quality` | `QualityTaskConfigurationError` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:245` | Error raised when a quality task cannot resolve its required configuration. |
@@ -2320,7 +2320,7 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/test/Quality` | `QualityTaskStep` | class | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:130` | Planned subprocess invocation. |
 | `@beep/repo-cli/test/Quality` | `RepoExportsCatalogOptions` | class | `packages/tooling/tool/cli/src/commands/Quality/internal/RepoExportsCatalog.ts:119` | Options for building, writing, or checking the repo export catalog. |
 | `@beep/repo-cli/test/Quality` | `RepoExportsCatalogWriteResult` | class | `packages/tooling/tool/cli/src/commands/Quality/internal/RepoExportsCatalog.ts:137` | Result returned after writing or checking repo export catalog artifacts. |
-| `@beep/repo-cli/test/Quality` | `rootQualityStepsForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:995` | Build root quality task subprocess steps. Exposed for focused unit tests. |
+| `@beep/repo-cli/test/Quality` | `rootQualityStepsForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:994` | Build root quality task subprocess steps. Exposed for focused unit tests. |
 | `@beep/repo-cli/test/Quality` | `runBunAudit` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:357` | Run Bun's high-severity package audit with OSV ignores mirrored from config. |
 | `@beep/repo-cli/test/Quality` | `runChangesetGraphCheck` | const | `packages/tooling/tool/cli/src/commands/Quality/ChangesetGraph.ts:464` | Run the non-mutating changeset package graph guard. |
 | `@beep/repo-cli/test/Quality` | `runDtslintTsgoChecks` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1202` | Run repo-wide tsgo diagnostics for dtslint files. |
@@ -2328,16 +2328,16 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/test/Quality` | `runJSDocInventory` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1522` | Run the JSDoc inventory generator now owned by repo-cli. |
 | `@beep/repo-cli/test/Quality` | `runJSDocModuleTagsCheck` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1445` | Verify tracked fileoverview comments do not use the legacy `@module` tag. |
 | `@beep/repo-cli/test/Quality` | `runJSDocQuality` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1613` | Run the repo-wide JSDoc quality gate. |
-| `@beep/repo-cli/test/Quality` | `runQualityTask` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1142` | Run a parsed quality task in either repo-root or package-local mode. |
-| `@beep/repo-cli/test/Quality` | `runQualityTaskIfRequested` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1172` | Run a quality task directly from a raw argv vector. |
-| `@beep/repo-cli/test/Quality` | `runQualityTaskStepGroupForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1221` | Run a bounded quality task group. Exposed for focused unit tests. |
+| `@beep/repo-cli/test/Quality` | `runQualityTask` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1141` | Run a parsed quality task in either repo-root or package-local mode. |
+| `@beep/repo-cli/test/Quality` | `runQualityTaskIfRequested` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1171` | Run a quality task directly from a raw argv vector. |
+| `@beep/repo-cli/test/Quality` | `runQualityTaskStepGroupForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:1220` | Run a bounded quality task group. Exposed for focused unit tests. |
 | `@beep/repo-cli/test/Quality` | `runRepoExportsCatalog` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1557` | Run the repo export catalog generator now owned by repo-cli. |
-| `@beep/repo-cli/test/Quality` | `runSqlIntegrationTestLaneForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:805` | Run the SQL integration lane with an injected resource and child command. |
+| `@beep/repo-cli/test/Quality` | `runSqlIntegrationTestLaneForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:804` | Run the SQL integration lane with an injected resource and child command. |
 | `@beep/repo-cli/test/Quality` | `runTestTsgoChecks` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1248` | Run repo-wide Effect diagnostics for test files. |
 | `@beep/repo-cli/test/Quality` | `runTsgoRulesCheck` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1011` | Check that the root tsgo Effect diagnostics configuration enables every installed rule as an error. |
 | `@beep/repo-cli/test/Quality` | `runTsgoSmokeCheck` | const | `packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts:1344` | Verify that tsgo reports the Effect diagnostic expected by this repo. |
-| `@beep/repo-cli/test/Quality` | `sqlIntegrationConnectionUriFromEnvForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:819` | Resolve the SQL integration database connection URI from environment variables. |
-| `@beep/repo-cli/test/Quality` | `sqlIntegrationStepForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:786` | Build the SQL integration test subprocess step. Exposed for focused unit tests. |
+| `@beep/repo-cli/test/Quality` | `sqlIntegrationConnectionUriFromEnvForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:818` | Resolve the SQL integration database connection URI from environment variables. |
+| `@beep/repo-cli/test/Quality` | `sqlIntegrationStepForTesting` | const | `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts:785` | Build the SQL integration test subprocess step. Exposed for focused unit tests. |
 | `@beep/repo-cli/test/Quality` | `UnexpectedQualityTaskFailure` | class | `packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts:277` | Error raised when an unexpected quality task cause reaches the command boundary. |
 | `@beep/repo-cli/test/Quality` | `writeJSDocDocumentationInventory` | const | `packages/tooling/tool/cli/src/commands/Quality/internal/JSDocDocumentationInventory.ts:995` | Write JSDoc inventory JSONC and Markdown artifacts. |
 | `@beep/repo-cli/test/Quality` | `writeOrCheckRepoExportsCatalog` | const | `packages/tooling/tool/cli/src/commands/Quality/internal/RepoExportsCatalog.ts:698` | Write or freshness-check repo export catalog JSONC and Markdown artifacts. |
@@ -2413,24 +2413,24 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/test/VersionSync` | `VersionSyncResolution` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:382` | Resolver output consumed by reporting and write-mode services. |
 | `@beep/repo-cli/test/VersionSync` | `VersionSyncUpdateLocation` | class | `packages/tooling/tool/cli/src/commands/VersionSync/internal/Models.ts:366` | YAML location to update in write mode. |
 | `@beep/repo-cli/test/Yeet` | `buildQualityIssueIndex` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/QualityIssueIndex.ts:716` | Build a schema-first issue index from normalized issues. |
-| `@beep/repo-cli/test/Yeet` | `buildYeetRunPlan` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:358` | Build the publish-mode yeet run plan. |
-| `@beep/repo-cli/test/Yeet` | `buildYeetRunPlanForTesting` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:980` | Build a plan for tests without reading repository state. |
-| `@beep/repo-cli/test/Yeet` | `buildYeetRunPlanWithMode` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:320` | Build a yeet run plan for a specific mode. |
+| `@beep/repo-cli/test/Yeet` | `buildYeetRunPlan` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:360` | Build the publish-mode yeet run plan. |
+| `@beep/repo-cli/test/Yeet` | `buildYeetRunPlanForTesting` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:1025` | Build a plan for tests without reading repository state. |
+| `@beep/repo-cli/test/Yeet` | `buildYeetRunPlanWithMode` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:322` | Build a yeet run plan for a specific mode. |
 | `@beep/repo-cli/test/Yeet` | `byRepoPlanStepAscending` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:375` | Order repository plan steps by phase, then identifier. |
 | `@beep/repo-cli/test/Yeet` | `commandTextForStep` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:417` | Render a planned step as a shell-like command string. |
-| `@beep/repo-cli/test/Yeet` | `decodeTurboPlanTasksFromQueryJsonForTesting` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:595` | Decode Turbo query JSON into Yeet Turbo plan task metadata for focused tests. |
-| `@beep/repo-cli/test/Yeet` | `DEFAULT_YEET_PACKET_DIR` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:33` | Default ignored directory for yeet run artifacts. |
-| `@beep/repo-cli/test/Yeet` | `defaultYeetRunOptions` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:999` | Construct baseline yeet options for focused tests. |
-| `@beep/repo-cli/test/Yeet` | `emptyTurboPlanSnapshot` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:157` | Create an empty Turbo metadata snapshot. |
+| `@beep/repo-cli/test/Yeet` | `decodeTurboPlanTasksFromQueryJsonForTesting` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:613` | Decode Turbo query JSON into Yeet Turbo plan task metadata for focused tests. |
+| `@beep/repo-cli/test/Yeet` | `DEFAULT_YEET_PACKET_DIR` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:34` | Default ignored directory for yeet run artifacts. |
+| `@beep/repo-cli/test/Yeet` | `defaultYeetRunOptions` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:1044` | Construct baseline yeet options for focused tests. |
+| `@beep/repo-cli/test/Yeet` | `emptyTurboPlanSnapshot` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:158` | Create an empty Turbo metadata snapshot. |
 | `@beep/repo-cli/test/Yeet` | `enforceConservativeResume` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:456` | Ensure a step's resume field follows v1 safety rules. |
 | `@beep/repo-cli/test/Yeet` | `executeRepoPlanStep` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.executor.ts:162` | Execute a planned repository step and optionally persist its raw output. |
 | `@beep/repo-cli/test/Yeet` | `GITHUB_CHECK_MODE_VALUES` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.proofs.ts:26` | GitHub check mode handled by `beep quality github-checks`. |
 | `@beep/repo-cli/test/Yeet` | `GithubCheckMode` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.proofs.ts:42` | GitHub check mode handled by `beep quality github-checks`. |
 | `@beep/repo-cli/test/Yeet` | `GithubCheckMode` | type | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.proofs.ts:54` | GitHub check mode handled by `beep quality github-checks`. |
 | `@beep/repo-cli/test/Yeet` | `gitPathListFromNulOutputForTesting` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:250` | Parse NUL-delimited Git path output for Yeet publish-safety tests. |
-| `@beep/repo-cli/test/Yeet` | `hydrateYeetRunContext` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:644` | Hydrate a shared yeet run context from repository state. |
+| `@beep/repo-cli/test/Yeet` | `hydrateYeetRunContext` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:662` | Hydrate a shared yeet run context from repository state. |
 | `@beep/repo-cli/test/Yeet` | `isConservativeResumeCandidate` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:445` | Determine whether a planned step may use conservative resume metadata. |
-| `@beep/repo-cli/test/Yeet` | `jsonObjectTextFromMixedOutputForTesting` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:476` | Extract the last decodable JSON object from mixed command output for tests. |
+| `@beep/repo-cli/test/Yeet` | `jsonObjectTextFromMixedOutputForTesting` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:494` | Extract the last decodable JSON object from mixed command output for tests. |
 | `@beep/repo-cli/test/Yeet` | `PackageQualityReport` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/QualityIssueIndex.ts:224` | Package-level issue report rendered into a quality packet. |
 | `@beep/repo-cli/test/Yeet` | `publishPathsOutsideIntentForTesting` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:258` | Return observed paths that are not part of the reviewed Yeet publish intent. |
 | `@beep/repo-cli/test/Yeet` | `QualityIssue` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/QualityIssueIndex.ts:170` | One normalized quality issue. |
@@ -2465,19 +2465,19 @@ The package universe is the current `bun run topo-sort` output. This catalog exi
 | `@beep/repo-cli/test/Yeet` | `RepoStepRunResult` | class | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:346` | Captured subprocess result for a planned step. |
 | `@beep/repo-cli/test/Yeet` | `resolveLocalRepoBinary` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.executor.ts:203` | Resolve a local node_modules binary when present. |
 | `@beep/repo-cli/test/Yeet` | `runRepoCommandCapture` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.executor.ts:92` | Execute a command and capture combined output. |
-| `@beep/repo-cli/test/Yeet` | `runYeet` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:954` | Run yeet with the provided options. |
+| `@beep/repo-cli/test/Yeet` | `runYeet` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:999` | Run yeet with the provided options. |
 | `@beep/repo-cli/test/Yeet` | `TurboPlanSnapshot` | class | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:214` | Turbo snapshot stored in the shared run context. |
 | `@beep/repo-cli/test/Yeet` | `TurboPlanTask` | class | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:162` | Turbo task metadata captured from dry-runs or summaries. |
 | `@beep/repo-cli/test/Yeet` | `turboTaskForStep` | const | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:473` | Lookup Turbo metadata for a planned step, if available. |
 | `@beep/repo-cli/test/Yeet` | `TurboWorkspacePackage` | class | `packages/tooling/tool/cli/src/internal/repo-run/RepoRun.models.ts:191` | Workspace package metadata captured from Turbo graph queries. |
-| `@beep/repo-cli/test/Yeet` | `YEET_FEEDBACK_TASKS` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:41` | Turbo tasks used by the Yeet feedback phase. |
+| `@beep/repo-cli/test/Yeet` | `YEET_FEEDBACK_TASKS` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:42` | Turbo tasks used by the Yeet feedback phase. |
 | `@beep/repo-cli/test/Yeet` | `yeetCommand` | const | `packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts:91` | Command that repairs, verifies, or publishes repository work through Yeet. |
 | `@beep/repo-cli/test/Yeet` | `YeetCommandError` | class | `packages/tooling/tool/cli/src/commands/Yeet/Yeet.errors.ts:40` | Operational error raised by the yeet command. |
-| `@beep/repo-cli/test/Yeet` | `yeetPlanPhases` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:375` | Return plan phases in execution order. |
-| `@beep/repo-cli/test/Yeet` | `YeetRunMode` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:57` | Yeet execution modes. |
-| `@beep/repo-cli/test/Yeet` | `YeetRunMode` | type | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:69` | Yeet execution modes. |
+| `@beep/repo-cli/test/Yeet` | `yeetPlanPhases` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:377` | Return plan phases in execution order. |
+| `@beep/repo-cli/test/Yeet` | `YeetRunMode` | const | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:58` | Yeet execution modes. |
+| `@beep/repo-cli/test/Yeet` | `YeetRunMode` | type | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:70` | Yeet execution modes. |
 | `@beep/repo-cli/test/Yeet` | `YeetRunOptions` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:150` | Runtime options accepted by the yeet handler. |
-| `@beep/repo-cli/test/Yeet` | `YeetRunPlanModeOptions` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:83` | Options for building a Yeet run plan in a specific mode. |
+| `@beep/repo-cli/test/Yeet` | `YeetRunPlanModeOptions` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts:84` | Options for building a Yeet run plan in a specific mode. |
 | `@beep/repo-cli/test/Yeet` | `YeetRunResult` | class | `packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts:178` | Result returned by a yeet execution attempt. |
 
 ### @beep/ai-sync


### PR DESCRIPTION
## Summary
- split Yeet into repair, verify, and publish modes while keeping bare `yeet --message` as a publish alias
- route Yeet full proof through the shared `quality github-checks pre-push` proof definition
- add repair artifact generation for docgen and `repo-exports:catalog`, with docs marking Yeet as proof-mode until this PR is green
- tighten feedback tests to unit/type lanes and refresh the repo export catalog

## Local Proof
- `bun run beep yeet repair`
- `bun run beep yeet verify`
- `git push` pre-push hook: `repo-exports:catalog:check` passed
- focused checks: Yeet tests, repo-cli check/lint, dual-arity, repo export catalog check

## Follow-up
- If GitHub Actions fails while local Yeet proof passed, treat it as a Yeet/quality parity issue before canonizing the skill.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Yeet workflow is in proof mode and should not replace manual quality gates until the proof PR and Yeet agent skill are merged; documented which yeet commands to run for proof.

* **New Features**
  * Exposed granular Yeet subcommands: verify, repair, and publish, with clearer behaviors for repair/verify/publish flows and publish requiring a commit message.

* **Tests**
  * Updated Yeet planner tests to assert new phase ordering and proof/publish behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->