### PR TITLE
chore(security): close out Codex findings initiative (P7/P8)

### DIFF
--- a/goals/codex-security-findings-2026-06-17/history/reflections/2026-06-18-closeout.md
+++ b/goals/codex-security-findings-2026-06-17/history/reflections/2026-06-18-closeout.md
@@ -1,0 +1,52 @@
+# Closeout Reflection — Codex Security Findings (2026-06-17)
+
+**Status:** complete · **Merged:** PR #254 → `main` (`dc2e44fb70`), 2026-06-18 · **Findings:** all closed (STILL_OPEN=0)
+
+## Outcome
+
+The Codex Cloud Security scan (`f4128216…`) surfaced 71 findings. Triage (GATE 1
+approved) split them into **16 invalid** (14 false-positive, 2 won't-fix — closed
+in P3) and **55 remediate**. All 55 were fixed and landed in a single PR (#254)
+alongside four reusable foundation helpers:
+
+- `@beep/file-processing/PathSafety` — fail-closed path-traversal guard
+- `@beep/schema` `SafeRemoteHost` — SSRF allowlist (+ opt-in DNS resolver hook)
+- `@beep/observability` `CauseRedaction` — bounded secret-stripping of causes (+ sanitized fingerprint)
+- `@beep/repo-utils` `ProcessArgs` — CLI option-injection guard
+
+By merge time a **re-scan had grown the live open set to 56**: the original 55
+remediate plus one genuinely new finding (`turbo.json` global `passThroughEnv`
+leaking live third-party API keys), which was fixed in-PR (keys scoped to
+`test:integration`). All 56 were closed as **"fixed"** via the aardvark API with
+per-finding PR #254 comments.
+
+## What also shipped in the same PR (the "make green-up faster" overhaul)
+
+The remediation was straightforward; the *green-up* was brutal, so the PR also
+landed a repo-quality overhaul (separate goal, folded in at the maintainer's
+request to unblock subsequent work):
+
+- **T7** — removed the repo-exports catalog + Reuse subsystem + effect-capability-kg (~819K lines), the #1 churn source.
+- **T1** — local↔CI parity: gitleaks `--config`, authoritative-gate guidance, T6 CI-token lesson.
+- **T3** — `yeet repair` now runs the full deterministic fixer set in one command.
+- **T5.1** — `fallow:audit` → advisory (kept dead-code + boundaries blocking).
+
+## Lessons
+
+1. **Open the PR for backpressure, but a not-fully-proven base carries latent
+   failures.** The security commit was opened early; dogfooding `yeet verify`
+   later surfaced its latent biome/jsdoc/lint failures. Prove before relying on green.
+2. **Local turbo cache hits can give false-green.** `bun run test … --types`
+   reported a FULL-TURBO cache hit (no execution) → a false local pass while CI
+   actually ran and failed. Force-run (`--force`) when validating a CI failure.
+3. **Pre-scan the review-bot *summaries*, not just inline threads.** Greptile's
+   summary carried two real issues (DatasetLoader RFC1918 gap, Turbo creds in the
+   verify job) that were not inline comments — catching them avoided another cycle.
+4. **A security fix that changes CI/secrets must be validated against the runner
+   reality.** Scoping `TURBO_TOKEN` to push (closing CSF-001) removed the Vercel
+   remote cache on PR runs; the `@beep/md` Test Unit lane still timed out under
+   GitHub runner load (exit 130 / SIGINT) — accepted as environmental, with a
+   planned Blacksmith CI migration to reduce churn.
+5. **Re-scans expand the finding set.** Closing findings must map the *live* set
+   to triage by title, not assume the original count — and new findings need real
+   triage (the turbo.json one was a genuine fix, not a close-as-fixed).

--- a/goals/codex-security-findings-2026-06-17/ops/manifest.json
+++ b/goals/codex-security-findings-2026-06-17/ops/manifest.json
@@ -3,13 +3,13 @@
   "initiative": {
     "id": "codex-security-findings-2026-06-17",
     "title": "Codex Security Findings (2026-06-17)",
-    "status": "active",
+    "status": "complete",
     "created": "2026-06-17",
-    "updated": "2026-06-17",
+    "updated": "2026-06-18",
     "packetAnchorDocument": "SPEC.md"
   },
   "packetPath": "goals/codex-security-findings-2026-06-17",
-  "lifecycle": "active",
+  "lifecycle": "complete",
   "executionCapable": true,
   "reflectionRequired": true,
   "branch": "security/6-17-2026",
@@ -43,12 +43,12 @@
       "Informational": 24
     },
     "verdictCounts": {
-      "fixed": 0,
+      "fixed": 55,
       "dismissed": 14,
       "wont-fix": 2,
       "untriaged": 0,
       "notCaptured": 0,
-      "openRemediate": 55
+      "openRemediate": 0
     },
     "dispositionCounts": {
       "remediate": 55,
@@ -59,7 +59,7 @@
       "untriaged": 0,
       "notCaptured": 0
     },
-    "note": "P3 complete 2026-06-17T23:55:39Z: 16 closed in Codex (14 false_positive, 2 wontfix); 55 remediate open."
+    "note": "P3 complete 2026-06-17T23:55:39Z: 16 closed in Codex (14 false_positive, 2 wontfix); 55 remediate open. | P7 complete 2026-06-18: PR #254 merged to main (dc2e44fb70); all 56 live open Codex findings closed as fixed via aardvark API (55 remediate + 1 new turbo.json passThroughEnv finding fixed in PR). STILL_OPEN=0."
   },
   "closeoutPolicy": {
     "fixed": "Already fixed",
@@ -154,26 +154,26 @@
     {
       "id": "P6",
       "name": "yeet-to-mergeable",
-      "status": "in-progress",
+      "status": "complete",
       "exit": "bun run beep yeet green incl. security lanes; PR open and mergeable; review bot pass; 0 unresolved threads."
     },
     {
       "id": "GATE2",
       "name": "merge-gate",
-      "status": "pending",
+      "status": "complete",
       "type": "stop",
       "exit": "Human approves before merge; PR merged."
     },
     {
       "id": "P7",
       "name": "close-remediated",
-      "status": "pending",
+      "status": "complete",
       "exit": "Chrome pass 2: all remediated findings marked 'Already fixed' with PR evidence; all 71 closed."
     },
     {
       "id": "P8",
       "name": "closeout",
-      "status": "pending",
+      "status": "complete",
       "exit": "INDEX/manifest/triage reconciled; closeout reflection written; packet status updated."
     }
   ],
@@ -276,6 +276,10 @@
     ]
   },
   "meta": {
-    "gate1ApprovedAt": "2026-06-17T23:47:51Z"
+    "gate1ApprovedAt": "2026-06-17T23:47:51Z",
+    "gate2ApprovedAt": "2026-06-18T09:03:34Z",
+    "mergeCommit": "dc2e44fb70773cb3b4498fa767d85e467ad733d5",
+    "mergedAt": "2026-06-18T09:03:34Z",
+    "findingsClosedAt": "2026-06-18"
   }
 }


### PR DESCRIPTION
Closeout of the Codex Cloud Security findings initiative now that PR #254 is merged to \`main\` (\`dc2e44fb70\`).

## What this does
- Marks the packet manifest phases **P6 / GATE2 / P7 / P8 complete** and the initiative **status → complete**.
- Reconciles verdict counts (55 remediated → fixed; 14 false-positive + 2 won't-fix already closed; openRemediate → 0).
- Adds the closeout reflection (`history/reflections/2026-06-18-closeout.md`).

## Findings state (verified live)
All **56 open Codex findings closed as "fixed"** via the aardvark API with per-finding PR #254 comments — **STILL_OPEN = 0**. 55 matched the original remediated triage; the 1 genuinely-new finding (turbo.json global `passThroughEnv` leaking live API keys) was fixed in PR #254 first, then closed.

Docs/packet only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)