### PR TITLE
fix(ai-metrics): keep forwarder run accepting --retention-enforce for generated timers

### DIFF
--- a/packages/tooling/tool/cli/src/commands/AIMetrics/AIMetrics.command.ts
+++ b/packages/tooling/tool/cli/src/commands/AIMetrics/AIMetrics.command.ts
@@ -298,6 +298,14 @@ const forwarderRunMaxSnapshotExportsFlag = Flag.integer("max-snapshot-exports").
     "Per-run Parquet snapshot exports to keep; older snapshots are pruned automatically after each forwarder run"
   )
 );
+// Accepted but inert: `forwarder run` now always enforces snapshot retention. Retained so that
+// already-installed systemd timer units (and any timer-rendered command) that still pass
+// --retention-enforce continue to parse instead of failing with an unrecognized-flag error.
+const forwarderRunRetentionEnforceCompatFlag = Flag.boolean("retention-enforce").pipe(
+  Flag.withDescription(
+    "Deprecated no-op: forwarder run always prunes old per-run Parquet snapshots; kept for backward compatibility"
+  )
+);
 const hashSaltFlag = Flag.string("hash-salt").pipe(
   Flag.withDescription("Salt for hashing private paths and session identifiers"),
   Flag.optional
@@ -1579,9 +1587,10 @@ const makeForwarderTimerProgram = Effect.fn("AIMetrics.makeForwarderTimerProgram
         `${maxFiles}`,
         "--parquet-mode",
         parquetExportMode,
-        ...(retentionEnforce
-          ? ["--retention-enforce", "--max-snapshot-exports", `${retentionMaxSnapshotExports}`]
-          : []),
+        // `forwarder run` always enforces retention now, so the rendered timer only needs to pass the
+        // keep-N count when the operator opted into a non-default window. The legacy --retention-enforce
+        // token is intentionally not emitted (run accepts it as a no-op for older installed units).
+        ...(retentionEnforce ? ["--max-snapshot-exports", `${retentionMaxSnapshotExports}`] : []),
         "--json",
       ],
       ...O.getSomesStruct({ hashSaltSecretRef: O.fromUndefinedOr(resolvedHashSaltSecretRef) }),
@@ -2928,6 +2937,8 @@ const forwarderRunCommand = Command.make(
     parquetExportMode: parquetExportModeFlag,
     rawArchiveKeySecretRef: rawArchiveKeySecretRefFlag,
     repoRoot: repoRootFlag,
+    // Inert backward-compat flag: parsed and ignored (run always enforces retention).
+    retentionEnforce: forwarderRunRetentionEnforceCompatFlag,
     retentionMaxSnapshotExports: forwarderRunMaxSnapshotExportsFlag,
     since: sinceFlag,
     target: targetFlag,


### PR DESCRIPTION
## Summary
Follow-up regression fix for the ai-metrics snapshot self-pruning change that merged in #249.

#249 made `ai-metrics forwarder run` **always** self-prune per-run Parquet snapshots and, in doing so, **removed the `--retention-enforce` flag from the `run` command**. That broke the `timer` path:

- `ai-metrics forwarder timer --retention-enforce` renders a systemd `ExecStart` that invokes `ai-metrics forwarder run … --retention-enforce …`.
- Any **already-installed** timer unit may also still contain that flag.

After #249, those commands fail at parse time:
```
ERROR  Unrecognized flag: --retention-enforce in command beep-cli ai-metrics forwarder run
```

## Fix (1 file: `AIMetrics.command.ts`)
1. **Re-accept `--retention-enforce` on `forwarder run` as a deprecated no-op.** `run` always enforces retention now, so the flag is parsed and ignored — this keeps already-installed timer units and any timer-rendered command working.
2. **Stop emitting `--retention-enforce` from the timer builder.** The rendered `ExecStart` now passes only `--max-snapshot-exports <N>` when the operator opted into a non-default keep-N window, so newly generated units are clean. Keep-N semantics are unchanged.

## Verification
- `bun run beep ai-metrics forwarder run --retention-enforce --target local` → now parses (fails only on the missing `BEEP_AI_METRICS_RAW_ARCHIVE_KEY`, i.e. past flag parsing), no "Unrecognized flag".
- `forwarder timer --retention-enforce --max-snapshot-exports 3 --parquet-mode snapshot --json` → rendered `ExecStart` contains `--max-snapshot-exports 3 --json` and **no** `--retention-enforce` token.
- `turbo run check --filter=@beep/repo-cli` ✓ · `turbo run lint --filter=@beep/repo-cli` ✓.

Note: the timer builder's command array is assembled inside the CLI program (not the library `renderAiMetricsForwarderTimerPlan`), so it isn't covered by a unit test; verified empirically via the CLI above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
