### PR TITLE
feat(lint-rules): add @beep/lint-rules GritQL package + advisory Biome effect-smol alignment

### DIFF
--- a/.changeset/dull-experts-march.md
+++ b/.changeset/dull-experts-march.md
@@ -1,0 +1,6 @@
+---
+---
+
+Lint-toolchain-modernization P1: add the private `@beep/lint-rules` GritQL package and
+advisory Biome effect-smol alignment. Internal tooling/config only; no package releases
+required.

--- a/STYLE.md
+++ b/STYLE.md
@@ -1,0 +1,58 @@
+# Code Style — beep vs effect-smol
+
+beep's lint toolchain is aligned to **effect-smol**'s code style where it fits, but beep
+keeps **Biome** as its formatter and primary linter and intentionally diverges in several
+places. This file is the durable record of those decisions (see
+`goals/lint-toolchain-modernization/` for the initiative that produced it). effect-smol's
+own style is enforced by **oxlint + dprint**; beep maps the *intent* of those rules onto
+Biome lint rules + repo-local GritQL rules, not a 1:1 port.
+
+## Formatting (frozen — Biome owns it)
+
+Biome formatting is **not** changed by this initiative. effect-smol uses dprint with
+`semiColons: "asi"` and `trailingCommas: "never"`; beep keeps Biome's
+`semicolons: "always"` and `trailingCommas: "es5"`. Biome cannot replicate dprint's ASI
+exactly, and a whole-repo reformat is out of scope.
+
+| Concern | effect-smol (dprint) intent | beep choice | Status | Rationale |
+| --- | --- | --- | --- | --- |
+| Semicolons | `asi` (omit) | Biome `semicolons: "always"` | kept | Biome can't replicate dprint ASI; avoid whole-repo reformat. |
+| Trailing commas | `never` | Biome `trailingCommas: "es5"` | kept | Same; formatting frozen for this initiative. |
+| Arrow parens | force parens | Biome `arrowParentheses: "always"` (formatter default) | aligned via formatter | Biome's formatter already forces single-param arrow parens, so no separate lint rule is needed. |
+| Quote style / width / indent | double / 120 / 2 | same | aligned | beep already matched these. |
+
+## Lint rules — divergences (intentionally NOT ported / deferred)
+
+| Rule (effect-smol) | Intent | beep choice | Status | Rationale |
+| --- | --- | --- | --- | --- |
+| `consistent-type-imports` (inline) | inline `import type` | Biome `useImportType: "separatedType"` | kept | beep keeps separated type-import statements. |
+| `no-import-from-barrel-package` | forbid barrel/root package imports | not ported | skipped | `CLAUDE.md` deliberately allows root `effect` imports for core combinators; `laws effect-imports` already owns beep's import discipline (with `--write` remediation). |
+| `no-js-extension-imports` | mandate `.ts` extension in relative imports | not ported | skipped | beep's `tsconfig.base.json` uses `module/moduleResolution: NodeNext`, which **requires** `.js` extensions on relative imports (~838 in-tree, all `.js`); porting would flag correct, required imports. |
+| `jsdocs` | effect-smol JSDoc shape rule | not ported | skipped | beep has its own JSDoc tooling (`quality jsdoc-inventory`, jsdoc skills). |
+| `no-opaque-instance-fields` | no instance members on `Schema.Opaque` classes | deferred to P3 oxlint | deferred | needs import-binding + static-vs-instance member scope; GritQL cannot express it cleanly. effect-smol's own implementation is an oxlint ESTree rule — beep ports it faithfully in the P3 oxlint lane. |
+| `import/no-duplicates`, `import/no-self-import` | one import per module / no self-import | deferred to P3 oxlint | deferred | no Biome builtin; need multi-import / current-package scope (oxlint `import` plugin). |
+| `no-bigint-literals` | forbid bigint literals | advisory only (P1); P2 scopes to source | advisory | 446 in-tree occurrences are **dominated by legitimate test/domain data** (e.g. `LiteralKit([1, 20n, ...])`); forcing `BigInt(n)` reduces readability in those contexts. P2 scopes to source (excluding tests/fixtures) before any mandatory flip, or keeps it advisory. |
+
+## beep checks kept in `ts-morph` (not migrated to GritQL)
+
+These are type-aware, whole-file, or path-scoped and cannot be reproduced as single-file
+GritQL patterns without coverage loss (SPEC Parity Gate / Stop Conditions):
+
+| Check | Why it stays in `ts-morph` |
+| --- | --- |
+| `laws effect-fn --check` | A GritQL port produced 51 false positives in `packages/foundation` alone (the precise check finds 0) and a ~100× slowdown (~98s on `apps`) from `within`-ancestor traversal on the hot `Effect.gen` pattern. Needs direct-return-owner / nearest-owner / generator scope analysis. |
+| `laws effect-imports --check`/`--write` | Whole-file import consolidation (moving named imports between root and submodules per an 8-entry alias table) is not a single-file pattern; the `--write` codemod is also required by `yeet` repair (`Yeet/internal/Planner.ts`). |
+| `laws native-runtime --check` | Hybrid: path-scoped allowlist reconciliation + native method-call scope. GritQL could only detect `node:` imports, not the allowlist/scope logic. |
+| `lint schema-first`, `lint circular`, `quality {turbo-config-proof,changeset-graph,jsdoc-inventory}` | Cross-file inventory / graph / governance validators — out of scope by design. |
+
+## Lint rules — alignments (enabled by this initiative)
+
+| Concern | Mechanism | Status |
+| --- | --- | --- |
+| `no-console` | Biome `suspicious/noConsole` | enabled (advisory P1 → mandatory P2 with test/example overrides) |
+| `no-var` | Biome `suspicious/noVar` | enabled (0 violations) |
+| `no-useless-constructor` | Biome `complexity/noUselessConstructor` | re-enabled (was `off`) |
+| tagged errors in tooling | GritQL `no-native-error` (`@beep/lint-rules`) | replaces `lint tooling-tagged-errors` (parity-proven) |
+| empty named imports | GritQL `no-empty-named-blocks` | enabled |
+| `.map().flat()` | GritQL `prefer-array-flat-map` | enabled |
+| PascalCase tooling filenames | Biome `style/useFilenamingConvention` (scoped) | replaces the filename portion of `lint tooling-schema-first` (P2) |

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -6,6 +6,15 @@
     "useIgnoreFile": true
   },
   "root": true,
+  // Repo-local GritQL lint rules from @beep/lint-rules. Biome resolves plugin paths
+  // relative to this config file, so they are listed repo-root-relative. These ship
+  // advisory (severity "warn" inside each .grit) and run inside the single lint pass.
+  // `no-native-error` is registered via `overrides` (tooling source only), not here.
+  "plugins": [
+    "./packages/tooling/policy-pack/lint-rules/rules/no-bigint-literals.grit",
+    "./packages/tooling/policy-pack/lint-rules/rules/no-empty-named-blocks.grit",
+    "./packages/tooling/policy-pack/lint-rules/rules/prefer-array-flat-map.grit"
+  ],
   "files": {
     "includes": [
       "**",
@@ -109,7 +118,8 @@
       },
       "complexity": {
         "noBannedTypes": "off",
-        "noUselessConstructor": "off",
+        // effect-smol alignment (advisory in P1; flips to "error" in P2 after remediation).
+        "noUselessConstructor": "warn",
         "noUselessFragments": "off",
         "noThisInStatic": "off",
         "noForEach": "off",
@@ -146,6 +156,9 @@
       },
       "suspicious": {
         "noDeprecatedImports": "error",
+        // effect-smol alignment (advisory in P1; flips to "error" in P2 after remediation).
+        "noConsole": "warn",
+        "noVar": "warn",
         "noControlCharactersInRegex": "off",
         "noSelfCompare": "off",
         "noUnsafeDeclarationMerging": "off",
@@ -186,5 +199,34 @@
         "noUselessElse": "error"
       }
     }
-  }
+  },
+  "overrides": [
+    {
+      // @beep/lint-rules no-native-error: replaces `beep lint tooling-tagged-errors`,
+      // scoped to tooling source roots only (advisory "warn"; flips to error in P2).
+      "includes": ["packages/tooling/**/src/**"],
+      "plugins": [
+        "./packages/tooling/policy-pack/lint-rules/rules/no-native-error.grit"
+      ]
+    },
+    {
+      // noConsole allowlist: tests, examples, stories, scripts, seeds, and CLI bins
+      // legitimately use console. Keeps the advisory signal focused on runtime source.
+      "includes": [
+        "**/test/**",
+        "**/*.test.*",
+        "**/*.spec.*",
+        "**/examples/**",
+        "**/*.stories.*",
+        "**/stories/**",
+        "**/scripts/**",
+        "**/*.bench.*",
+        "**/seed/**",
+        "**/seeds/**",
+        "**/bin.ts",
+        "**/bin-main.ts"
+      ],
+      "linter": { "rules": { "suspicious": { "noConsole": "off" } } }
+    }
+  ]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -1497,6 +1497,18 @@
         "@types/node": "catalog:",
       },
     },
+    "packages/tooling/policy-pack/lint-rules": {
+      "name": "@beep/lint-rules",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@biomejs/biome": "catalog:",
+        "@effect/platform-node": "catalog:",
+        "@effect/vitest": "catalog:",
+        "@types/node": "catalog:",
+        "@typescript/native-preview": "catalog:",
+        "effect": "catalog:",
+      },
+    },
     "packages/tooling/policy-pack/repo-configs": {
       "name": "@beep/repo-configs",
       "version": "0.1.1",
@@ -2151,6 +2163,8 @@
     "@beep/lexical-schema": ["@beep/lexical-schema@workspace:packages/foundation/modeling/lexical"],
 
     "@beep/libpff": ["@beep/libpff@workspace:packages/drivers/libpff"],
+
+    "@beep/lint-rules": ["@beep/lint-rules@workspace:packages/tooling/policy-pack/lint-rules"],
 
     "@beep/m365": ["@beep/m365@workspace:packages/drivers/m365"],
 

--- a/goals/lint-toolchain-modernization/GOAL.md
+++ b/goals/lint-toolchain-modernization/GOAL.md
@@ -1,0 +1,76 @@
+# GOAL: modernize the lint toolchain (Biome GritQL + effect-smol alignment + oxlint lane)
+
+Repo: `/home/elpresidank/YeeBois/projects/beep-effect5`.
+
+Outcome: faster, effect-smol-aligned quality enforcement — syntactic CLI checks moved
+to Biome GritQL rules, `biome.jsonc` lint rules aligned to effect-smol (formatting
+kept), a `@beep/lint-rules` package, an oxlint lint-only lane for the t3code rules — all
+violations remediated and merged to `main` via `/yeet`.
+
+This is a compact `/goal` launcher. The packet files are the detailed contract:
+
+- `goals/lint-toolchain-modernization/README.md`
+- `goals/lint-toolchain-modernization/SPEC.md` (normative)
+- `goals/lint-toolchain-modernization/PLAN.md`
+- `goals/lint-toolchain-modernization/ops/manifest.json`
+- `goals/lint-toolchain-modernization/research/{recon-2026-06-20,rule-inventory}.md`
+
+Read those first, then `AGENTS.md`, `CLAUDE.md`, and the standards named by `SPEC.md`
+(`standards/ARCHITECTURE.md`, `architecture/07-non-slice-families.md`,
+`effect-laws-v1.md`). Higher-priority repo standards outrank packet prose.
+
+Scope:
+
+- In: `biome.jsonc`; new `packages/tooling/policy-pack/lint-rules` (`@beep/lint-rules`);
+  migrated commands in `packages/tooling/tool/cli` + lint aggregators; `turbo.json` and
+  `.github/workflows/check.yml` lint lanes; new `STYLE.md`; `.oxlintrc.json` (P3 only).
+- Out: replacing Biome with oxlint; changing Biome **formatting** (semicolons / ES5
+  trailing commas stay); adding dprint; migrating type-aware/graph checks off `ts-morph`
+  (`dual-arity`, `terse-effect`, `schema-first` inventory, `circular`, `allowlist`,
+  `turbo-config-proof`, `changeset-graph`, `jsdoc-inventory`).
+
+Workflow (5 phases; 2 config→remediate waves — see `PLAN.md`):
+
+1. P0 Spike: prove GritQL plugin resolution in Biome on a fixture; baseline runtimes.
+2. P1 Configure: build `@beep/lint-rules`; author GritQL rules; align `biome.jsonc`
+   lint rules; write `STYLE.md`; wire CI advisory; deprecate migrated CLI commands.
+3. P2 Remediate: fix all violations (Biome safe-fix / `ts-morph --write` / agent edits);
+   flip rules mandatory; `/yeet` to merged PR(s).
+4. P3 oxlint lane: add oxlint lint-only; port the 4 t3code rules + stateful rules;
+   advisory→mandatory; remediate; `/yeet` to merged PR.
+5. P4 Close: closeout reflection + status updates.
+
+Rules:
+
+- GritQL is diagnostics-only — never silent mass rewrites; remediate via Biome safe-fix,
+  existing `ts-morph --write` codemods (e.g. `laws effect-imports --write`), or edits.
+- Remove a CLI check only after its GritQL replacement proves parity (fixtures +
+  baseline diff on the current tree).
+- Each code-changing phase ends green via `bun run beep yeet verify` before its PR merges.
+- Keep decisions tied to evidence from files, tests, docs, or command output.
+- At P4 Close, write a closeout reflection to
+  `history/reflections/<YYYY-MM-DD>-<agent>.md` via `/reflect`;
+  `bun run beep lint reflection-artifacts` must pass.
+
+Acceptance:
+
+- [ ] `SPEC.md` acceptance criteria are satisfied.
+- [ ] `bun run lint` and `bun run beep yeet verify` are green; PR(s) merged, CI green.
+- [ ] No unrelated refactors or formatting churn.
+
+Verification:
+
+```sh
+test "$(wc -m < goals/lint-toolchain-modernization/GOAL.md)" -le 4000
+jq . goals/lint-toolchain-modernization/ops/manifest.json
+git diff --check -- goals/lint-toolchain-modernization
+bun run lint
+bun run beep yeet verify
+bun run beep lint reflection-artifacts
+```
+
+Stop and report before changing Biome formatting, public API, schema, data migration,
+auth, infra, dependencies, lockfiles, or generated files unless `SPEC.md` requires it.
+
+Done only when acceptance passes and verification is complete, or when a blocker is
+reported with file/command evidence.

--- a/goals/lint-toolchain-modernization/PLAN.md
+++ b/goals/lint-toolchain-modernization/PLAN.md
@@ -1,0 +1,71 @@
+# Lint Toolchain Modernization Plan
+
+## Status
+
+Status: `pending`
+
+This initiative runs as two **config → remediate** waves plus a research spike and a
+close. Wave 1 (P1–P2) is the stable Biome + GritQL work; wave 2 (P3) adds the oxlint
+lint-only lane. Each code-changing phase ends green via `/yeet` to a merged PR.
+
+## Phases
+
+| Phase | Status | Goal | Exit criteria |
+| --- | --- | --- | --- |
+| **P0 Research & Spike** | pending | Prove GritQL-plugin-in-Biome wiring; baseline runtimes **and** violation counts; lock the advisory mechanism; finalize `research/rule-inventory.md`; draft `STYLE.md`. | **Binding gate** (all required to enter P1): (1) ≥3 GritQL rules load via `biome.jsonc` `plugins` and emit `warn`/`error` diagnostics, with the chosen path-resolution strategy recorded in `research/p0-spike-result.md`; (2) confirm exact Biome 2.5 rule ids for `noConsole`/`noVar`/`noUselessConstructor` and whether Biome has builtins for the import rules; (3) runtime baselines for the 4 migration-candidate commands + per-rule advisory violation counts captured (used to size P2 chunks); (4) fallback recorded: if path resolution is unreliable after investigation, keep those checks in `ts-morph` and note it. No P1 work before this file exists with green evidence. |
+| **P1 Configuration** (user "phase 1") | pending | Build `@beep/lint-rules` (GritQL rules + presets + Vitest harness); author all GritQL rules (effect-smol custom + the CLI-replacement rules); comprehensively align `biome.jsonc` lint rules to effect-smol (formatting frozen); write `STYLE.md`; wire GritQL into turbo/CI/yeet **advisory**; deprecate migrated CLI commands + update aggregators. Capture per-rule baseline violation counts. | Rules load + unit tests green; advisory lane reports counts; parity fixtures pass; no remediation yet. |
+| **P2 Remediation** (user "phase 2") | pending | Fix all P1 violations, **chunked by subsystem** — one `/yeet` cycle each for `apps`, `packages/schema`, `packages/tooling`, and remaining packages (sub-divide further if a P0 count exceeds ~300). Biome safe-fix where available, `ts-morph --write`/agent codemods otherwise; flip the new rules `warn` → `error` (mandatory) once each subsystem is clean. | Each chunk: `bun run lint` + `bun run beep yeet verify` green and merged before the next. Final: all rules mandatory; `main` green. |
+| **P3a Reconcile t3code state** (P3 pre-work) | pending | Rebuild beep-specific rule state before wiring oxlint: grep beep `*.test\|*.spec` for `Effect.run*`/`ManagedRuntime.make` to build the real `LEGACY_BASELINE`; designate beep's host-process reference path (mirror `packages/shared/src/hostProcess.ts`) and configure `no-global-process-runtime`. | Baseline + path configured; the ported rules emit **zero new** violations on the current tree. |
+| **P3 oxlint lane** (deferred dual) | pending | Add oxlint scoped **lint-only** (`.oxlintrc.json` + `bun run lint:oxlint` task); port the four t3code rules + any stateful/scope rules as oxlint plugins in `@beep/lint-rules`; wire advisory → mandatory; remediate; `/yeet` to merged PR. | Per SPEC: oxlint mandatory + green on Linux CI → P3 `done`; **or** stays unstable → P3 `complete-with-exception` with the 2026-09-20 re-assessment recorded. Either way the goal closes. |
+| **P4 Close** | pending | Closeout reflection (`/reflect`), README/manifest status, readiness. | `bun run beep lint reflection-artifacts` passes; statuses updated; evidence linked. |
+
+## Sequencing Notes
+
+- P0 is a de-risking gate — do not author the full rule set before GritQL plugin
+  resolution is proven on a real fixture.
+- "Comprehensive" enablement means P1 turns on the whole mappable rule set (advisory);
+  P2 **will** chunk remediation into one `/yeet` cycle per subsystem (`apps`,
+  `packages/schema`, `packages/tooling`, remaining), sub-dividing any subsystem whose P0
+  violation count exceeds ~300, so every PR stays reviewable and each merges green.
+- A migrated CLI command is removed only after its GritQL replacement proves parity
+  against the current tree (fixtures + baseline diff). Until then, keep both and run
+  the GritQL rule advisory.
+- The four t3code rules are stateful/path-aware (legacy baselines, path scoping,
+  function-body scope) → oxlint in P3, not GritQL. See `research/rule-inventory.md`.
+
+## P4 Close — Closeout Checklist
+
+> This packet uses an expanded 5-phase structure (P0–P4); the template's P3=Close maps to
+> this packet's **P4**.
+
+Before marking the packet closed (and `status` → `completed-retained` / `complete`):
+
+1. Write a closeout reflection via the `/reflect` skill (or copy
+   `_template/history/reflections/_TEMPLATE.md`) to
+   `history/reflections/<YYYY-MM-DD>-<agent>.md`. Critique the repo **tooling** (GritQL
+   ergonomics, Biome plugin resolution, oxlint stability, `ts-morph` startup cost), the
+   **implementation** (parity strategy, remediation automation ROI), and the
+   **goal/prompt**. Capture TODOs worth codifying. Frontmatter must validate against
+   `ReflectionFrontmatter`.
+2. Run `bun run beep lint reflection-artifacts` (this packet has
+   `reflectionRequired: true`).
+3. Update `README.md` (status, latest evidence) and `ops/manifest.json` phase statuses +
+   `initiative.status`.
+
+## Execution Notes
+
+- Preserve unrelated worktree changes.
+- Keep `SPEC.md` normative; update it only when the contract changes.
+- Keep this plan current; archive run outputs under `history/`.
+
+## Verification Commands
+
+```sh
+test "$(wc -m < goals/lint-toolchain-modernization/GOAL.md)" -le 4000
+jq . goals/lint-toolchain-modernization/ops/manifest.json
+rg -n "lint-toolchain-modernization|GOAL.md|agentLaunchers|packetAnchorDocument" goals/lint-toolchain-modernization
+git diff --check -- goals/lint-toolchain-modernization
+bun run lint
+bun run beep yeet verify
+bun run beep lint reflection-artifacts
+```

--- a/goals/lint-toolchain-modernization/README.md
+++ b/goals/lint-toolchain-modernization/README.md
@@ -1,0 +1,65 @@
+# Lint Toolchain Modernization
+
+## Status
+
+Lifecycle: `active`
+
+Source: [`ops/manifest.json`](./ops/manifest.json)
+
+## Mission
+
+Speed up repo quality enforcement and align it to effect-smol's code style by
+migrating pure-syntactic CLI checks to **Biome GritQL** rules, aligning
+`biome.jsonc` lint rules to effect-smol (formatting kept), shipping a
+**`@beep/lint-rules`** package, and adding a later **oxlint** lint-only lane for
+the t3code custom rules — then remediating every violation and merging via `/yeet`.
+
+## Launch
+
+Use this command for execution-capable sessions:
+
+```text
+/goal follow the instructions in goals/lint-toolchain-modernization/GOAL.md
+```
+
+`GOAL.md` is the compact launcher. `SPEC.md` remains the normative contract.
+
+## Read This First
+
+1. [`GOAL.md`](./GOAL.md) - compact `/goal` launcher.
+2. [`SPEC.md`](./SPEC.md) - normative source of truth.
+3. [`PLAN.md`](./PLAN.md) - active execution plan (5 phases / 2 config→remediate waves).
+4. [`ops/manifest.json`](./ops/manifest.json) - machine-readable routing.
+5. [`tasks/tasks.jsonc`](./tasks/tasks.jsonc) - execution task inventory.
+6. [`research/recon-2026-06-20.md`](./research/recon-2026-06-20.md) - grounded recon + decisions.
+7. [`research/rule-inventory.md`](./research/rule-inventory.md) - rule-by-rule engine/severity/status.
+
+## Current Phase
+
+**P1 Configuration (near-complete; advisory wired, lint green)** — P0 gate PASSED. The
+`@beep/lint-rules` package ships 4 GritQL rules + presets + a Vitest harness + a parity
+harness; `biome.jsonc` enables `noConsole`/`noVar`/`noUselessConstructor` + the GritQL
+plugins **advisory**; `STYLE.md` records ≥12 deviations; `turbo.json` lint inputs updated.
+Remaining: `/yeet` this additive PR to merged. **P2** then remediates + flips rules
+mandatory + removes the superseded `tooling-tagged-errors` CLI check.
+
+## Latest Evidence
+
+`P1 advisory green (2026-06-21)` — `bun run lint`, package `bun test` (13), `bun run beep
+tsconfig-sync --check`, `lint schema-first`, `lint deprecated-apis`, and the jsdoc eslint
+lane all pass. Advisory counts: `noConsole` 128, `noVar` 0, `noUselessConstructor` 4,
+`no-bigint-literals` 446 (23 source-only; rest are test/`LiteralKit` data),
+`no-empty-named-blocks` 1, `prefer-array-flat-map` 4, `no-native-error` 0 (parity ∅⊆∅).
+Two checks proven non-viable as GritQL and kept in `ts-morph` with evidence: `effect-fn`
+(51 false positives + ~98s on `apps` from `within` traversal) and `effect-imports`
+(whole-file consolidation + `--write` needed by yeet). See `research/p0-spike-result.md`
+and `STYLE.md`.
+
+## Notes
+
+- Decisions are locked (see `research/recon-2026-06-20.md` decision log): **phased
+  dual** (Biome+GritQL first, oxlint lint-only lane later), **keep Biome formatting**,
+  **comprehensive rule enablement**, **rules live in `@beep/lint-rules`**.
+- The diff will be large; that is acceptable. Each wave still merges green via `/yeet`.
+- GritQL is diagnostics-only — remediation uses Biome safe-fixes, `ts-morph --write`,
+  or agent edits, never silent mass rewrites.

--- a/goals/lint-toolchain-modernization/SPEC.md
+++ b/goals/lint-toolchain-modernization/SPEC.md
@@ -1,0 +1,189 @@
+# Lint Toolchain Modernization Spec
+
+## Objective
+
+Make repo quality enforcement **faster** and **closer to effect-smol's code style**,
+without giving up Biome as the formatter, by:
+
+1. Migrating pure-syntactic CLI quality checks from `ts-morph`/regex to **Biome
+   GritQL** (`.grit`) plugin rules, so they run inside the single Biome pass
+   instead of bespoke `ts-morph` Project loads.
+2. Aligning `biome.jsonc`'s **lint-rule** enforcement to effect-smol's rule intent
+   (import discipline, `no-console`, `no-var`, etc.), while keeping Biome's
+   **formatting** (semicolons, ES5 trailing commas) unchanged.
+3. Shipping a first-class **`@beep/lint-rules`** package
+   (`packages/tooling/policy-pack/lint-rules`) that holds the repo's custom GritQL
+   rules and, in a later wave, the custom **oxlint** rules — including the four
+   t3code rules.
+4. Remediating every violation surfaced by the new configuration and driving the
+   work to merged PR(s) via `/yeet`.
+
+The goal is complete only when local quality checks are green **and** `/yeet` has
+driven the work all the way to merged PR(s) on `main` with CI green and review
+comments addressed.
+
+## Non-Goals
+
+- Replacing Biome with oxlint as the primary linter. Oxlint is added **lint-only**;
+  Biome keeps formatting and remains the primary lint engine.
+- Changing Biome **formatting** options. `semicolons: "always"` and
+  `trailingCommas: "es5"` stay; the divergence from effect-smol's dprint
+  (`asi`, `never`, forced arrow parens) is recorded in `STYLE.md`, not "fixed".
+- Adding **dprint**.
+- Migrating type-aware or cross-file/graph checks off `ts-morph`: `laws dual-arity`,
+  `laws terse-effect`, `lint schema-first` (inventory reconciliation),
+  `lint circular` (madge graph), `lint allowlist`, `quality turbo-config-proof`,
+  `quality changeset-graph`, `quality jsdoc-inventory` all stay as they are.
+- Promoting any Fallow advisory lane.
+
+## Source Hierarchy
+
+1. User objective that created this packet (`scratch_6.md`, summarized in
+   `research/recon-2026-06-20.md`).
+2. `AGENTS.md`, `CLAUDE.md`, and required skills (`yeet`, `effect-first-development`,
+   `schema-first-development`, `reflect`).
+3. Governing standards: `standards/ARCHITECTURE.md`, `standards/architecture/07-non-slice-families.md`
+   (tooling family placement), `standards/effect-laws-v1.md`.
+4. This `SPEC.md`.
+5. `PLAN.md`.
+6. `GOAL.md`.
+7. Supporting `research/`, `ops/`, and `history/` files.
+
+Higher sources outrank lower sources when they conflict.
+
+## Target Surfaces
+
+- `biome.jsonc` — lint-rule alignment and `plugins: [...]` GritQL registration.
+- **New** `packages/tooling/policy-pack/lint-rules` (`@beep/lint-rules`) — `rules/*.grit`,
+  `configs/{core,schema,services}.jsonc` presets, Vitest harness, `docs/rule-guidance.md`;
+  later the oxlint plugin and `.oxlintrc.json` extends.
+- `packages/tooling/tool/cli` — deprecate/remove the commands migrated to GritQL and
+  update the lint-policy aggregators that reference them.
+- `turbo.json` + `.github/workflows/check.yml` — wire the GritQL/oxlint lanes
+  (advisory first, then mandatory).
+- **New** `STYLE.md` — the formatting/lint deviation record vs effect-smol.
+- `.oxlintrc.json` (wave P3 only).
+
+## Constraints
+
+- **GritQL is diagnostics-only**: rules report, they do not rewrite. Remediation uses
+  Biome safe-fixes (`fix_kind` where available), `ts-morph --write` codemods (e.g. the
+  existing `laws effect-imports --write`), or agent edits — never silent mass rewrites.
+- **Plugin paths**: Biome resolves GritQL plugins by path; use the agreed resolution
+  approach (absolute/`node_modules` path or workspace indirection) and document it.
+- **Biome formatting is frozen** for this initiative; no semicolon/trailing-comma churn.
+- **No parity loss**: a CLI check may only be removed once its GritQL/oxlint replacement
+  reproduces its coverage (proven by fixtures + a baseline diff on the current tree).
+- **Each wave ends green**: every code-changing phase must pass `bun run beep yeet verify`
+  before its PR merges.
+- The new `@beep/lint-rules` package must obey tooling-family doctrine
+  (`standards/architecture/07-non-slice-families.md`): no slice/product imports, no
+  cross-slice coupling.
+- The four t3code oxlint rules are **stateful/path-aware** (legacy baselines, file-path
+  scoping, function-body scope) and therefore land as oxlint plugins in P3, not GritQL.
+
+## Rule Overlap Decisions
+
+These are **locked** so execution never has to decide mid-flight which rule owns a concern:
+
+| Concern | Candidate rules | Decision |
+| --- | --- | --- |
+| Effect import discipline / barrels | effect-smol `no-import-from-barrel-package` vs existing `laws effect-imports` | **`laws effect-imports` owns it.** Do **not** port `no-import-from-barrel-package`: `CLAUDE.md` deliberately allows root `effect` imports for core combinators, which that rule would forbid. `laws effect-imports` encodes beep's real policy and has `--write` remediation. |
+| `node:` builtins | t3code `namespace-node-imports` (style) vs `laws native-runtime` (native-API allowlist) | **Both run, complementary.** Different concerns (import alias *style* vs forbidden native APIs); they flag different things, so no dedup needed. |
+| Schema compile hot-path | t3code `no-inline-schema-compile` vs `lint schema-first` (inventory) | **Both run, complementary.** Allocation-in-hot-path vs schema-first pattern inventory. |
+
+## Advisory → Mandatory Mechanism
+
+The transition is by **diagnostic severity**, mirroring the repo's existing
+`fallow-advisory` CI job pattern (`.github/workflows/check.yml`):
+
+- **Advisory** (P1, and P3 entry): each new GritQL/oxlint rule ships at `severity = "warn"`.
+  `bun run lint` does **not** fail on warnings (no `--error-on-warnings`), so CI reports the
+  diagnostics without blocking. Capture per-rule counts.
+- **Mandatory** (P2, and P3 exit): flip each rule to `severity = "error"` in its rule file
+  and confirm `biome.jsonc` enables it; `bun run lint` now fails on any occurrence.
+- No new CI job is required for the GritQL path (rules run inside the existing single
+  `bun run lint` pass, `check.yml:192`). The oxlint lane (P3) is added as a separate
+  `bun run lint:oxlint` task, advisory until promoted.
+
+## Parity Gate
+
+A migrated CLI check is removed only after a runnable parity proof, not by inspection:
+
+1. Build a Vitest harness at `packages/tooling/policy-pack/lint-rules/test/parity/` that runs
+   **both** the old CLI command and the new GritQL/oxlint rule over the same fixture set
+   (5–10 fixtures incl. edge cases) and the current repo tree.
+2. Normalize each to JSONL `{rule, file, line, message}` and diff.
+3. **Accept** the replacement only when: (a) every violation the old check flags is also
+   flagged by the new rule (old ⊆ new — no coverage loss), and (b) new-only diagnostics are
+   triaged (true gaps vs false positives), with false positives driven to zero or allowlisted.
+4. Until accepted, run both (new rule advisory). The harness is committed and reviewable.
+
+## Acceptance Criteria
+
+- [ ] `@beep/lint-rules` exists under `packages/tooling/policy-pack/lint-rules`, builds,
+      and its rule unit tests pass.
+- [ ] The GritQL-eligible CLI checks (`lint tooling-tagged-errors`, the filename portion
+      of `lint tooling-schema-first`, `laws effect-fn --check`, and `laws effect-imports
+      --check` lint path) are replaced by GritQL rules with proven parity; the superseded
+      CLI commands are removed or marked deprecated and dropped from the lint aggregators.
+- [ ] `biome.jsonc` enables the full effect-smol-mappable lint-rule set (import discipline,
+      `noConsole`, `noVar`, etc.); Biome formatting options are unchanged.
+- [ ] `STYLE.md` documents, with rationale, every deviation in a table (rule | effect-smol
+      intent | beep choice | status): formatting kept (semicolons/ES5 vs ASI/never),
+      `useImportType: separatedType` kept, `no-import-from-barrel-package` not ported, plus
+      every rule intentionally skipped/deferred. Minimum ≥5 documented deviations.
+- [ ] After any CLI command removal, no dangling references remain (help text, aggregators,
+      `package.json` scripts, README) — verified by grep.
+- [ ] The four t3code rules (`namespace-node-imports`, `no-global-process-runtime`,
+      `no-inline-schema-compile`, `no-manual-effect-runtime-in-tests`) plus the
+      effect-smol custom rules are enforced (GritQL where syntactic, oxlint lint-only
+      lane in P3 where stateful/path-aware).
+- [ ] All resulting violations are remediated: `bun run lint` and `bun run beep yeet verify`
+      are green locally.
+- [ ] `/yeet` has driven the work to merged PR(s) on `main` with CI (`check.yml`) green
+      and review comments addressed.
+- [ ] No unrelated refactors or formatting churn.
+
+## Verification Matrix
+
+| Check | Command or evidence | Required result |
+| --- | --- | --- |
+| Packet launcher size | `test "$(wc -m < goals/lint-toolchain-modernization/GOAL.md)" -le 4000` | Passes |
+| Manifest JSON | `jq . goals/lint-toolchain-modernization/ops/manifest.json` | Passes |
+| Whitespace | `git diff --check -- goals/lint-toolchain-modernization` | Passes |
+| Rule package tests | `bun test` in `packages/tooling/policy-pack/lint-rules` | Passes |
+| GritQL rules load | `bun run lint` (Biome resolves `plugins`, emits expected diagnostics) | Rules active |
+| Migrated-check parity | Fixture suite + baseline diff vs pre-migration `ts-morph` output | No coverage loss |
+| Repo lint green | `bun run lint` | Zero errors |
+| No dangling refs | `rg -n "tooling-tagged-errors\|effect-fn\|<removed cmds>" packages/tooling/tool/cli package.json README.md` | Zero live refs (or `@deprecated`) |
+| STYLE.md complete | `test "$(rg -c '\|' STYLE.md)" -ge 5` | ≥5 deviation rows (STYLE.md lives at repo root per Target Surfaces) |
+| Quality gate | `bun run beep yeet verify` | Green per wave |
+| Reflection gate | `bun run beep lint reflection-artifacts` | Passes |
+| Merge evidence | `gh pr list --state merged` + `gh run list --branch main` | PR(s) merged, CI green |
+
+## Stop Conditions
+
+- Biome's GritQL plugin resolution cannot load workspace `.grit` rules reliably after
+  reasonable investigation (escalate: keep the check in `ts-morph`).
+- A migrated GritQL/oxlint rule cannot reproduce the original CLI check's coverage
+  without type information.
+- oxlint's custom-plugin API is too unstable to gate CI on Linux (keep P3 advisory-only).
+- The implementation would exceed named scope (e.g. touching formatting or type-aware
+  checks).
+- Verification requires unnamed credentials, cost, destructive side effects, or policy
+  approval.
+- The same blocker repeats after reasonable investigation.
+
+## Exception Ledger
+
+| Exception | Scope | Owner | Rationale | Removal condition |
+| --- | --- | --- | --- | --- |
+| Biome formatting kept (not effect-smol's dprint ASI/`never`) | `biome.jsonc` formatter | repo | Avoids whole-repo reformat; Biome cannot replicate dprint ASI exactly; user decision | Revisit only if a dedicated formatting-parity initiative is opened |
+| oxlint deferred to P3, advisory-first | CI lint lane | repo | oxlint custom-plugin API is alpha (Windows/type-aware gaps) | Promote to mandatory when "stable" (oxlint lint lane runs green on Linux CI for 3+ consecutive weeks with no custom-plugin-API breakage). Re-assess **2026-09-20**. |
+
+**P3 exit is closeable either way:** (a) oxlint reaches mandatory + green and all four t3code
+rules pass → P3 `done`, goal `done`; or (b) oxlint stays too unstable → P3
+`complete-with-exception` (lane live + advisory), the ledger row above carries the
+2026-09-20 re-assessment, and a follow-up promotion is tracked separately. The goal does
+**not** stay perpetually open waiting on oxlint stability.

--- a/goals/lint-toolchain-modernization/ops/manifest.json
+++ b/goals/lint-toolchain-modernization/ops/manifest.json
@@ -1,0 +1,101 @@
+{
+  "schemaVersion": "initiative-manifest/v1",
+  "initiative": {
+    "id": "lint-toolchain-modernization",
+    "title": "Lint Toolchain Modernization",
+    "status": "active",
+    "created": "2026-06-20",
+    "updated": "2026-06-20",
+    "currentPhase": "P1",
+    "packetAnchorDocument": "SPEC.md"
+  },
+  "packetPath": "goals/lint-toolchain-modernization",
+  "lifecycle": "active",
+  "executionCapable": true,
+  "reflectionRequired": true,
+  "ownership": {
+    "family": "tooling",
+    "primaryPackage": "@beep/lint-rules",
+    "primaryPath": "packages/tooling/policy-pack/lint-rules"
+  },
+  "currentSourceOfTruth": [
+    "AGENTS.md",
+    "CLAUDE.md",
+    "standards/ARCHITECTURE.md",
+    "standards/architecture/07-non-slice-families.md",
+    "standards/effect-laws-v1.md",
+    "biome.jsonc",
+    "goals/lint-toolchain-modernization/README.md",
+    "goals/lint-toolchain-modernization/SPEC.md",
+    "goals/lint-toolchain-modernization/PLAN.md",
+    "goals/lint-toolchain-modernization/GOAL.md",
+    "goals/lint-toolchain-modernization/tasks/tasks.jsonc",
+    "goals/lint-toolchain-modernization/research/recon-2026-06-20.md",
+    "goals/lint-toolchain-modernization/research/rule-inventory.md"
+  ],
+  "relatedPackets": [
+    {
+      "path": "goals/lint-advisory-hardening",
+      "relationship": "quality-workflow-precedent"
+    },
+    {
+      "path": "goals/repo-quality-acceleration",
+      "relationship": "reference-only"
+    }
+  ],
+  "agentLaunchers": [
+    {
+      "kind": "codex-goal",
+      "path": "GOAL.md",
+      "targetChars": 3500,
+      "maxChars": 4000,
+      "command": "/goal follow the instructions in goals/lint-toolchain-modernization/GOAL.md"
+    }
+  ],
+  "taskInventory": "tasks/tasks.jsonc",
+  "phases": [
+    {
+      "id": "P0",
+      "name": "Research & Spike",
+      "status": "done",
+      "evidence": "research/p0-spike-result.md"
+    },
+    {
+      "id": "P1",
+      "name": "Configuration",
+      "status": "in-progress"
+    },
+    {
+      "id": "P2",
+      "name": "Remediation",
+      "status": "pending"
+    },
+    {
+      "id": "P3",
+      "name": "Oxlint lint-only lane",
+      "status": "pending"
+    },
+    {
+      "id": "P4",
+      "name": "Close",
+      "status": "pending"
+    }
+  ],
+  "verificationCommands": [
+    "test \"$(wc -m < goals/lint-toolchain-modernization/GOAL.md)\" -le 4000",
+    "jq . goals/lint-toolchain-modernization/ops/manifest.json",
+    "rg -n \"lint-toolchain-modernization|GOAL.md|agentLaunchers|packetAnchorDocument\" goals/lint-toolchain-modernization",
+    "git diff --check -- goals/lint-toolchain-modernization",
+    "bun run lint",
+    "bun run beep yeet verify",
+    "bun run beep lint reflection-artifacts"
+  ],
+  "stopConditions": [
+    "Biome GritQL plugin resolution cannot load workspace .grit rules reliably after reasonable investigation.",
+    "A migrated GritQL/oxlint rule cannot reproduce the original CLI check coverage without type information.",
+    "oxlint custom-plugin API is too unstable to gate CI; keep the P3 lane advisory-only.",
+    "The implementation would exceed named scope (formatting changes or type-aware check migration).",
+    "Verification requires unnamed credentials, cost, destructive side effects, or policy approval.",
+    "The same blocker repeats after reasonable investigation."
+  ]
+}

--- a/goals/lint-toolchain-modernization/research/p0-spike-result.md
+++ b/goals/lint-toolchain-modernization/research/p0-spike-result.md
@@ -1,0 +1,210 @@
+# P0 Spike Result — GritQL-in-Biome wiring, rule ids, baselines
+
+Status: **PASS — P1 unblocked.** Date: 2026-06-20. Engine versions: Biome `2.5.0`,
+bun `1.3.14`, node `v26.3.0`.
+
+This file is the binding P0 gate artifact required by `PLAN.md` ("No P1 work before
+this file exists with green evidence"). Every claim below is backed by a runnable
+command; the spike fixtures live in `/tmp/grit-spike` and `/tmp/grit-layout`
+(throwaway, not committed — reproduction steps are inline).
+
+---
+
+## Gate item 1 — ≥3 GritQL rules load via `biome.jsonc` `plugins` and emit diagnostics
+
+**Result: PASS.** Three `.grit` plugins registered in a Biome config `plugins` array
+loaded and emitted diagnostics over a fixture in a single Biome pass.
+
+Reproduction (`/tmp/grit-spike`): `biome.json` with
+`"plugins": ["./rules/no-new-error.grit", "./rules/no-bigint-literal.grit", "./rules/no-js-ext-import.grit"]`,
+each rule using the Biome plugin form:
+
+```grit
+language js
+
+`new Error($message)` as $err where {
+  register_diagnostic(
+    span = $err,
+    message = "Use a tagged error (TaggedErrorClass from @beep/schema) instead of native Error.",
+    severity = "warn"
+  )
+}
+```
+
+`bunx biome lint --config-path=. fixture.ts` emitted all three diagnostics
+(`new Error` → warn, `console.log` → error, relative `.js` import → warn),
+`Checked 1 file in 5ms`.
+
+### Path-resolution strategy (LOCKED)
+
+- Biome resolves each `plugins[]` entry **relative to the directory of the config
+  file**. A root `biome.jsonc` (`root: true`) referencing a rule in a deeply nested
+  package resolves correctly:
+  - Reproduction (`/tmp/grit-layout`): root config
+    `"plugins": ["./packages/tooling/policy-pack/lint-rules/rules/no-new-error.grit"]`
+    flagged `packages/app/src/sample.ts` (`nested-path rule fired`, exit 0 warn).
+- **Chosen strategy:** in the repo-root `biome.jsonc`, list each rule by its
+  **repo-root-relative path** under the new package, e.g.
+  `"./packages/tooling/policy-pack/lint-rules/rules/no-bigint-literals.grit"`.
+  No `node_modules` indirection or absolute paths required; nothing to build.
+- **Caveat for P1:** Biome `plugins` takes explicit **file** paths (no directory/glob
+  expansion observed) — every rule file must be listed individually. Keep the array
+  generated/sorted to avoid drift, or add a `lint policy` check that asserts every
+  `rules/*.grit` is registered.
+- **turbo cache:** `turbo.json`'s `lint` task `inputs` currently lists
+  `$TURBO_ROOT$/biome.jsonc` but **not** the `.grit` files. P1 must add the
+  `@beep/lint-rules` rule files (or the package dir) to the `lint` task inputs so rule
+  edits invalidate the lint cache.
+
+### Severity → advisory/mandatory mechanism (LOCKED)
+
+`register_diagnostic(..., severity = "warn" | "error")` is honored per-rule, and that
+is the entire advisory→mandatory lever:
+
+| Scenario | Biome exit | Meaning |
+| --- | --- | --- |
+| Only `severity="warn"` diagnostics, default flags | **0** | Advisory — CI does not block |
+| Any `severity="error"` diagnostic | **1** | Mandatory — CI blocks |
+| Warn-only **with** `--error-on-warnings` | **1** | Alternate global lever (not used) |
+
+The repo runs lint as `biome check .` per package (see
+`CreatePackage/Handler.ts:1347`, `OperationPlanPackageJson.ts:86`) with **no
+`--error-on-warnings`**, so warn-severity rules are inherently advisory under
+`bun run lint`. P1 ships every new rule at `severity="warn"`; P2 flips each to
+`"error"` once its subsystem is clean. **No new CI job is needed** for the GritQL path
+(rules run inside the existing single `bun run lint` Biome pass, `check.yml:192`).
+
+---
+
+## Gate item 2 — Biome 2.5 rule ids + import builtins
+
+Confirmed via `biome explain <rule>` (Biome 2.5.0):
+
+| Intent | Biome rule id (group/name) | Default severity | Fix | Current state in `biome.jsonc` | P1 action |
+| --- | --- | --- | --- | --- | --- |
+| `no-console` | `lint/suspicious/noConsole` | warn | unsafe | absent | enable `error` + overrides (tests/examples/CLI/scripts/stories) |
+| `no-var` | `lint/suspicious/noVar` | warn | unsafe | absent | enable `error` (0 violations) |
+| `no-useless-constructor` | `lint/complexity/noUselessConstructor` | info | unsafe | `off` (`biome.jsonc:112`) | re-enable `error` (4 violations) |
+| inline type imports | `lint/style/useImportType` | warn | safe | `error`/`separatedType` | **KEEP** `separatedType` (divergence; STYLE.md) |
+| filename casing | `lint/style/useFilenamingConvention` | info | none | absent | **builtin candidate** for the `pascal-case-file` migration, override-scoped to the tooling CLI (see gate item 3) |
+
+**Import builtins:** Biome 2.5 has **no** `noEmptyNamedBlocks`, **no**
+`noDuplicateImports`, no bigint-literal rule, and no `.js`-extension-import rule
+(`biome explain` → "Unrecognized option"). It *does* expose
+`useNodejsImportProtocol` (style/info), `noBarrelFile`, `noReExportAll`,
+`noNamespaceImport`, `noExportedImports`, `noImportCycles`. Consequences:
+
+- `import/no-empty-named-blocks`, `no-bigint-literals` → **GritQL** (P1). Confirmed: no builtin.
+- `import/no-duplicates`, `import/no-self-import` → **oxlint** (P3); no Biome builtin
+  (`noDuplicateImports` unrecognized).
+- `no-import-from-barrel-package`/`noBarrelFile` → **NOT enabled** (CLAUDE.md allows root
+  `effect` imports; `laws effect-imports` owns import discipline). Already locked.
+
+---
+
+## Gate item 3 — Runtime baselines + per-rule violation counts (P2 sizing)
+
+### Migration-candidate CLI command baselines (current tree, `main`)
+
+| Command | Wall time | Exit | Violations on current tree |
+| --- | --- | --- | --- |
+| `beep lint tooling-tagged-errors` | 1.5s | 0 | **0** (clean) |
+| `beep lint tooling-schema-first` | 1.5s | 1 | **69 total** — 57 `[pascal-case-file]`, 3 `[export-interface]`, 1 `[schema-annotation]`, 8 `[tagged-union-pattern]`. **Only the 57 filename violations are in migration scope**; the rest stay in `ts-morph` (`lint schema-first` inventory). |
+| `beep laws effect-fn --check` | 5.3s | 0 | **0** (scanned 1601 files) |
+| `beep laws effect-imports --check` | 4.8s | 0 | **0** (touched 0) |
+| `beep laws native-runtime --check` | 6.8s | 0 | **0** (18 allowlisted) |
+
+**Speed motivation confirmed:** the three `ts-morph` `laws` commands cost ~17s combined
+(full `Project` loads); the equivalent GritQL rules run inside the existing Biome pass
+(`Checked 2763 files in 124ms` for one rule repo-wide). The migrated checks are also
+**clean today**, so migrating them adds near-zero P2 remediation — the P2 cost comes from
+the newly-enabled `biome.jsonc` + GritQL rule set, sized below.
+
+### New-rule accurate counts (AST-based, via `biome lint --only=<rule> --reporter=summary .`)
+
+`--only` enables a rule ad-hoc without editing config — used to measure real counts.
+**Critical:** ripgrep over-counts because this repo is JSDoc-`@example`-dense
+(e.g. naive `console\.` grep = 6931, real AST `noConsole` = **127**). Use Biome counts.
+
+| Rule | Engine | Accurate count | Notes |
+| --- | --- | --- | --- |
+| `suspicious/noConsole` | biome-builtin | **127 warnings** | over 2763 files; small. Needs overrides for tests/examples/CLI/scripts/stories before flipping to error. |
+| `suspicious/noVar` | biome-builtin | **0** | trivial. (The "Found 1 error" in runs is `.ai/mcp/mcp.json` JSON parse, pre-existing & unrelated.) |
+| `complexity/noUselessConstructor` | biome-builtin | **4 infos** | trivial. |
+| `no-bigint-literals` | gritql | ~**25** (ripgrep, code lines) | no builtin; needs GritQL rule to count exactly in P1. |
+| `import/no-empty-named-blocks` | gritql | **0** | no `import {}` in tree. |
+| `pascal-case-file` (filename) | biome-builtin (scoped) | **57** | matches the current `tooling-schema-first` filename violations; see parity note. |
+
+**P2 chunk sizing:** every migration-candidate + new rule is small (largest is noConsole
+at 127, mostly auto-allowlistable). No subsystem is projected to exceed the ~300
+threshold that forces sub-division. The dominant P2 work is GritQL/biome-builtin
+remediation that Biome safe-fix (`noConsole`/`noVar`/`noUselessConstructor` all have
+fixes) or targeted edits can clear. Final per-rule counts get re-captured at P1 advisory
+entry (after overrides are set).
+
+---
+
+## Gate item 4 — Fallback decision
+
+**Path resolution is reliable → no `ts-morph` fallback needed for the wiring.** But the
+spike surfaced two rules that must NOT be ported as written, recorded here and destined
+for `STYLE.md`:
+
+1. **`no-js-extension-imports` — DO NOT PORT.** beep's `tsconfig.base.json` sets
+   `module: "NodeNext"` + `moduleResolution: "nodenext"`, which **requires** `.js`
+   extensions on relative imports (verified: `packages/shared` has 28 `.js` relative
+   imports, **0** extensionless). effect-smol forbids `.js` because it uses bundler
+   resolution. Porting this rule would flag ~838 *correct, required* imports as errors.
+   This is a hard, NodeNext-driven divergence — new STYLE.md row alongside
+   `no-import-from-barrel-package`.
+
+2. **`pascal-case-file` filename check — route to builtin, prove parity, else keep
+   ts-morph.** GritQL `file($name, $body)` *can* see the file, but the canonical Biome
+   tool is the builtin `style/useFilenamingConvention` (`filenameCases` + `match`
+   regex), **override-scoped** to `packages/tooling/tool/cli/src/**` only (enabling it
+   repo-wide flags thousands of legitimately-named files). The current ts-morph check
+   strips only `.ts` so compound-extension files (`X.command.ts`, `X.errors.ts`,
+   `X.service.ts`) fail its `^[A-Z][A-Za-z0-9]*$` basename test — P1 must reproduce that
+   exact semantics through `useFilenamingConvention`'s `match`/`filenameCases` and prove
+   parity (fixtures + the 57-violation baseline diff). If it can't, **keep the ts-morph
+   filename check** (Stop Condition: "a migrated rule cannot reproduce coverage") and
+   record the exception.
+
+---
+
+## P1 advisory results (captured after wiring, 2026-06-21)
+
+All new rules ship `severity = "warn"` (advisory); `bun run lint` stays green. Counts via
+`biome lint --reporter=summary` over the tree (excluding `dist`/`.repos`/`*.gen.*`/the
+lint-rules fixtures):
+
+| Rule | Engine | Advisory count | P2 disposition |
+| --- | --- | --- | --- |
+| `suspicious/noConsole` | biome-builtin | 128 | remediate (Effect.log / overrides for tests/examples/CLI/scripts/stories), flip error |
+| `suspicious/noVar` | biome-builtin | 0 | flip error (clean) |
+| `complexity/noUselessConstructor` | biome-builtin | 4 | remediate (safe-fix), flip error |
+| `no-native-error` (tooling src) | gritql | 0 | flip error; remove `lint tooling-tagged-errors` |
+| `no-bigint-literals` | gritql | **446 (23 source-only)** | **scope to source (exclude tests/fixtures)** before any flip — 423 are legitimate `LiteralKit`/test data; or keep advisory (STYLE.md divergence) |
+| `no-empty-named-blocks` | gritql | 1 | remediate, flip error |
+| `prefer-array-flat-map` | gritql | 4 | remediate, flip error |
+
+Source-level enforceable total ≈ **160**; no subsystem exceeds the ~300 sub-division
+threshold. The big headline number (446 bigint) is test/domain data, not a real backlog.
+
+**P1→P2 sequencing decision (recorded):** the P1 PR is purely **additive** (new
+`@beep/lint-rules` package + advisory `biome.jsonc`/`turbo.json` wiring + `STYLE.md` +
+research). Per the SPEC Parity Gate ("run both until accepted"), the migrated `ts-morph`
+CLI checks keep running (blocking) alongside the advisory GritQL rules; **CLI
+deprecation/removal from the lint aggregators is coupled with the P2 mandatory flip** of
+the replacing rule, so enforcement never regresses.
+
+## Decisions carried into P1 (delta to `rule-inventory.md`)
+
+- **Add divergence:** `no-js-extension-imports` → NOT ported (NodeNext). STYLE.md row.
+- **Re-route:** `pascal-case-file` engine `gritql` → **`biome-builtin`
+  (`useFilenamingConvention`, override-scoped)**, parity-gated; ts-morph fallback if parity fails.
+- **Confirm:** `noVar` lives in group **`suspicious`** (not `style`).
+- **Confirm:** `noUselessConstructor` default severity is **info** (re-enable at `error`).
+- **Wiring:** add `@beep/lint-rules` rule files to `turbo.json` `lint` task `inputs`.
+- **Advisory by default:** `bun run lint` uses `biome check .` w/o `--error-on-warnings`;
+  ship rules at `warn`, no new CI job for the GritQL path.

--- a/goals/lint-toolchain-modernization/research/recon-2026-06-20.md
+++ b/goals/lint-toolchain-modernization/research/recon-2026-06-20.md
@@ -1,0 +1,75 @@
+# Recon & Decision Log — 2026-06-20
+
+Source of this packet: a scratch prompt (WebStorm `scratch_6.md`) asking to speed up
+the repo's slow `ts-morph`/eslint quality CLI by moving syntactic checks to **Biome
+GritQL**, align `biome.jsonc` to **effect-smol**'s code style, and add **t3code's**
+custom oxlint rules (optionally adopting oxlint scoped to lint-only, Biome keeps
+formatting). Grounded by a 7-lane read-only recon workflow (`lint-grit-oxlint-recon`,
+8 agents, ~446k tokens) + a grilling round.
+
+## Research repos consulted (on disk)
+
+- `~/YeeBois/research/linting_codestyle_stuff/t3code/oxlint-plugin-t3code` — 4 custom
+  oxlint rules + tests (the named "add these" rules).
+- `~/YeeBois/research/linting_codestyle_stuff/biome-effect-linting-rules` — GritQL
+  `.grit` authoring pattern, `biome.jsonc` `plugins` wiring, Vitest-spawns-Biome test
+  harness, Effect-specific rule set.
+- `~/YeeBois/research/linting_codestyle_stuff/effect-smol` (== `.repos/effect-v4`) —
+  style = **oxlint** (`.oxlintrc.json` + custom plugin `packages/tools/oxc`) + **dprint**
+  (`dprint.json`).
+- `~/YeeBois/research/linting_codestyle_stuff` (linteffect) — prior art.
+
+## Key grounded facts
+
+- **effect-smol formatting (dprint)**: `semiColons: "asi"`, `trailingCommas: "never"`,
+  `arrowFunction.useParentheses: "force"`, `quoteStyle: alwaysDouble`, width 120,
+  indent 2. beep `biome.jsonc` already matches width/quotes/indent; **diverges** on
+  semicolons (`always`) and trailing commas (`es5`).
+- **effect-smol `lint`** = `jsdocs && oxlint -f unix && dprint check`.
+- **No oxlint / grit / dprint config exists in beep yet** — Biome is the only
+  linter/formatter (`biome.jsonc`).
+- **Package home**: `packages/tooling/policy-pack/` already exists (holds `repo-configs`)
+  → natural sibling for a new `lint-rules` package.
+- **CI lint lane** = `.github/workflows/check.yml`.
+- **GritQL feasibility = HIGH** for ~7–10 syntactic rules. Limits: diagnostics-only (no
+  rewrites); single-file scope; TS-specific nodes need ESTree wrapping; plugin paths need
+  explicit/absolute resolution. Stable since Biome v2.
+- **oxlint JS-plugin feasibility = MEDIUM-LOW (alpha)**: Windows OOM, type-aware custom
+  rules unsupported, framework parsers pending. The t3code rules are written against the
+  `@oxlint/plugins` `defineRule` API and are stateful/path-aware → they fit oxlint, not
+  GritQL. → defer to P3, advisory-first.
+
+## Decisions (locked via grilling)
+
+| # | Decision | Choice | Rationale |
+| - | --- | --- | --- |
+| 1 | Custom-rule tooling strategy | **Phased dual** — Biome+GritQL (stable) in P1–P2; oxlint lint-only lane in P3 | Honors "add oxlint, biome formats" while keeping the alpha oxlint plugin API off the early critical path |
+| 2 | Formatting parity with effect-smol | **Keep Biome formatting**; align lint rules only; record deviation in `STYLE.md` | Avoids whole-repo reformat; Biome can't replicate dprint ASI exactly |
+| 3 | P1 rule-enablement ambition | **Comprehensive** — enable the full mappable rule set; remediate everything (chunked) | User: "more closely match" + "massive diff is fine" |
+| 4 | Custom-rule package home | **New `packages/tooling/policy-pack/lint-rules`** (`@beep/lint-rules`) | Matches existing policy-pack family; independent reuse; clean separation from the CLI |
+
+Consequent structural decisions:
+- **PR chunking**: remediation (P2) may be split into multiple `/yeet` cycles per rule
+  or per subsystem to keep PRs reviewable; each ends green. The "single massive PR vs
+  stacked PRs" choice is left to execution; default = per-phase/per-subsystem `/yeet`.
+- **Parity gate**: a CLI command is removed only after its GritQL replacement reproduces
+  coverage (fixtures + baseline diff on the current tree); until then run both, GritQL
+  advisory.
+
+## CLI command migration verdicts (wave 1 scope)
+
+See `rule-inventory.md` for the rule-level table. Summary: ~4 high/medium-ROI GritQL
+migrations (`tooling-tagged-errors`, `tooling-schema-first` filename checks,
+`laws effect-fn`, `laws effect-imports` lint path), 1 hybrid (`laws native-runtime`
+node: import detection), and the type-aware/graph/inventory checks stay in `ts-morph`.
+
+## Open risks carried into execution
+
+- Biome GritQL plugin **path resolution** in a workspace (absolute paths / indirection)
+  — P0 spike must prove this before authoring the full set.
+- GritQL **false positives / scope gaps** (e.g. re-exported aliases for import rules) —
+  mitigate with fixtures + allowlist where a rule supports it.
+- **CI time growth** from added rules — profile; the rules run inside the existing Biome
+  pass, but watch the lint lane budget.
+- oxlint **alpha instability** — P3 stays advisory until green on Linux CI; exception
+  recorded in `SPEC.md` ledger if it can't be promoted.

--- a/goals/lint-toolchain-modernization/research/rule-inventory.md
+++ b/goals/lint-toolchain-modernization/research/rule-inventory.md
@@ -1,0 +1,90 @@
+# Rule Inventory — engine / severity / status
+
+Rule-by-rule routing for the initiative. **Engine**: `gritql` (Biome plugin, P1),
+`oxlint` (lint-only lane, P3), `keep-tsmorph` (unchanged), `hybrid`, or `biome-builtin`
+(enable an existing Biome rule). **Status** starts `planned`; execution flips it to
+`advisory` → `mandatory` → `done`. Confidence reflects recon certainty; verify in P0.
+
+## A. CLI quality commands → migration verdict
+
+| CLI command | Tech today | Engine | Conf. | Notes |
+| --- | --- | --- | --- | --- |
+| `lint tooling-tagged-errors` | ts-morph regex (`new Error`) | **gritql** | high | Cleanest port; match `new Error(...)`, suggest tagged error. ~40 LoC removed. |
+| `lint tooling-schema-first` (filename checks only) | ts-morph + regex | **gritql** | high | Split the PascalCase/index-bin filename check into a GritQL rule; keep the pattern/inventory checks in ts-morph. |
+| `laws effect-fn --check` | ts-morph Project | **gritql** | medium | Match `function*` decls + `Effect.fn.Return<…>` JSDoc; syntactic. JSDoc parsing is the risk. |
+| `laws effect-imports --check` (lint path) | ts-morph Project + rewrite | **gritql** (lint) | medium | GritQL for the *diagnostic*; keep `laws effect-imports --write` (ts-morph) for remediation. |
+| `laws native-runtime --check` | ts-morph + allowlist | **hybrid** | medium | GritQL detects `node:` imports; keep ts-morph for method-call scope + allowlist reconciliation. (Exact name confirmed: `native-runtime`, not `no-native-runtime`.) |
+| `laws dual-arity --check` | ts-morph (types) | keep-tsmorph | high | Needs type info + exception inventory. |
+| `laws terse-effect --check` | ts-morph (scope + rewrite) | keep-tsmorph | high | Multi-node codemods + scope analysis. |
+| `lint schema-first` (full) | ts-morph + inventory | keep-tsmorph | high | Cross-file inventory reconciliation. |
+| `lint circular` | madge graph | keep-tsmorph | high | Graph algorithm; no single-file AST equivalent. |
+| `lint allowlist`, `quality turbo-config-proof`, `quality changeset-graph`, `quality jsdoc-inventory` | custom Effect / ts-morph | keep-tsmorph | high | Governance/graph/inventory validators, not lint rules. |
+
+## B. New custom rules — t3code (named "add these"; P3 oxlint lane)
+
+All four are **stateful / path-aware / scope-aware** → oxlint plugins in `@beep/lint-rules`,
+not GritQL. Sourced from `t3code/oxlint-plugin-t3code/rules/*`.
+
+| Rule | Enforces | Engine | Severity | Status / notes |
+| --- | --- | --- | --- | --- |
+| `namespace-node-imports` | Canonical namespace import for `node:*` builtins, e.g. `import * as NodeFS from "node:fs"` (alias = `Node` + PascalCased module; special maps `fs→FS`, `assert/strict→Assert`, …). | oxlint | error | New to beep. **Complements** `laws native-runtime` (different concern: import *style* vs native-API allowlist) — both run lint-only, no flag overlap. See SPEC "Rule Overlap Decisions". |
+| `no-global-process-runtime` | Forbid `process.platform`/`process.arch` (incl. `globalThis.process`) outside a shared host-process reference file; tracks `node:os` imports. | oxlint | error | New to beep; needs a beep-specific host-process reference path (t3code hardcodes `packages/shared/src/hostProcess.ts`). |
+| `no-inline-schema-compile` | Forbid `Schema` compiler methods (`is`/`asserts`/`decode*`/`encode*`) called **inside function bodies** on static schema refs (hot-path allocation). | oxlint | error | New to beep; complements schema-first discipline. Needs function-body scope. |
+| `no-manual-effect-runtime-in-tests` | Forbid `Effect.run*` / `ManagedRuntime.make` in `*.test|spec` files, with a legacy baseline allowing existing counts. | oxlint | error | New to beep; **rebuild the `LEGACY_BASELINE` for beep's tree** (t3code's baseline is theirs). |
+
+## C. New custom rules borrowed from effect-smol
+
+effect-smol's own custom oxlint plugin (`packages/tools/oxc/src/oxlint`) exports exactly
+**5** rules: `no-bigint-literals`, `no-import-from-barrel-package`, `no-js-extension-imports`,
+`no-opaque-instance-fields`, `jsdocs`. The rest below are general lint rules effect-smol
+enables via its `eslint`/`unicorn`/`import` oxlint presets, not custom rules. This table is
+**beep's target**, not a 1:1 copy — routed by what each rule actually needs.
+
+### C1. effect-smol custom rules → GritQL (P1)
+
+| Rule | Enforces | Engine | Severity | Notes |
+| --- | --- | --- | --- | --- |
+| `no-bigint-literals` | Disallow `1n` literals; require `BigInt(1)`. | gritql | error | Syntactic, single-file. |
+| `no-js-extension-imports` | Forbid `.js/.jsx/.mjs/.cjs` in relative imports. | gritql | error | Syntactic. |
+| `no-opaque-instance-fields` | No instance fields on `Schema.Opaque` classes. | gritql | warn | Compound pattern (class + extends + field); medium complexity. |
+| `jsdocs` | effect-smol's JSDoc shape rule. | keep-tsmorph | — | **Skip port** — beep already has its own JSDoc tooling (`quality jsdoc-inventory`, jsdoc skills). |
+
+### C2. effect-smol preset lint rules → routed by need
+
+| Rule | Enforces | Engine | Severity | Notes |
+| --- | --- | --- | --- | --- |
+| `import/no-empty-named-blocks` | No `import {} from "…"`. | gritql | error | Trivial single-file. P1. |
+| `unicorn/prefer-array-flat-map` | `.map().flat()` → `.flatMap()`. | gritql | warn | Cosmetic; P1, low priority. |
+| `arrow-function-parens` (force) | Lint mirror of effect-smol's dprint arrow-paren preference. | gritql | warn | Biome doesn't own this formatting; document in `STYLE.md`. P1. |
+| `import/no-duplicates` | One import statement per module. | oxlint (P3) | error | Multi-import file scope; effect-smol uses the oxlint `import` plugin. Confirm a Biome builtin in P0 before authoring. |
+| `import/no-self-import` | No import of the current package. | oxlint (P3) | error | Needs current-package context; effect-smol uses the oxlint `import` plugin. |
+
+### C3. Deferred — type-aware (cannot be GritQL)
+
+| Rule | Engine | Notes |
+| --- | --- | --- |
+| `no-unnecessary-type-assertion`, `no-unnecessary-type-constraint` | oxlint type-aware / keep-tsmorph | **Defer** — needs type inference; out of P1/P2 scope. |
+
+### C4. Intentional divergences — do NOT port
+
+| Rule | Why not ported |
+| --- | --- |
+| `consistent-type-imports` (inline) | beep keeps Biome `useImportType: separatedType`. Documented in `STYLE.md`. |
+| `no-import-from-barrel-package` | **Contradicts beep policy** — `CLAUDE.md` deliberately allows root `effect` imports for core combinators. `laws effect-imports` owns Effect import discipline (it encodes beep's actual policy + has `--write` remediation). See SPEC "Rule Overlap Decisions". |
+
+## D. `biome.jsonc` lint-rule alignment (P1 — enable/verify existing Biome rules)
+
+Formatting is **frozen** (semicolons/ES5 trailing commas kept; see `STYLE.md`). These are
+lint-rule toggles only. The packet describes the *current* state correctly — these rules are
+off/absent today and P1 turns them on. Confirm exact Biome v2.5 rule ids/groups in P0
+(`biome explain` / Biome docs) before editing.
+
+| Intent (effect-smol) | Biome rule (confirm id in P0) | Current state | Action |
+| --- | --- | --- | --- |
+| `no-console` | `suspicious/noConsole` | absent | Enable (`error`); allowlist tests/examples via `overrides`. |
+| `no-var` | `noVar` (confirm group — `style` vs `suspicious` in 2.5) | absent | Enable (`error`). |
+| `no-useless-constructor` | `complexity/noUselessConstructor` | `off` (biome.jsonc:112) | Re-enable (`error`). |
+| inline type imports | `style/useImportType` | `error`/`separatedType` | **Keep `separatedType`** (divergence, documented). |
+
+> Import discipline overlaps are **pre-decided** in SPEC "Rule Overlap Decisions" — there is
+> no open C/D dedup left to resolve during execution.

--- a/goals/lint-toolchain-modernization/tasks/tasks.jsonc
+++ b/goals/lint-toolchain-modernization/tasks/tasks.jsonc
@@ -1,0 +1,113 @@
+{
+  "schemaVersion": "lint-toolchain-modernization/tasks/v1",
+  "updated": "2026-06-20",
+  "tasks": [
+    {
+      "id": "ltm-001",
+      "title": "Create packet, recon synthesis, and rule inventory",
+      "lane": "packet",
+      "status": "done",
+      "proof": [
+        "goals/lint-toolchain-modernization/research/recon-2026-06-20.md",
+        "goals/lint-toolchain-modernization/research/rule-inventory.md"
+      ]
+    },
+    {
+      "id": "ltm-002",
+      "title": "P0 spike: prove GritQL plugin resolution + emit diagnostics (>=3 rules)",
+      "lane": "spike",
+      "status": "done",
+      "proof": [
+        "goals/lint-toolchain-modernization/research/p0-spike-result.md"
+      ]
+    },
+    {
+      "id": "ltm-003",
+      "title": "P0: confirm Biome 2.5 rule ids (noConsole/noVar/noUselessConstructor) + import builtins",
+      "lane": "spike",
+      "status": "done",
+      "proof": [
+        "goals/lint-toolchain-modernization/research/p0-spike-result.md"
+      ]
+    },
+    {
+      "id": "ltm-004",
+      "title": "P0: baseline runtimes + per-rule advisory violation counts (size P2 chunks)",
+      "lane": "spike",
+      "status": "done",
+      "proof": [
+        "goals/lint-toolchain-modernization/research/p0-spike-result.md"
+      ]
+    },
+    {
+      "id": "ltm-005",
+      "title": "Scaffold @beep/lint-rules package (rules/, configs/, test harness)",
+      "lane": "rules",
+      "status": "done",
+      "proof": ["packages/tooling/policy-pack/lint-rules/package.json"]
+    },
+    {
+      "id": "ltm-006",
+      "title": "Author GritQL rules: 4 P1 syntactic (no-native-error, no-bigint-literals, no-empty-named-blocks, prefer-array-flat-map); effect-fn/opaque deferred with evidence",
+      "lane": "rules",
+      "status": "done",
+      "proof": ["packages/tooling/policy-pack/lint-rules/rules"]
+    },
+    {
+      "id": "ltm-007",
+      "title": "Parity-gate harness (old CLI vs new rule, coverage diff) + rule unit tests",
+      "lane": "rules",
+      "status": "done",
+      "proof": ["packages/tooling/policy-pack/lint-rules/test/parity"]
+    },
+    {
+      "id": "ltm-008",
+      "title": "Align biome.jsonc lint rules to effect-smol advisory (noConsole/noVar/noUselessConstructor + 4 GritQL plugins; formatting frozen)",
+      "lane": "biome",
+      "status": "done",
+      "proof": ["biome.jsonc"]
+    },
+    {
+      "id": "ltm-009",
+      "title": "Write STYLE.md deviation record (>=5 rows, with rationale)",
+      "lane": "biome",
+      "status": "done",
+      "proof": ["STYLE.md"]
+    },
+    {
+      "id": "ltm-010",
+      "title": "Wire GritQL into turbo lint inputs + existing CI lint lane (advisory). CLI deprecation/removal coupled to P2 mandatory flip (parity 'run both until accepted')",
+      "lane": "ci",
+      "status": "in-progress",
+      "proof": ["turbo.json"]
+    },
+    {
+      "id": "ltm-011",
+      "title": "P2 remediation per subsystem; flip rules warn->error; /yeet each chunk green",
+      "lane": "remediation",
+      "status": "pending",
+      "proof": ["bun run lint", "bun run beep yeet verify"]
+    },
+    {
+      "id": "ltm-012",
+      "title": "P3a: rebuild t3code LEGACY_BASELINE + host-process path for beep tree",
+      "lane": "oxlint",
+      "status": "pending",
+      "proof": ["packages/tooling/policy-pack/lint-rules/oxlint"]
+    },
+    {
+      "id": "ltm-013",
+      "title": "P3: add oxlint lint-only lane + port 4 t3code rules; advisory->mandatory",
+      "lane": "oxlint",
+      "status": "pending",
+      "proof": [".oxlintrc.json", "bun run lint:oxlint"]
+    },
+    {
+      "id": "ltm-014",
+      "title": "P4 close: reflection + status updates + reflection-artifacts lint",
+      "lane": "close",
+      "status": "pending",
+      "proof": ["bun run beep lint reflection-artifacts"]
+    }
+  ]
+}

--- a/packages/tooling/policy-pack/lint-rules/CLAUDE.md
+++ b/packages/tooling/policy-pack/lint-rules/CLAUDE.md
@@ -1,0 +1,33 @@
+# @beep/lint-rules Agent Guide
+
+## Purpose & Fit
+- Repo-local Biome GritQL lint rules (later: oxlint plugins) for effect-smol-aligned
+  quality enforcement. Tooling family, `policy-pack` kind. No slice/product imports.
+
+## Surface Map
+| Surface | Key exports | Notes |
+| --- | --- | --- |
+| entry module | `VERSION`, `RULES`, `RULE_NAMES`, `rulePath`, `rulesDir` | canonical rule registry |
+| rules | `rules/*.grit` | one anti-pattern per rule, diagnostics-only |
+| presets | `configs/{core,services,schema}.jsonc` | documented groupings |
+
+## Laws
+- GritQL is diagnostics-only — never silent rewrites.
+- New rule = add `.grit` + `src/index.ts` registry entry + `test/fixtures/<rule>/{invalid,valid}.ts`.
+- Ship advisory (`severity = "warn"`); flip to `"error"` only when the subsystem is clean.
+- Keep rules fast: avoid `within`/deep-ancestor operators on hot patterns.
+
+## Quick Recipes
+```ts
+import { RULES, rulePath } from "@beep/lint-rules"
+```
+
+## Verifications
+- `bunx turbo run test --filter=@beep/lint-rules`
+- `bunx turbo run check --filter=@beep/lint-rules`
+- `bunx turbo run lint --filter=@beep/lint-rules`
+
+## Contributor Checklist
+- [ ] New rule registered in `src/index.ts` and `biome.jsonc`
+- [ ] Fixture pair + test added
+- [ ] `bun run check` / `bun run test` / `bun run lint` pass

--- a/packages/tooling/policy-pack/lint-rules/LICENSE
+++ b/packages/tooling/policy-pack/lint-rules/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 beep-effect
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/tooling/policy-pack/lint-rules/README.md
+++ b/packages/tooling/policy-pack/lint-rules/README.md
@@ -1,0 +1,34 @@
+# @beep/lint-rules
+
+Repo-local **Biome GritQL** lint rules for effect-smol-aligned quality enforcement.
+Each rule is a single `.grit` file under `rules/`, registered by beep's root
+`biome.jsonc` so it runs inside the one Biome lint pass — no bespoke `ts-morph` Project
+loads. (A later wave adds oxlint plugins here for stateful/scope-aware rules.)
+
+## Layout
+
+| Path | Purpose |
+| --- | --- |
+| `rules/*.grit` | the GritQL rules (one anti-pattern each, diagnostics-only) |
+| `src/index.ts` | canonical rule registry (`RULES`, `RULE_NAMES`, `rulePath`) |
+| `configs/*.jsonc` | `core` / `services` / `schema` presets (documented groupings) |
+| `test/harness.ts` | spawns Biome over a fixture and returns plugin diagnostics |
+| `test/rules.test.ts` | data-driven invalid/valid fixture assertions |
+| `test/registry.test.ts` | registry ↔ `rules/` ↔ metadata drift guard |
+| `test/parity/` | old-CLI-vs-new-rule coverage proof on the current tree |
+| `docs/rule-guidance.md` | authoring conventions + rule table |
+
+## Verifications
+
+- `bunx turbo run test --filter=@beep/lint-rules`
+- `bunx turbo run check --filter=@beep/lint-rules`
+- `bunx turbo run lint --filter=@beep/lint-rules`
+
+## Notes
+
+- GritQL is **diagnostics-only**; remediation uses Biome safe-fix, `ts-morph --write`
+  codemods, or hand edits.
+- Rules ship advisory (`severity = "warn"`, Biome exits 0) and flip to `"error"`
+  (mandatory, Biome exits 1) once their subsystem is clean.
+- See `goals/lint-toolchain-modernization/` for the initiative contract and the
+  decisions on which checks stay in `ts-morph`.

--- a/packages/tooling/policy-pack/lint-rules/configs/core.jsonc
+++ b/packages/tooling/policy-pack/lint-rules/configs/core.jsonc
@@ -1,0 +1,14 @@
+{
+  // @beep/lint-rules — core preset: repo-wide syntactic hygiene rules.
+  //
+  // beep's root `biome.jsonc` registers these `.grit` files directly in its top-level
+  // `plugins` array (Biome resolves plugin paths relative to the config file, so the
+  // root config uses repo-root-relative paths). This preset documents the canonical
+  // grouping; the paths below are package-relative for external `extends` consumers.
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+  "plugins": [
+    "./rules/no-bigint-literals.grit",
+    "./rules/no-empty-named-blocks.grit",
+    "./rules/prefer-array-flat-map.grit"
+  ]
+}

--- a/packages/tooling/policy-pack/lint-rules/configs/schema.jsonc
+++ b/packages/tooling/policy-pack/lint-rules/configs/schema.jsonc
@@ -1,0 +1,13 @@
+{
+  // @beep/lint-rules — schema preset: the core hygiene rules apply to schema-heavy
+  // packages today. Schema-specific custom rules that need import-binding / member
+  // scope (effect-smol `no-opaque-instance-fields`, t3code `no-inline-schema-compile`)
+  // are stateful/scope-aware and land in the P3 oxlint lane, not GritQL — see
+  // `goals/lint-toolchain-modernization/research/rule-inventory.md`.
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+  "plugins": [
+    "./rules/no-bigint-literals.grit",
+    "./rules/no-empty-named-blocks.grit",
+    "./rules/prefer-array-flat-map.grit"
+  ]
+}

--- a/packages/tooling/policy-pack/lint-rules/configs/services.jsonc
+++ b/packages/tooling/policy-pack/lint-rules/configs/services.jsonc
@@ -1,0 +1,12 @@
+{
+  // @beep/lint-rules — services preset: core hygiene plus tooling/service-source
+  // discipline. `no-native-error` is meant to be registered via a biome `overrides`
+  // entry scoped to `packages/tooling/**/src/**` (it should not lint tests/fixtures).
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+  "plugins": [
+    "./rules/no-bigint-literals.grit",
+    "./rules/no-empty-named-blocks.grit",
+    "./rules/prefer-array-flat-map.grit",
+    "./rules/no-native-error.grit"
+  ]
+}

--- a/packages/tooling/policy-pack/lint-rules/package.json
+++ b/packages/tooling/policy-pack/lint-rules/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "@beep/lint-rules",
+  "version": "0.1.0",
+  "description": "Repo-local Biome GritQL lint rules (and, later, oxlint plugins) for effect-smol-aligned quality enforcement",
+  "license": "Apache-2.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "bun run beep:build",
+    "check": "bun run beep:check",
+    "lint": "bun run beep:lint",
+    "lint:fix": "bun run beep:lint:fix",
+    "test": "bun run beep:test",
+    "coverage": "bunx --bun vitest run --coverage",
+    "beep:build": "tsc -b tsconfig.json",
+    "beep:check": "tsgo -b tsconfig.json",
+    "beep:test": "bunx --bun vitest run",
+    "beep:lint": "biome check .",
+    "beep:lint:fix": "biome check . --write",
+    "beep:audit": "bun run beep:build && bun run beep:check && bun run beep:test && bun run beep:lint",
+    "audit": "bun run --if-present beep:audit"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "catalog:",
+    "@effect/platform-node": "catalog:",
+    "@effect/vitest": "catalog:",
+    "@types/node": "catalog:",
+    "@typescript/native-preview": "catalog:",
+    "effect": "catalog:"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./src/index.ts",
+    "./recommended": "./configs/core.jsonc",
+    "./core": "./configs/core.jsonc",
+    "./schema": "./configs/schema.jsonc",
+    "./services": "./configs/services.jsonc"
+  },
+  "files": [
+    "src/**/*.ts",
+    "rules/*.grit",
+    "configs/*.jsonc",
+    "docs/**/*.md",
+    "dist/**/*.js",
+    "dist/**/*.js.map",
+    "dist/**/*.d.ts",
+    "dist/**/*.d.ts.map"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:beep-effect/beep-effect.git",
+    "directory": "packages/tooling/policy-pack/lint-rules"
+  },
+  "beep": {
+    "family": "tooling",
+    "kind": "policy-pack"
+  },
+  "homepage": "https://github.com/beep-effect/beep-effect/tree/main/packages/tooling/policy-pack/lint-rules",
+  "sideEffects": [],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true,
+    "exports": {
+      "./package.json": "./package.json",
+      ".": "./dist/index.js",
+      "./recommended": "./configs/core.jsonc",
+      "./core": "./configs/core.jsonc",
+      "./schema": "./configs/schema.jsonc",
+      "./services": "./configs/services.jsonc"
+    }
+  }
+}

--- a/packages/tooling/policy-pack/lint-rules/rules/no-bigint-literals.grit
+++ b/packages/tooling/policy-pack/lint-rules/rules/no-bigint-literals.grit
@@ -1,0 +1,7 @@
+language js
+
+// effect-smol (v4) `no-bigint-literals`: any bigint literal (1n, 0xFFn, ...).
+// `BigInt(1)` is a CallExpression and stays allowed.
+JsBigintLiteralExpression() as $lit where {
+  register_diagnostic(span=$lit, message="Rule: BigInt literals are not allowed. Why: aligns with effect-smol code style. Fix: use BigInt(<value>) instead of a bigint literal.", severity="warn")
+}

--- a/packages/tooling/policy-pack/lint-rules/rules/no-empty-named-blocks.grit
+++ b/packages/tooling/policy-pack/lint-rules/rules/no-empty-named-blocks.grit
@@ -1,0 +1,6 @@
+language js
+
+// effect-smol preset `import/no-empty-named-blocks`: `import {} from "..."`.
+`import {} from $source` as $imp where {
+  register_diagnostic(span=$imp, message="Rule: empty named import block. Why: `import {}` imports nothing. Fix: remove the empty braces or the whole import.", severity="warn")
+}

--- a/packages/tooling/policy-pack/lint-rules/rules/no-native-error.grit
+++ b/packages/tooling/policy-pack/lint-rules/rules/no-native-error.grit
@@ -1,0 +1,7 @@
+language js
+
+// Replaces `beep lint tooling-tagged-errors`. Scope to packages/tooling/** via
+// the consuming biome config `overrides`. Flags native `new Error(...)`.
+`new Error($message)` as $err where {
+  register_diagnostic(span=$err, message="Rule: do not construct a native Error in tooling source. Why: native errors bypass typed error channels. Fix: use TaggedErrorClass from @beep/schema (or a tagged error subclass) instead.", severity="warn")
+}

--- a/packages/tooling/policy-pack/lint-rules/rules/prefer-array-flat-map.grit
+++ b/packages/tooling/policy-pack/lint-rules/rules/prefer-array-flat-map.grit
@@ -1,0 +1,6 @@
+language js
+
+// effect-smol preset `unicorn/prefer-array-flat-map`: `.map(f).flat()`.
+`$arr.map($fn).flat()` as $chain where {
+  register_diagnostic(span=$chain, message="Rule: avoid .map(...).flat(). Why: map+flat allocates an intermediate array. Fix: use .flatMap(...) instead.", severity="warn")
+}

--- a/packages/tooling/policy-pack/lint-rules/src/index.ts
+++ b/packages/tooling/policy-pack/lint-rules/src/index.ts
@@ -1,0 +1,162 @@
+/**
+ * \@beep/lint-rules
+ *
+ * Repo-local Biome GritQL lint rules for effect-smol-aligned quality enforcement.
+ * This module is the canonical registry of the GritQL rules shipped by the package:
+ * each rule's slug, `.grit` file, advisory/mandatory severity, the CLI check it
+ * supersedes (if any), and a one-line summary. Tooling (presets, the biome.jsonc
+ * drift check, and the parity harness) reads the registry instead of hardcoding paths.
+ *
+ * @packageDocumentation
+ * @since 0.1.0
+ */
+
+/**
+ * Package version for `@beep/lint-rules`.
+ *
+ * @example
+ * ```ts
+ * import { VERSION } from "@beep/lint-rules"
+ *
+ * if (VERSION.length > 0) {
+ *   // version is a non-empty semver string
+ * }
+ * ```
+ * @category configuration
+ * @since 0.1.0
+ */
+export const VERSION = "0.1.0" as const;
+
+/**
+ * Slugs of the GritQL rules shipped by this package (one `.grit` file each).
+ *
+ * @example
+ * ```ts
+ * import { RULE_NAMES } from "@beep/lint-rules"
+ *
+ * const count: number = RULE_NAMES.length
+ * ```
+ * @category rules
+ * @since 0.1.0
+ */
+export const RULE_NAMES = [
+  "no-native-error",
+  "no-bigint-literals",
+  "no-empty-named-blocks",
+  "prefer-array-flat-map",
+] as const;
+
+/**
+ * The slug of a single GritQL rule shipped by this package.
+ *
+ * @category rules
+ * @since 0.1.0
+ */
+export type RuleName = (typeof RULE_NAMES)[number];
+
+/**
+ * Diagnostic severity used to gate a rule. `warn` is advisory (Biome exits 0);
+ * `error` is mandatory (Biome exits 1). The advisory-to-mandatory transition flips
+ * this value in the rule's `.grit` file.
+ *
+ * @category rules
+ * @since 0.1.0
+ */
+export type RuleSeverity = "warn" | "error";
+
+/**
+ * Static metadata describing one GritQL rule. Internal: the public surface is the
+ * `RULES` record, whose values are inferred from this shape.
+ */
+type RuleMetadata = {
+  /** Rule slug; matches the `.grit` filename stem. */
+  readonly name: RuleName;
+  /** Current diagnostic severity baked into the `.grit` file. */
+  readonly severity: RuleSeverity;
+  /** The `bun run beep ...` CLI check this rule supersedes, if any. */
+  readonly replaces: string | null;
+  /** One-line description of what the rule flags. */
+  readonly summary: string;
+  /**
+   * Glob-ish path scope, when the rule is registered via biome.jsonc `overrides`
+   * rather than the top-level `plugins` array. `null` means repo-wide.
+   */
+  readonly scope: string | null;
+};
+
+/**
+ * Canonical registry of GritQL rule metadata, keyed by rule slug.
+ *
+ * @example
+ * ```ts
+ * import { RULES } from "@beep/lint-rules"
+ *
+ * const sev = RULES["no-bigint-literals"].severity
+ * ```
+ * @category rules
+ * @since 0.1.0
+ */
+export const RULES: { readonly [K in RuleName]: RuleMetadata } = {
+  "no-native-error": {
+    name: "no-native-error",
+    severity: "warn",
+    replaces: "lint tooling-tagged-errors",
+    summary: "Disallow native Error construction in tooling source; use TaggedErrorClass.",
+    scope: "packages/tooling/**/src/**",
+  },
+  "no-bigint-literals": {
+    name: "no-bigint-literals",
+    severity: "warn",
+    replaces: null,
+    summary: "Disallow bigint literals (1n, 0xFFn, ...); use BigInt(value).",
+    scope: null,
+  },
+  "no-empty-named-blocks": {
+    name: "no-empty-named-blocks",
+    severity: "warn",
+    replaces: null,
+    summary: 'Disallow empty named import blocks: `import {} from "..."`.',
+    scope: null,
+  },
+  "prefer-array-flat-map": {
+    name: "prefer-array-flat-map",
+    severity: "warn",
+    replaces: null,
+    summary: "Prefer `.flatMap(f)` over `.map(f).flat()`.",
+    scope: null,
+  },
+} as const;
+
+/**
+ * Absolute filesystem path to a rule's `.grit` file, resolved relative to this
+ * module so it works from `src/` (dev) and `dist/` (published) alike.
+ *
+ * @param name - The rule slug whose `.grit` file path to resolve.
+ * @returns The absolute filesystem path to `<name>.grit`.
+ * @example
+ * ```ts
+ * import { rulePath } from "@beep/lint-rules"
+ *
+ * const grit = rulePath("no-bigint-literals")
+ * // -> ".../packages/tooling/policy-pack/lint-rules/rules/no-bigint-literals.grit"
+ * ```
+ * @category rules
+ * @since 0.1.0
+ */
+export const rulePath = (name: RuleName): string =>
+  decodeURIComponent(new URL(`../rules/${name}.grit`, import.meta.url).pathname);
+
+/**
+ * Absolute filesystem path to the directory holding the `.grit` rule files.
+ *
+ * @returns The absolute filesystem path to the `rules/` directory.
+ * @example
+ * ```ts
+ * import { rulesDir } from "@beep/lint-rules"
+ *
+ * const dir = rulesDir()
+ * ```
+ * @category rules
+ * @since 0.1.0
+ */
+export const rulesDir = (): string => decodeURIComponent(new URL("../rules/", import.meta.url).pathname);

--- a/packages/tooling/policy-pack/lint-rules/test/harness.ts
+++ b/packages/tooling/policy-pack/lint-rules/test/harness.ts
@@ -1,0 +1,118 @@
+/**
+ * Vitest-spawns-Biome rule harness.
+ *
+ * Each invocation writes a throwaway Biome config that loads exactly ONE rule's
+ * `.grit` plugin, runs `biome lint --reporter=json` over a fixture, and returns the
+ * parsed plugin diagnostics. Because only the rule under test is registered, any
+ * `category: "plugin"` diagnostic in the output unambiguously belongs to that rule —
+ * so assertions work regardless of whether the rule is advisory (`warn`, Biome exits
+ * 0) or mandatory (`error`, Biome exits 1).
+ *
+ * This is a local test helper (not package `src`); it models all side effects as
+ * Effects (FileSystem temp dirs, Path joins, `Bun.spawnSync` subprocess), decodes the
+ * subprocess JSON through `effect/Schema`, and imports the package's public rule
+ * registry through the `@beep/lint-rules` alias.
+ */
+import { rulePath } from "@beep/lint-rules";
+import { Effect, FileSystem, Layer, Path } from "effect";
+import * as S from "effect/Schema";
+import type { RuleName } from "@beep/lint-rules";
+
+/** Absolute path to the package root (`.../lint-rules`). */
+const packageRoot = decodeURIComponent(new URL("../", import.meta.url).pathname);
+
+/**
+ * Provide a layer to an effect inside a scoped lifetime. Builds the layer to a
+ * `Context` and provides that (not the `Layer` itself), which is the test-friendly
+ * shape the effect language-service accepts outside application entry points.
+ */
+export const provideScopedLayer =
+  <ROut, E2, RIn>(layer: Layer.Layer<ROut, E2, RIn>) =>
+  <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E | E2, RIn | Exclude<R, ROut>> =>
+    Effect.scoped(Layer.build(layer).pipe(Effect.flatMap((context) => effect.pipe(Effect.provide(context)))));
+
+/** One parsed Biome plugin diagnostic. */
+type PluginDiagnostic = {
+  readonly message: string;
+  readonly severity: string;
+  readonly line: number;
+  readonly column: number;
+};
+
+/** Lenient schema over the subset of Biome's JSON report the harness reads. */
+const BiomeReport = S.Struct({
+  diagnostics: S.Array(
+    S.Struct({
+      category: S.String.pipe(S.optional),
+      message: S.String.pipe(S.optional),
+      severity: S.String.pipe(S.optional),
+      location: S.Struct({
+        start: S.Struct({
+          line: S.Finite.pipe(S.optional),
+          column: S.Finite.pipe(S.optional),
+        }).pipe(S.optional),
+      }).pipe(S.optional),
+    })
+  ).pipe(S.optional),
+});
+
+const encodeConfig = S.encodeUnknownSync(S.UnknownFromJsonString);
+const decodeReport = S.decodeUnknownEffect(S.fromJsonString(BiomeReport));
+
+const emptyReport: S.Schema.Type<typeof BiomeReport> = { diagnostics: undefined };
+
+/** Decode Biome's stdout, tolerating non-JSON noise by returning an empty report. */
+const parseReport = (stdout: string) => decodeReport(stdout).pipe(Effect.orElseSucceed(() => emptyReport));
+
+/**
+ * Lint the given `source` with only `ruleName`'s `.grit` plugin loaded and return the
+ * rule's plugin diagnostics plus Biome's raw exit status. The source is written to a
+ * temp directory so the intentional violations never touch the repo tree.
+ */
+export const runRule = Effect.fn("harness.runRule")(function* (ruleName: RuleName, source: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+
+  const tempDir = yield* fs.makeTempDirectory({ prefix: "beep-lint-rule-" });
+  const configPath = path.join(tempDir, "biome.json");
+  const sourcePath = path.join(tempDir, "fixture.ts");
+  const config = { linter: { enabled: true }, plugins: [rulePath(ruleName)] };
+
+  return yield* Effect.acquireUseRelease(
+    Effect.void,
+    () =>
+      Effect.gen(function* () {
+        yield* fs.writeFileString(configPath, `${encodeConfig(config)}\n`);
+        yield* fs.writeFileString(sourcePath, `${source}\n`);
+
+        const { exitCode, stdout } = yield* Effect.sync(() => {
+          const result = Bun.spawnSync(
+            [
+              "bunx",
+              "biome",
+              "lint",
+              "--reporter=json",
+              "--max-diagnostics=none",
+              `--config-path=${configPath}`,
+              sourcePath,
+            ],
+            { cwd: packageRoot, stdout: "pipe", stderr: "pipe" }
+          );
+          return { exitCode: result.exitCode, stdout: result.stdout.toString() } as const;
+        });
+
+        const report = yield* parseReport(stdout);
+        const diagnostics: ReadonlyArray<PluginDiagnostic> = (report.diagnostics ?? [])
+          .filter((d) => d.category === "plugin")
+          .map((d) => ({
+            message: d.message ?? "",
+            severity: d.severity ?? "",
+            line: d.location?.start?.line ?? -1,
+            column: d.location?.start?.column ?? -1,
+          }));
+
+        return { status: exitCode, diagnostics } as const;
+      }),
+    () => fs.remove(tempDir, { recursive: true, force: true }).pipe(Effect.ignore)
+  );
+});

--- a/packages/tooling/policy-pack/lint-rules/test/parity/parity.test.ts
+++ b/packages/tooling/policy-pack/lint-rules/test/parity/parity.test.ts
@@ -1,0 +1,34 @@
+import { NodeServices } from "@effect/platform-node";
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+import { provideScopedLayer } from "../harness.ts";
+import { coverageDiff, newRuleViolations, oldCliViolations } from "./parity.ts";
+
+// These proofs spawn the (ts-morph) beep CLI over the whole tree, so they are slow.
+const PARITY_TIMEOUT = 120_000;
+
+describe("parity: migrated CLI checks -> GritQL rules (no coverage loss on current tree)", () => {
+  it("no-native-error covers `lint tooling-tagged-errors`", { timeout: PARITY_TIMEOUT }, () =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const oldKeys = yield* oldCliViolations(["lint", "tooling-tagged-errors"]);
+        // Match the old check's scope (tooling source roots only) and the biome.jsonc
+        // override that registers this rule: packages/tooling/**/src/**.
+        const newKeys = yield* newRuleViolations(
+          "no-native-error",
+          ["packages/tooling"],
+          ["packages/tooling/**/src/**", "!**/dist/**", "!**/*.gen.*"]
+        );
+        const { missing, extra } = coverageDiff(oldKeys, newKeys);
+        if (missing.length > 0 || extra.length > 0) {
+          // Surface the diff for reviewers when parity drifts.
+          yield* Effect.log("[parity] tooling-tagged-errors", { missing, extra });
+        }
+        // Old must be a subset of new (no coverage loss). new-only (extra) is triaged
+        // separately; on the current clean tree both sets are empty.
+        expect(extra).toEqual([]);
+        expect(missing).toEqual([]);
+      }).pipe(provideScopedLayer(NodeServices.layer))
+    )
+  );
+});

--- a/packages/tooling/policy-pack/lint-rules/test/parity/parity.ts
+++ b/packages/tooling/policy-pack/lint-rules/test/parity/parity.ts
@@ -1,0 +1,148 @@
+/**
+ * Parity harness for migrated CLI checks.
+ *
+ * For each check being migrated from a `bun run beep ...` ts-morph command to a
+ * Biome GritQL rule, this runs BOTH over the current repo tree, normalizes each to a
+ * set of `file:line` violation keys, and computes the coverage diff. The Parity Gate
+ * (SPEC) accepts a migration only when the old check's violations are a subset of the
+ * new rule's (no coverage loss); new-only diagnostics are reported for triage.
+ *
+ * Local test helper (not package `src`): all side effects are modeled as Effects
+ * (`Bun.spawnSync` subprocesses, FileSystem temp dirs, Path normalization), the
+ * subprocess JSON is decoded through `effect/Schema`, and the package surface is
+ * imported through the `@beep/lint-rules` alias.
+ */
+import { rulePath } from "@beep/lint-rules";
+import { Effect, FileSystem, Path } from "effect";
+import * as S from "effect/Schema";
+import type { RuleName } from "@beep/lint-rules";
+
+/** Repo root (six levels up from `test/parity`). */
+const repoRoot = decodeURIComponent(new URL("../../../../../../", import.meta.url).pathname);
+
+/** A normalized violation key: `<repo-relative-file>:<line>`. */
+export type ViolationKey = string;
+
+/**
+ * Run a `bun run beep ...` check and parse its `file:line` violations. Works for the
+ * tooling-tagged-errors (`file:line:text`) and laws (`file:line:col`) output shapes.
+ */
+export const oldCliViolations = Effect.fn("parity.oldCliViolations")(function* (args: ReadonlyArray<string>) {
+  const path = yield* Path.Path;
+
+  const text = yield* Effect.sync(() => {
+    const result = Bun.spawnSync(["bun", "run", "beep", ...args], {
+      cwd: repoRoot,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    return `${result.stdout.toString()}${result.stderr.toString()}`;
+  });
+
+  const keys = new Set<ViolationKey>();
+  const re = /^([^\s:]+\.[cm]?tsx?):(\d+)/gm;
+  let match: RegExpExecArray | null = re.exec(text);
+  while (match !== null) {
+    const file = match[1] ?? "";
+    const line = match[2] ?? "";
+    keys.add(`${path.relative(repoRoot, path.resolve(repoRoot, file))}:${line}`);
+    match = re.exec(text);
+  }
+  return keys as ReadonlySet<ViolationKey>;
+});
+
+/** Lenient schema over the subset of Biome's JSON report the parity harness reads. */
+const BiomeReport = S.Struct({
+  diagnostics: S.Array(
+    S.Struct({
+      category: S.String.pipe(S.optional),
+      location: S.Struct({
+        path: S.String.pipe(S.optional),
+        start: S.Struct({ line: S.Finite.pipe(S.optional) }).pipe(S.optional),
+      }).pipe(S.optional),
+    })
+  ).pipe(S.optional),
+});
+
+const encodeConfig = S.encodeUnknownSync(S.UnknownFromJsonString);
+const decodeReport = S.decodeUnknownEffect(S.fromJsonString(BiomeReport));
+
+const emptyReport: S.Schema.Type<typeof BiomeReport> = { diagnostics: undefined };
+
+const parseReport = (stdout: string) => decodeReport(stdout).pipe(Effect.orElseSucceed(() => emptyReport));
+
+/**
+ * Run a single GritQL rule over `roots` (repo-relative) and parse its plugin
+ * diagnostics into `file:line` keys, mirroring the repo's Biome excludes.
+ */
+export const newRuleViolations = Effect.fn("parity.newRuleViolations")(function* (
+  ruleName: RuleName,
+  roots: ReadonlyArray<string>,
+  includes?: ReadonlyArray<string>
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+
+  const tempDir = yield* fs.makeTempDirectory({ prefix: "beep-parity-" });
+  const configPath = path.join(tempDir, "biome.json");
+  const config = {
+    linter: { enabled: true },
+    files: {
+      includes: includes ?? [
+        "**",
+        "!**/dist/**",
+        "!**/node_modules/**",
+        "!.repos/**",
+        "!**/*.gen.*",
+        "!**/__snapshots__/**",
+      ],
+    },
+    plugins: [rulePath(ruleName)],
+  };
+
+  return yield* Effect.acquireUseRelease(
+    Effect.void,
+    () =>
+      Effect.gen(function* () {
+        yield* fs.writeFileString(configPath, `${encodeConfig(config)}\n`);
+
+        const stdout = yield* Effect.sync(() => {
+          const result = Bun.spawnSync(
+            [
+              "bunx",
+              "biome",
+              "lint",
+              "--reporter=json",
+              "--max-diagnostics=none",
+              `--config-path=${configPath}`,
+              ...roots,
+            ],
+            { cwd: repoRoot, stdout: "pipe", stderr: "pipe" }
+          );
+          return result.stdout.toString();
+        });
+
+        const keys = new Set<ViolationKey>();
+        const report = yield* parseReport(stdout);
+        for (const d of report.diagnostics ?? []) {
+          if (d.category !== "plugin") continue;
+          const file = d.location?.path;
+          const line = d.location?.start?.line;
+          if (file !== undefined && line !== undefined) {
+            keys.add(`${path.relative(repoRoot, path.resolve(repoRoot, file))}:${line}`);
+          }
+        }
+        return keys as ReadonlySet<ViolationKey>;
+      }),
+    () => fs.remove(tempDir, { recursive: true, force: true }).pipe(Effect.ignore)
+  );
+});
+
+/** Coverage diff: `missing` = old\new (coverage loss, must be empty); `extra` = new\old. */
+export const coverageDiff = (
+  oldKeys: ReadonlySet<ViolationKey>,
+  newKeys: ReadonlySet<ViolationKey>
+): { readonly missing: ReadonlyArray<ViolationKey>; readonly extra: ReadonlyArray<ViolationKey> } => ({
+  missing: [...oldKeys].filter((k) => !newKeys.has(k)).sort(),
+  extra: [...newKeys].filter((k) => !oldKeys.has(k)).sort(),
+});

--- a/packages/tooling/policy-pack/lint-rules/test/registry.test.ts
+++ b/packages/tooling/policy-pack/lint-rules/test/registry.test.ts
@@ -1,0 +1,53 @@
+import { RULE_NAMES, RULES, rulePath, rulesDir } from "@beep/lint-rules";
+import { NodeServices } from "@effect/platform-node";
+import { Effect, FileSystem, Path } from "effect";
+import { describe, expect, it } from "vitest";
+import { provideScopedLayer } from "./harness.ts";
+
+const run = <A, E>(program: Effect.Effect<A, E, NodeServices.NodeServices>): Promise<A> =>
+  Effect.runPromise(program.pipe(provideScopedLayer(NodeServices.layer)));
+
+const sortedRuleNames = [...RULE_NAMES].sort();
+
+describe("rule registry", () => {
+  it("RULES keys match RULE_NAMES exactly", () => {
+    expect(Object.keys(RULES).sort()).toEqual(sortedRuleNames);
+  });
+
+  it("every registered rule has a non-empty .grit file declaring `language js`", () =>
+    run(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        for (const name of RULE_NAMES) {
+          const file = rulePath(name);
+          const exists = yield* fs.exists(file);
+          expect(exists, `${name}.grit must exist`).toBe(true);
+          const content = yield* fs.readFileString(file);
+          expect(content.includes("language js"), `${name}.grit must declare language js`).toBe(true);
+          expect(content.includes("register_diagnostic"), `${name}.grit must register a diagnostic`).toBe(true);
+        }
+      })
+    ));
+
+  it("has no orphan .grit files missing from the registry", () =>
+    run(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const entries = yield* fs.readDirectory(rulesDir());
+        const gritFiles = entries
+          .filter((f) => f.endsWith(".grit"))
+          .map((f) => path.basename(f, ".grit"))
+          .sort();
+        expect(gritFiles).toEqual(sortedRuleNames);
+      })
+    ));
+
+  it("every rule metadata entry is self-consistent", () => {
+    for (const name of RULE_NAMES) {
+      expect(RULES[name].name).toBe(name);
+      expect(["warn", "error"]).toContain(RULES[name].severity);
+      expect(RULES[name].summary.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/tooling/policy-pack/lint-rules/test/rules.test.ts
+++ b/packages/tooling/policy-pack/lint-rules/test/rules.test.ts
@@ -1,0 +1,37 @@
+import { RULE_NAMES, RULES } from "@beep/lint-rules";
+import { NodeServices } from "@effect/platform-node";
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+import { provideScopedLayer, runRule } from "./harness.ts";
+import { SOURCES } from "./sources.ts";
+
+const run = <A, E>(program: Effect.Effect<A, E, NodeServices.NodeServices>): Promise<A> =>
+  Effect.runPromise(program.pipe(provideScopedLayer(NodeServices.layer)));
+
+describe("GritQL rules", () => {
+  for (const rule of RULE_NAMES) {
+    const { invalid, invalidCount, valid, messageIncludes } = SOURCES[rule];
+    // Rules ship advisory: severity matches the registry value ("warn" -> "warning").
+    const expectedSeverity = RULES[rule].severity === "error" ? "error" : "warning";
+
+    describe(rule, () => {
+      it("flags the invalid source", () =>
+        run(
+          Effect.gen(function* () {
+            const { diagnostics } = yield* runRule(rule, invalid);
+            expect(diagnostics.length).toBe(invalidCount);
+            expect(diagnostics.every((d) => d.message.includes(messageIncludes))).toBe(true);
+            expect(diagnostics.every((d) => d.severity === expectedSeverity)).toBe(true);
+          })
+        ));
+
+      it("ignores the valid source", () =>
+        run(
+          Effect.gen(function* () {
+            const { diagnostics } = yield* runRule(rule, valid);
+            expect(diagnostics.length).toBe(0);
+          })
+        ));
+    });
+  }
+});

--- a/packages/tooling/policy-pack/lint-rules/test/sources.ts
+++ b/packages/tooling/policy-pack/lint-rules/test/sources.ts
@@ -1,0 +1,46 @@
+/**
+ * Inline rule fixture sources.
+ *
+ * Each rule has an `invalid` source (expected to trip the rule N times) and a `valid`
+ * source (expected to be silent). Keeping these as string constants — rather than
+ * on-disk `.ts` fixture files — avoids the intentional violations being linted/parsed by
+ * Biome, tsc, and ESLint; the harness writes each source to a temp file before linting.
+ */
+import type { RuleName } from "@beep/lint-rules";
+
+export type RuleSource = {
+  readonly invalid: string;
+  readonly invalidCount: number;
+  readonly valid: string;
+  readonly messageIncludes: string;
+};
+
+export const SOURCES: { readonly [K in RuleName]: RuleSource } = {
+  "no-native-error": {
+    invalidCount: 2,
+    messageIncludes: "native Error",
+    invalid: ["export const boom = () => new Error('nope');", "export const boom2 = () => new Error();"].join("\n"),
+    valid: "export const ok = () => 'no native error here';",
+  },
+  "no-bigint-literals": {
+    invalidCount: 3,
+    messageIncludes: "BigInt literals",
+    invalid: ["export const a = 1n;", "export const b = 0xffn;", "export const c = 0b1010n;"].join("\n"),
+    valid: ["export const a = BigInt(1);", "export const b = BigInt('255');", "export const c = 42;"].join("\n"),
+  },
+  "no-empty-named-blocks": {
+    invalidCount: 1,
+    messageIncludes: "empty named import",
+    invalid: "import {} from './side-effect.js';",
+    valid: ["import { join } from 'node:path';", "export const p = join('a', 'b');"].join("\n"),
+  },
+  "prefer-array-flat-map": {
+    invalidCount: 1,
+    messageIncludes: ".map(...).flat()",
+    invalid: "export const flattened = [[1], [2]].map((x) => x).flat();",
+    valid: [
+      "export const flattened = [[1], [2]].flatMap((x) => x);",
+      "export const mapped = [1, 2].map((x) => x + 1);",
+    ].join("\n"),
+  },
+};

--- a/packages/tooling/policy-pack/lint-rules/test/tsconfig.json
+++ b/packages/tooling/policy-pack/lint-rules/test/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../tsconfig.json",
+  "include": ["./**/*.test.ts", "./**/*.ts"],
+  "exclude": ["./fixtures/**"],
+  "compilerOptions": {
+    "composite": false,
+    "incremental": false,
+    "noEmit": true,
+    "types": ["node", "bun"]
+  }
+}

--- a/packages/tooling/policy-pack/lint-rules/tsconfig.json
+++ b/packages/tooling/policy-pack/lint-rules/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../../../tsconfig.base.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "types": ["node"],
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "references": []
+}

--- a/packages/tooling/policy-pack/lint-rules/vitest.config.ts
+++ b/packages/tooling/policy-pack/lint-rules/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig, mergeConfig } from "vitest/config";
+import shared from "../../../../vitest.shared.ts";
+
+export default mergeConfig(
+  shared,
+  defineConfig({
+    test: {
+      // Rule + parity harnesses spawn Biome as a subprocess; give them headroom.
+      testTimeout: 30_000,
+    },
+  })
+);

--- a/standards/fallow.boundaries.generated.jsonc
+++ b/standards/fallow.boundaries.generated.jsonc
@@ -276,6 +276,12 @@
         ]
       },
       {
+        "name": "@beep/lint-rules",
+        "patterns": [
+          "packages/tooling/policy-pack/lint-rules/src/**"
+        ]
+      },
+      {
         "name": "@beep/m365",
         "patterns": [
           "packages/drivers/m365/src/**"
@@ -1298,6 +1304,15 @@
           "@beep/libpff",
           "@beep/schema",
           "@beep/test-utils"
+        ]
+      },
+      {
+        "from": "@beep/lint-rules",
+        "allow": [
+          "@beep/lint-rules"
+        ],
+        "allowTypeOnly": [
+          "@beep/lint-rules"
         ]
       },
       {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1278,6 +1278,21 @@
       ],
       "@beep/schema/TerritoryName": [
         "./packages/foundation/modeling/schema/src/TerritoryName.ts"
+      ],
+      "@beep/lint-rules": [
+        "./packages/tooling/policy-pack/lint-rules/src/index.ts"
+      ],
+      "@beep/lint-rules/core": [
+        "./packages/tooling/policy-pack/lint-rules/configs/core.jsonc"
+      ],
+      "@beep/lint-rules/recommended": [
+        "./packages/tooling/policy-pack/lint-rules/configs/core.jsonc"
+      ],
+      "@beep/lint-rules/schema": [
+        "./packages/tooling/policy-pack/lint-rules/configs/schema.jsonc"
+      ],
+      "@beep/lint-rules/services": [
+        "./packages/tooling/policy-pack/lint-rules/configs/services.jsonc"
       ]
     }
   }

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -256,6 +256,9 @@
       "path": "packages/tooling/library/repo-utils"
     },
     {
+      "path": "packages/tooling/policy-pack/lint-rules"
+    },
+    {
       "path": "packages/tooling/policy-pack/repo-configs"
     },
     {

--- a/tsconfig.quality.packages.json
+++ b/tsconfig.quality.packages.json
@@ -253,6 +253,9 @@
       "path": "packages/tooling/library/repo-utils"
     },
     {
+      "path": "packages/tooling/policy-pack/lint-rules"
+    },
+    {
       "path": "packages/tooling/policy-pack/repo-configs"
     },
     {

--- a/tstyche.json
+++ b/tstyche.json
@@ -10,7 +10,6 @@
     "packages/shared/server/dtslint/**/*.tst.*",
     "packages/shared/tables/dtslint/**/*.tst.*",
     "packages/shared/ui/dtslint/**/*.tst.*",
-    "packages/tooling/policy-pack/*/dtslint/**/*.tst.*",
     "packages/tooling/test-kit/*/dtslint/**/*.tst.*",
     "packages/tooling/tool/*/dtslint/**/*.tst.*",
     "packages/agents/domain/dtslint/**/*.tst.*",
@@ -70,7 +69,8 @@
     "packages/foundation/modeling/schema/dtslint/**/*.tst.*",
     "packages/foundation/modeling/utils/dtslint/**/*.tst.*",
     "packages/tooling/library/ai-sync/dtslint/**/*.tst.*",
-    "packages/tooling/library/repo-utils/dtslint/**/*.tst.*"
+    "packages/tooling/library/repo-utils/dtslint/**/*.tst.*",
+    "packages/tooling/policy-pack/repo-configs/dtslint/**/*.tst.*"
   ],
   "tsconfig": "./tsconfig.dtslint.json"
 }

--- a/turbo.json
+++ b/turbo.json
@@ -67,6 +67,8 @@
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/biome.jsonc",
+        "$TURBO_ROOT$/packages/tooling/policy-pack/lint-rules/rules/**",
+        "$TURBO_ROOT$/packages/tooling/policy-pack/lint-rules/configs/**",
         "$TURBO_ROOT$/packages/foundation/ui-system/*/stories/**",
         "!.beep/**"
       ]


### PR DESCRIPTION
## feat(lint-rules): add @beep/lint-rules GritQL package + advisory Biome effect-smol alignment

Lint-toolchain-modernization P1. Ships @beep/lint-rules (4 GritQL rules:
no-native-error, no-bigint-literals, no-empty-named-blocks, prefer-array-flat-map)
with presets, an Effect-idiomatic Vitest harness, and a parity harness. Aligns
biome.jsonc to effect-smol advisory (noConsole/noVar/noUselessConstructor + the
GritQL plugins at warn; formatting frozen). Adds STYLE.md deviation record and the
goal packet. effect-fn/effect-imports stay in ts-morph (parity-gate stop conditions,
documented). Rules ship advisory; P2 remediates + flips mandatory.

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit:amend: passed
- full:pre-push: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/feat_lint-toolchain-modernization-p1-ea86cde2785a/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784617533&installation_id=141092090&pr_number=270&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F270&signature=5b7efee261f8cc80a8c78d444043eb144cd60cbb3a732fc9e0de1617b428462a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new repo-local lint rule package with multiple advisory lint rules (e.g., console/BigInt/empty imports/native Error patterns) integrated into the Biome lint setup.
* **Bug Fixes**
  * Adjusted lint severity/behavior for more consistent warnings while preserving formatting stability.
* **Documentation**
  * Added an end-to-end “Lint Toolchain Modernization” plan and comprehensive style guide describing lint alignment and rollout phases.
* **Chores**
  * Updated configuration (tsconfig paths, Turbo lint inputs, boundaries) and added parity/test coverage to verify rule migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->