### PR TITLE
fix(repo-ai-metrics): preflight OTLP export and reconcile goals

### DIFF
--- a/.changeset/ai-metrics-otlp-preflight.md
+++ b/.changeset/ai-metrics-otlp-preflight.md
@@ -1,0 +1,5 @@
+---
+"@beep/repo-ai-metrics": patch
+---
+
+Avoid duplicate AI metrics OTLP projection reads by exposing a batch export helper and using it from the CLI after preflight ingest-run resolution.

--- a/goals/agentic-professional-runtime/PLAN.md
+++ b/goals/agentic-professional-runtime/PLAN.md
@@ -56,7 +56,18 @@ bun run --cwd apps/professional-runtime-proof test
 
 ## Next Implementation Target
 
-P4 should design native first-run onboarding and the local runtime bootstrap:
+The active law-practice vertical should graduate office-action extraction beyond
+the rung-0 fixed candidate set:
+
+- invoke the langextract service/LLM extraction boundary instead of the fixed
+  `OfficeActionReviewSpikeCandidates` list
+- keep deterministic test mode and synthetic/public fixtures
+- preserve span-bearing `GroundedExtraction[]` into `IrToLaw`
+- add non-happy-path alignment candidates before broadening doctrine coverage
+- then add multi-reference §103 plus §101/§112 handling
+
+The broader runtime P4 remains native first-run onboarding and local runtime
+bootstrap design:
 
 - dependency checks for git, Node/Bun, and Python
 - Claude Desktop and OpenClaw setup guidance

--- a/goals/agentic-professional-runtime/README.md
+++ b/goals/agentic-professional-runtime/README.md
@@ -19,6 +19,14 @@ data model, and agent integration story to become concrete.
 Status note (2026-06-11): law is the sole active vertical; wealth-management
 is demoted to a dormant proof fixture (see the SPEC status amendment).
 
+Status note (2026-06-18): the law-practice office-action rung-0 loop merged to
+`main` in PR #262. It now ingests a synthetic/public office action through
+`@beep/file-processing` + `@beep/tika`, maps span-bearing
+`GroundedExtraction[]` into law entities, and gates a candidate distinction
+through the epistemic public surface. The next law vertical rung is to replace
+the fixed candidate set with langextract-service/LLM extraction while
+preserving deterministic tests and the privilege wall.
+
 ## Read This First
 
 ### Root

--- a/goals/agentic-professional-runtime/ops/manifest.json
+++ b/goals/agentic-professional-runtime/ops/manifest.json
@@ -5,21 +5,21 @@
     "title": "Agentic Professional Runtime",
     "status": "active",
     "created": "2026-05-01",
-    "updated": "2026-05-01",
+    "updated": "2026-06-18",
     "packetAnchorDocument": "SPEC.md"
   },
   "productProofs": [
     {
       "id": "law-practice",
       "title": "Agentic Solo Practice Law Firm",
-      "status": "product-definition",
+      "status": "active-vertical",
       "document": "docs/product-vision-law-practice.md",
       "dataModel": "docs/data-model-law-practice.md"
     },
     {
       "id": "wealth-management",
       "title": "Todox.ai Wealth Management Runtime",
-      "status": "product-definition",
+      "status": "dormant-proof-fixture",
       "document": "docs/product-vision-todox.md",
       "dataModel": "docs/data-model-wealth-management.md"
     }
@@ -114,6 +114,15 @@
       "full governance dashboard"
     ]
   },
+  "activeVerticalNotes": [
+    {
+      "id": "law-practice-office-action-rung-0",
+      "status": "merged",
+      "date": "2026-06-18",
+      "evidence": "PR #262 merged the synthetic/public office-action loop through @beep/file-processing, @beep/tika, span-bearing GroundedExtraction[], law entities, and the epistemic gate/projection public surface.",
+      "nextRung": "Replace the fixed OfficeActionReviewSpikeCandidates list with langextract-service/LLM extraction while preserving deterministic tests and the privilege wall."
+    }
+  ],
   "phases": [
     {
       "id": "P0",

--- a/goals/file-processing-capability/PLAN.md
+++ b/goals/file-processing-capability/PLAN.md
@@ -50,7 +50,7 @@ Required Checks:
 
 ## P1: Minimum Vertical File-Processing Proof
 
-Status: pending
+Status: completed on 2026-06-18 by PR #262
 
 Goal: Prove `@beep/file-processing` as a `foundation/capability` package by
 landing the capability contracts, at least two importing consumers, and the
@@ -82,34 +82,31 @@ Implementation Steps:
 8. Add package README consumer table naming real current imports from at least
    two of `@beep/tika`, `@beep/libpff`, and `@beep/repo-cli`.
 9. Refresh or update package manifests, project references, exports, lockfile,
-   and repo export catalog as required by the repo tooling.
+   docgen metadata, and config-sync artifacts as required by the repo tooling.
 
 Exit Criteria:
 
-- [ ] Public schemas encode/decode through Effect schema APIs.
-- [ ] Service contracts compile without concrete driver imports.
-- [ ] At least two real consumers import `@beep/file-processing`, and the
+- [x] Public schemas encode/decode through Effect schema APIs.
+- [x] Service contracts compile without concrete driver imports.
+- [x] At least two real consumers import `@beep/file-processing`, and the
   package README records them.
-- [ ] `@beep/tika` proves one non-PST extraction path or typed
+- [x] `@beep/tika` proves one non-PST extraction path or typed
   engine-unavailable behavior.
-- [ ] `@beep/libpff` proves PST availability/export behavior, or records a
+- [x] `@beep/libpff` proves PST availability/export behavior, or records a
   typed engine-unavailable/fixture-unavailable deferral in tests.
-- [ ] `beep files process` writes the V1 manifest tree shape for generated
+- [x] `beep files process` writes the V1 manifest tree shape for generated
   fixtures.
-- [ ] Dtslint covers subpath imports and operation result types.
-- [ ] Unit tests cover operation schemas, strategy matching, and manifest
+- [x] Dtslint covers subpath imports and operation result types.
+- [x] Unit tests cover operation schemas, strategy matching, and manifest
   encoding.
 
 Required Checks:
 
-- `bun run --filter=@beep/file-processing check`
-- `bun run --filter=@beep/file-processing test`
-- `bun run --filter=@beep/file-processing lint`
-- `bun run --filter=@beep/tika check`
-- `bun run --filter=@beep/libpff check`
-- `bun run --filter=@beep/repo-cli check`
+- `bun run check`
+- `bun run test`
 - `bun run docgen:local`
-- `bun run repo-exports:catalog:check`
+- `bun run config-sync:check`
+- `bun run beep yeet verify` before claiming branch-level green
 
 Stop Conditions:
 
@@ -235,5 +232,6 @@ Exit Criteria:
 Required Checks:
 
 - `bun run docgen:local`
-- `bun run repo-exports:catalog:check`
+- `bun run config-sync:check`
+- `bun run beep yeet verify`
 - affected package `check`, `test`, and `lint`

--- a/goals/file-processing-capability/README.md
+++ b/goals/file-processing-capability/README.md
@@ -2,9 +2,12 @@
 
 ## Status
 
-Active — implementing P1 (minimum vertical proof). Packet hardening complete; the
-`@beep/file-processing` capability and the `@beep/tika` / `@beep/libpff` drivers exist
-on disk.
+Active — P1 minimum vertical proof complete; P2/P3/P4 driver and corpus
+completion phases remain pending.
+
+Packet hardening completed on 2026-06-02. The P1 implementation landed through
+the law-practice office-action branch and merged to `main` in PR #262 on
+2026-06-18.
 
 ## Mission
 
@@ -42,6 +45,24 @@ For topology, package placement, boundary, and error doctrine,
 typed failures, strategy selection, and service contracts. It does not own
 format-specific engines. Drivers implement declared operation capabilities.
 
+## Latest Evidence
+
+- `@beep/file-processing` exists at
+  `packages/foundation/capability/file-processing` with runtime-neutral
+  artifact, operation, extraction, strategy, service, path-safety, fixture, and
+  manifest contracts.
+- Current real consumers import it from `@beep/tika`, `@beep/libpff`,
+  `@beep/repo-cli`, and the law-practice office-action loop.
+- `@beep/tika` proves the P1 text extraction path and typed
+  engine-unavailable behavior.
+- `@beep/libpff` proves typed engine-unavailable behavior and a synthetic PST
+  child-artifact export proof.
+- `beep files process` writes the schema-encoded manifest tree for generated
+  fixtures.
+- The P1 proof is a minimum vertical slice. Broad Tika coverage across every
+  non-PST V1 family, real/public PST export coverage, and optional corpus
+  profiling remain later phases.
+
 ## V1 Cutline
 
 In scope:
@@ -73,10 +94,9 @@ Out of scope:
 
 ## Completion Standard
 
-This goal is implementation-ready when future agents can scaffold the packages,
-drivers, CLI command, fixtures, and tests without reopening package-placement,
-engine-runner, manifest-shape, error-boundary, or operation-model decisions.
+P1 is complete when the foundation capability has at least two real consumers,
+driver-backed proof paths, and CLI manifest output. That proof is now present.
 
-The next implementation target is a minimum vertical proof, not a contract-only
-package. `@beep/file-processing` is promotion-ready only when at least two real
-consumers import it and its README records those consumers.
+The remaining completion standard is P2/P3/P4/P5: finish broad non-PST Tika
+coverage, deepen libpff PST export, calibrate CLI output against generated and
+operator-local corpus inputs, and record final handoff evidence.

--- a/goals/file-processing-capability/SPEC.md
+++ b/goals/file-processing-capability/SPEC.md
@@ -2,10 +2,15 @@
 
 ## Status
 
-**PENDING IMPLEMENTATION**
+**P1 MINIMUM VERTICAL PROOF COMPLETE**
 
-Packet hardening completed on 2026-06-02. Package implementation has not
-started.
+Packet hardening completed on 2026-06-02. The minimum vertical implementation
+landed through the law-practice office-action branch and merged to `main` in
+PR #262 on 2026-06-18.
+
+The remaining phases are breadth and hardening work: complete broad Tika
+coverage, deepen libpff PST export, calibrate `beep files process` against
+generated and operator-local corpus inputs, and record final handoff evidence.
 
 ## Owner
 
@@ -14,7 +19,7 @@ started.
 ## Created / Updated
 
 - **Created:** 2026-06-02
-- **Updated:** 2026-06-02
+- **Updated:** 2026-06-18
 
 ## Purpose
 
@@ -65,17 +70,22 @@ The repo CLI is the first non-product consumer:
 | OCR | Strategy flag and skipped capability only in V1; no OCR implementation. |
 | Product semantics | Future document-management and legal-domain semantics stay outside this packet. |
 
-## Open Questions Before Package Implementation
+## P1 Decisions And Remaining Driver Questions
 
-These must be resolved in the implementation PR or explicitly deferred with a
-typed skip/failure policy:
+The P1 implementation resolved the minimum vertical decisions:
 
-- whether the first `@beep/libpff` proof uses a generated PST fixture, a public
-  sample fixture, or an engine-unavailable availability proof
-- exact generated fixture tooling for DOC, DOCX, RTF, HTML, PDF, text, Markdown,
-  and image metadata
-- whether an explicit `@beep/file-processing/node` entrypoint is needed, or
-  whether CLI-owned filesystem adapters are sufficient for V1
+- The first `@beep/libpff` proof records typed engine-unavailable behavior and
+  includes a synthetic child-artifact export proof.
+- Generated synthetic fixtures cover the P1 package and CLI proof surfaces.
+- No `@beep/file-processing/node` entrypoint was required for P1; filesystem
+  and process composition stayed in drivers, tooling, and the law-practice
+  server boundary.
+
+Remaining driver questions belong to P2/P3/P4:
+
+- broad Tika extraction and metadata proof for every non-PST V1 family
+- real/public PST export proof beyond the synthetic P1 child-artifact path
+- optional coverage profiling against operator-local corpus inputs
 
 ## Schema-First Operation Model
 

--- a/goals/file-processing-capability/ops/manifest.json
+++ b/goals/file-processing-capability/ops/manifest.json
@@ -5,7 +5,7 @@
     "title": "File Processing Capability",
     "status": "active",
     "created": "2026-06-02",
-    "updated": "2026-06-02",
+    "updated": "2026-06-18",
     "packetAnchorDocument": "SPEC.md"
   },
   "mission": "Define and implement a product-neutral schema-first file processing capability with driver-backed extraction and repo CLI proof.",
@@ -14,7 +14,7 @@
     "standards/architecture/*",
     "goals/file-processing-capability/SPEC.md"
   ],
-  "currentTargetPhase": "P1",
+  "currentTargetPhase": "P2",
   "reportDirectory": "research",
   "rawOutputDirectory": "history/outputs",
   "phaseStatusMeaning": {
@@ -52,23 +52,25 @@
   "openQuestions": [
     {
       "id": "pst-fixture",
-      "question": "Will the first libpff proof use a generated PST fixture, a public sample fixture, or an engine-unavailable availability proof?",
-      "default": "Use a generated fixture when feasible; otherwise record a typed fixture-unavailable deferral and still prove error translation."
+      "question": "What real or public PST fixture should prove libpff export beyond the synthetic P1 child-artifact path?",
+      "default": "Keep the P1 typed engine-unavailable and synthetic export proof until P3 selects a public/generated fixture."
     },
     {
       "id": "node-entrypoint",
-      "question": "Does @beep/file-processing need an explicit /node entrypoint in V1?",
-      "default": "Do not add /node in P1 unless implementation proves CLI-owned filesystem adapters are insufficient."
+      "question": "Does @beep/file-processing need an explicit /node entrypoint after the P1 vertical proof?",
+      "default": "Do not add /node unless a later consumer proves driver/tooling/server adapters are insufficient."
     },
     {
       "id": "fixture-generation",
-      "question": "Which fixture generator creates DOC, DOCX, RTF, HTML, PDF, text, Markdown, and image metadata fixtures?",
+      "question": "Which fixture generator should broaden DOC, DOCX, RTF, HTML, PDF, text, Markdown, and image metadata coverage after P1?",
       "default": "Prefer generated synthetic fixtures committed or generated through repo test helpers, with no private corpus content."
     }
   ],
   "knownGaps": [
-    "No packages are scaffolded yet.",
-    "No engine availability has been tested yet.",
+    "P1 packages and consumers are scaffolded and merged; the remaining work is breadth, real-engine hardening, and corpus calibration.",
+    "Broad Tika coverage for every non-PST V1 format family is pending.",
+    "Real/public PST export coverage beyond the typed engine-unavailable and synthetic child-artifact P1 proof is pending.",
+    "Optional operator-local corpus profiling remains pending.",
     "HTML was promoted into V1 during packet hardening because the local corpus contains substantial exported email HTML.",
     "The local corpus has XLS/XLSX and DOCM inputs that are known non-core inputs for V1.",
     "PDF text-layer status for the local corpus has not been verified."
@@ -229,7 +231,8 @@
     "rg -n \"P0.5|Minimum Vertical|HTML|Source-Of-Truth|error-translation|ProcessRunManifest\" goals/file-processing-capability",
     "git diff --check",
     "bun run docgen:local",
-    "bun run repo-exports:catalog:check"
+    "bun run config-sync:check",
+    "bun run beep yeet verify"
   ],
   "phases": [
     {
@@ -247,8 +250,8 @@
     {
       "id": "P1",
       "name": "Minimum Vertical File-Processing Proof",
-      "status": "pending",
-      "exitCriteriaSummary": "@beep/file-processing is scaffolded and imported by at least two real consumers, with the smallest driver and CLI manifest proof."
+      "status": "completed",
+      "exitCriteriaSummary": "@beep/file-processing is scaffolded and imported by @beep/tika, @beep/libpff, @beep/repo-cli, and law-practice; P1 driver and CLI manifest proofs landed in PR #262."
     },
     {
       "id": "P2",
@@ -275,5 +278,5 @@
       "exitCriteriaSummary": "Affected quality gates pass and implementation evidence is recorded."
     }
   ],
-  "nextAction": "Implement P1 by landing the minimum vertical file-processing proof across @beep/file-processing, at least two real consumers, and beep files process manifest output."
+  "nextAction": "Advance P2/P3/P4 as needed: broaden Tika coverage, deepen libpff PST export, and calibrate files process against generated or operator-local corpus inputs. Law-practice can proceed to LLM extraction without reopening P1."
 }

--- a/goals/law-practice-office-action-extraction-rung/GOAL.md
+++ b/goals/law-practice-office-action-extraction-rung/GOAL.md
@@ -1,0 +1,62 @@
+# GOAL: replace fixed office-action candidates with LangExtract service extraction
+
+Repo: `/home/elpresidank/YeeBois/projects/beep-effect3`.
+
+Outcome: graduate the law-practice office-action loop from fixed spike
+candidates to provider-neutral `@beep/langextract` service extraction, while
+keeping deterministic tests and exact source-span grounding.
+
+Read first: `goals/law-practice-office-action-extraction-rung/{README,SPEC,PLAN}.md`
+and `ops/manifest.json`, then `AGENTS.md`, `CLAUDE.md`,
+`standards/ARCHITECTURE.md`, `goals/agentic-professional-runtime/SPEC.md`,
+`goals/agentic-professional-runtime/docs/data-model-law-practice.md`, and the
+completed `goals/law-practice-office-action-spike/` packet. Higher repo
+standards outrank packet prose.
+
+Scope:
+
+- In: `packages/law-practice/use-cases/src/OfficeActionReview/**`,
+  `IrToLaw` only as needed for extraction failure/breadth, server layer wiring,
+  and synthetic/public tests.
+- In: invoke `LangExtractService.extract` and feed
+  `LangExtractResult.extractions` / `GroundedExtraction[]` to `IrToLaw`.
+- In: deterministic fake model/service tests for happy path plus at least one
+  non-happy path.
+- Out: real client matter, live provider credentials, paid network calls,
+  provider-specific dependency in law-practice, KG/GraphRAG, full response
+  drafting, and broad doctrine before extraction is green.
+
+Hard constraints:
+
+- Keep law-domain free of extraction, driver, and epistemic runtime imports.
+- Do not route law anchoring through the nlp `AnnotatedDocument` envelope; it is
+  span-lossy at entity level. Use span-bearing `GroundedExtraction[]`.
+- Missing required labels or unaligned distinction text must not fabricate
+  evidence spans.
+- Compose epistemic only through the public surface already documented by the
+  rung-0 spike.
+- Fixtures are synthetic/public only.
+
+Acceptance:
+
+- [ ] Production `OfficeActionReview` no longer builds extractions from
+      `OfficeActionReviewSpikeCandidates`.
+- [ ] The loop invokes `LangExtractService.extract` with schema-backed targets
+      and maps the resulting `GroundedExtraction[]` through `IrToLaw`.
+- [ ] Happy-path and non-happy-path tests pass deterministically.
+- [ ] Multi-reference 103 plus 101/112 breadth is implemented after extraction
+      is green or explicitly deferred as the next phase.
+- [ ] No unrelated refactors or formatting churn.
+
+Verify:
+
+```sh
+test "$(wc -m < goals/law-practice-office-action-extraction-rung/GOAL.md)" -le 4000
+jq . goals/law-practice-office-action-extraction-rung/ops/manifest.json
+git diff --check -- goals/law-practice-office-action-extraction-rung
+bun run check
+bun run beep lint reflection-artifacts
+```
+
+Done when acceptance passes and verification is complete, or a blocker is
+reported with evidence.

--- a/goals/law-practice-office-action-extraction-rung/GOAL.md
+++ b/goals/law-practice-office-action-extraction-rung/GOAL.md
@@ -1,6 +1,6 @@
 # GOAL: replace fixed office-action candidates with LangExtract service extraction
 
-Repo: `/home/elpresidank/YeeBois/projects/beep-effect3`.
+Repo: repository root (`./`).
 
 Outcome: graduate the law-practice office-action loop from fixed spike
 candidates to provider-neutral `@beep/langextract` service extraction, while
@@ -56,6 +56,7 @@ jq . goals/law-practice-office-action-extraction-rung/ops/manifest.json
 git diff --check -- goals/law-practice-office-action-extraction-rung
 bun run check
 bun run beep lint reflection-artifacts
+bun run beep yeet verify
 ```
 
 Done when acceptance passes and verification is complete, or a blocker is

--- a/goals/law-practice-office-action-extraction-rung/PLAN.md
+++ b/goals/law-practice-office-action-extraction-rung/PLAN.md
@@ -42,5 +42,7 @@ test "$(wc -m < goals/law-practice-office-action-extraction-rung/GOAL.md)" -le 4
 jq . goals/law-practice-office-action-extraction-rung/ops/manifest.json
 rg -n "law-practice-office-action-extraction-rung|GOAL.md|agentLaunchers|packetAnchorDocument" goals/law-practice-office-action-extraction-rung
 git diff --check -- goals/law-practice-office-action-extraction-rung
+bun run check
 bun run beep lint reflection-artifacts
+bun run beep yeet verify
 ```

--- a/goals/law-practice-office-action-extraction-rung/PLAN.md
+++ b/goals/law-practice-office-action-extraction-rung/PLAN.md
@@ -1,0 +1,46 @@
+# Law-Practice Office-Action Extraction Rung Plan
+
+## Status
+
+Status: `pending`
+
+## Phases
+
+| Phase | Status | Goal | Exit criteria |
+| --- | --- | --- | --- |
+| P0 Scope and contracts | pending | Confirm the current `OfficeActionReview` seam, `LangExtractService` contract, law labels, and deterministic test strategy. | Required source facts and any blockers are recorded; no implementation ambiguity remains. |
+| P1 Service-backed extraction | pending | Replace production fixed candidates with `LangExtractService.extract` and feed `LangExtractResult.extractions` into `IrToLaw`. | Happy-path loop test passes with deterministic fake model/service output. |
+| P2 Non-happy paths and breadth gate | pending | Add required-label/alignment failure handling and decide whether this packet also implements first doctrine breadth. | At least one non-happy-path test passes; 103/101/112 scope is implemented or explicitly deferred. |
+| P3 Verify and close | pending | Run required checks, update packet evidence, write reflection, and prepare PR readiness if requested. | Verification is green or unrelated failures are classified; packet status and evidence are current. |
+
+## Execution Notes
+
+- Preserve unrelated worktree changes.
+- Keep `SPEC.md` normative and update it only when the contract changes.
+- Keep the law-domain package isolated from extraction and epistemic runtime
+  dependencies.
+- Prefer composing the existing `LangExtractService` over adding a new law-only
+  extraction abstraction unless a real complexity boundary appears.
+- Keep fixed candidate data under test surfaces only after P1.
+- Archive old run outputs under `history/` when a future execution run closes
+  the packet.
+
+## P3 Closeout Checklist
+
+Before marking the packet closed:
+
+1. Write a closeout reflection to
+   `history/reflections/<YYYY-MM-DD>-<agent>.md`.
+2. Run `bun run beep lint reflection-artifacts`.
+3. Update `README.md` latest evidence and `ops/manifest.json` phase statuses.
+4. Run `bun run beep yeet verify` before claiming branch-level green.
+
+## Verification Commands
+
+```sh
+test "$(wc -m < goals/law-practice-office-action-extraction-rung/GOAL.md)" -le 4000
+jq . goals/law-practice-office-action-extraction-rung/ops/manifest.json
+rg -n "law-practice-office-action-extraction-rung|GOAL.md|agentLaunchers|packetAnchorDocument" goals/law-practice-office-action-extraction-rung
+git diff --check -- goals/law-practice-office-action-extraction-rung
+bun run beep lint reflection-artifacts
+```

--- a/goals/law-practice-office-action-extraction-rung/README.md
+++ b/goals/law-practice-office-action-extraction-rung/README.md
@@ -1,0 +1,55 @@
+# Law-Practice Office-Action Extraction Rung
+
+## Status
+
+Lifecycle: `active`
+
+Source: [`ops/manifest.json`](./ops/manifest.json)
+
+## Mission
+
+Graduate the law-practice office-action loop beyond the rung-0 fixed candidate
+list by invoking the provider-neutral `@beep/langextract` service, preserving
+span-grounded `GroundedExtraction[]`, and adding enough adverse extraction cases
+to make the next doctrine breadth slice safe.
+
+## Launch
+
+Use this command for execution-capable sessions:
+
+```text
+/goal follow the instructions in goals/law-practice-office-action-extraction-rung/GOAL.md
+```
+
+`GOAL.md` is the compact launcher. `SPEC.md` remains the normative contract.
+
+## Read This First
+
+1. [`GOAL.md`](./GOAL.md) - compact `/goal` launcher.
+2. [`SPEC.md`](./SPEC.md) - normative source of truth.
+3. [`PLAN.md`](./PLAN.md) - active execution plan.
+4. [`ops/manifest.json`](./ops/manifest.json) - machine-readable routing.
+5. [`../agentic-professional-runtime/SPEC.md`](../agentic-professional-runtime/SPEC.md) - product authority.
+6. [`../agentic-professional-runtime/docs/data-model-law-practice.md`](../agentic-professional-runtime/docs/data-model-law-practice.md) - law data model authority.
+7. [`../law-practice-office-action-spike/`](../law-practice-office-action-spike/) - completed rung-0 reference.
+
+## Current Phase
+
+P0 Scope confirmation is pending. Start by inspecting the current
+`OfficeActionReview` loop, the `@beep/langextract/Service` contract, and the
+law-practice server layer composition.
+
+## Latest Evidence
+
+Not started. This packet was opened after PR #262 merged the file-processing
+and rung-0 office-action loop to `main` on 2026-06-18.
+
+## Notes
+
+- The fixed `OfficeActionReviewSpikeCandidates` list is the implementation seam
+  to replace.
+- Keep tests deterministic with fake language-model output; live provider
+  credentials are not required for packet completion.
+- The nlp `AnnotatedDocument` envelope is still span-lossy for law anchoring.
+  Feed `LangExtractResult.extractions` / `GroundedExtraction[]` into `IrToLaw`.
+- Fixtures must remain synthetic/public only.

--- a/goals/law-practice-office-action-extraction-rung/SPEC.md
+++ b/goals/law-practice-office-action-extraction-rung/SPEC.md
@@ -98,11 +98,17 @@ Higher sources outrank lower sources when they conflict.
 | --- | --- | --- |
 | Packet launcher size | `test "$(wc -m < goals/law-practice-office-action-extraction-rung/GOAL.md)" -le 4000` | Passes |
 | Manifest JSON | `jq . goals/law-practice-office-action-extraction-rung/ops/manifest.json` | Passes |
-| Packet references | `rg -n "law-practice-office-action-extraction-rung|GOAL.md|agentLaunchers|packetAnchorDocument" goals/law-practice-office-action-extraction-rung` | Finds expected references |
+| Packet references | See packet reference search below. | Finds expected references |
 | Whitespace | `git diff --check -- goals/law-practice-office-action-extraction-rung` | Passes |
 | Focused tests | `bun test packages/law-practice/server/test/LawPracticeServer.test.ts` | Happy and non-happy paths covered |
 | Authoritative typecheck | `bun run check` | Green or unrelated failures classified |
 | Final quality | `bun run beep yeet verify` | Green or no new failures classified |
+
+Packet reference search:
+
+```bash
+rg -n "law-practice-office-action-extraction-rung|GOAL.md|agentLaunchers|packetAnchorDocument" goals/law-practice-office-action-extraction-rung
+```
 
 ## Stop Conditions
 

--- a/goals/law-practice-office-action-extraction-rung/SPEC.md
+++ b/goals/law-practice-office-action-extraction-rung/SPEC.md
@@ -1,0 +1,122 @@
+# Law-Practice Office-Action Extraction Rung Spec
+
+## Objective
+
+Replace the law-practice office-action spike's fixed extraction candidate list
+with a real `@beep/langextract` service call, while keeping the loop fully
+deterministic in tests and preserving exact source-span grounding into
+`IrToLaw`.
+
+Observable end state: one synthetic/public office action is processed through
+`@beep/file-processing` + `@beep/tika`, sent to `LangExtractService.extract`,
+mapped from `LangExtractResult.extractions` into law entities, gated through the
+epistemic public surface, and projected into the same trivial answer as the
+rung-0 spike. Tests also prove at least one non-happy-path extraction/alignment
+case does not silently become an admitted unsupported claim.
+
+## Non-Goals
+
+- No real client matter, private corpus fixture, or privileged document.
+- No live provider credential requirement in CI or local proof.
+- No provider-specific driver dependency inside law-practice use-cases.
+- No knowledge graph, FalkorDB, GraphRAG, or full response-drafting workflow.
+- No broad doctrine expansion until the service-backed extraction path is
+  stable; multi-reference 103 plus 101/112 can begin only after P1 is green.
+- No direct imports from epistemic internals; compose only public surfaces.
+- No rework of `@beep/file-processing` P1 unless a narrow blocker is proven.
+
+## Source Hierarchy
+
+1. User objective or issue that created this packet.
+2. `AGENTS.md`, `CLAUDE.md`, and required skills.
+3. Governing architecture/package standards.
+4. `goals/agentic-professional-runtime/SPEC.md` and
+   `goals/agentic-professional-runtime/docs/data-model-law-practice.md`.
+5. `goals/law-practice-office-action-spike/` as the completed rung-0
+   reference.
+6. `goals/file-processing-capability/` and `goals/langextract-capability/`
+   public-surface contracts.
+7. This `SPEC.md`.
+8. `PLAN.md`.
+9. `GOAL.md`.
+10. Supporting `research/`, `ops/`, and `history/` files.
+
+Higher sources outrank lower sources when they conflict.
+
+## Target Surfaces
+
+- `packages/law-practice/use-cases/src/OfficeActionReview/**`
+- `packages/law-practice/use-cases/src/IrToLaw/**`
+- `packages/law-practice/server/src/Layer.ts`
+- `packages/law-practice/server/test/**`
+- `@beep/langextract/Service`, `@beep/langextract/Extraction`, and
+  `@beep/langextract/Target` public surfaces
+- Packet docs under `goals/law-practice-office-action-extraction-rung/**`
+
+## Constraints
+
+- Keep design sequencing: schema/model, service contract, implementation,
+  verify.
+- Use schema-first request/target models; do not introduce ad hoc JSON parsing
+  in law-practice.
+- Decode schemas at module scope, not inside `Effect.gen` or `Effect.sync`.
+- Use `Effect.fn("snake.case.name")` for new service methods.
+- Keep the law-practice domain tier free of `@beep/epistemic-*`,
+  `@beep/langextract`, `@beep/file-processing`, and driver imports.
+- The review loop must consume `LangExtractResult.extractions` or equivalent
+  `GroundedExtraction[]`; do not route law anchoring through the span-lossy nlp
+  handoff envelope.
+- Deterministic tests may provide a fake `LanguageModel.LanguageModel` layer or
+  a fake `LangExtractService`; live providers are optional local diagnostics.
+- Missing or unaligned required extraction labels must produce a typed failure,
+  candidate rejection, or explicit deferred status. They must not fabricate
+  source spans.
+
+## Acceptance Criteria
+
+- [ ] `OfficeActionReview` no longer builds production loop extractions from
+      `OfficeActionReviewSpikeCandidates`; it invokes `LangExtractService`.
+- [ ] A schema-backed law office-action extraction request/target builder
+      exists, or an existing `LangExtractRequest` construction path is reused
+      with clear law labels.
+- [ ] Deterministic tests prove the happy path with fake model output:
+      extracted text -> `LangExtractService.extract` -> `GroundedExtraction[]`
+      -> `IrToLaw` -> gate -> lifecycle -> projection.
+- [ ] Tests prove at least one non-happy path: missing required label,
+      unaligned distinction text, or malformed model output.
+- [ ] The fixed candidate list remains only as a test fixture/helper, or is
+      removed if no longer needed.
+- [ ] Doctrine breadth is explicitly gated: multi-reference 103 and 101/112
+      handling are either implemented after service extraction is green or
+      recorded as the next packet phase with no overclaim.
+- [ ] No real client fixtures or provider secrets are introduced.
+- [ ] No unrelated refactors or formatting churn.
+
+## Verification Matrix
+
+| Check | Command or evidence | Required result |
+| --- | --- | --- |
+| Packet launcher size | `test "$(wc -m < goals/law-practice-office-action-extraction-rung/GOAL.md)" -le 4000` | Passes |
+| Manifest JSON | `jq . goals/law-practice-office-action-extraction-rung/ops/manifest.json` | Passes |
+| Packet references | `rg -n "law-practice-office-action-extraction-rung|GOAL.md|agentLaunchers|packetAnchorDocument" goals/law-practice-office-action-extraction-rung` | Finds expected references |
+| Whitespace | `git diff --check -- goals/law-practice-office-action-extraction-rung` | Passes |
+| Focused tests | `bun test packages/law-practice/server/test/LawPracticeServer.test.ts` | Happy and non-happy paths covered |
+| Authoritative typecheck | `bun run check` | Green or unrelated failures classified |
+| Final quality | `bun run beep yeet verify` | Green or no new failures classified |
+
+## Stop Conditions
+
+- Required source files are missing or materially contradictory.
+- The current `@beep/langextract` service cannot be composed without a
+  provider-specific dependency in law-practice.
+- The implementation would require real client documents, provider secrets, or
+  paid network calls for the required test proof.
+- The implementation would exceed named scope before service-backed extraction
+  is green.
+- The same blocker repeats after reasonable investigation.
+
+## Exception Ledger
+
+| Exception | Scope | Owner | Rationale | Removal condition |
+| --- | --- | --- | --- | --- |
+| Direct cross-slice composition of the epistemic gate/projection | `law-practice-use-cases` and `law-practice-server` continue the bounded public-surface composition accepted by the rung-0 spike | law-practice slice | This packet graduates extraction only; it does not reopen the already documented epistemic composition exception. | Extract a shared use-case contract or event boundary when a third consumer of the epistemic mechanism appears. |

--- a/goals/law-practice-office-action-extraction-rung/ops/manifest.json
+++ b/goals/law-practice-office-action-extraction-rung/ops/manifest.json
@@ -1,0 +1,105 @@
+{
+  "schemaVersion": "initiative-manifest/v1",
+  "initiative": {
+    "id": "law-practice-office-action-extraction-rung",
+    "title": "Law-Practice Office-Action Extraction Rung",
+    "status": "active",
+    "created": "2026-06-18",
+    "updated": "2026-06-18",
+    "packetAnchorDocument": "SPEC.md"
+  },
+  "packetPath": "goals/law-practice-office-action-extraction-rung",
+  "lifecycle": "active",
+  "executionCapable": true,
+  "reflectionRequired": true,
+  "relatedPackets": {
+    "productAuthority": "goals/agentic-professional-runtime",
+    "predecessor": "goals/law-practice-office-action-spike",
+    "dependsOn": [
+      "goals/file-processing-capability",
+      "goals/langextract-capability",
+      "goals/epistemic-claim-lifecycle-gate"
+    ],
+    "reference": [
+      "goals/ip-law-knowledge-graph",
+      "goals/oppold-corpus-pipeline"
+    ]
+  },
+  "currentSourceOfTruth": [
+    "AGENTS.md",
+    "CLAUDE.md",
+    "standards/ARCHITECTURE.md",
+    "goals/agentic-professional-runtime/SPEC.md",
+    "goals/agentic-professional-runtime/docs/data-model-law-practice.md",
+    "goals/law-practice-office-action-spike/README.md",
+    "goals/law-practice-office-action-extraction-rung/README.md",
+    "goals/law-practice-office-action-extraction-rung/SPEC.md",
+    "goals/law-practice-office-action-extraction-rung/PLAN.md",
+    "goals/law-practice-office-action-extraction-rung/GOAL.md"
+  ],
+  "agentLaunchers": [
+    {
+      "kind": "codex-goal",
+      "path": "GOAL.md",
+      "targetChars": 3500,
+      "maxChars": 4000,
+      "command": "/goal follow the instructions in goals/law-practice-office-action-extraction-rung/GOAL.md"
+    }
+  ],
+  "phases": [
+    {
+      "id": "P0",
+      "name": "Scope and contracts",
+      "status": "pending"
+    },
+    {
+      "id": "P1",
+      "name": "Service-backed extraction",
+      "status": "pending"
+    },
+    {
+      "id": "P2",
+      "name": "Non-happy paths and breadth gate",
+      "status": "pending"
+    },
+    {
+      "id": "P3",
+      "name": "Verify and close",
+      "status": "pending"
+    }
+  ],
+  "targetPackages": [
+    "packages/law-practice/use-cases",
+    "packages/law-practice/server"
+  ],
+  "requiredPublicSurfaces": [
+    "@beep/file-processing",
+    "@beep/tika",
+    "@beep/langextract/Service",
+    "@beep/langextract/Extraction",
+    "@beep/langextract/Target",
+    "@beep/epistemic-use-cases",
+    "@beep/epistemic-server/layer"
+  ],
+  "knownGaps": [
+    "OfficeActionReview currently uses OfficeActionReviewSpikeCandidates as the stand-in for LLM extraction.",
+    "Non-happy-path extraction/alignment behavior is not yet covered.",
+    "Multi-reference 103 plus 101/112 doctrine breadth remains deferred until service-backed extraction is green."
+  ],
+  "verificationCommands": [
+    "test \"$(wc -m < goals/law-practice-office-action-extraction-rung/GOAL.md)\" -le 4000",
+    "jq . goals/law-practice-office-action-extraction-rung/ops/manifest.json",
+    "rg -n \"law-practice-office-action-extraction-rung|GOAL.md|agentLaunchers|packetAnchorDocument\" goals/law-practice-office-action-extraction-rung",
+    "git diff --check -- goals/law-practice-office-action-extraction-rung",
+    "bun run check",
+    "bun run beep lint reflection-artifacts",
+    "bun run beep yeet verify"
+  ],
+  "stopConditions": [
+    "Required source files are missing or materially contradictory.",
+    "The current @beep/langextract service cannot be composed without a provider-specific dependency in law-practice.",
+    "The implementation would require real client documents, provider secrets, or paid network calls for the required test proof.",
+    "The implementation would exceed named scope before service-backed extraction is green.",
+    "The same blocker repeats after reasonable investigation."
+  ]
+}

--- a/goals/law-practice-office-action-spike/GOAL.md
+++ b/goals/law-practice-office-action-spike/GOAL.md
@@ -1,6 +1,6 @@
 # GOAL: wire the rung-0 office-action review loop in the law-practice slice
 
-Repo: `/home/elpresidank/YeeBois/projects/beep-effect3`.
+Repo: repository root (`./`).
 
 Outcome: graduate `law-practice` from domain-only to minimum-viable (domain +
 use-cases + server) — add the IP-law vertical and turn the office-action loop

--- a/goals/law-practice-office-action-spike/GOAL.md
+++ b/goals/law-practice-office-action-spike/GOAL.md
@@ -1,6 +1,6 @@
 # GOAL: wire the rung-0 office-action review loop in the law-practice slice
 
-Repo: `/home/elpresidank/YeeBois/projects/beep-effect`.
+Repo: `/home/elpresidank/YeeBois/projects/beep-effect3`.
 
 Outcome: graduate `law-practice` from domain-only to minimum-viable (domain +
 use-cases + server) — add the IP-law vertical and turn the office-action loop
@@ -71,7 +71,8 @@ Verification:
 test "$(wc -m < goals/law-practice-office-action-spike/GOAL.md)" -le 4000
 jq . goals/law-practice-office-action-spike/ops/manifest.json
 git diff --check -- goals/law-practice-office-action-spike
-bun run check --filter @beep/law-practice-domain
+bun run check
+bun run beep lint reflection-artifacts
 ```
 
 Stop and report before changing public API, schema, migrations, auth, infra,

--- a/goals/law-practice-office-action-spike/PLAN.md
+++ b/goals/law-practice-office-action-spike/PLAN.md
@@ -14,7 +14,7 @@ acceptance).
 | Phase | Status | Goal | Exit criteria |
 | --- | --- | --- | --- |
 | P0 Schema / data-model | complete | Bespoke Effect-Schema for `OfficeAction`/`Claim`/`Rejection`(§101/§102/§103/§112)/`PriorArtReference`/`Distinction` in `@beep/law-practice-domain`; extend existing `Matter`/`PatentAsset`. Light `@source` JSDoc (CPC/IPC, PROV-O, SKOS). | Entities exist as `.model.ts` (+`.values.ts`/`.errors.ts`) with `$I` identity; `Rejection` cardinality encoded (§102=1 ref, §103=≥1+rationale, §101/§112=0); `Distinction.lifecycleState` typed from epistemic public `ClaimLifecycle`; field names reconciled with `docs/data-model-law-practice.md`; domain tests green. **No service code yet.** |
-| P1 Service contract | complete | Define the `Context.Service` ports/interfaces for `IrToLaw` and `OfficeActionReview` in `@beep/law-practice-use-cases`. Typed, **no implementation**. | `IrToLaw: (HandoffIR) => Effect<LawEntities>` and `OfficeActionReview: (fixtureDocRef) => Effect<ClaimProjectionView>` exist as typed services declaring deps on `@beep/file-processing`, `@beep/langextract`, `IrToLaw`, and the epistemic `ClaimGate`/`ClaimLifecycle`/`ClaimProjection`. **No loose helpers extracted before the contract.** |
+| P1 Service contract | complete | Define the `Context.Service` ports/interfaces for `IrToLaw` and `OfficeActionReview` in `@beep/law-practice-use-cases`. Typed, **no implementation**. | `IrToLaw: (ReadonlyArray<GroundedExtraction>) => Effect<LawEntities>` and `OfficeActionReview: (OfficeActionReviewInput) => Effect<ClaimProjectionView>` exist as typed services declaring deps on `@beep/file-processing`, `@beep/langextract`, `IrToLaw`, and the epistemic `ClaimGate`/`ClaimLifecycle`/`ClaimProjection`. **No loose helpers extracted before the contract.** |
 | P2 Implementation | complete | Implement `IrToLaw` (generic `Entity`/`Relation` discriminants → typed law entities, carrying `Span` → `Evidence(char-span)`); implement the `OfficeActionReview` orchestrator; wire the loop in `@beep/law-practice-server`; author one synthetic/public fixture OA. | The loop turns once GREEN on the fixture: one integration test asserts (a) exactly one `Distinction` candidate; (b) `Evidence` char-span re-slices the fixture to the expected quote; (c) gate admits, lifecycle reaches `shape_valid`; (d) trivial ask returns distinction + span. Bun test green. Candidate-only writes; no slice-to-slice internal imports. |
 | P3 Verify / close | complete | Run required checks; capture evidence; prepare PR, review response, and the closeout reflection. | `bun run check` green (no NEW failures vs `@beep/schema` Bun baseline) for `@beep/law-practice-{domain,use-cases,server}`; slice-leakage check clean; packet status + evidence updated; a closeout reflection exists. |
 
@@ -56,7 +56,6 @@ test "$(wc -m < goals/law-practice-office-action-spike/GOAL.md)" -le 4000
 jq . goals/law-practice-office-action-spike/ops/manifest.json
 rg -n "law-practice-office-action-spike|GOAL.md|agentLaunchers|packetAnchorDocument" goals/law-practice-office-action-spike
 git diff --check -- goals/law-practice-office-action-spike
-bun run check --filter @beep/law-practice-domain
-bun run check --filter @beep/law-practice-use-cases --filter @beep/law-practice-server
+bun run check
 bun run beep lint reflection-artifacts
 ```

--- a/goals/law-practice-office-action-spike/README.md
+++ b/goals/law-practice-office-action-spike/README.md
@@ -60,9 +60,12 @@ retained as reference.
 - P1 — `@beep/law-practice-use-cases`: typed `IrToLaw` + `OfficeActionReview`
   `Context.Service` ports.
 - P2 — IR→law impl + office-action review loop wired in new
-  `@beep/law-practice-server` (`LawPracticeServerLive`); 2 integration tests
-  green (anchor re-slices source to original-case quote via `match_lesser`;
-  gate admits → lifecycle reaches `shape_valid`, `admittedKeys === []`).
+  `@beep/law-practice-server` (`LawPracticeServerLive`); source ingestion now
+  routes through `@beep/file-processing` + `@beep/tika` from a typed
+  `OfficeActionReviewInput` carrying `SourceArtifact`/`OperationId`; 2
+  integration tests green (anchor re-slices source to original-case quote via
+  `match_lesser`; gate admits → lifecycle reaches `shape_valid`,
+  `admittedKeys === []`).
 - P3 — global `bun run check` EXIT=0 (88 packages + dtslint/test-tsgo/smoke);
   `rg "@beep/epistemic" packages/law-practice/domain/src` empty;
   `bun run beep lint reflection-artifacts` blocking_findings=0.
@@ -71,16 +74,18 @@ retained as reference.
   fully clean. Applied non-blocking polish: synced the SPEC `IrToLaw` signature
   to `GroundedExtraction[]`, widened the Exception Ledger to the full epistemic
   surface, fixed the leakage-check `rg` blind spot, added a `match_lesser`
-  assertion + candidate-sync caveat to the loop test, and a decoder-rationale
-  comment. Deferred to graduation: candidate-list sharing, non-happy-path
-  candidates, `Option`-style absence handling.
+  assertion, shared the fixed candidate list between loop and tests, and added
+  a decoder-rationale comment. Deferred to graduation: LLM extraction through
+  the langextract service, non-happy-path candidates, `Option`-style absence
+  handling, multi-reference §103, and §101/§112 breadth.
 - Built on the post-#254 baseline (origin/main merged into `baseline-synthesis`;
   repo-exports catalog/shards removed in the merge).
+- Merged to `main` in PR #262 on 2026-06-18 (merge commit `daae48be5b`; head
+  `a872fac6ea`).
 - Reflection: [`history/reflections/2026-06-18-claude.md`](./history/reflections/2026-06-18-claude.md).
 - Key spike finding: the nlp `AnnotatedDocument` envelope is span-lossy at the
   entity level; `IrToLaw` consumes span-bearing `GroundedExtraction[]`
   (`@beep/langextract`) instead — see the reflection + SPEC.
-- Not committed/pushed: all spike code is in the working tree (local only).
 
 ## Notes
 

--- a/goals/law-practice-office-action-spike/SPEC.md
+++ b/goals/law-practice-office-action-spike/SPEC.md
@@ -12,7 +12,7 @@ rung-0 office-action review loop end-to-end on **one** fixture office action.
 Observable end state: a single integration test runs one synthetic/public
 office-action document through the full loop —
 `tika`/`@beep/file-processing` extract text → `@beep/langextract` aligns a
-span → `@beep/nlp` Handoff IR → **IR→law-entity mapping** → one
+span-bearing `GroundedExtraction[]` → **IR→law-entity mapping** → one
 `OfficeAction` + one `Rejection(§102)` + one `Claim` + one
 `PriorArtReference` → one `Distinction` candidate emitted as a
 `CandidateClaim` carrying `Evidence(char-span)` → the epistemic `ClaimGate` +
@@ -95,7 +95,7 @@ tier):**
   langextract output, not the span-lossy nlp `AnnotatedDocument` envelope)
 - `src/OfficeActionReview/OfficeActionReview.ports.ts` +
   `OfficeActionReview.service.ts` (loop orchestrator
-  `(fixtureDocRef) => Effect<ClaimProjectionView>`)
+  `(OfficeActionReviewInput) => Effect<ClaimProjectionView>`)
 
 **`@beep/law-practice-server` (`packages/law-practice/server` — NEW tier):**
 
@@ -173,9 +173,8 @@ implementation before verify).
       `OfficeActionReview: (OfficeActionReviewInput) => Effect<ClaimProjectionView>`
       declaring deps on `@beep/langextract` (span-bearing `GroundedExtraction`),
       `IrToLaw`, and the epistemic `ClaimGate`/`ClaimLifecycle`/
-      `ClaimProjection`. (The spike consumes pre-extracted `sourceText`, so
-      `@beep/file-processing`/tika ingestion is deferred, not composed.) No loose
-      helpers precede the contract.
+      `ClaimProjection`, plus typed `SourceArtifact`/`OperationId` ingestion
+      through `@beep/file-processing`. No loose helpers precede the contract.
 - [ ] **P2 (implementation):** `IrToLaw` maps span-bearing `GroundedExtraction`
       records (keyed on the `label` vocabulary) → typed law entities, grounding
       the distinction's aligned `span` + original-case `matchedText` →
@@ -203,8 +202,7 @@ implementation before verify).
 | Packet launcher size | `test "$(wc -m < goals/law-practice-office-action-spike/GOAL.md)" -le 4000` | Passes |
 | Manifest JSON | `jq . goals/law-practice-office-action-spike/ops/manifest.json` | Passes |
 | Whitespace | `git diff --check -- goals/law-practice-office-action-spike` | Passes |
-| Domain schema check | `bun run check --filter @beep/law-practice-domain` | Green (no new failures) |
-| Use-cases + server check | `bun run check --filter @beep/law-practice-use-cases --filter @beep/law-practice-server` | Green (no new failures) |
+| Authoritative typecheck | `bun run check` | Green (no new failures) |
 | Loop integration test | `bun test` on the office-action loop test | One distinction, char-span linked, gate admits, ask answers |
 | No slice leakage | `rg -n 'from "@beep/epistemic-(domain\|use-cases\|server)' packages/law-practice/**/src` — every hit resolves to a canonical public subpath (root, `/values`, `/ClaimGate`, `/ClaimLifecycle`, `/ClaimProjection`, `/layer`); zero `/internal/*` | No internal imports; `packages/law-practice/domain/src` has zero hits |
 | Reflection present | `bun run beep lint reflection-artifacts` | Passes |

--- a/goals/law-practice-office-action-spike/history/reflections/2026-06-18-claude.md
+++ b/goals/law-practice-office-action-spike/history/reflections/2026-06-18-claude.md
@@ -47,7 +47,8 @@ to the use-cases/server tiers per the documented Exception Ledger entry.
 
 ## Tooling experience
 
-- **Worked:** `bunx turbo run check --filter=…` gave fast per-package iteration;
+- **Worked:** `bunx turbo run check --filter=…` gave fast per-package
+  iteration only; the authoritative proof stayed the global repo check;
   the existing P0 test and `EpistemicUseCases.test.ts` were precise templates for
   entity decode shapes and the gate/transition/projection composition;
   `bun run beep docgen init -p <pkg>` cleanly produced the docgen config once I

--- a/goals/law-practice-office-action-spike/ops/manifest.json
+++ b/goals/law-practice-office-action-spike/ops/manifest.json
@@ -71,8 +71,7 @@
     "jq . goals/law-practice-office-action-spike/ops/manifest.json",
     "rg -n \"law-practice-office-action-spike|GOAL.md|agentLaunchers|packetAnchorDocument\" goals/law-practice-office-action-spike",
     "git diff --check -- goals/law-practice-office-action-spike",
-    "bun run check --filter @beep/law-practice-domain",
-    "bun run check --filter @beep/law-practice-use-cases --filter @beep/law-practice-server",
+    "bun run check",
     "bun run beep lint reflection-artifacts"
   ],
   "stopConditions": [

--- a/packages/tooling/library/ai-metrics/src/otlp.ts
+++ b/packages/tooling/library/ai-metrics/src/otlp.ts
@@ -461,6 +461,37 @@ const emitSpanProjection = Effect.fn("AiMetrics.otlp.emitSpanProjection")((proje
   )
 );
 
+const withOtlpExportSpan =
+  (input: AiMetricsOtlpExportInput) =>
+  <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
+    effect.pipe(
+      Effect.withSpan("repo_ai_metrics.otlp.export", {
+        attributes: {
+          "ai_metrics.otlp.signal_scope": input.endpoint.signalScope,
+          "ai_metrics.otlp.trace_url": input.endpoint.traceUrl,
+          "ai_metrics.target": input.target,
+        },
+      })
+    );
+
+const runAiMetricsOtlpProjectionBatchExportUntraced: (
+  input: AiMetricsOtlpExportInput,
+  batch: AiMetricsOtlpSpanProjectionBatch
+) => Effect.Effect<AiMetricsOtlpExportResult> = Effect.fn("AiMetrics.runAiMetricsOtlpProjectionBatchExport.untraced")(
+  function* (input, batch) {
+    yield* Effect.forEach(batch.projections, emitSpanProjection, { discard: true, concurrency: 8 });
+
+    return AiMetricsOtlpExportResult.make({
+      endpointTraceUrl: input.endpoint.traceUrl,
+      ingestRunId: batch.ingestRunId,
+      sessionSpanCount: batch.sessionSpanCount,
+      spanCount: A.length(batch.projections),
+      target: input.target,
+      turnSpanCount: batch.turnSpanCount,
+    });
+  }
+);
+
 /**
  * Emit a pre-resolved redacted AI metrics OTLP span projection batch.
  *
@@ -477,32 +508,8 @@ export const runAiMetricsOtlpProjectionBatchExport: {
   (
     batch: AiMetricsOtlpSpanProjectionBatch
   ): (input: AiMetricsOtlpExportInput) => Effect.Effect<AiMetricsOtlpExportResult>;
-} = dual(
-  2,
-  Effect.fn("AiMetrics.runAiMetricsOtlpProjectionBatchExport")(
-    function* (input: AiMetricsOtlpExportInput, batch: AiMetricsOtlpSpanProjectionBatch) {
-      yield* Effect.forEach(batch.projections, emitSpanProjection, { discard: true, concurrency: 8 });
-
-      return AiMetricsOtlpExportResult.make({
-        endpointTraceUrl: input.endpoint.traceUrl,
-        ingestRunId: batch.ingestRunId,
-        sessionSpanCount: batch.sessionSpanCount,
-        spanCount: A.length(batch.projections),
-        target: input.target,
-        turnSpanCount: batch.turnSpanCount,
-      });
-    },
-    (effect, input) =>
-      effect.pipe(
-        Effect.withSpan("repo_ai_metrics.otlp.export", {
-          attributes: {
-            "ai_metrics.otlp.signal_scope": input.endpoint.signalScope,
-            "ai_metrics.otlp.trace_url": input.endpoint.traceUrl,
-            "ai_metrics.target": input.target,
-          },
-        })
-      )
-  )
+} = dual(2, (input: AiMetricsOtlpExportInput, batch: AiMetricsOtlpSpanProjectionBatch) =>
+  runAiMetricsOtlpProjectionBatchExportUntraced(input, batch).pipe(withOtlpExportSpan(input))
 );
 
 /**
@@ -520,11 +527,14 @@ export const runAiMetricsOtlpExport: (
   input: AiMetricsOtlpExportInput
 ) => Effect.Effect<AiMetricsOtlpExportResult, AiMetricsOtlpExportError, DuckDb> = Effect.fn(
   "AiMetrics.runAiMetricsOtlpExport"
-)(function* (input) {
-  const batch = yield* readAiMetricsOtlpSpanProjections(input);
+)(
+  function* (input) {
+    const batch = yield* readAiMetricsOtlpSpanProjections(input);
 
-  return yield* runAiMetricsOtlpProjectionBatchExport(input, batch);
-});
+    return yield* runAiMetricsOtlpProjectionBatchExportUntraced(input, batch);
+  },
+  (effect, input) => effect.pipe(withOtlpExportSpan(input))
+);
 
 /**
  * Render an OTLP export result as JSON.

--- a/packages/tooling/library/ai-metrics/src/otlp.ts
+++ b/packages/tooling/library/ai-metrics/src/otlp.ts
@@ -10,6 +10,7 @@ import { $RepoAiMetricsId } from "@beep/identity/packages";
 import { TaggedErrorClass } from "@beep/schema";
 import { A, Str } from "@beep/utils";
 import { Effect, flow, pipe } from "effect";
+import { dual } from "effect/Function";
 import * as O from "effect/Option";
 import * as R from "effect/Record";
 import * as S from "effect/Schema";
@@ -461,6 +462,50 @@ const emitSpanProjection = Effect.fn("AiMetrics.otlp.emitSpanProjection")((proje
 );
 
 /**
+ * Emit a pre-resolved redacted AI metrics OTLP span projection batch.
+ *
+ * @example
+ * ```ts
+ * import { runAiMetricsOtlpProjectionBatchExport } from "@beep/repo-ai-metrics"
+ * console.log(runAiMetricsOtlpProjectionBatchExport)
+ * ```
+ * @category services
+ * @since 0.0.0
+ */
+export const runAiMetricsOtlpProjectionBatchExport: {
+  (input: AiMetricsOtlpExportInput, batch: AiMetricsOtlpSpanProjectionBatch): Effect.Effect<AiMetricsOtlpExportResult>;
+  (
+    batch: AiMetricsOtlpSpanProjectionBatch
+  ): (input: AiMetricsOtlpExportInput) => Effect.Effect<AiMetricsOtlpExportResult>;
+} = dual(
+  2,
+  Effect.fn("AiMetrics.runAiMetricsOtlpProjectionBatchExport")(
+    function* (input: AiMetricsOtlpExportInput, batch: AiMetricsOtlpSpanProjectionBatch) {
+      yield* Effect.forEach(batch.projections, emitSpanProjection, { discard: true, concurrency: 8 });
+
+      return AiMetricsOtlpExportResult.make({
+        endpointTraceUrl: input.endpoint.traceUrl,
+        ingestRunId: batch.ingestRunId,
+        sessionSpanCount: batch.sessionSpanCount,
+        spanCount: A.length(batch.projections),
+        target: input.target,
+        turnSpanCount: batch.turnSpanCount,
+      });
+    },
+    (effect, input) =>
+      effect.pipe(
+        Effect.withSpan("repo_ai_metrics.otlp.export", {
+          attributes: {
+            "ai_metrics.otlp.signal_scope": input.endpoint.signalScope,
+            "ai_metrics.otlp.trace_url": input.endpoint.traceUrl,
+            "ai_metrics.target": input.target,
+          },
+        })
+      )
+  )
+);
+
+/**
  * Emit redacted AI metrics derived spans through the active Effect tracer.
  *
  * @example
@@ -475,31 +520,11 @@ export const runAiMetricsOtlpExport: (
   input: AiMetricsOtlpExportInput
 ) => Effect.Effect<AiMetricsOtlpExportResult, AiMetricsOtlpExportError, DuckDb> = Effect.fn(
   "AiMetrics.runAiMetricsOtlpExport"
-)(
-  function* (input) {
-    const batch = yield* readAiMetricsOtlpSpanProjections(input);
-    yield* Effect.forEach(batch.projections, emitSpanProjection, { discard: true, concurrency: 8 });
+)(function* (input) {
+  const batch = yield* readAiMetricsOtlpSpanProjections(input);
 
-    return AiMetricsOtlpExportResult.make({
-      endpointTraceUrl: input.endpoint.traceUrl,
-      ingestRunId: batch.ingestRunId,
-      sessionSpanCount: batch.sessionSpanCount,
-      spanCount: A.length(batch.projections),
-      target: input.target,
-      turnSpanCount: batch.turnSpanCount,
-    });
-  },
-  (effect, input) =>
-    effect.pipe(
-      Effect.withSpan("repo_ai_metrics.otlp.export", {
-        attributes: {
-          "ai_metrics.otlp.signal_scope": input.endpoint.signalScope,
-          "ai_metrics.otlp.trace_url": input.endpoint.traceUrl,
-          "ai_metrics.target": input.target,
-        },
-      })
-    )
-);
+  return yield* runAiMetricsOtlpProjectionBatchExport(input, batch);
+});
 
 /**
  * Render an OTLP export result as JSON.

--- a/packages/tooling/library/ai-metrics/test/ingest.test.ts
+++ b/packages/tooling/library/ai-metrics/test/ingest.test.ts
@@ -59,6 +59,7 @@ import {
   renderAiMetricsLocalPhoenixCompose,
   runAiMetricsForwarder,
   runAiMetricsOtlpExport,
+  runAiMetricsOtlpProjectionBatchExport,
   runAiMetricsRetentionCompact,
   runAiMetricsRetentionDelete,
   runAiMetricsRetentionRestoreDrill,
@@ -994,6 +995,7 @@ volumes:
             });
             const batch = yield* readAiMetricsOtlpSpanProjections(input);
             const result = yield* runAiMetricsOtlpExport(input);
+            const pipeableResult = yield* pipe(input, runAiMetricsOtlpProjectionBatchExport(batch));
             const json = yield* otlpExportResultToJson(result);
 
             expect(batch.ingestRunId).toBe("forwarder-otlp");
@@ -1027,6 +1029,7 @@ volumes:
               ])
             );
             expect(result.spanCount).toBe(4);
+            expect(pipeableResult).toEqual(result);
             expect(json).toContain("forwarder-otlp");
             expect(json).not.toContain("private-input");
             expect(json).not.toContain("private-model-output");

--- a/packages/tooling/tool/cli/src/commands/AIMetrics/AIMetrics.command.ts
+++ b/packages/tooling/tool/cli/src/commands/AIMetrics/AIMetrics.command.ts
@@ -1673,9 +1673,7 @@ const makeOtlpExportProgram = Effect.fn("AIMetrics.makeOtlpExportProgram")(funct
     target,
   });
   const result = yield* Effect.scoped(
-    Layer.build(
-      Layer.mergeAll(duckDbLayer, layerNodeSdkServerTraces(serverObservabilityConfigFor(target, endpoint)))
-    ).pipe(
+    Layer.build(layerNodeSdkServerTraces(serverObservabilityConfigFor(target, endpoint))).pipe(
       Effect.flatMap((context) =>
         runAiMetricsOtlpProjectionBatchExport(resolvedInput, batch).pipe(Effect.provide(context))
       )

--- a/packages/tooling/tool/cli/src/commands/AIMetrics/AIMetrics.command.ts
+++ b/packages/tooling/tool/cli/src/commands/AIMetrics/AIMetrics.command.ts
@@ -91,6 +91,7 @@ import {
   renderAiMetricsLocalPhoenixCompose,
   runAiMetricsForwarder,
   runAiMetricsOtlpExport,
+  runAiMetricsOtlpProjectionBatchExport,
   runAiMetricsRetentionCompact,
   runAiMetricsRetentionDelete,
   runAiMetricsRetentionRestoreDrill,
@@ -1674,7 +1675,11 @@ const makeOtlpExportProgram = Effect.fn("AIMetrics.makeOtlpExportProgram")(funct
   const result = yield* Effect.scoped(
     Layer.build(
       Layer.mergeAll(duckDbLayer, layerNodeSdkServerTraces(serverObservabilityConfigFor(target, endpoint)))
-    ).pipe(Effect.flatMap((context) => runAiMetricsOtlpExport(resolvedInput).pipe(Effect.provide(context))))
+    ).pipe(
+      Effect.flatMap((context) =>
+        runAiMetricsOtlpProjectionBatchExport(resolvedInput, batch).pipe(Effect.provide(context))
+      )
+    )
   );
 
   if (json) {

--- a/packages/tooling/tool/cli/src/commands/AIMetrics/AIMetrics.command.ts
+++ b/packages/tooling/tool/cli/src/commands/AIMetrics/AIMetrics.command.ts
@@ -84,6 +84,7 @@ import {
   otlpExportResultToJson,
   privacyCheckToJson,
   queueAiMetricsLabels,
+  readAiMetricsOtlpSpanProjections,
   readEncryptedRawArchiveEnvelope,
   recordAiMetricsBenchmarkRun,
   renderAiMetricsForwarderTimerPlan,
@@ -1652,24 +1653,28 @@ const makeOtlpExportProgram = Effect.fn("AIMetrics.makeOtlpExportProgram")(funct
     })
   );
   const endpoint = yield* defaultServiceEndpoint(spec, otlpBaseUrl);
+  const input = AiMetricsOtlpExportInput.make({
+    duckDbPath: spec.storage.duckDbPath,
+    endpoint,
+    ingestRunId,
+    target,
+  });
+  const duckDbLayer = DuckDb.makeNodeLayer(DuckDbConnectionOptions.make({ databasePath: spec.storage.duckDbPath }));
+  const batch = yield* Effect.scoped(
+    Layer.build(duckDbLayer).pipe(
+      Effect.flatMap((context) => readAiMetricsOtlpSpanProjections(input).pipe(Effect.provide(context)))
+    )
+  );
+  const resolvedInput = AiMetricsOtlpExportInput.make({
+    duckDbPath: spec.storage.duckDbPath,
+    endpoint,
+    ingestRunId: batch.ingestRunId,
+    target,
+  });
   const result = yield* Effect.scoped(
     Layer.build(
-      Layer.mergeAll(
-        DuckDb.makeNodeLayer(DuckDbConnectionOptions.make({ databasePath: spec.storage.duckDbPath })),
-        layerNodeSdkServerTraces(serverObservabilityConfigFor(target, endpoint))
-      )
-    ).pipe(
-      Effect.flatMap((context) =>
-        runAiMetricsOtlpExport(
-          AiMetricsOtlpExportInput.make({
-            duckDbPath: spec.storage.duckDbPath,
-            endpoint,
-            ingestRunId,
-            target,
-          })
-        ).pipe(Effect.provide(context))
-      )
-    )
+      Layer.mergeAll(duckDbLayer, layerNodeSdkServerTraces(serverObservabilityConfigFor(target, endpoint)))
+    ).pipe(Effect.flatMap((context) => runAiMetricsOtlpExport(resolvedInput).pipe(Effect.provide(context))))
   );
 
   if (json) {

--- a/packages/tooling/tool/cli/test/ai-metrics-command.test.ts
+++ b/packages/tooling/tool/cli/test/ai-metrics-command.test.ts
@@ -165,8 +165,9 @@ const seedAiMetricsData = Effect.fn("AIMetricsCommandTest.seedAiMetricsData")(fu
     "test-salt",
     "--json",
   ]);
+  const forwarderResult = yield* decodeForwarderResult(yield* lastLoggedLine());
 
-  return { dataRoot, homeDir, repoRoot };
+  return { dataRoot, forwarderResult, homeDir, repoRoot };
 });
 
 const withPrependedPath = <A, E, R>(binDir: string, use: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
@@ -1249,6 +1250,7 @@ describe("ai-metrics command", () => {
                 "--json",
               ])
             );
+            const forwarderResult = yield* decodeForwarderResult(yield* lastLoggedLine());
 
             yield* runAiMetricsCommand([
               "otlp",
@@ -1273,6 +1275,7 @@ describe("ai-metrics command", () => {
             expect(traceRequest.bodyText).not.toContain("private-otlp-fixture");
             expect(traceRequest.bodyText).not.toContain(tmpDir);
             expect(result.endpointTraceUrl).toBe(`${otlpBaseUrl}/v1/traces`);
+            expect(result.ingestRunId).toBe(forwarderResult.ingestRunId);
             expect(result.spanCount).toBeGreaterThan(0);
             expect(resultJson).not.toContain("private-otlp-fixture");
             expect(resultJson).not.toContain(rawArchiveKey);
@@ -1282,9 +1285,42 @@ describe("ai-metrics command", () => {
       )
     ));
 
+  it("exports an explicit derived OTLP ingest run without resolving latest", () =>
+    Effect.runPromise(
+      withOtlpSink((otlpBaseUrl, requests) =>
+        withTempDirectory((tmpDir) =>
+          Effect.gen(function* () {
+            const rawArchiveKey = Encoding.encodeBase64(new Uint8Array(32).fill(31));
+            const { dataRoot, forwarderResult } = yield* withRawArchiveKeyEnv(rawArchiveKey, seedAiMetricsData(tmpDir));
+
+            yield* runAiMetricsCommand([
+              "otlp",
+              "export",
+              "--target",
+              "local",
+              "--data-root",
+              dataRoot,
+              "--ingest-run",
+              forwarderResult.ingestRunId,
+              "--otlp-base-url",
+              otlpBaseUrl,
+              "--json",
+            ]);
+
+            const result = yield* decodeOtlpExportResult(yield* lastLoggedLine());
+            const traceRequest = yield* waitForCapturedOtlpTraceRequest(requests);
+
+            expect(traceRequest.contentType).toContain("application/x-protobuf");
+            expect(result.ingestRunId).toBe(forwarderResult.ingestRunId);
+            expect(result.spanCount).toBeGreaterThan(0);
+          })
+        )
+      )
+    ));
+
   it("accepts non-local OTLP export install secret references before reading derived runs", () =>
     Effect.runPromise(
-      withOtlpSink((otlpBaseUrl) =>
+      withOtlpSink((otlpBaseUrl, requests) =>
         withTempDirectory((tmpDir) =>
           Effect.gen(function* () {
             const path = yield* Path.Path;
@@ -1309,6 +1345,7 @@ describe("ai-metrics command", () => {
             ]);
 
             expect(output).toContain("Failed to select the latest AI metrics ingest run.");
+            expect(requests).toHaveLength(0);
             expect(output).not.toContain("hash-salt-secret-ref");
             expect(output).not.toContain("raw-archive-key-secret-ref");
             expect(output).not.toContain(dataRoot);


### PR DESCRIPTION
## docs(goals): reconcile law-practice next rung


## fix(repo-cli): preflight ai metrics otlp export

## Local proof

- publish:git:push: passed

Verdict: .beep/yeet/runs/goal-packet-reconciliation-1b10c49b0aee/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784392317&installation_id=141092090&pr_number=264&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F264&signature=5b1477e9a4b1ba5ba49bd34f7d22c2ed0dd9e6287f33d32663bdf2b600f6edcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded law-practice office-action extraction beyond the initial rung-0 loop, moving toward provider-neutral LLM extraction with deterministic, fixture-based verification.

* **Updates**
  * Marked file-processing capability Phase 1 complete; updated README/spec/criteria and advanced planning to Phase 2.
  * Updated initiative and mission documentation, including active vertical status notes and new rung planning for office-action extraction.

* **Chores**
  * Improved AI metrics OTLP export flow to use a projection-batch workflow.
  * Strengthened CLI/test coverage for derived OTLP exports and secret-safety behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->