### PR TITLE
feat(law-practice): service-backed office action extraction

### DIFF
--- a/.changeset/service-backed-office-action-extraction.md
+++ b/.changeset/service-backed-office-action-extraction.md
@@ -1,0 +1,6 @@
+---
+"@beep/law-practice-server": patch
+"@beep/law-practice-use-cases": patch
+---
+
+Route office-action review extraction through the provider-neutral LangExtract service and fail typed when required grounded extraction spans are missing or unaligned.

--- a/bun.lock
+++ b/bun.lock
@@ -1312,6 +1312,7 @@
         "@beep/epistemic-server": "workspace:^",
         "@beep/epistemic-use-cases": "workspace:^",
         "@beep/file-processing": "workspace:^",
+        "@beep/langextract": "workspace:^",
         "@beep/law-practice-domain": "workspace:^",
         "@beep/law-practice-use-cases": "workspace:^",
         "@beep/tika": "workspace:^",
@@ -1333,6 +1334,8 @@
         "@beep/identity": "workspace:^",
         "@beep/langextract": "workspace:^",
         "@beep/law-practice-domain": "workspace:^",
+        "@beep/nlp": "workspace:^",
+        "@beep/schema": "workspace:^",
         "effect": "catalog:",
       },
       "devDependencies": {

--- a/goals/law-practice-office-action-extraction-rung/GOAL.md
+++ b/goals/law-practice-office-action-extraction-rung/GOAL.md
@@ -13,6 +13,19 @@ and `ops/manifest.json`, then `AGENTS.md`, `CLAUDE.md`,
 completed `goals/law-practice-office-action-spike/` packet. Higher repo
 standards outrank packet prose.
 
+Branch/PR contract:
+
+- If launched on `main` or another protected/default branch, first fetch
+  `origin/main`, confirm it is fresh, then create a feature branch from the
+  intended base before editing.
+- See the packet through to a mergeable PR with Yeet: use
+  `bun run beep yeet verify`, then
+  `bun run beep yeet publish --pr --monitor --message "feat(law-practice): service-backed office action extraction"`.
+- Run `bun run beep yeet monitor --summary` and
+  `bun run beep yeet closeout --summary --require-greptile-score 5/5 --require-greptile-issues 0 --require-review-comments 0`;
+  fix failed checks or actionable review comments with follow-up Yeet publishes
+  until the PR is mergeable. Do not auto-merge without explicit user approval.
+
 Scope:
 
 - In: `packages/law-practice/use-cases/src/OfficeActionReview/**`,
@@ -46,6 +59,9 @@ Acceptance:
 - [ ] Happy-path and non-happy-path tests pass deterministically.
 - [ ] Multi-reference 103 plus 101/112 breadth is implemented after extraction
       is green or explicitly deferred as the next phase.
+- [ ] Work lands on a feature branch and a Yeet-published PR is mergeable:
+      hosted checks green, closeout clean, and no unresolved actionable review
+      comments.
 - [ ] No unrelated refactors or formatting churn.
 
 Verify:
@@ -60,4 +76,5 @@ bun run beep yeet verify
 ```
 
 Done when acceptance passes and verification is complete, or a blocker is
-reported with evidence.
+reported with evidence. For successful implementation, "done" includes the
+mergeable PR state above, not just a local green worktree.

--- a/goals/law-practice-office-action-extraction-rung/PLAN.md
+++ b/goals/law-practice-office-action-extraction-rung/PLAN.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-Status: `in-progress`
+Status: `complete` (2026-06-18) - P0-P3 implemented; PR #265 published; hosted
+checks reached green; closeout review findings addressed in the follow-up patch.
 
 ## Phases
 
@@ -11,7 +12,7 @@ Status: `in-progress`
 | P0 Scope and contracts | complete | Confirm the current `OfficeActionReview` seam, `LangExtractService` contract, law labels, and deterministic test strategy. | Required source facts and any blockers are recorded; no implementation ambiguity remains. |
 | P1 Service-backed extraction | complete | Replace production fixed candidates with `LangExtractService.extract` and feed `LangExtractResult.extractions` into `IrToLaw`. | Happy-path loop test passes with deterministic fake model/service output. |
 | P2 Non-happy paths and breadth gate | complete | Add required-label/alignment failure handling and decide whether this packet also implements first doctrine breadth. | At least one non-happy-path test passes; 103/101/112 scope is implemented or explicitly deferred. |
-| P3 Verify and close | in-progress | Run required checks, update packet evidence, write reflection, publish the feature branch with Yeet, and close out hosted PR feedback. | Verification is green or unrelated failures are classified; PR is open and mergeable; packet status and evidence are current. |
+| P3 Verify and close | complete | Run required checks, update packet evidence, write reflection, publish the feature branch with Yeet, and close out hosted PR feedback. | Verification is green or unrelated failures are classified; PR is open and mergeable; packet status and evidence are current. |
 
 ## Execution Notes
 

--- a/goals/law-practice-office-action-extraction-rung/PLAN.md
+++ b/goals/law-practice-office-action-extraction-rung/PLAN.md
@@ -2,26 +2,32 @@
 
 ## Status
 
-Status: `pending`
+Status: `in-progress`
 
 ## Phases
 
 | Phase | Status | Goal | Exit criteria |
 | --- | --- | --- | --- |
-| P0 Scope and contracts | pending | Confirm the current `OfficeActionReview` seam, `LangExtractService` contract, law labels, and deterministic test strategy. | Required source facts and any blockers are recorded; no implementation ambiguity remains. |
-| P1 Service-backed extraction | pending | Replace production fixed candidates with `LangExtractService.extract` and feed `LangExtractResult.extractions` into `IrToLaw`. | Happy-path loop test passes with deterministic fake model/service output. |
-| P2 Non-happy paths and breadth gate | pending | Add required-label/alignment failure handling and decide whether this packet also implements first doctrine breadth. | At least one non-happy-path test passes; 103/101/112 scope is implemented or explicitly deferred. |
-| P3 Verify and close | pending | Run required checks, update packet evidence, write reflection, and prepare PR readiness if requested. | Verification is green or unrelated failures are classified; packet status and evidence are current. |
+| P0 Scope and contracts | complete | Confirm the current `OfficeActionReview` seam, `LangExtractService` contract, law labels, and deterministic test strategy. | Required source facts and any blockers are recorded; no implementation ambiguity remains. |
+| P1 Service-backed extraction | complete | Replace production fixed candidates with `LangExtractService.extract` and feed `LangExtractResult.extractions` into `IrToLaw`. | Happy-path loop test passes with deterministic fake model/service output. |
+| P2 Non-happy paths and breadth gate | complete | Add required-label/alignment failure handling and decide whether this packet also implements first doctrine breadth. | At least one non-happy-path test passes; 103/101/112 scope is implemented or explicitly deferred. |
+| P3 Verify and close | in-progress | Run required checks, update packet evidence, write reflection, publish the feature branch with Yeet, and close out hosted PR feedback. | Verification is green or unrelated failures are classified; PR is open and mergeable; packet status and evidence are current. |
 
 ## Execution Notes
 
 - Preserve unrelated worktree changes.
+- If execution starts on `main` or another protected/default branch, fetch
+  `origin/main`, confirm the base is fresh, and create a feature branch before
+  editing.
 - Keep `SPEC.md` normative and update it only when the contract changes.
 - Keep the law-domain package isolated from extraction and epistemic runtime
   dependencies.
 - Prefer composing the existing `LangExtractService` over adding a new law-only
   extraction abstraction unless a real complexity boundary appears.
-- Keep fixed candidate data under test surfaces only after P1.
+- Fixed candidate data is retained only through the package test surface after
+  P1; production `OfficeActionReview` now uses `LangExtractService.extract`.
+- Multi-reference 103 plus 101/112 breadth is deferred to the next rung; this
+  packet closes the service-backed extraction path first.
 - Archive old run outputs under `history/` when a future execution run closes
   the packet.
 
@@ -34,6 +40,13 @@ Before marking the packet closed:
 2. Run `bun run beep lint reflection-artifacts`.
 3. Update `README.md` latest evidence and `ops/manifest.json` phase statuses.
 4. Run `bun run beep yeet verify` before claiming branch-level green.
+5. Publish via
+   `bun run beep yeet publish --pr --monitor --message "feat(law-practice): service-backed office action extraction"`.
+6. Run `bun run beep yeet monitor --summary` and
+   `bun run beep yeet closeout --summary --require-greptile-score 5/5 --require-greptile-issues 0 --require-review-comments 0`.
+7. Fix failed hosted checks or actionable review nits with follow-up Yeet
+   publishes until the PR is mergeable. Do not auto-merge without explicit user
+   approval.
 
 ## Verification Commands
 
@@ -45,4 +58,7 @@ git diff --check -- goals/law-practice-office-action-extraction-rung
 bun run check
 bun run beep lint reflection-artifacts
 bun run beep yeet verify
+bun run beep yeet publish --pr --monitor --message "feat(law-practice): service-backed office action extraction"
+bun run beep yeet monitor --summary
+bun run beep yeet closeout --summary --require-greptile-score 5/5 --require-greptile-issues 0 --require-review-comments 0
 ```

--- a/goals/law-practice-office-action-extraction-rung/README.md
+++ b/goals/law-practice-office-action-extraction-rung/README.md
@@ -35,21 +35,43 @@ Use this command for execution-capable sessions:
 
 ## Current Phase
 
-P0 Scope confirmation is pending. Start by inspecting the current
-`OfficeActionReview` loop, the `@beep/langextract/Service` contract, and the
-law-practice server layer composition.
+P3 Verify and close is in progress. P0-P2 are locally complete: production
+`OfficeActionReview` invokes `LangExtractService.extract`, feeds
+`LangExtractResult.extractions` to `IrToLaw`, and rejects unaligned distinction
+output before claim admission. Remaining closeout work is Yeet verify, PR
+publish/monitor, and hosted review closeout.
 
 ## Latest Evidence
 
-Not started. This packet was opened after PR #262 merged the file-processing
-and rung-0 office-action loop to `main` on 2026-06-18.
+- P0/P1 - current seams confirmed: fixed spike candidates were only in
+  `OfficeActionReview.service.ts`, `LangExtractService.extract` takes a
+  schema-backed `LangExtractRequest`, and server Layer composition can require a
+  generic `LanguageModel.LanguageModel` without provider-specific law-practice
+  dependencies.
+- P1/P2 - production `OfficeActionReview` now constructs law extraction targets
+  (`office_action`, `claim`, `rejection_reference`, `distinction`), calls
+  `LangExtractService.extract`, and passes `LangExtractResult.extractions` into
+  `IrToLaw`.
+- P2 - `IrToLaw` now returns typed `IrToLawExtractionError` failures for missing
+  required labels or unaligned distinction evidence instead of fabricating
+  fallback spans.
+- P2 - deterministic server test has 3 passing cases: direct `IrToLaw`
+  grounding, happy-path review through fake model output, and unaligned
+  distinction rejection before admission.
+- P2 - doctrine breadth is explicitly deferred to the next rung: multi-reference
+  103 plus 101/112 handling stays out of this extraction-service graduation.
+- P3 - local focused tests, package checks/lints, and root `bun run check` are
+  green as of 2026-06-18; Yeet verify/publish/hosted closeout remain pending.
 
 ## Notes
 
-- The fixed `OfficeActionReviewSpikeCandidates` list is the implementation seam
-  to replace.
+- The fixed `OfficeActionReviewSpikeCandidates` list is retained only through
+  the package test surface for deterministic mapping assertions.
 - Keep tests deterministic with fake language-model output; live provider
   credentials are not required for packet completion.
+- Use Yeet for branch proof, PR creation, hosted monitor, and closeout:
+  `yeet verify` -> `yeet publish --pr --monitor` -> `yeet monitor --summary`
+  -> `yeet closeout --summary ...`.
 - The nlp `AnnotatedDocument` envelope is still span-lossy for law anchoring.
   Feed `LangExtractResult.extractions` / `GroundedExtraction[]` into `IrToLaw`.
 - Fixtures must remain synthetic/public only.

--- a/goals/law-practice-office-action-extraction-rung/README.md
+++ b/goals/law-practice-office-action-extraction-rung/README.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Lifecycle: `active`
+Lifecycle: `complete` (2026-06-18)
 
 Source: [`ops/manifest.json`](./ops/manifest.json)
 
@@ -35,11 +35,10 @@ Use this command for execution-capable sessions:
 
 ## Current Phase
 
-P3 Verify and close is in progress. P0-P2 are locally complete: production
-`OfficeActionReview` invokes `LangExtractService.extract`, feeds
-`LangExtractResult.extractions` to `IrToLaw`, and rejects unaligned distinction
-output before claim admission. Remaining closeout work is Yeet verify, PR
-publish/monitor, and hosted review closeout.
+`P3 Verify and close` is complete. Production `OfficeActionReview` invokes
+`LangExtractService.extract`, feeds `LangExtractResult.extractions` to
+`IrToLaw`, rejects missing/empty/unaligned required extraction output before
+claim admission, and PR #265 carries the Yeet-published branch.
 
 ## Latest Evidence
 
@@ -52,16 +51,23 @@ publish/monitor, and hosted review closeout.
   (`office_action`, `claim`, `rejection_reference`, `distinction`), calls
   `LangExtractService.extract`, and passes `LangExtractResult.extractions` into
   `IrToLaw`.
-- P2 - `IrToLaw` now returns typed `IrToLawExtractionError` failures for missing
-  required labels or unaligned distinction evidence instead of fabricating
-  fallback spans.
-- P2 - deterministic server test has 3 passing cases: direct `IrToLaw`
-  grounding, happy-path review through fake model output, and unaligned
-  distinction rejection before admission.
+- P2 - `IrToLaw` now returns typed `IrToLawExtractionError` failures for
+  missing, empty, or unaligned required labels instead of fabricating fallback
+  spans.
+- P2 - deterministic server test has 4 passing cases: LangExtract-backed
+  grounding, happy-path review through fake model output, missing distinction
+  rejection, and unaligned distinction rejection before admission.
 - P2 - doctrine breadth is explicitly deferred to the next rung: multi-reference
   103 plus 101/112 handling stays out of this extraction-service graduation.
-- P3 - local focused tests, package checks/lints, and root `bun run check` are
-  green as of 2026-06-18; Yeet verify/publish/hosted closeout remain pending.
+- P3 - local focused tests, package checks/lints, root `bun run check`, and
+  `bun run beep yeet verify` with optional live-provider tokens blanked are
+  green as of 2026-06-18.
+- P3 - `bun run beep yeet publish --pr --monitor --message
+  "feat(law-practice): service-backed office action extraction"` opened PR #265;
+  hosted monitor reported 20 checks, 0 failing, 0 pending. Initial strict
+  closeout surfaced 5 actionable review threads and a Greptile 3/5 issue; the
+  follow-up closeout patch addresses those review findings before final
+  monitor/closeout.
 
 ## Notes
 

--- a/goals/law-practice-office-action-extraction-rung/SPEC.md
+++ b/goals/law-practice-office-action-extraction-rung/SPEC.md
@@ -14,6 +14,12 @@ epistemic public surface, and projected into the same trivial answer as the
 rung-0 spike. Tests also prove at least one non-happy-path extraction/alignment
 case does not silently become an admitted unsupported claim.
 
+Operational end state: the implementation is completed on a feature branch and
+published with Yeet into a mergeable PR. "Mergeable" means hosted checks are
+green, `yeet closeout` reports no unresolved actionable review comments or bot
+blockers, and GitHub reports the branch as mergeable/not conflicted. Do not
+auto-merge without explicit user approval.
+
 ## Non-Goals
 
 - No real client matter, private corpus fixture, or privileged document.
@@ -24,6 +30,19 @@ case does not silently become an admitted unsupported claim.
   stable; multi-reference 103 plus 101/112 can begin only after P1 is green.
 - No direct imports from epistemic internals; compose only public surfaces.
 - No rework of `@beep/file-processing` P1 unless a narrow blocker is proven.
+
+## Branch And PR Contract
+
+- If the `/goal` launcher starts on `main` or another protected/default branch,
+  fetch `origin/main`, confirm the base is fresh, and create a feature branch
+  before editing.
+- Use Yeet for the end-to-end path: local proof with
+  `bun run beep yeet verify`, publish with
+  `bun run beep yeet publish --pr --monitor --message "feat(law-practice): service-backed office action extraction"`,
+  then monitor and close out hosted checks/review feedback.
+- Use follow-up Yeet publishes for failed checks or actionable PR nits. The goal
+  is not closed merely because local tests pass; it closes only when the PR is
+  ready to merge.
 
 ## Source Hierarchy
 
@@ -90,6 +109,9 @@ Higher sources outrank lower sources when they conflict.
       handling are either implemented after service extraction is green or
       recorded as the next packet phase with no overclaim.
 - [ ] No real client fixtures or provider secrets are introduced.
+- [ ] The branch is published through Yeet as a PR and brought to mergeable
+      state: hosted checks green, closeout clean, and no unresolved actionable
+      review comments.
 - [ ] No unrelated refactors or formatting churn.
 
 ## Verification Matrix
@@ -103,6 +125,8 @@ Higher sources outrank lower sources when they conflict.
 | Focused tests | `bun test packages/law-practice/server/test/LawPracticeServer.test.ts` | Happy and non-happy paths covered |
 | Authoritative typecheck | `bun run check` | Green or unrelated failures classified |
 | Final quality | `bun run beep yeet verify` | Green or no new failures classified |
+| PR publish | `bun run beep yeet publish --pr --monitor --message "feat(law-practice): service-backed office action extraction"` | PR exists for the feature branch |
+| Hosted closeout | `bun run beep yeet monitor --summary` and `bun run beep yeet closeout --summary --require-greptile-score 5/5 --require-greptile-issues 0 --require-review-comments 0` | Checks green; no actionable review/bot blockers |
 
 Packet reference search:
 

--- a/goals/law-practice-office-action-extraction-rung/history/reflections/2026-06-18-codex.md
+++ b/goals/law-practice-office-action-extraction-rung/history/reflections/2026-06-18-codex.md
@@ -1,0 +1,92 @@
+---
+goal: law-practice-office-action-extraction-rung
+agent: codex
+date: 2026-06-18
+trigger: closeout
+confidence: high
+findings:
+  - category: tooling-friction
+    confidence: high
+    instruction: Keep root `bun run check` in the loop for schema-aware test diagnostics, even after package-local checks pass.
+    explanation: Package-local law-practice checks and focused tests passed, but root `bun run check` caught `effect(instanceOfSchema)` in the server test and required replacing `instanceof` with `S.is(IrToLawExtractionError)`.
+  - category: implementation-improvement
+    confidence: medium
+    instruction: Promote the office-action extraction target vocabulary to a small exported schema when a second law extraction workflow appears.
+    explanation: This packet keeps labels file-local because only `OfficeActionReview` consumes them, but the request builder now makes the label set explicit enough to promote without changing the service contract.
+  - category: goal-critique
+    confidence: medium
+    instruction: State whether packet docs should be updated before or after Yeet hosted closeout when PR mergeability is part of "done".
+    explanation: The packet requires reflection and manifest evidence before closeout, while the goal also requires hosted PR closeout; this creates a natural two-step evidence update.
+todos:
+  - Consider a tiny test helper for fake `LanguageModel.LanguageModel` layers so deterministic LangExtract tests do not repeat overloaded service casts.
+  - Add a packet convention for "local implementation complete, hosted PR pending" status when Yeet mergeability is part of the goal.
+---
+
+# Reflection - law-practice-office-action-extraction-rung (2026-06-18, codex)
+
+## Summary
+
+This rung replaced the production office-action review loop's fixed extraction
+candidates with a provider-neutral `LangExtractService.extract` call and kept
+`GroundedExtraction[]` as the path into `IrToLaw`. The local implementation is
+green through focused tests and root `bun run check`; hosted Yeet publish and
+closeout remain the final completion proof.
+
+## Tooling experience
+
+- **Worked:** The packet's source hierarchy made the intended boundary clear:
+  law domain stayed clean, use-cases owned contracts and mapping, and server
+  owned live Layer wiring. Focused `bun test
+  packages/law-practice/server/test/LawPracticeServer.test.ts` caught behavior
+  regressions quickly, while root `bun run check` caught Effect-specific test
+  law after package checks passed.
+- **Didn't:** There was no ready fake `LanguageModel.LanguageModel` helper in
+  the law-practice test surface, so the deterministic LangExtract proof had to
+  mirror the overload-cast pattern from the langextract package test.
+- **Frustrating:** The first root check failed only in the global test-tsgo lane
+  for schema-aware `instanceof`; the package-local server check did not cover
+  that Effect diagnostic.
+- **Wished existed:** A Yeet/packet status helper that can mark phases as
+  "local proof green, hosted PR pending" without hand-editing manifest prose.
+
+## Implementation improvement opportunities
+
+- The office-action extraction target list is explicit and schema-backed, but
+  file-local. Promote it to an exported law extraction vocabulary if another
+  office-action, docket, or trademark workflow needs the same labels.
+- `IrToLaw` now rejects missing labels and unaligned distinctions. A future rung
+  should make each required label's error expectation table-driven as doctrine
+  breadth grows beyond one 102 rejection.
+- The fake model output lives in the server test as compact JSON strings. A
+  reusable fixture builder would make malformed-output and missing-label cases
+  easier to add without native JSON helpers.
+
+## Goal & prompt critique
+
+I would revise the closeout wording to say:
+
+- "Before Yeet publish, update packet evidence to local implementation complete
+  and P3 in progress. After hosted closeout is clean, update the packet to
+  complete."
+
+That would remove the ambiguity between reflection-before-publish and
+mergeable-PR-as-done.
+
+## TODOs worth codifying
+
+- Add a shared deterministic fake language model layer helper for packages that
+  test `@beep/langextract/Service`.
+- Add a packet-status phrase and manifest convention for local-green but
+  hosted-PR-pending work.
+
+## Lessons (confidence-tiered)
+
+- **HIGH - Critical:** Use schema-aware guards for schema-backed errors in
+  tests - root `bun run check` enforces `S.is(...)` where `instanceof` looks
+  locally plausible.
+- **MEDIUM - Best practice:** Keep fixed spike candidates on the package test
+  surface only - production no longer imports them, but they still provide a
+  compact deterministic mapping fixture.
+- **LOW - Consideration:** Promote extraction label schemas only when reuse
+  appears - this packet needed explicit labels, not a broader abstraction yet.
+

--- a/goals/law-practice-office-action-extraction-rung/ops/manifest.json
+++ b/goals/law-practice-office-action-extraction-rung/ops/manifest.json
@@ -3,13 +3,13 @@
   "initiative": {
     "id": "law-practice-office-action-extraction-rung",
     "title": "Law-Practice Office-Action Extraction Rung",
-    "status": "active",
+    "status": "complete",
     "created": "2026-06-18",
     "updated": "2026-06-18",
     "packetAnchorDocument": "SPEC.md"
   },
   "packetPath": "goals/law-practice-office-action-extraction-rung",
-  "lifecycle": "active",
+  "lifecycle": "complete",
   "executionCapable": true,
   "reflectionRequired": true,
   "relatedPackets": {
@@ -65,7 +65,7 @@
     {
       "id": "P3",
       "name": "Verify and close",
-      "status": "in-progress"
+      "status": "complete"
     }
   ],
   "targetPackages": [

--- a/goals/law-practice-office-action-extraction-rung/ops/manifest.json
+++ b/goals/law-practice-office-action-extraction-rung/ops/manifest.json
@@ -50,22 +50,22 @@
     {
       "id": "P0",
       "name": "Scope and contracts",
-      "status": "pending"
+      "status": "complete"
     },
     {
       "id": "P1",
       "name": "Service-backed extraction",
-      "status": "pending"
+      "status": "complete"
     },
     {
       "id": "P2",
       "name": "Non-happy paths and breadth gate",
-      "status": "pending"
+      "status": "complete"
     },
     {
       "id": "P3",
       "name": "Verify and close",
-      "status": "pending"
+      "status": "in-progress"
     }
   ],
   "targetPackages": [
@@ -82,9 +82,17 @@
     "@beep/epistemic-server/layer"
   ],
   "knownGaps": [
-    "OfficeActionReview currently uses OfficeActionReviewSpikeCandidates as the stand-in for LLM extraction.",
-    "Non-happy-path extraction/alignment behavior is not yet covered.",
-    "Multi-reference 103 plus 101/112 doctrine breadth remains deferred until service-backed extraction is green."
+    "Multi-reference 103 plus 101/112 doctrine breadth remains deferred to the next rung after service-backed extraction."
+  ],
+  "closeoutGates": [
+    "Execution starts from a feature branch when launched from main or another protected/default branch.",
+    "Full local proof runs through bun run beep yeet verify.",
+    "Implementation is published with bun run beep yeet publish --pr --monitor.",
+    "Hosted checks are green before closeout.",
+    "PR has no unresolved actionable review comments.",
+    "Greptile score is 5/5 and issue count is 0 when required.",
+    "GitHub reports the branch as mergeable/not conflicted.",
+    "Do not auto-merge without explicit user approval."
   ],
   "verificationCommands": [
     "test \"$(wc -m < goals/law-practice-office-action-extraction-rung/GOAL.md)\" -le 4000",
@@ -93,7 +101,10 @@
     "git diff --check -- goals/law-practice-office-action-extraction-rung",
     "bun run check",
     "bun run beep lint reflection-artifacts",
-    "bun run beep yeet verify"
+    "bun run beep yeet verify",
+    "bun run beep yeet publish --pr --monitor --message \"feat(law-practice): service-backed office action extraction\"",
+    "bun run beep yeet monitor --summary",
+    "bun run beep yeet closeout --summary --require-greptile-score 5/5 --require-greptile-issues 0 --require-review-comments 0"
   ],
   "stopConditions": [
     "Required source files are missing or materially contradictory.",

--- a/packages/law-practice/server/README.md
+++ b/packages/law-practice/server/README.md
@@ -4,8 +4,9 @@ Server tier for the law-practice slice: the live `Layer` surface that wires the
 slice's use-case ports to real implementations.
 
 - `@beep/law-practice-server/layer` — `LawPracticeServerLive`, composing the
-  `IrToLaw` mapping and the `OfficeActionReview` loop over the epistemic server
-  (`ClaimGate` + `ClaimTransition`, themselves over the bounded SHACL engine).
+  `IrToLaw` mapping, provider-neutral `@beep/langextract` extraction, and the
+  `OfficeActionReview` loop over the epistemic server (`ClaimGate` +
+  `ClaimTransition`, themselves over the bounded SHACL engine).
 
 The review loop depends on the epistemic admission services, so this tier
 provides `EpistemicServerLive` at the merge boundary. The cross-slice
@@ -13,7 +14,6 @@ provides `EpistemicServerLive` at the merge boundary. The cross-slice
 the spike SPEC Exception Ledger + `DECISIONS.md`); the law-practice DOMAIN tier
 stays clean.
 
-This is a spike: source ingestion (`@beep/file-processing` +
-`@beep/langextract` model-driven extraction) is stubbed by a fixed candidate set
-inside the `OfficeActionReview` implementation, and entity id/audit fields come
-from a spike shim rather than a real id generator / `Clock` / request context.
+The review loop now invokes the provider-neutral LangExtract service; tests keep
+deterministic fake model output. Entity id/audit fields still come from a spike
+shim rather than a real id generator / `Clock` / request context.

--- a/packages/law-practice/server/README.md
+++ b/packages/law-practice/server/README.md
@@ -8,6 +8,10 @@ slice's use-case ports to real implementations.
   `OfficeActionReview` loop over the epistemic server (`ClaimGate` +
   `ClaimTransition`, themselves over the bounded SHACL engine).
 
+`LawPracticeServerLive` requires the host application to provide a
+`LanguageModel.LanguageModel` layer for `@beep/langextract`; model selection and
+credentials stay at the application merge boundary.
+
 The review loop depends on the epistemic admission services, so this tier
 provides `EpistemicServerLive` at the merge boundary. The cross-slice
 `@beep/epistemic-*` dependency is the slice's documented bounded exception (per

--- a/packages/law-practice/server/docgen.json
+++ b/packages/law-practice/server/docgen.json
@@ -88,6 +88,27 @@
       "@beep/file-processing/test": [
         "../../../packages/foundation/capability/file-processing/src/test.ts"
       ],
+      "@beep/langextract": [
+        "../../../packages/foundation/capability/langextract/src/index.ts"
+      ],
+      "@beep/langextract/*": [
+        "../../../packages/foundation/capability/langextract/src/*.ts"
+      ],
+      "@beep/langextract/Alignment": [
+        "../../../packages/foundation/capability/langextract/src/Alignment/index.ts"
+      ],
+      "@beep/langextract/Extraction": [
+        "../../../packages/foundation/capability/langextract/src/Extraction/index.ts"
+      ],
+      "@beep/langextract/Handoff": [
+        "../../../packages/foundation/capability/langextract/src/Handoff/index.ts"
+      ],
+      "@beep/langextract/Service": [
+        "../../../packages/foundation/capability/langextract/src/Service/index.ts"
+      ],
+      "@beep/langextract/Target": [
+        "../../../packages/foundation/capability/langextract/src/Target/index.ts"
+      ],
       "@beep/law-practice-domain": [
         "../../../packages/law-practice/domain/src/index.ts"
       ],

--- a/packages/law-practice/server/package.json
+++ b/packages/law-practice/server/package.json
@@ -45,6 +45,7 @@
     "@beep/epistemic-server": "workspace:^",
     "@beep/epistemic-use-cases": "workspace:^",
     "@beep/file-processing": "workspace:^",
+    "@beep/langextract": "workspace:^",
     "@beep/law-practice-domain": "workspace:^",
     "@beep/law-practice-use-cases": "workspace:^",
     "@beep/tika": "workspace:^",

--- a/packages/law-practice/server/src/Layer.ts
+++ b/packages/law-practice/server/src/Layer.ts
@@ -22,6 +22,7 @@ import { IrToLaw, makeIrToLaw } from "@beep/law-practice-use-cases/IrToLaw";
 import { makeOfficeActionReview, OfficeActionReview } from "@beep/law-practice-use-cases/OfficeActionReview";
 import { TikaFileProcessingEngine } from "@beep/tika";
 import { Effect, Layer } from "effect";
+import type * as LanguageModel from "effect/unstable/ai/LanguageModel";
 
 const IrToLawLayer = Layer.succeed(IrToLaw, IrToLaw.of(makeIrToLaw()));
 const FileProcessingLayer = makeFileProcessingServiceLayer([TikaFileProcessingEngine]);
@@ -43,6 +44,10 @@ const OfficeActionReviewLayer = Layer.effect(
  * office-action review loop over provider-neutral extraction and the epistemic
  * admission services.
  *
+ * Hosts must merge in a `LanguageModel.LanguageModel` provider; this layer keeps
+ * model selection outside law-practice while `LangExtractLayer` consumes that
+ * provider to perform structured extraction.
+ *
  * @example
  * ```ts
  * import { LawPracticeServerLive } from "@beep/law-practice-server/layer"
@@ -53,14 +58,15 @@ const OfficeActionReviewLayer = Layer.effect(
  * @category layers
  * @since 0.0.0
  */
-export const LawPracticeServerLive = OfficeActionReviewLayer.pipe(
-  // `provideMerge` satisfies the loop's `IrToLaw` dependency while keeping
-  // `IrToLaw` in the output surface (a sibling `mergeAll` would race the
-  // provider against the consumer); the file-processing capability supplies
-  // extracted source text, LangExtract supplies grounded source spans, and the
-  // epistemic server supplies the gate + transition the loop also requires.
-  Layer.provideMerge(IrToLawLayer),
-  Layer.provide(FileProcessingLayer),
-  Layer.provide(LangExtractLayer),
-  Layer.provide(EpistemicServerLive)
-);
+export const LawPracticeServerLive: Layer.Layer<OfficeActionReview | IrToLaw, never, LanguageModel.LanguageModel> =
+  OfficeActionReviewLayer.pipe(
+    // `provideMerge` satisfies the loop's `IrToLaw` dependency while keeping
+    // `IrToLaw` in the output surface (a sibling `mergeAll` would race the
+    // provider against the consumer); the file-processing capability supplies
+    // extracted source text, LangExtract supplies grounded source spans, and the
+    // epistemic server supplies the gate + transition the loop also requires.
+    Layer.provideMerge(IrToLawLayer),
+    Layer.provide(FileProcessingLayer),
+    Layer.provide(LangExtractLayer),
+    Layer.provide(EpistemicServerLive)
+  );

--- a/packages/law-practice/server/src/Layer.ts
+++ b/packages/law-practice/server/src/Layer.ts
@@ -3,10 +3,10 @@
  *
  * Composes the slice's live service surface: the `IrToLaw` mapping (pure, no
  * dependencies), the file-processing capability backed by the P1 Tika engine,
- * and the `OfficeActionReview` loop (which resolves `IrToLaw`, file
- * processing, plus the epistemic `ClaimGate` and `ClaimTransition`). The
- * epistemic server surface is provided once at the merge boundary so the
- * bounded SHACL engine is built a single time.
+ * the provider-neutral LangExtract service, and the `OfficeActionReview` loop
+ * (which resolves `IrToLaw`, file processing, LangExtract, plus the epistemic
+ * `ClaimGate` and `ClaimTransition`). The epistemic server surface is provided
+ * once at the merge boundary so the bounded SHACL engine is built a single time.
  *
  * @packageDocumentation
  * @category layers
@@ -17,6 +17,7 @@ import { EpistemicServerLive } from "@beep/epistemic-server/layer";
 import { ClaimGate } from "@beep/epistemic-use-cases/ClaimGate";
 import { ClaimTransition } from "@beep/epistemic-use-cases/ClaimLifecycle";
 import { FileProcessingService, makeFileProcessingServiceLayer } from "@beep/file-processing/Service";
+import { layer as LangExtractLayer, LangExtractService } from "@beep/langextract/Service";
 import { IrToLaw, makeIrToLaw } from "@beep/law-practice-use-cases/IrToLaw";
 import { makeOfficeActionReview, OfficeActionReview } from "@beep/law-practice-use-cases/OfficeActionReview";
 import { TikaFileProcessingEngine } from "@beep/tika";
@@ -30,15 +31,17 @@ const OfficeActionReviewLayer = Layer.effect(
   Effect.gen(function* () {
     const fileProcessing = yield* FileProcessingService;
     const irToLaw = yield* IrToLaw;
+    const langExtract = yield* LangExtractService;
     const gate = yield* ClaimGate;
     const transition = yield* ClaimTransition;
-    return OfficeActionReview.of(makeOfficeActionReview({ fileProcessing, gate, irToLaw, transition }));
+    return OfficeActionReview.of(makeOfficeActionReview({ fileProcessing, gate, irToLaw, langExtract, transition }));
   })
 );
 
 /**
  * Live law-practice server layer providing the IR-to-law mapping and the
- * office-action review loop over the epistemic admission services.
+ * office-action review loop over provider-neutral extraction and the epistemic
+ * admission services.
  *
  * @example
  * ```ts
@@ -54,9 +57,10 @@ export const LawPracticeServerLive = OfficeActionReviewLayer.pipe(
   // `provideMerge` satisfies the loop's `IrToLaw` dependency while keeping
   // `IrToLaw` in the output surface (a sibling `mergeAll` would race the
   // provider against the consumer); the file-processing capability supplies
-  // extracted source text, and the epistemic server supplies the gate +
-  // transition the loop also requires.
+  // extracted source text, LangExtract supplies grounded source spans, and the
+  // epistemic server supplies the gate + transition the loop also requires.
   Layer.provideMerge(IrToLawLayer),
   Layer.provide(FileProcessingLayer),
+  Layer.provide(LangExtractLayer),
   Layer.provide(EpistemicServerLive)
 );

--- a/packages/law-practice/server/test/LawPracticeServer.test.ts
+++ b/packages/law-practice/server/test/LawPracticeServer.test.ts
@@ -1,9 +1,11 @@
-import { alignCandidates } from "@beep/langextract/Alignment";
+import { LangExtractRequest } from "@beep/langextract/Extraction";
+import { layer as LangExtractLayer, LangExtractService } from "@beep/langextract/Service";
+import { ExtractionTarget } from "@beep/langextract/Target";
 import { Distinction } from "@beep/law-practice-domain";
 import { LawPracticeServerLive } from "@beep/law-practice-server/layer";
 import { IrToLaw, IrToLawExtractionError } from "@beep/law-practice-use-cases/IrToLaw";
 import { OfficeActionReview } from "@beep/law-practice-use-cases/OfficeActionReview";
-import { OfficeActionReviewSpikeCandidates } from "@beep/law-practice-use-cases/test";
+import { DocumentId } from "@beep/nlp/Core";
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, Layer, Stream } from "effect";
 import * as S from "effect/Schema";
@@ -19,6 +21,38 @@ const OFFICE_ACTION_MODEL_OUTPUT = `{"extractions":[{"label":"office_action","te
 
 const UNALIGNED_DISTINCTION_MODEL_OUTPUT = `{"extractions":[{"label":"office_action","text":"Office Action"},{"label":"claim","text":"A widget comprising a lid and a base."},{"label":"rejection_reference","text":"Smith"},{"label":"distinction","text":"an impossible limitation"}]}`;
 
+const MISSING_DISTINCTION_MODEL_OUTPUT = `{"extractions":[{"label":"office_action","text":"Office Action"},{"label":"claim","text":"A widget comprising a lid and a base."},{"label":"rejection_reference","text":"Smith"}]}`;
+
+const extractionTargets: LangExtractRequest["targets"] = [
+  ExtractionTarget.make({
+    description: "The office-action document identifier or heading.",
+    kind: "entity",
+    name: "office_action",
+  }),
+  ExtractionTarget.make({
+    description: "The rejected claim text.",
+    kind: "entity",
+    name: "claim",
+  }),
+  ExtractionTarget.make({
+    description: "The prior-art reference cited by the rejection.",
+    kind: "entity",
+    name: "rejection_reference",
+  }),
+  ExtractionTarget.make({
+    description: "Applicant distinction text copied from the office-action response material.",
+    kind: "custom",
+    name: "distinction",
+  }),
+];
+
+const makeExtractionRequest = (): LangExtractRequest =>
+  LangExtractRequest.make({
+    documentId: DocumentId.make("office-action-review-test"),
+    targets: extractionTargets,
+    text: OFFICE_ACTION_FIXTURE,
+  });
+
 const makeLanguageModelLayer = (text: string): Layer.Layer<LanguageModel.LanguageModel> =>
   Layer.succeed(LanguageModel.LanguageModel, {
     generateObject: () => Effect.die("generateObject is not used by law-practice tests") as never,
@@ -27,7 +61,7 @@ const makeLanguageModelLayer = (text: string): Layer.Layer<LanguageModel.Languag
   } as LanguageModel.Service);
 
 const makeLawPracticeServerTestLayer = (modelOutput: string) =>
-  LawPracticeServerLive.pipe(Layer.provide(makeLanguageModelLayer(modelOutput)));
+  Layer.mergeAll(LawPracticeServerLive, LangExtractLayer).pipe(Layer.provide(makeLanguageModelLayer(modelOutput)));
 
 describe("@beep/law-practice-server", () => {
   it.layer(makeLawPracticeServerTestLayer(OFFICE_ACTION_MODEL_OUTPUT))(
@@ -35,8 +69,10 @@ describe("@beep/law-practice-server", () => {
     (it) => {
       it.effect("IrToLaw grounds exactly one distinction to its source anchor", () =>
         Effect.gen(function* () {
+          const langExtract = yield* LangExtractService;
           const irToLaw = yield* IrToLaw;
-          const extractions = alignCandidates(OFFICE_ACTION_FIXTURE, OfficeActionReviewSpikeCandidates);
+          const extractionResult = yield* langExtract.extract(makeExtractionRequest());
+          const extractions = extractionResult.extractions;
 
           // The distinction candidate is lower case vs the Title-Case source, so
           // alignment MUST take the case-insensitive `match_lesser` path (not a
@@ -80,6 +116,26 @@ describe("@beep/law-practice-server", () => {
           expect(view.counts.candidate).toBe(0);
           expect(view.counts.admitted).toBe(0);
           expect([...view.admittedKeys]).toEqual([]);
+        })
+      );
+    }
+  );
+
+  it.layer(makeLawPracticeServerTestLayer(MISSING_DISTINCTION_MODEL_OUTPUT))(
+    "office-action review loop with missing extraction output",
+    (it) => {
+      it.effect("review rejects a missing required distinction label before admission", () =>
+        Effect.gen(function* () {
+          const review = yield* OfficeActionReview;
+          const input = yield* makeOfficeActionReviewInput();
+
+          const error = yield* review.review(input).pipe(Effect.flip);
+
+          expect(S.is(IrToLawExtractionError)(error)).toBe(true);
+          if (S.is(IrToLawExtractionError)(error)) {
+            expect(error.reason).toBe("required-extraction-missing");
+            expect(error.label).toBe("distinction");
+          }
         })
       );
     }

--- a/packages/law-practice/server/test/LawPracticeServer.test.ts
+++ b/packages/law-practice/server/test/LawPracticeServer.test.ts
@@ -39,23 +39,22 @@ const makeLanguageModelLayer = (text: string): Layer.Layer<LanguageModel.Languag
 const makeLawPracticeServerTestLayer = (modelOutput: string) =>
   Layer.mergeAll(LawPracticeServerLive, LangExtractLayer).pipe(Layer.provide(makeLanguageModelLayer(modelOutput)));
 
-const expectReviewExtractionError = (
+const expectReviewExtractionError = Effect.fn("law_practice.server.test.expect_review_extraction_error")(function* (
   reason: IrToLawExtractionError["reason"],
   assert?: (error: IrToLawExtractionError) => void
-) =>
-  Effect.gen(function* () {
-    const review = yield* OfficeActionReview;
-    const input = yield* makeOfficeActionReviewInput();
+) {
+  const review = yield* OfficeActionReview;
+  const input = yield* makeOfficeActionReviewInput();
 
-    const error = yield* review.review(input).pipe(Effect.flip);
+  const error = yield* review.review(input).pipe(Effect.flip);
 
-    expect(S.is(IrToLawExtractionError)(error)).toBe(true);
-    if (S.is(IrToLawExtractionError)(error)) {
-      expect(error.reason).toBe(reason);
-      expect(error.label).toBe("distinction");
-      assert?.(error);
-    }
-  });
+  expect(S.is(IrToLawExtractionError)(error)).toBe(true);
+  if (S.is(IrToLawExtractionError)(error)) {
+    expect(error.reason).toBe(reason);
+    expect(error.label).toBe("distinction");
+    assert?.(error);
+  }
+});
 
 describe("@beep/law-practice-server", () => {
   it.layer(makeLawPracticeServerTestLayer(OFFICE_ACTION_MODEL_OUTPUT))(

--- a/packages/law-practice/server/test/LawPracticeServer.test.ts
+++ b/packages/law-practice/server/test/LawPracticeServer.test.ts
@@ -1,10 +1,9 @@
 import { LangExtractRequest } from "@beep/langextract/Extraction";
 import { layer as LangExtractLayer, LangExtractService } from "@beep/langextract/Service";
-import { ExtractionTarget } from "@beep/langextract/Target";
 import { Distinction } from "@beep/law-practice-domain";
 import { LawPracticeServerLive } from "@beep/law-practice-server/layer";
 import { IrToLaw, IrToLawExtractionError } from "@beep/law-practice-use-cases/IrToLaw";
-import { OfficeActionReview } from "@beep/law-practice-use-cases/OfficeActionReview";
+import { OfficeActionReview, officeActionExtractionTargets } from "@beep/law-practice-use-cases/OfficeActionReview";
 import { DocumentId } from "@beep/nlp/Core";
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, Layer, Stream } from "effect";
@@ -23,33 +22,10 @@ const UNALIGNED_DISTINCTION_MODEL_OUTPUT = `{"extractions":[{"label":"office_act
 
 const MISSING_DISTINCTION_MODEL_OUTPUT = `{"extractions":[{"label":"office_action","text":"Office Action"},{"label":"claim","text":"A widget comprising a lid and a base."},{"label":"rejection_reference","text":"Smith"}]}`;
 
-const extractionTargets: LangExtractRequest["targets"] = [
-  ExtractionTarget.make({
-    description: "The office-action document identifier or heading.",
-    kind: "entity",
-    name: "office_action",
-  }),
-  ExtractionTarget.make({
-    description: "The rejected claim text.",
-    kind: "entity",
-    name: "claim",
-  }),
-  ExtractionTarget.make({
-    description: "The prior-art reference cited by the rejection.",
-    kind: "entity",
-    name: "rejection_reference",
-  }),
-  ExtractionTarget.make({
-    description: "Applicant distinction text copied from the office-action response material.",
-    kind: "custom",
-    name: "distinction",
-  }),
-];
-
 const makeExtractionRequest = (): LangExtractRequest =>
   LangExtractRequest.make({
     documentId: DocumentId.make("office-action-review-test"),
-    targets: extractionTargets,
+    targets: officeActionExtractionTargets,
     text: OFFICE_ACTION_FIXTURE,
   });
 
@@ -62,6 +38,24 @@ const makeLanguageModelLayer = (text: string): Layer.Layer<LanguageModel.Languag
 
 const makeLawPracticeServerTestLayer = (modelOutput: string) =>
   Layer.mergeAll(LawPracticeServerLive, LangExtractLayer).pipe(Layer.provide(makeLanguageModelLayer(modelOutput)));
+
+const expectReviewExtractionError = (
+  reason: IrToLawExtractionError["reason"],
+  assert?: (error: IrToLawExtractionError) => void
+) =>
+  Effect.gen(function* () {
+    const review = yield* OfficeActionReview;
+    const input = yield* makeOfficeActionReviewInput();
+
+    const error = yield* review.review(input).pipe(Effect.flip);
+
+    expect(S.is(IrToLawExtractionError)(error)).toBe(true);
+    if (S.is(IrToLawExtractionError)(error)) {
+      expect(error.reason).toBe(reason);
+      expect(error.label).toBe("distinction");
+      assert?.(error);
+    }
+  });
 
 describe("@beep/law-practice-server", () => {
   it.layer(makeLawPracticeServerTestLayer(OFFICE_ACTION_MODEL_OUTPUT))(
@@ -125,18 +119,7 @@ describe("@beep/law-practice-server", () => {
     "office-action review loop with missing extraction output",
     (it) => {
       it.effect("review rejects a missing required distinction label before admission", () =>
-        Effect.gen(function* () {
-          const review = yield* OfficeActionReview;
-          const input = yield* makeOfficeActionReviewInput();
-
-          const error = yield* review.review(input).pipe(Effect.flip);
-
-          expect(S.is(IrToLawExtractionError)(error)).toBe(true);
-          if (S.is(IrToLawExtractionError)(error)) {
-            expect(error.reason).toBe("required-extraction-missing");
-            expect(error.label).toBe("distinction");
-          }
-        })
+        expectReviewExtractionError("required-extraction-missing")
       );
     }
   );
@@ -145,18 +128,8 @@ describe("@beep/law-practice-server", () => {
     "office-action review loop with unaligned extraction output",
     (it) => {
       it.effect("review rejects unaligned distinction text before admission", () =>
-        Effect.gen(function* () {
-          const review = yield* OfficeActionReview;
-          const input = yield* makeOfficeActionReviewInput();
-
-          const error = yield* review.review(input).pipe(Effect.flip);
-
-          expect(S.is(IrToLawExtractionError)(error)).toBe(true);
-          if (S.is(IrToLawExtractionError)(error)) {
-            expect(error.reason).toBe("required-extraction-unaligned");
-            expect(error.label).toBe("distinction");
-            expect(error.alignmentStatus).toBe("unaligned");
-          }
+        expectReviewExtractionError("required-extraction-unaligned", (error) => {
+          expect(error.alignmentStatus).toBe("unaligned");
         })
       );
     }

--- a/packages/law-practice/server/test/LawPracticeServer.test.ts
+++ b/packages/law-practice/server/test/LawPracticeServer.test.ts
@@ -1,11 +1,13 @@
 import { alignCandidates } from "@beep/langextract/Alignment";
 import { Distinction } from "@beep/law-practice-domain";
 import { LawPracticeServerLive } from "@beep/law-practice-server/layer";
-import { IrToLaw } from "@beep/law-practice-use-cases/IrToLaw";
+import { IrToLaw, IrToLawExtractionError } from "@beep/law-practice-use-cases/IrToLaw";
 import { OfficeActionReview } from "@beep/law-practice-use-cases/OfficeActionReview";
 import { OfficeActionReviewSpikeCandidates } from "@beep/law-practice-use-cases/test";
 import { describe, expect, it } from "@effect/vitest";
-import { Effect } from "effect";
+import { Effect, Layer, Stream } from "effect";
+import * as S from "effect/Schema";
+import * as LanguageModel from "effect/unstable/ai/LanguageModel";
 import {
   EXPECTED_DISTINCTION_LIMITATION,
   EXPECTED_DISTINCTION_QUOTE,
@@ -13,56 +15,94 @@ import {
   OFFICE_ACTION_FIXTURE,
 } from "./fixture.ts";
 
+const OFFICE_ACTION_MODEL_OUTPUT = `{"extractions":[{"label":"office_action","text":"Office Action"},{"label":"claim","text":"A widget comprising a lid and a base."},{"label":"rejection_reference","text":"Smith"},{"label":"distinction","text":"a hinge coupling the lid to the base"}]}`;
+
+const UNALIGNED_DISTINCTION_MODEL_OUTPUT = `{"extractions":[{"label":"office_action","text":"Office Action"},{"label":"claim","text":"A widget comprising a lid and a base."},{"label":"rejection_reference","text":"Smith"},{"label":"distinction","text":"an impossible limitation"}]}`;
+
+const makeLanguageModelLayer = (text: string): Layer.Layer<LanguageModel.LanguageModel> =>
+  Layer.succeed(LanguageModel.LanguageModel, {
+    generateObject: () => Effect.die("generateObject is not used by law-practice tests") as never,
+    generateText: () => Effect.succeed({ text }) as never,
+    streamText: () => Stream.empty as never,
+  } as LanguageModel.Service);
+
+const makeLawPracticeServerTestLayer = (modelOutput: string) =>
+  LawPracticeServerLive.pipe(Layer.provide(makeLanguageModelLayer(modelOutput)));
+
 describe("@beep/law-practice-server", () => {
-  it.layer(LawPracticeServerLive)("office-action review loop over the epistemic server", (it) => {
-    it.effect("IrToLaw grounds exactly one distinction to its source anchor", () =>
-      Effect.gen(function* () {
-        const irToLaw = yield* IrToLaw;
-        const extractions = alignCandidates(OFFICE_ACTION_FIXTURE, OfficeActionReviewSpikeCandidates);
+  it.layer(makeLawPracticeServerTestLayer(OFFICE_ACTION_MODEL_OUTPUT))(
+    "office-action review loop over service-backed extraction",
+    (it) => {
+      it.effect("IrToLaw grounds exactly one distinction to its source anchor", () =>
+        Effect.gen(function* () {
+          const irToLaw = yield* IrToLaw;
+          const extractions = alignCandidates(OFFICE_ACTION_FIXTURE, OfficeActionReviewSpikeCandidates);
 
-        // The distinction candidate is lower case vs the Title-Case source, so
-        // alignment MUST take the case-insensitive `match_lesser` path (not a
-        // trivial `match_exact`). This is what makes the re-slice below a real
-        // grounding proof, and it rules out the fabricated span-undefined anchor
-        // fallback in IrToLaw (which would yield `unaligned`/no span).
-        const distinctionExtraction = extractions.find((e) => e.label === "distinction");
-        expect(distinctionExtraction?.alignmentStatus).toBe("match_lesser");
+          // The distinction candidate is lower case vs the Title-Case source, so
+          // alignment MUST take the case-insensitive `match_lesser` path (not a
+          // trivial `match_exact`). This is what makes the re-slice below a real
+          // grounding proof, and it rules out the fabricated span-undefined anchor
+          // fallback in IrToLaw (which would yield `unaligned`/no span).
+          const distinctionExtraction = extractions.find((e) => e.label === "distinction");
+          expect(distinctionExtraction?.alignmentStatus).toBe("match_lesser");
 
-        const law = yield* irToLaw.toLaw(extractions);
+          const law = yield* irToLaw.toLaw(extractions);
 
-        // (a) exactly one Distinction, well-formed.
-        expect(law.distinction).toBeInstanceOf(Distinction);
-        expect(law.distinction.detail.kind).toBe("missing_limitation");
+          // (a) exactly one Distinction, well-formed.
+          expect(law.distinction).toBeInstanceOf(Distinction);
+          expect(law.distinction.detail.kind).toBe("missing_limitation");
 
-        // (b) the anchor re-slices the source to its own quote, and that quote is
-        // the original-case substring recovered via the case-insensitive match.
-        const { endChar, quote, startChar } = law.distinction.anchor;
-        expect(OFFICE_ACTION_FIXTURE.slice(startChar, endChar)).toBe(quote);
-        expect(quote).toBe(EXPECTED_DISTINCTION_QUOTE);
+          // (b) the anchor re-slices the source to its own quote, and that quote is
+          // the original-case substring recovered via the case-insensitive match.
+          const { endChar, quote, startChar } = law.distinction.anchor;
+          expect(OFFICE_ACTION_FIXTURE.slice(startChar, endChar)).toBe(quote);
+          expect(quote).toBe(EXPECTED_DISTINCTION_QUOTE);
 
-        // (d) the distinction's answer: missing limitation + recovered anchor quote.
-        if (law.distinction.detail.kind === "missing_limitation") {
-          expect(law.distinction.detail.limitation).toBe(EXPECTED_DISTINCTION_LIMITATION);
-        }
-      })
-    );
+          // (d) the distinction's answer: missing limitation + recovered anchor quote.
+          if (law.distinction.detail.kind === "missing_limitation") {
+            expect(law.distinction.detail.limitation).toBe(EXPECTED_DISTINCTION_LIMITATION);
+          }
+        })
+      );
 
-    it.effect("review admits the claim, advancing it to shape_valid", () =>
-      Effect.gen(function* () {
-        const review = yield* OfficeActionReview;
-        const input = yield* makeOfficeActionReviewInput();
+      it.effect("review admits the claim, advancing it to shape_valid", () =>
+        Effect.gen(function* () {
+          const review = yield* OfficeActionReview;
+          const input = yield* makeOfficeActionReviewInput();
 
-        const view = yield* review.review(input);
+          const view = yield* review.review(input);
 
-        // (c) gate admits -> transition advances candidate -> shape_valid. The
-        // claim ends at "shape_valid" (NOT lifecycle "admitted"), so admittedKeys
-        // is empty — per SPEC "gate admits, lifecycle reaches shape_valid".
-        expect(view.total).toBe(1);
-        expect(view.counts.shape_valid).toBe(1);
-        expect(view.counts.candidate).toBe(0);
-        expect(view.counts.admitted).toBe(0);
-        expect([...view.admittedKeys]).toEqual([]);
-      })
-    );
-  });
+          // (c) gate admits -> transition advances candidate -> shape_valid. The
+          // claim ends at "shape_valid" (NOT lifecycle "admitted"), so admittedKeys
+          // is empty — per SPEC "gate admits, lifecycle reaches shape_valid".
+          expect(view.total).toBe(1);
+          expect(view.counts.shape_valid).toBe(1);
+          expect(view.counts.candidate).toBe(0);
+          expect(view.counts.admitted).toBe(0);
+          expect([...view.admittedKeys]).toEqual([]);
+        })
+      );
+    }
+  );
+
+  it.layer(makeLawPracticeServerTestLayer(UNALIGNED_DISTINCTION_MODEL_OUTPUT))(
+    "office-action review loop with unaligned extraction output",
+    (it) => {
+      it.effect("review rejects unaligned distinction text before admission", () =>
+        Effect.gen(function* () {
+          const review = yield* OfficeActionReview;
+          const input = yield* makeOfficeActionReviewInput();
+
+          const error = yield* review.review(input).pipe(Effect.flip);
+
+          expect(S.is(IrToLawExtractionError)(error)).toBe(true);
+          if (S.is(IrToLawExtractionError)(error)) {
+            expect(error.reason).toBe("required-extraction-unaligned");
+            expect(error.label).toBe("distinction");
+            expect(error.alignmentStatus).toBe("unaligned");
+          }
+        })
+      );
+    }
+  );
 });

--- a/packages/law-practice/server/tsconfig.json
+++ b/packages/law-practice/server/tsconfig.json
@@ -21,6 +21,9 @@
       "path": "../../foundation/capability/file-processing/tsconfig.json"
     },
     {
+      "path": "../../foundation/capability/langextract/tsconfig.json"
+    },
+    {
       "path": "../domain/tsconfig.json"
     },
     {

--- a/packages/law-practice/use-cases/docgen.json
+++ b/packages/law-practice/use-cases/docgen.json
@@ -190,6 +190,385 @@
       "@beep/law-practice-domain/entities/Rejection": [
         "../../../packages/law-practice/domain/src/entities/Rejection/index.ts"
       ],
+      "@beep/nlp": ["../../../packages/foundation/capability/nlp/src/index.ts"],
+      "@beep/nlp/Algebra": [
+        "../../../packages/foundation/capability/nlp/src/Algebra/index.ts"
+      ],
+      "@beep/nlp/Backend": [
+        "../../../packages/foundation/capability/nlp/src/Backend/index.ts"
+      ],
+      "@beep/nlp/Core": [
+        "../../../packages/foundation/capability/nlp/src/Core/index.ts"
+      ],
+      "@beep/nlp/Graph": [
+        "../../../packages/foundation/capability/nlp/src/Graph/index.ts"
+      ],
+      "@beep/nlp/Graph/GraphOperations": [
+        "../../../packages/foundation/capability/nlp/src/Graph/GraphOperations/index.ts"
+      ],
+      "@beep/nlp/Handoff": [
+        "../../../packages/foundation/capability/nlp/src/Handoff/index.ts"
+      ],
+      "@beep/nlp/IdentifierText": [
+        "../../../packages/foundation/capability/nlp/src/IdentifierText.ts"
+      ],
+      "@beep/nlp/NLPService": [
+        "../../../packages/foundation/capability/nlp/src/NLPService.ts"
+      ],
+      "@beep/nlp/Ontology": [
+        "../../../packages/foundation/capability/nlp/src/Ontology/index.ts"
+      ],
+      "@beep/nlp/Operations": [
+        "../../../packages/foundation/capability/nlp/src/Operations/index.ts"
+      ],
+      "@beep/nlp/PathText": [
+        "../../../packages/foundation/capability/nlp/src/PathText.ts"
+      ],
+      "@beep/nlp/QueryText": [
+        "../../../packages/foundation/capability/nlp/src/QueryText.ts"
+      ],
+      "@beep/nlp/Tools": [
+        "../../../packages/foundation/capability/nlp/src/Tools/index.ts"
+      ],
+      "@beep/nlp/VariantText": [
+        "../../../packages/foundation/capability/nlp/src/VariantText.ts"
+      ],
+      "@beep/schema": [
+        "../../../packages/foundation/modeling/schema/src/index.ts"
+      ],
+      "@beep/schema/AbortSignal": [
+        "../../../packages/foundation/modeling/schema/src/AbortSignal.ts"
+      ],
+      "@beep/schema/Age": [
+        "../../../packages/foundation/modeling/schema/src/Age/index.ts"
+      ],
+      "@beep/schema/ArrayOf": [
+        "../../../packages/foundation/modeling/schema/src/ArrayOf.ts"
+      ],
+      "@beep/schema/BigDecimal": [
+        "../../../packages/foundation/modeling/schema/src/BigDecimal.ts"
+      ],
+      "@beep/schema/BinaryFileExtension": [
+        "../../../packages/foundation/modeling/schema/src/BinaryFileExtension.ts"
+      ],
+      "@beep/schema/BufferEncoding": [
+        "../../../packages/foundation/modeling/schema/src/BufferEncoding.ts"
+      ],
+      "@beep/schema/CardinalDirection": [
+        "../../../packages/foundation/modeling/schema/src/CardinalDirection/index.ts"
+      ],
+      "@beep/schema/CauseTaggedError": [
+        "../../../packages/foundation/modeling/schema/src/CauseTaggedError/index.ts"
+      ],
+      "@beep/schema/Color": [
+        "../../../packages/foundation/modeling/schema/src/Color/index.ts"
+      ],
+      "@beep/schema/CommonTextSchemas": [
+        "../../../packages/foundation/modeling/schema/src/CommonTextSchemas.ts"
+      ],
+      "@beep/schema/CrossOriginEmbedderPolicy": [
+        "../../../packages/foundation/modeling/schema/src/CrossOriginEmbedderPolicy/index.ts"
+      ],
+      "@beep/schema/CrossOriginOpenerPolicy": [
+        "../../../packages/foundation/modeling/schema/src/CrossOriginOpenerPolicy/index.ts"
+      ],
+      "@beep/schema/CrossOriginResourcePolicy": [
+        "../../../packages/foundation/modeling/schema/src/CrossOriginResourcePolicy/index.ts"
+      ],
+      "@beep/schema/CryptoTxnHash": [
+        "../../../packages/foundation/modeling/schema/src/CryptoTxnHash/index.ts"
+      ],
+      "@beep/schema/CryptoWalletAddress": [
+        "../../../packages/foundation/modeling/schema/src/CryptoWalletAddress/index.ts"
+      ],
+      "@beep/schema/Csp": [
+        "../../../packages/foundation/modeling/schema/src/Csp/index.ts"
+      ],
+      "@beep/schema/Csv": [
+        "../../../packages/foundation/modeling/schema/src/Csv/index.ts"
+      ],
+      "@beep/schema/CsvCodecOptions": [
+        "../../../packages/foundation/modeling/schema/src/CsvCodecOptions/index.ts"
+      ],
+      "@beep/schema/CsvError": [
+        "../../../packages/foundation/modeling/schema/src/CsvError/index.ts"
+      ],
+      "@beep/schema/CsvFormatter": [
+        "../../../packages/foundation/modeling/schema/src/CsvFormatter/index.ts"
+      ],
+      "@beep/schema/CsvParser": [
+        "../../../packages/foundation/modeling/schema/src/CsvParser/index.ts"
+      ],
+      "@beep/schema/Cuid": [
+        "../../../packages/foundation/modeling/schema/src/Cuid.ts"
+      ],
+      "@beep/schema/CurrencyCode": [
+        "../../../packages/foundation/modeling/schema/src/CurrencyCode.ts"
+      ],
+      "@beep/schema/DateTimeUtcFromValid": [
+        "../../../packages/foundation/modeling/schema/src/DateTimeUtcFromValid/index.ts"
+      ],
+      "@beep/schema/DomCssProperties": [
+        "../../../packages/foundation/modeling/schema/src/DomCssProperties/index.ts"
+      ],
+      "@beep/schema/DomDragEvent": [
+        "../../../packages/foundation/modeling/schema/src/DomDragEvent/index.ts"
+      ],
+      "@beep/schema/DomEvent": [
+        "../../../packages/foundation/modeling/schema/src/DomEvent/index.ts"
+      ],
+      "@beep/schema/DomHtmlElement": [
+        "../../../packages/foundation/modeling/schema/src/DomHtmlElement/index.ts"
+      ],
+      "@beep/schema/DomMouseEvent": [
+        "../../../packages/foundation/modeling/schema/src/DomMouseEvent/index.ts"
+      ],
+      "@beep/schema/DomReactNode": [
+        "../../../packages/foundation/modeling/schema/src/DomReactNode/index.ts"
+      ],
+      "@beep/schema/DomainModel": [
+        "../../../packages/foundation/modeling/schema/src/DomainModel.ts"
+      ],
+      "@beep/schema/Duration": [
+        "../../../packages/foundation/modeling/schema/src/Duration/index.ts"
+      ],
+      "@beep/schema/EffectSchema": [
+        "../../../packages/foundation/modeling/schema/src/EffectSchema.ts"
+      ],
+      "@beep/schema/Email": [
+        "../../../packages/foundation/modeling/schema/src/Email.ts"
+      ],
+      "@beep/schema/EntitySchema": [
+        "../../../packages/foundation/modeling/schema/src/EntitySchema/index.ts"
+      ],
+      "@beep/schema/EthAmount": [
+        "../../../packages/foundation/modeling/schema/src/EthAmount/index.ts"
+      ],
+      "@beep/schema/EthereumValidatorPublicKey": [
+        "../../../packages/foundation/modeling/schema/src/EthereumValidatorPublicKey/index.ts"
+      ],
+      "@beep/schema/EvmAddress": [
+        "../../../packages/foundation/modeling/schema/src/EvmAddress/index.ts"
+      ],
+      "@beep/schema/ExpectCt": [
+        "../../../packages/foundation/modeling/schema/src/ExpectCt/index.ts"
+      ],
+      "@beep/schema/FileExtension": [
+        "../../../packages/foundation/modeling/schema/src/FileExtension.ts"
+      ],
+      "@beep/schema/FileName": [
+        "../../../packages/foundation/modeling/schema/src/FileName.ts"
+      ],
+      "@beep/schema/FilePath": [
+        "../../../packages/foundation/modeling/schema/src/FilePath/index.ts"
+      ],
+      "@beep/schema/Float16Array": [
+        "../../../packages/foundation/modeling/schema/src/Float16Array.ts"
+      ],
+      "@beep/schema/Float32Array": [
+        "../../../packages/foundation/modeling/schema/src/Float32Array.ts"
+      ],
+      "@beep/schema/Float64Array": [
+        "../../../packages/foundation/modeling/schema/src/Float64Array.ts"
+      ],
+      "@beep/schema/Fn": [
+        "../../../packages/foundation/modeling/schema/src/Fn/index.ts"
+      ],
+      "@beep/schema/ForceHttpsRedirect": [
+        "../../../packages/foundation/modeling/schema/src/ForceHttpsRedirect/index.ts"
+      ],
+      "@beep/schema/FrameGuard": [
+        "../../../packages/foundation/modeling/schema/src/FrameGuard/index.ts"
+      ],
+      "@beep/schema/Glob": [
+        "../../../packages/foundation/modeling/schema/src/Glob/index.ts"
+      ],
+      "@beep/schema/Graph": [
+        "../../../packages/foundation/modeling/schema/src/Graph/index.ts"
+      ],
+      "@beep/schema/Html": [
+        "../../../packages/foundation/modeling/schema/src/Html.ts"
+      ],
+      "@beep/schema/HttpHeaders": [
+        "../../../packages/foundation/modeling/schema/src/HttpHeaders/index.ts"
+      ],
+      "@beep/schema/HttpMethod": [
+        "../../../packages/foundation/modeling/schema/src/HttpMethod/index.ts"
+      ],
+      "@beep/schema/HttpProtocol": [
+        "../../../packages/foundation/modeling/schema/src/HttpProtocol/index.ts"
+      ],
+      "@beep/schema/HttpStatus": [
+        "../../../packages/foundation/modeling/schema/src/HttpStatus/index.ts"
+      ],
+      "@beep/schema/Int": [
+        "../../../packages/foundation/modeling/schema/src/Int.ts"
+      ],
+      "@beep/schema/Json": [
+        "../../../packages/foundation/modeling/schema/src/Json.ts"
+      ],
+      "@beep/schema/Jsonc": [
+        "../../../packages/foundation/modeling/schema/src/Jsonc.ts"
+      ],
+      "@beep/schema/Jsonl": [
+        "../../../packages/foundation/modeling/schema/src/Jsonl.ts"
+      ],
+      "@beep/schema/KebabStr": [
+        "../../../packages/foundation/modeling/schema/src/KebabStr.ts"
+      ],
+      "@beep/schema/LiteralKit": [
+        "../../../packages/foundation/modeling/schema/src/LiteralKit/index.ts"
+      ],
+      "@beep/schema/LocalDate": [
+        "../../../packages/foundation/modeling/schema/src/LocalDate/index.ts"
+      ],
+      "@beep/schema/Logs": [
+        "../../../packages/foundation/modeling/schema/src/Logs.ts"
+      ],
+      "@beep/schema/MappedLiteralKit": [
+        "../../../packages/foundation/modeling/schema/src/MappedLiteralKit/index.ts"
+      ],
+      "@beep/schema/Markdown": [
+        "../../../packages/foundation/modeling/schema/src/Markdown.ts"
+      ],
+      "@beep/schema/MimeType": [
+        "../../../packages/foundation/modeling/schema/src/MimeType.ts"
+      ],
+      "@beep/schema/Model": [
+        "../../../packages/foundation/modeling/schema/src/Model/index.ts"
+      ],
+      "@beep/schema/MutableHashMap": [
+        "../../../packages/foundation/modeling/schema/src/MutableHashMap.ts"
+      ],
+      "@beep/schema/MutableHashSet": [
+        "../../../packages/foundation/modeling/schema/src/MutableHashSet.ts"
+      ],
+      "@beep/schema/NoOpen": [
+        "../../../packages/foundation/modeling/schema/src/NoOpen/index.ts"
+      ],
+      "@beep/schema/NoSniff": [
+        "../../../packages/foundation/modeling/schema/src/NoSniff/index.ts"
+      ],
+      "@beep/schema/Number": [
+        "../../../packages/foundation/modeling/schema/src/Number.ts"
+      ],
+      "@beep/schema/Options": [
+        "../../../packages/foundation/modeling/schema/src/Options.ts"
+      ],
+      "@beep/schema/ParserOptions": [
+        "../../../packages/foundation/modeling/schema/src/ParserOptions/index.ts"
+      ],
+      "@beep/schema/PascalStr": [
+        "../../../packages/foundation/modeling/schema/src/PascalStr.ts"
+      ],
+      "@beep/schema/Percentage": [
+        "../../../packages/foundation/modeling/schema/src/Percentage.ts"
+      ],
+      "@beep/schema/PermissionsPolicy": [
+        "../../../packages/foundation/modeling/schema/src/PermissionsPolicy/index.ts"
+      ],
+      "@beep/schema/PermittedCrossDomainPolicies": [
+        "../../../packages/foundation/modeling/schema/src/PermittedCrossDomainPolicies/index.ts"
+      ],
+      "@beep/schema/PosixPath": [
+        "../../../packages/foundation/modeling/schema/src/PosixPath.ts"
+      ],
+      "@beep/schema/Primitive": [
+        "../../../packages/foundation/modeling/schema/src/Primitive.ts"
+      ],
+      "@beep/schema/PromiseSchema": [
+        "../../../packages/foundation/modeling/schema/src/PromiseSchema.ts"
+      ],
+      "@beep/schema/Record": [
+        "../../../packages/foundation/modeling/schema/src/Record/index.ts"
+      ],
+      "@beep/schema/ReferrerPolicy": [
+        "../../../packages/foundation/modeling/schema/src/ReferrerPolicy/index.ts"
+      ],
+      "@beep/schema/RegExp": [
+        "../../../packages/foundation/modeling/schema/src/RegExp.ts"
+      ],
+      "@beep/schema/SchemaUtils": [
+        "../../../packages/foundation/modeling/schema/src/SchemaUtils/index.ts"
+      ],
+      "@beep/schema/SecureHeader": [
+        "../../../packages/foundation/modeling/schema/src/SecureHeader/index.ts"
+      ],
+      "@beep/schema/SecureHeaderError": [
+        "../../../packages/foundation/modeling/schema/src/SecureHeaderError/index.ts"
+      ],
+      "@beep/schema/SecureHeaderOptions": [
+        "../../../packages/foundation/modeling/schema/src/SecureHeaderOptions/index.ts"
+      ],
+      "@beep/schema/SemanticVersion": [
+        "../../../packages/foundation/modeling/schema/src/SemanticVersion.ts"
+      ],
+      "@beep/schema/SeverityLevel": [
+        "../../../packages/foundation/modeling/schema/src/SeverityLevel.ts"
+      ],
+      "@beep/schema/Sex": [
+        "../../../packages/foundation/modeling/schema/src/Sex/index.ts"
+      ],
+      "@beep/schema/Sha256": [
+        "../../../packages/foundation/modeling/schema/src/Sha256.ts"
+      ],
+      "@beep/schema/Slug": [
+        "../../../packages/foundation/modeling/schema/src/Slug.ts"
+      ],
+      "@beep/schema/SnakeStr": [
+        "../../../packages/foundation/modeling/schema/src/SnakeStr.ts"
+      ],
+      "@beep/schema/StatusCauseError": [
+        "../../../packages/foundation/modeling/schema/src/StatusCauseError.ts"
+      ],
+      "@beep/schema/StatusCauseTaggedErrorClass": [
+        "../../../packages/foundation/modeling/schema/src/StatusCauseTaggedErrorClass/index.ts"
+      ],
+      "@beep/schema/String": [
+        "../../../packages/foundation/modeling/schema/src/String.ts"
+      ],
+      "@beep/schema/TaggedErrorClass": [
+        "../../../packages/foundation/modeling/schema/src/TaggedErrorClass/index.ts"
+      ],
+      "@beep/schema/Thunk": [
+        "../../../packages/foundation/modeling/schema/src/Thunk.ts"
+      ],
+      "@beep/schema/Timestamp": [
+        "../../../packages/foundation/modeling/schema/src/Timestamp/index.ts"
+      ],
+      "@beep/schema/Timezone": [
+        "../../../packages/foundation/modeling/schema/src/Timezone.ts"
+      ],
+      "@beep/schema/Toml": [
+        "../../../packages/foundation/modeling/schema/src/Toml.ts"
+      ],
+      "@beep/schema/Transformations": [
+        "../../../packages/foundation/modeling/schema/src/Transformations.ts"
+      ],
+      "@beep/schema/URL": [
+        "../../../packages/foundation/modeling/schema/src/URL.ts"
+      ],
+      "@beep/schema/UnitInterval": [
+        "../../../packages/foundation/modeling/schema/src/UnitInterval.ts"
+      ],
+      "@beep/schema/VariantSchema": [
+        "../../../packages/foundation/modeling/schema/src/VariantSchema/index.ts"
+      ],
+      "@beep/schema/Xml": [
+        "../../../packages/foundation/modeling/schema/src/Xml.ts"
+      ],
+      "@beep/schema/XssProtection": [
+        "../../../packages/foundation/modeling/schema/src/XssProtection/index.ts"
+      ],
+      "@beep/schema/Yaml": [
+        "../../../packages/foundation/modeling/schema/src/Yaml.ts"
+      ],
+      "@beep/schema/test/Markdown": [
+        "../../../packages/foundation/modeling/schema/src/internal/test/Markdown.test-kit.ts"
+      ],
+      "@beep/schema/test/Yaml": [
+        "../../../packages/foundation/modeling/schema/src/internal/test/Yaml.test-kit.ts"
+      ],
       "@beep/test-utils": [
         "../../../packages/tooling/test-kit/test-utils/src/index.ts"
       ],

--- a/packages/law-practice/use-cases/package.json
+++ b/packages/law-practice/use-cases/package.json
@@ -52,6 +52,8 @@
     "@beep/identity": "workspace:^",
     "@beep/langextract": "workspace:^",
     "@beep/law-practice-domain": "workspace:^",
+    "@beep/nlp": "workspace:^",
+    "@beep/schema": "workspace:^",
     "effect": "catalog:"
   },
   "devDependencies": {

--- a/packages/law-practice/use-cases/src/IrToLaw/IrToLaw.errors.ts
+++ b/packages/law-practice/use-cases/src/IrToLaw/IrToLaw.errors.ts
@@ -1,0 +1,89 @@
+/**
+ * IR-to-law extraction failures.
+ *
+ * @packageDocumentation
+ * @category errors
+ * @since 0.0.0
+ */
+
+import { $LawPracticeUseCasesId } from "@beep/identity/packages";
+import { LiteralKit, TaggedErrorClass } from "@beep/schema";
+import * as S from "effect/Schema";
+
+const $I = $LawPracticeUseCasesId.create("IrToLaw/IrToLaw.errors");
+
+/**
+ * Machine-readable reasons for rejecting span-bearing extraction output before
+ * it becomes law-practice entities.
+ *
+ * @example
+ * ```ts
+ * import { IrToLawExtractionErrorReason } from "@beep/law-practice-use-cases/IrToLaw"
+ *
+ * console.log(IrToLawExtractionErrorReason.is["required-extraction-missing"]("required-extraction-missing"))
+ * ```
+ *
+ * @category errors
+ * @since 0.0.0
+ */
+export const IrToLawExtractionErrorReason = LiteralKit([
+  "required-extraction-missing",
+  "required-extraction-unaligned",
+]).pipe(
+  $I.annoteSchema("IrToLawExtractionErrorReason", {
+    description: "Reasons the law-practice IR mapper rejects extraction output.",
+  })
+);
+
+/**
+ * Type for {@link IrToLawExtractionErrorReason}.
+ *
+ * @category errors
+ * @since 0.0.0
+ */
+export type IrToLawExtractionErrorReason = typeof IrToLawExtractionErrorReason.Type;
+
+/**
+ * Failure raised when required office-action extraction output is missing or
+ * lacks a source-grounded span needed for legal evidence.
+ *
+ * @example
+ * ```ts
+ * import { IrToLawExtractionError } from "@beep/law-practice-use-cases/IrToLaw"
+ *
+ * console.log(IrToLawExtractionError.fromReason("required-extraction-missing", {
+ *   label: "distinction",
+ *   message: "Missing distinction extraction."
+ * }))
+ * ```
+ *
+ * @category errors
+ * @since 0.0.0
+ */
+export class IrToLawExtractionError extends TaggedErrorClass<IrToLawExtractionError>($I`IrToLawExtractionError`)(
+  "IrToLawExtractionError",
+  {
+    alignmentStatus: S.optionalKey(S.String),
+    label: S.NonEmptyString,
+    message: S.String,
+    reason: IrToLawExtractionErrorReason,
+  },
+  $I.annote("IrToLawExtractionError", {
+    description: "Sanitized failure emitted when office-action extraction output cannot be grounded.",
+  })
+) {
+  /**
+   * Create a sanitized IR-to-law extraction error.
+   *
+   * @category constructors
+   * @since 0.0.0
+   */
+  static readonly fromReason = (
+    reason: IrToLawExtractionErrorReason,
+    options: {
+      readonly alignmentStatus?: string;
+      readonly label: string;
+      readonly message: string;
+    }
+  ): IrToLawExtractionError => IrToLawExtractionError.make({ reason, ...options });
+}

--- a/packages/law-practice/use-cases/src/IrToLaw/IrToLaw.ports.ts
+++ b/packages/law-practice/use-cases/src/IrToLaw/IrToLaw.ports.ts
@@ -20,6 +20,7 @@ import { Context } from "effect";
 import type { GroundedExtraction } from "@beep/langextract/Extraction";
 import type { Claim, Distinction, OfficeAction, PriorArtReference, Rejection } from "@beep/law-practice-domain";
 import type { Effect } from "effect";
+import type { IrToLawExtractionError } from "./IrToLaw.errors.js";
 
 const $I = $LawPracticeUseCasesId.create("IrToLaw/IrToLaw.ports");
 
@@ -65,7 +66,9 @@ export interface LawEntities {
  * @since 0.0.0
  */
 export interface IrToLawShape {
-  readonly toLaw: (extractions: ReadonlyArray<GroundedExtraction>) => Effect.Effect<LawEntities>;
+  readonly toLaw: (
+    extractions: ReadonlyArray<GroundedExtraction>
+  ) => Effect.Effect<LawEntities, IrToLawExtractionError>;
 }
 
 /**

--- a/packages/law-practice/use-cases/src/IrToLaw/IrToLaw.service.ts
+++ b/packages/law-practice/use-cases/src/IrToLaw/IrToLaw.service.ts
@@ -10,8 +10,8 @@
  *
  * Entities are decoded through their schemas with a spike audit envelope (see
  * {@link spikeEntityInput}) — a spike affordance, not the production id/audit
- * path. The mapping is pure and total over the fixed label vocabulary, so it is
- * built synchronously and lifted with `Effect.succeed`.
+ * path. The mapping is effectful and fails typed when required extraction labels
+ * are missing, empty, or unaligned before any law entity is decoded.
  *
  * @packageDocumentation
  * @since 0.0.0
@@ -44,6 +44,12 @@ const missingExtraction = (label: string): IrToLawExtractionError =>
     message: `Office-action extraction output is missing required label "${label}".`,
   });
 
+const emptyExtraction = (extraction: GroundedExtraction): IrToLawExtractionError =>
+  IrToLawExtractionError.fromReason("required-extraction-missing", {
+    label: extraction.label,
+    message: `Office-action extraction label "${extraction.label}" is empty.`,
+  });
+
 const unalignedExtraction = (extraction: GroundedExtraction): IrToLawExtractionError =>
   IrToLawExtractionError.fromReason("required-extraction-unaligned", {
     alignmentStatus: extraction.alignmentStatus,
@@ -55,13 +61,22 @@ const requiredExtraction = Effect.fn("law_practice.ir_to_law.required_extraction
   extractions: ReadonlyArray<GroundedExtraction>,
   label: string
 ): Effect.fn.Return<GroundedExtraction, IrToLawExtractionError> {
-  return yield* pipe(
+  const extraction = yield* pipe(
     A.findFirst(extractions, (extraction) => extraction.label === label),
     O.match({
       onNone: () => Effect.fail(missingExtraction(label)),
       onSome: Effect.succeed,
     })
   );
+
+  if (extraction.text.trim().length === 0) {
+    return yield* emptyExtraction(extraction);
+  }
+  if (extraction.alignmentStatus === "unaligned") {
+    return yield* unalignedExtraction(extraction);
+  }
+
+  return extraction;
 });
 
 const textOf = Effect.fn("law_practice.ir_to_law.text_of")(function* (

--- a/packages/law-practice/use-cases/src/IrToLaw/IrToLaw.service.ts
+++ b/packages/law-practice/use-cases/src/IrToLaw/IrToLaw.service.ts
@@ -18,11 +18,12 @@
  */
 
 import { Claim, Distinction, OfficeAction, PriorArtReference, Rejection } from "@beep/law-practice-domain";
-import { Effect } from "effect";
+import { Effect, pipe } from "effect";
 import * as A from "effect/Array";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
 import { spikeEntityInput } from "../internal/spikeEntity.js";
+import { IrToLawExtractionError } from "./IrToLaw.errors.js";
 import type { GroundedExtraction } from "@beep/langextract/Extraction";
 import type { IrToLawShape, LawEntities } from "./IrToLaw.ports.js";
 
@@ -37,26 +38,67 @@ const decodePriorArtReference = S.decodeUnknownSync(PriorArtReference);
 const decodeRejection = S.decodeUnknownSync(Rejection);
 const decodeDistinction = S.decodeUnknownSync(Distinction);
 
-const textOf = (extractions: ReadonlyArray<GroundedExtraction>, label: string, fallback: string): string =>
-  O.match(
+const missingExtraction = (label: string): IrToLawExtractionError =>
+  IrToLawExtractionError.fromReason("required-extraction-missing", {
+    label,
+    message: `Office-action extraction output is missing required label "${label}".`,
+  });
+
+const unalignedExtraction = (extraction: GroundedExtraction): IrToLawExtractionError =>
+  IrToLawExtractionError.fromReason("required-extraction-unaligned", {
+    alignmentStatus: extraction.alignmentStatus,
+    label: extraction.label,
+    message: `Office-action extraction label "${extraction.label}" is not source-grounded.`,
+  });
+
+const requiredExtraction = Effect.fn("law_practice.ir_to_law.required_extraction")(function* (
+  extractions: ReadonlyArray<GroundedExtraction>,
+  label: string
+): Effect.fn.Return<GroundedExtraction, IrToLawExtractionError> {
+  return yield* pipe(
     A.findFirst(extractions, (extraction) => extraction.label === label),
-    {
-      onNone: () => fallback,
-      onSome: (found) => found.text,
-    }
+    O.match({
+      onNone: () => Effect.fail(missingExtraction(label)),
+      onSome: Effect.succeed,
+    })
+  );
+});
+
+const textOf = Effect.fn("law_practice.ir_to_law.text_of")(function* (
+  extractions: ReadonlyArray<GroundedExtraction>,
+  label: string
+): Effect.fn.Return<string, IrToLawExtractionError> {
+  const extraction = yield* requiredExtraction(extractions, label);
+  return extraction.text;
+});
+
+const anchorOf = Effect.fn("law_practice.ir_to_law.anchor_of")(function* (
+  extractions: ReadonlyArray<GroundedExtraction>,
+  label: string
+): Effect.fn.Return<
+  { readonly endChar: number; readonly quote: string; readonly startChar: number },
+  IrToLawExtractionError
+> {
+  const extraction = yield* requiredExtraction(extractions, label);
+
+  if (extraction.alignmentStatus === "unaligned") {
+    return yield* unalignedExtraction(extraction);
+  }
+
+  const span = yield* pipe(
+    O.fromUndefinedOr(extraction.span),
+    O.match({
+      onNone: () => Effect.fail(unalignedExtraction(extraction)),
+      onSome: Effect.succeed,
+    })
+  );
+  const quote = pipe(
+    O.fromUndefinedOr(extraction.matchedText),
+    O.getOrElse(() => extraction.text)
   );
 
-const anchorOf = (extractions: ReadonlyArray<GroundedExtraction>, label: string, fallback: string) =>
-  O.match(
-    A.findFirst(extractions, (extraction) => extraction.label === label),
-    {
-      onNone: () => ({ endChar: fallback.length, quote: fallback, startChar: 0 }),
-      onSome: (found) =>
-        found.span === undefined
-          ? { endChar: (found.matchedText ?? found.text).length, quote: found.matchedText ?? found.text, startChar: 0 }
-          : { endChar: found.span.end, quote: found.matchedText ?? found.text, startChar: found.span.start },
-    }
-  );
+  return { endChar: span.end, quote, startChar: span.start };
+});
 
 const officeActionFixtureKey = "office-action.spike";
 const patentAssetFixtureKey = "patent-asset.spike";
@@ -65,8 +107,14 @@ const referenceFixtureKey = "prior-art.spike";
 const rejectionFixtureKey = "rejection.spike";
 const distinctionFixtureKey = "distinction.spike";
 
-const buildLawEntities = (extractions: ReadonlyArray<GroundedExtraction>): LawEntities => {
-  const distinctionText = textOf(extractions, "distinction", "the distinguishing limitation");
+const buildLawEntities = Effect.fn("law_practice.ir_to_law.build_entities")(function* (
+  extractions: ReadonlyArray<GroundedExtraction>
+): Effect.fn.Return<LawEntities, IrToLawExtractionError> {
+  const officeActionText = yield* textOf(extractions, "office_action");
+  const claimText = yield* textOf(extractions, "claim");
+  const referenceText = yield* textOf(extractions, "rejection_reference");
+  const distinctionText = yield* textOf(extractions, "distinction");
+  const distinctionAnchor = yield* anchorOf(extractions, "distinction");
 
   return {
     claim: decodeClaim({
@@ -75,11 +123,11 @@ const buildLawEntities = (extractions: ReadonlyArray<GroundedExtraction>): LawEn
       fixtureKey: claimFixtureKey,
       independent: true,
       patentAssetFixtureKey,
-      text: textOf(extractions, "claim", "A claim."),
+      text: claimText,
     }),
     distinction: decodeDistinction({
       ...spikeEntityInput("LawPracticeDistinction", 5),
-      anchor: anchorOf(extractions, "distinction", distinctionText),
+      anchor: distinctionAnchor,
       claimFixtureKey,
       detail: { kind: "missing_limitation", limitation: distinctionText },
       fixtureKey: distinctionFixtureKey,
@@ -88,7 +136,7 @@ const buildLawEntities = (extractions: ReadonlyArray<GroundedExtraction>): LawEn
     }),
     officeAction: decodeOfficeAction({
       ...spikeEntityInput("LawPracticeOfficeAction", 1),
-      applicationNumber: textOf(extractions, "office_action", "16/000,000"),
+      applicationNumber: officeActionText,
       fixtureKey: officeActionFixtureKey,
       matterFixtureKey: "matter.spike",
       patentAssetFixtureKey,
@@ -98,7 +146,7 @@ const buildLawEntities = (extractions: ReadonlyArray<GroundedExtraction>): LawEn
       documentNumber: "US 0,000,000 B2",
       fixtureKey: referenceFixtureKey,
       officeActionFixtureKey,
-      title: textOf(extractions, "rejection_reference", "Prior Art Reference"),
+      title: referenceText,
     }),
     rejection: decodeRejection({
       ...spikeEntityInput("LawPracticeRejection", 4),
@@ -108,7 +156,7 @@ const buildLawEntities = (extractions: ReadonlyArray<GroundedExtraction>): LawEn
       officeActionFixtureKey,
     }),
   };
-};
+});
 
 /**
  * Build the pure IR-to-law mapping shape.
@@ -124,6 +172,6 @@ const buildLawEntities = (extractions: ReadonlyArray<GroundedExtraction>): LawEn
  * @since 0.0.0
  */
 export const makeIrToLaw = (): IrToLawShape => ({
-  toLaw: (extractions: ReadonlyArray<GroundedExtraction>): Effect.Effect<LawEntities> =>
-    Effect.succeed(buildLawEntities(extractions)),
+  toLaw: (extractions: ReadonlyArray<GroundedExtraction>): Effect.Effect<LawEntities, IrToLawExtractionError> =>
+    buildLawEntities(extractions),
 });

--- a/packages/law-practice/use-cases/src/IrToLaw/index.ts
+++ b/packages/law-practice/use-cases/src/IrToLaw/index.ts
@@ -6,6 +6,20 @@
  */
 
 /**
+ * IR-to-law extraction error exports.
+ *
+ * @example
+ * ```ts
+ * import * as Module from "@beep/law-practice-use-cases/IrToLaw"
+ *
+ * console.log(Module.IrToLawExtractionError)
+ * ```
+ *
+ * @category errors
+ * @since 0.0.0
+ */
+export * from "./IrToLaw.errors.js";
+/**
  * IR-to-law port exports.
  *
  * @example

--- a/packages/law-practice/use-cases/src/OfficeActionReview/OfficeActionReview.candidates.ts
+++ b/packages/law-practice/use-cases/src/OfficeActionReview/OfficeActionReview.candidates.ts
@@ -1,5 +1,5 @@
 /**
- * Fixed office-action extraction candidates used by the spike review loop.
+ * Fixed office-action extraction candidates used by tests for the spike mapping.
  *
  * @packageDocumentation
  * @since 0.0.0
@@ -8,11 +8,11 @@
 import { ExtractionCandidate } from "@beep/langextract/Extraction";
 
 /**
- * Fixed candidate set for the office-action review spike.
+ * Fixed candidate set for the office-action review spike mapping tests.
  *
- * This is the stand-in for the deferred LLM extraction step. It is exported
- * through the package test surface so integration tests can assert grounding
- * against the exact candidates the loop consumes.
+ * This is retained through the package test surface so integration tests can
+ * assert grounding for the same synthetic office-action phrases without
+ * coupling the production loop back to fixed candidates.
  *
  * @example
  * ```ts

--- a/packages/law-practice/use-cases/src/OfficeActionReview/OfficeActionReview.ports.ts
+++ b/packages/law-practice/use-cases/src/OfficeActionReview/OfficeActionReview.ports.ts
@@ -11,11 +11,13 @@
  */
 
 import { OperationId, SourceArtifact } from "@beep/file-processing/Artifact";
+import { FileProcessingOperationError } from "@beep/file-processing/Operation";
 import { $LawPracticeUseCasesId } from "@beep/identity/packages";
+import { LangExtractError } from "@beep/langextract/Extraction";
 import { Context } from "effect";
 import * as S from "effect/Schema";
+import { IrToLawExtractionError } from "../IrToLaw/IrToLaw.errors.js";
 import type { ClaimProjectionView } from "@beep/epistemic-domain/values";
-import type { FileProcessingOperationError } from "@beep/file-processing/Operation";
 import type { Effect } from "effect";
 
 const $I = $LawPracticeUseCasesId.create("OfficeActionReview/OfficeActionReview.ports");
@@ -48,16 +50,46 @@ export class OfficeActionReviewInput extends S.Class<OfficeActionReviewInput>($I
 ) {}
 
 /**
+ * Failure raised by the office-action review loop while extracting source text,
+ * extracting grounded law labels, or mapping those labels into law entities.
+ *
+ * @example
+ * ```ts
+ * import { OfficeActionReviewError } from "@beep/law-practice-use-cases/OfficeActionReview"
+ *
+ * console.log(OfficeActionReviewError)
+ * ```
+ *
+ * @category errors
+ * @since 0.0.0
+ */
+export const OfficeActionReviewError = S.Union([
+  FileProcessingOperationError,
+  LangExtractError,
+  IrToLawExtractionError,
+]).annotate(
+  $I.annote("OfficeActionReviewError", {
+    description: "Failure union for the law-practice office-action review loop.",
+  })
+);
+
+/**
+ * Type for {@link OfficeActionReviewError}.
+ *
+ * @category errors
+ * @since 0.0.0
+ */
+export type OfficeActionReviewError = typeof OfficeActionReviewError.Type;
+
+/**
  * Service shape for the office-action review loop: take an
  * {@link OfficeActionReviewInput} and return the epistemic
  * {@link ClaimProjectionView} folded from the reviewed claims.
  *
- * The eventual P2 live Layer satisfying this contract will depend on
- * `@beep/file-processing` + `@beep/langextract` for source ingestion, the
- * {@link IrToLaw} mapping for IR-to-entity translation, and the epistemic
- * `ClaimGate` / `ClaimLifecycle` services (plus the pure `projectClaims` fold)
- * for admission and projection. None of that orchestration lives in this tier —
- * this is a contract only.
+ * The server Layer satisfying this contract composes `@beep/file-processing`,
+ * `@beep/langextract`, the {@link IrToLaw} mapper, and the epistemic `ClaimGate`
+ * / `ClaimLifecycle` services. The shape stays driver-neutral so tests can
+ * inject deterministic fake extraction output without live provider credentials.
  *
  * @example
  * ```ts
@@ -71,7 +103,7 @@ export class OfficeActionReviewInput extends S.Class<OfficeActionReviewInput>($I
  * @since 0.0.0
  */
 export interface OfficeActionReviewShape {
-  readonly review: (input: OfficeActionReviewInput) => Effect.Effect<ClaimProjectionView, FileProcessingOperationError>;
+  readonly review: (input: OfficeActionReviewInput) => Effect.Effect<ClaimProjectionView, OfficeActionReviewError>;
 }
 
 /**

--- a/packages/law-practice/use-cases/src/OfficeActionReview/OfficeActionReview.service.ts
+++ b/packages/law-practice/use-cases/src/OfficeActionReview/OfficeActionReview.service.ts
@@ -33,7 +33,20 @@ import type { OfficeActionReviewInput, OfficeActionReviewShape } from "./OfficeA
 const decodeCandidateClaim = S.decodeUnknownSync(CandidateClaim);
 const decodeEvidence = S.decodeUnknownSync(Evidence);
 
-const officeActionExtractionTargets: LangExtractRequest["targets"] = [
+/**
+ * Structured extraction targets required by the office-action review workflow.
+ *
+ * @example
+ * ```ts
+ * import { officeActionExtractionTargets } from "@beep/law-practice-use-cases/OfficeActionReview"
+ *
+ * console.log(officeActionExtractionTargets.map((target) => target.name))
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const officeActionExtractionTargets: LangExtractRequest["targets"] = [
   ExtractionTarget.make({
     description: "The office-action document identifier or heading.",
     kind: "entity",

--- a/packages/law-practice/use-cases/src/OfficeActionReview/OfficeActionReview.service.ts
+++ b/packages/law-practice/use-cases/src/OfficeActionReview/OfficeActionReview.service.ts
@@ -109,7 +109,7 @@ const sourceTextFrom = Effect.fn("law_practice.office_action.source_text_from")(
 
 const extractionRequestFrom = (input: OfficeActionReviewInput, sourceText: string): LangExtractRequest =>
   LangExtractRequest.make({
-    documentId: DocumentId.make(input.officeActionFixtureKey),
+    documentId: DocumentId.make(input.operationId),
     targets: officeActionExtractionTargets,
     text: sourceText,
   });

--- a/packages/law-practice/use-cases/src/OfficeActionReview/OfficeActionReview.service.ts
+++ b/packages/law-practice/use-cases/src/OfficeActionReview/OfficeActionReview.service.ts
@@ -2,17 +2,11 @@
  * Office-action review loop implementation.
  *
  * The end-to-end loop for reviewing one office action: extract text through
- * `@beep/file-processing`, build a fixed candidate set (stand-in for LLM
- * extraction), deterministically align those candidates to the extracted text
- * via `@beep/langextract`, map the grounded extractions into law entities
+ * `@beep/file-processing`, invoke `@beep/langextract` for provider-neutral
+ * structured extraction, map the resulting grounded extractions into law entities
  * through {@link IrToLaw}, then run the distinction's claim through the
  * epistemic admission lifecycle (gate to transition) and fold the result into a
  * {@link ClaimProjectionView}.
- *
- * The candidate set is FIXED here as a spike affordance — the LLM-driven
- * extraction step that would emit these candidates from the source text is
- * deferred. Everything downstream of the candidates (alignment, mapping,
- * gating, transition, projection) is the real pipeline.
  *
  * @packageDocumentation
  * @since 0.0.0
@@ -21,21 +15,46 @@
 import { CandidateClaim, Evidence } from "@beep/epistemic-domain";
 import { projectClaims } from "@beep/epistemic-use-cases/ClaimProjection";
 import { FileProcessingOperationError, ProcessFileOperation } from "@beep/file-processing/Operation";
-import { alignCandidates } from "@beep/langextract/Alignment";
+import { LangExtractRequest } from "@beep/langextract/Extraction";
+import { ExtractionTarget } from "@beep/langextract/Target";
+import { DocumentId } from "@beep/nlp/Core";
 import { Effect } from "effect";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
 import { spikeEntityInput } from "../internal/spikeEntity.js";
-import { OfficeActionReviewSpikeCandidates } from "./OfficeActionReview.candidates.js";
 import type { ClaimGateShape } from "@beep/epistemic-use-cases/ClaimGate";
 import type { ClaimTransitionShape } from "@beep/epistemic-use-cases/ClaimLifecycle";
 import type { ProcessFileResult } from "@beep/file-processing/Extraction";
 import type { FileProcessingServiceShape } from "@beep/file-processing/Service";
+import type { LangExtractError, LangExtractResult } from "@beep/langextract/Extraction";
 import type { IrToLawShape, LawEntities } from "../IrToLaw/IrToLaw.ports.js";
-import type { OfficeActionReviewShape } from "./OfficeActionReview.ports.js";
+import type { OfficeActionReviewInput, OfficeActionReviewShape } from "./OfficeActionReview.ports.js";
 
 const decodeCandidateClaim = S.decodeUnknownSync(CandidateClaim);
 const decodeEvidence = S.decodeUnknownSync(Evidence);
+
+const officeActionExtractionTargets: LangExtractRequest["targets"] = [
+  ExtractionTarget.make({
+    description: "The office-action document identifier or heading.",
+    kind: "entity",
+    name: "office_action",
+  }),
+  ExtractionTarget.make({
+    description: "The rejected claim text.",
+    kind: "entity",
+    name: "claim",
+  }),
+  ExtractionTarget.make({
+    description: "The prior-art reference cited by the rejection.",
+    kind: "entity",
+    name: "rejection_reference",
+  }),
+  ExtractionTarget.make({
+    description: "Applicant distinction text copied from the office-action response material.",
+    kind: "custom",
+    name: "distinction",
+  }),
+];
 
 const candidateClaimOf = (law: LawEntities): CandidateClaim =>
   decodeCandidateClaim({
@@ -88,6 +107,13 @@ const sourceTextFrom = Effect.fn("law_practice.office_action.source_text_from")(
   });
 });
 
+const extractionRequestFrom = (input: OfficeActionReviewInput, sourceText: string): LangExtractRequest =>
+  LangExtractRequest.make({
+    documentId: DocumentId.make(input.officeActionFixtureKey),
+    targets: officeActionExtractionTargets,
+    text: sourceText,
+  });
+
 /**
  * Dependencies the office-action review loop composes: file-processing source
  * extraction, the IR-to-law mapping, plus the epistemic claim gate and
@@ -108,6 +134,9 @@ export interface OfficeActionReviewDeps {
   readonly fileProcessing: FileProcessingServiceShape;
   readonly gate: ClaimGateShape;
   readonly irToLaw: IrToLawShape;
+  readonly langExtract: {
+    readonly extract: (request: LangExtractRequest) => Effect.Effect<LangExtractResult, LangExtractError>;
+  };
   readonly transition: ClaimTransitionShape;
 }
 
@@ -136,12 +165,10 @@ export const makeOfficeActionReview = (deps: OfficeActionReviewDeps): OfficeActi
       })
     );
     const sourceText = yield* sourceTextFrom(processed);
-
-    // Deterministically align the fixed candidates against the extracted source text.
-    const extractions = alignCandidates(sourceText, OfficeActionReviewSpikeCandidates);
+    const extractionResult = yield* deps.langExtract.extract(extractionRequestFrom(input, sourceText));
 
     // Map the grounded extractions into law entities.
-    const law = yield* deps.irToLaw.toLaw(extractions);
+    const law = yield* deps.irToLaw.toLaw(extractionResult.extractions);
 
     // Build the epistemic candidate claim + evidence from the distinction.
     const candidate = candidateClaimOf(law);

--- a/packages/law-practice/use-cases/tsconfig.json
+++ b/packages/law-practice/use-cases/tsconfig.json
@@ -21,7 +21,13 @@
       "path": "../../foundation/capability/langextract/tsconfig.json"
     },
     {
+      "path": "../../foundation/capability/nlp/tsconfig.json"
+    },
+    {
       "path": "../../foundation/modeling/identity/tsconfig.json"
+    },
+    {
+      "path": "../../foundation/modeling/schema/tsconfig.json"
     },
     {
       "path": "../domain/tsconfig.json"

--- a/standards/fallow.boundaries.generated.jsonc
+++ b/standards/fallow.boundaries.generated.jsonc
@@ -1216,6 +1216,7 @@
           "@beep/epistemic-server",
           "@beep/epistemic-use-cases",
           "@beep/file-processing",
+          "@beep/langextract",
           "@beep/law-practice-domain",
           "@beep/law-practice-server",
           "@beep/law-practice-use-cases",
@@ -1226,6 +1227,7 @@
           "@beep/epistemic-server",
           "@beep/epistemic-use-cases",
           "@beep/file-processing",
+          "@beep/langextract",
           "@beep/law-practice-domain",
           "@beep/law-practice-server",
           "@beep/law-practice-use-cases",
@@ -1243,6 +1245,8 @@
           "@beep/langextract",
           "@beep/law-practice-domain",
           "@beep/law-practice-use-cases",
+          "@beep/nlp",
+          "@beep/schema",
           "@beep/test-utils"
         ],
         "allowTypeOnly": [
@@ -1253,6 +1257,8 @@
           "@beep/langextract",
           "@beep/law-practice-domain",
           "@beep/law-practice-use-cases",
+          "@beep/nlp",
+          "@beep/schema",
           "@beep/test-utils"
         ]
       },


### PR DESCRIPTION
## feat(law-practice): service-backed office action extraction

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- full:pre-push: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/chore_extraction-rung-yeet-contract-3fb2bbf0adba/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784404865&installation_id=141092090&pr_number=265&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F265&signature=28d276daf5b57ac185e629eab02ef22f4cf53c1eb9daf3953aa58d0af286fc49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Office-action review extraction is now routed through the provider-neutral LangExtract service.
* **Bug Fixes**
  * Missing, empty, or unaligned required extractions now fail with clear typed errors (instead of fallback text).
* **Documentation**
  * Updated the office-action extraction packet lifecycle, Branch/PR contract, and Yeet-based verify/publish/monitor/closeout requirements; refined README/manifest closeout gates.
* **Tests**
  * Expanded deterministic test coverage, including negative cases for missing and unaligned required output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->