### PR TITLE
fix(lint-rules): address PR #270 review-bot findings

### DIFF
--- a/.changeset/pink-eels-see.md
+++ b/.changeset/pink-eels-see.md
@@ -1,0 +1,4 @@
+---
+---
+
+Lint-toolchain-modernization P1 review follow-up: address PR #270 review-bot findings (LICENSE Apache-2.0, preset plugin paths, no-bigint-literals src scope, noConsole __tests__, doc consistency, harness/parity resource+spawn safety, biome.jsonc registration test). Internal tooling/config; no package releases.

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -11,7 +11,6 @@
   // advisory (severity "warn" inside each .grit) and run inside the single lint pass.
   // `no-native-error` is registered via `overrides` (tooling source only), not here.
   "plugins": [
-    "./packages/tooling/policy-pack/lint-rules/rules/no-bigint-literals.grit",
     "./packages/tooling/policy-pack/lint-rules/rules/no-empty-named-blocks.grit",
     "./packages/tooling/policy-pack/lint-rules/rules/prefer-array-flat-map.grit"
   ],
@@ -210,10 +209,20 @@
       ]
     },
     {
+      // no-bigint-literals: scope to source roots only. The repo uses bigint literals
+      // legitimately as test/`LiteralKit` data (P0 counted 446 hits, ~423 in tests);
+      // enforcing in `**/src/**` keeps the advisory signal on real source (~23).
+      "includes": ["**/src/**", "infra/**"],
+      "plugins": [
+        "./packages/tooling/policy-pack/lint-rules/rules/no-bigint-literals.grit"
+      ]
+    },
+    {
       // noConsole allowlist: tests, examples, stories, scripts, seeds, and CLI bins
       // legitimately use console. Keeps the advisory signal focused on runtime source.
       "includes": [
         "**/test/**",
+        "**/__tests__/**",
         "**/*.test.*",
         "**/*.spec.*",
         "**/examples/**",

--- a/goals/lint-toolchain-modernization/SPEC.md
+++ b/goals/lint-toolchain-modernization/SPEC.md
@@ -123,10 +123,14 @@ A migrated CLI check is removed only after a runnable parity proof, not by inspe
 
 - [ ] `@beep/lint-rules` exists under `packages/tooling/policy-pack/lint-rules`, builds,
       and its rule unit tests pass.
-- [ ] The GritQL-eligible CLI checks (`lint tooling-tagged-errors`, the filename portion
-      of `lint tooling-schema-first`, `laws effect-fn --check`, and `laws effect-imports
-      --check` lint path) are replaced by GritQL rules with proven parity; the superseded
-      CLI commands are removed or marked deprecated and dropped from the lint aggregators.
+- [ ] The GritQL-reproducible CLI checks (`lint tooling-tagged-errors`; the filename
+      portion of `lint tooling-schema-first` via the `useFilenamingConvention` builtin) are
+      replaced with proven parity; the superseded CLI commands are removed or marked
+      deprecated and dropped from the lint aggregators. **`laws effect-fn --check` and
+      `laws effect-imports --check` are NOT migrated** — the P1 spike proved them
+      non-reproducible in GritQL (effect-fn: 51 false positives + ~98s runtime; effect-imports:
+      whole-file consolidation + `--write` needed by yeet). They stay in `ts-morph` per the
+      Stop Conditions, recorded in the Exception Ledger, `STYLE.md`, and `rule-inventory.md`.
 - [ ] `biome.jsonc` enables the full effect-smol-mappable lint-rule set (import discipline,
       `noConsole`, `noVar`, etc.); Biome formatting options are unchanged.
 - [ ] `STYLE.md` documents, with rationale, every deviation in a table (rule | effect-smol
@@ -180,6 +184,7 @@ A migrated CLI check is removed only after a runnable parity proof, not by inspe
 | Exception | Scope | Owner | Rationale | Removal condition |
 | --- | --- | --- | --- | --- |
 | Biome formatting kept (not effect-smol's dprint ASI/`never`) | `biome.jsonc` formatter | repo | Avoids whole-repo reformat; Biome cannot replicate dprint ASI exactly; user decision | Revisit only if a dedicated formatting-parity initiative is opened |
+| `laws effect-fn` + `laws effect-imports` kept in `ts-morph` (not GritQL) | `packages/tooling/tool/cli` | repo | P1 spike: effect-fn GritQL = 51 false positives + ~98s runtime; effect-imports needs whole-file consolidation + a `--write` codemod yeet depends on. Not single-file-reproducible (SPEC Stop Condition). | Revisit only if a type-aware lint engine (e.g. oxlint type-aware) makes faithful single-pass replacement viable |
 | oxlint deferred to P3, advisory-first | CI lint lane | repo | oxlint custom-plugin API is alpha (Windows/type-aware gaps) | Promote to mandatory when "stable" (oxlint lint lane runs green on Linux CI for 3+ consecutive weeks with no custom-plugin-API breakage). Re-assess **2026-09-20**. |
 
 **P3 exit is closeable either way:** (a) oxlint reaches mandatory + green and all four t3code

--- a/goals/lint-toolchain-modernization/research/rule-inventory.md
+++ b/goals/lint-toolchain-modernization/research/rule-inventory.md
@@ -11,8 +11,8 @@ Rule-by-rule routing for the initiative. **Engine**: `gritql` (Biome plugin, P1)
 | --- | --- | --- | --- | --- |
 | `lint tooling-tagged-errors` | ts-morph regex (`new Error`) | **gritql** | high | Cleanest port; match `new Error(...)`, suggest tagged error. ~40 LoC removed. |
 | `lint tooling-schema-first` (filename checks only) | ts-morph + regex | **gritql** | high | Split the PascalCase/index-bin filename check into a GritQL rule; keep the pattern/inventory checks in ts-morph. |
-| `laws effect-fn --check` | ts-morph Project | **gritql** | medium | Match `function*` decls + `Effect.fn.Return<…>` JSDoc; syntactic. JSDoc parsing is the risk. |
-| `laws effect-imports --check` (lint path) | ts-morph Project + rewrite | **gritql** (lint) | medium | GritQL for the *diagnostic*; keep `laws effect-imports --write` (ts-morph) for remediation. |
+| `laws effect-fn --check` | ts-morph Project | **keep-tsmorph** (P1 verdict) | ~~medium~~ | **Not migrated.** P1 GritQL spike produced 51 false positives in `packages/foundation` (precise check finds 0) and ~98s runtime on `apps` (`within`-ancestor traversal on the hot `Effect.gen` pattern). Needs direct-return-owner/nearest-owner/generator scope analysis → stays in ts-morph (SPEC Stop Condition). See `STYLE.md`, `p0-spike-result.md`. |
+| `laws effect-imports --check` (lint path) | ts-morph Project + rewrite | **keep-tsmorph** (P1 verdict) | ~~medium~~ | **Not migrated.** Whole-file import consolidation (8-entry alias table, moving named imports root↔submodule) is not a single-file GritQL pattern; the `--write` codemod is also required by `yeet` repair (`Yeet/internal/Planner.ts`) → stays in ts-morph. See `STYLE.md`. |
 | `laws native-runtime --check` | ts-morph + allowlist | **hybrid** | medium | GritQL detects `node:` imports; keep ts-morph for method-call scope + allowlist reconciliation. (Exact name confirmed: `native-runtime`, not `no-native-runtime`.) |
 | `laws dual-arity --check` | ts-morph (types) | keep-tsmorph | high | Needs type info + exception inventory. |
 | `laws terse-effect --check` | ts-morph (scope + rewrite) | keep-tsmorph | high | Multi-node codemods + scope analysis. |

--- a/packages/tooling/policy-pack/lint-rules/CLAUDE.md
+++ b/packages/tooling/policy-pack/lint-rules/CLAUDE.md
@@ -13,7 +13,9 @@
 
 ## Laws
 - GritQL is diagnostics-only — never silent rewrites.
-- New rule = add `.grit` + `src/index.ts` registry entry + `test/fixtures/<rule>/{invalid,valid}.ts`.
+- New rule = add `.grit` + `src/index.ts` registry entry + a `SOURCES[<rule>]` entry
+  (inline `invalid`/`valid` strings) in `test/sources.ts`; the harness writes them to a
+  temp file at test time (no on-disk fixture files).
 - Ship advisory (`severity = "warn"`); flip to `"error"` only when the subsystem is clean.
 - Keep rules fast: avoid `within`/deep-ancestor operators on hot patterns.
 
@@ -28,6 +30,6 @@ import { RULES, rulePath } from "@beep/lint-rules"
 - `bunx turbo run lint --filter=@beep/lint-rules`
 
 ## Contributor Checklist
-- [ ] New rule registered in `src/index.ts` and `biome.jsonc`
-- [ ] Fixture pair + test added
+- [ ] New rule registered in `src/index.ts` and `biome.jsonc` (top-level `plugins` or an `overrides` entry)
+- [ ] `SOURCES[<rule>]` invalid/valid pair added to `test/sources.ts`
 - [ ] `bun run check` / `bun run test` / `bun run lint` pass

--- a/packages/tooling/policy-pack/lint-rules/LICENSE
+++ b/packages/tooling/policy-pack/lint-rules/LICENSE
@@ -1,21 +1,201 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2026 beep-effect
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/tooling/policy-pack/lint-rules/configs/core.jsonc
+++ b/packages/tooling/policy-pack/lint-rules/configs/core.jsonc
@@ -4,11 +4,12 @@
   // beep's root `biome.jsonc` registers these `.grit` files directly in its top-level
   // `plugins` array (Biome resolves plugin paths relative to the config file, so the
   // root config uses repo-root-relative paths). This preset documents the canonical
-  // grouping; the paths below are package-relative for external `extends` consumers.
+  // grouping for external `extends` consumers; Biome resolves the paths below relative
+  // to THIS file (`configs/`), so they point up into the sibling `rules/` directory.
   "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
   "plugins": [
-    "./rules/no-bigint-literals.grit",
-    "./rules/no-empty-named-blocks.grit",
-    "./rules/prefer-array-flat-map.grit"
+    "../rules/no-bigint-literals.grit",
+    "../rules/no-empty-named-blocks.grit",
+    "../rules/prefer-array-flat-map.grit"
   ]
 }

--- a/packages/tooling/policy-pack/lint-rules/configs/schema.jsonc
+++ b/packages/tooling/policy-pack/lint-rules/configs/schema.jsonc
@@ -3,11 +3,12 @@
   // packages today. Schema-specific custom rules that need import-binding / member
   // scope (effect-smol `no-opaque-instance-fields`, t3code `no-inline-schema-compile`)
   // are stateful/scope-aware and land in the P3 oxlint lane, not GritQL — see
-  // `goals/lint-toolchain-modernization/research/rule-inventory.md`.
+  // `goals/lint-toolchain-modernization/research/rule-inventory.md`. Biome resolves the
+  // paths below relative to this file (`configs/`), pointing at the sibling `rules/`.
   "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
   "plugins": [
-    "./rules/no-bigint-literals.grit",
-    "./rules/no-empty-named-blocks.grit",
-    "./rules/prefer-array-flat-map.grit"
+    "../rules/no-bigint-literals.grit",
+    "../rules/no-empty-named-blocks.grit",
+    "../rules/prefer-array-flat-map.grit"
   ]
 }

--- a/packages/tooling/policy-pack/lint-rules/configs/services.jsonc
+++ b/packages/tooling/policy-pack/lint-rules/configs/services.jsonc
@@ -1,12 +1,14 @@
 {
-  // @beep/lint-rules — services preset: core hygiene plus tooling/service-source
-  // discipline. `no-native-error` is meant to be registered via a biome `overrides`
-  // entry scoped to `packages/tooling/**/src/**` (it should not lint tests/fixtures).
+  // @beep/lint-rules — services preset: the core hygiene rules apply to Effect
+  // service/tooling source. `no-native-error` is intentionally NOT listed here: it is
+  // path-scoped (tooling source only) and must be registered via a biome `overrides`
+  // entry (`packages/tooling/**/src/**`), not a flat `plugins` array — a preset cannot
+  // express that scope. Service-authoring discipline (`laws effect-fn`) stays in
+  // ts-morph (see STYLE.md). Biome resolves the paths below relative to this file.
   "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
   "plugins": [
-    "./rules/no-bigint-literals.grit",
-    "./rules/no-empty-named-blocks.grit",
-    "./rules/prefer-array-flat-map.grit",
-    "./rules/no-native-error.grit"
+    "../rules/no-bigint-literals.grit",
+    "../rules/no-empty-named-blocks.grit",
+    "../rules/prefer-array-flat-map.grit"
   ]
 }

--- a/packages/tooling/policy-pack/lint-rules/src/index.ts
+++ b/packages/tooling/policy-pack/lint-rules/src/index.ts
@@ -109,7 +109,7 @@ export const RULES: { readonly [K in RuleName]: RuleMetadata } = {
     severity: "warn",
     replaces: null,
     summary: "Disallow bigint literals (1n, 0xFFn, ...); use BigInt(value).",
-    scope: null,
+    scope: "**/src/**",
   },
   "no-empty-named-blocks": {
     name: "no-empty-named-blocks",

--- a/packages/tooling/policy-pack/lint-rules/test/harness.ts
+++ b/packages/tooling/policy-pack/lint-rules/test/harness.ts
@@ -72,16 +72,14 @@ const parseReport = (stdout: string) => decodeReport(stdout).pipe(Effect.orElseS
 export const runRule = Effect.fn("harness.runRule")(function* (ruleName: RuleName, source: string) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
-
-  const tempDir = yield* fs.makeTempDirectory({ prefix: "beep-lint-rule-" });
-  const configPath = path.join(tempDir, "biome.json");
-  const sourcePath = path.join(tempDir, "fixture.ts");
   const config = { linter: { enabled: true }, plugins: [rulePath(ruleName)] };
 
   return yield* Effect.acquireUseRelease(
-    Effect.void,
-    () =>
+    fs.makeTempDirectory({ prefix: "beep-lint-rule-" }),
+    (tempDir) =>
       Effect.gen(function* () {
+        const configPath = path.join(tempDir, "biome.json");
+        const sourcePath = path.join(tempDir, "fixture.ts");
         yield* fs.writeFileString(configPath, `${encodeConfig(config)}\n`);
         yield* fs.writeFileString(sourcePath, `${source}\n`);
 
@@ -113,6 +111,6 @@ export const runRule = Effect.fn("harness.runRule")(function* (ruleName: RuleNam
 
         return { status: exitCode, diagnostics } as const;
       }),
-    () => fs.remove(tempDir, { recursive: true, force: true }).pipe(Effect.ignore)
+    (tempDir) => fs.remove(tempDir, { recursive: true, force: true }).pipe(Effect.ignore)
   );
 });

--- a/packages/tooling/policy-pack/lint-rules/test/parity/parity.ts
+++ b/packages/tooling/policy-pack/lint-rules/test/parity/parity.ts
@@ -30,14 +30,21 @@ export type ViolationKey = string;
 export const oldCliViolations = Effect.fn("parity.oldCliViolations")(function* (args: ReadonlyArray<string>) {
   const path = yield* Path.Path;
 
-  const text = yield* Effect.sync(() => {
+  const { exitCode, text } = yield* Effect.sync((): { readonly exitCode: number | null; readonly text: string } => {
     const result = Bun.spawnSync(["bun", "run", "beep", ...args], {
       cwd: repoRoot,
       stdout: "pipe",
       stderr: "pipe",
     });
-    return `${result.stdout.toString()}${result.stderr.toString()}`;
+    return { exitCode: result.exitCode, text: `${result.stdout.toString()}${result.stderr.toString()}` };
   });
+
+  // A normal non-zero exit is expected (the beep CLI returns 1 when it finds
+  // violations); only a `null` exitCode means the process never spawned, which would
+  // otherwise let an empty output silently false-pass the ∅⊆∅ parity assertion.
+  if (exitCode === null) {
+    return yield* Effect.die(`parity: \`bun run beep ${args.join(" ")}\` failed to spawn`);
+  }
 
   const keys = new Set<ViolationKey>();
   const re = /^([^\s:]+\.[cm]?tsx?):(\d+)/gm;
@@ -82,9 +89,6 @@ export const newRuleViolations = Effect.fn("parity.newRuleViolations")(function*
 ) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
-
-  const tempDir = yield* fs.makeTempDirectory({ prefix: "beep-parity-" });
-  const configPath = path.join(tempDir, "biome.json");
   const config = {
     linter: { enabled: true },
     files: {
@@ -101,26 +105,36 @@ export const newRuleViolations = Effect.fn("parity.newRuleViolations")(function*
   };
 
   return yield* Effect.acquireUseRelease(
-    Effect.void,
-    () =>
+    fs.makeTempDirectory({ prefix: "beep-parity-" }),
+    (tempDir) =>
       Effect.gen(function* () {
+        const configPath = path.join(tempDir, "biome.json");
         yield* fs.writeFileString(configPath, `${encodeConfig(config)}\n`);
 
-        const stdout = yield* Effect.sync(() => {
-          const result = Bun.spawnSync(
-            [
-              "bunx",
-              "biome",
-              "lint",
-              "--reporter=json",
-              "--max-diagnostics=none",
-              `--config-path=${configPath}`,
-              ...roots,
-            ],
-            { cwd: repoRoot, stdout: "pipe", stderr: "pipe" }
-          );
-          return result.stdout.toString();
-        });
+        const { exitCode, stdout } = yield* Effect.sync(
+          (): { readonly exitCode: number | null; readonly stdout: string } => {
+            const result = Bun.spawnSync(
+              [
+                "bunx",
+                "biome",
+                "lint",
+                "--reporter=json",
+                "--max-diagnostics=none",
+                `--config-path=${configPath}`,
+                ...roots,
+              ],
+              { cwd: repoRoot, stdout: "pipe", stderr: "pipe" }
+            );
+            return { exitCode: result.exitCode, stdout: result.stdout.toString() };
+          }
+        );
+
+        // Biome exits 0 (warn) or 1 (error) for findings — both expected. Only a `null`
+        // exitCode means biome never spawned, which would let empty output silently
+        // false-pass the ∅⊆∅ parity assertion.
+        if (exitCode === null) {
+          return yield* Effect.die(`parity: \`bunx biome lint ${roots.join(" ")}\` failed to spawn`);
+        }
 
         const keys = new Set<ViolationKey>();
         const report = yield* parseReport(stdout);
@@ -134,7 +148,7 @@ export const newRuleViolations = Effect.fn("parity.newRuleViolations")(function*
         }
         return keys as ReadonlySet<ViolationKey>;
       }),
-    () => fs.remove(tempDir, { recursive: true, force: true }).pipe(Effect.ignore)
+    (tempDir) => fs.remove(tempDir, { recursive: true, force: true }).pipe(Effect.ignore)
   );
 });
 

--- a/packages/tooling/policy-pack/lint-rules/test/registry.test.ts
+++ b/packages/tooling/policy-pack/lint-rules/test/registry.test.ts
@@ -9,6 +9,9 @@ const run = <A, E>(program: Effect.Effect<A, E, NodeServices.NodeServices>): Pro
 
 const sortedRuleNames = [...RULE_NAMES].sort();
 
+/** Repo root (five levels up from `test/registry.test.ts`). */
+const repoRoot = decodeURIComponent(new URL("../../../../../", import.meta.url).pathname);
+
 describe("rule registry", () => {
   it("RULES keys match RULE_NAMES exactly", () => {
     expect(Object.keys(RULES).sort()).toEqual(sortedRuleNames);
@@ -50,4 +53,21 @@ describe("rule registry", () => {
       expect(RULES[name].summary.length).toBeGreaterThan(0);
     }
   });
+
+  it("every rule is wired into the repo-root biome.jsonc lint pass", () =>
+    run(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        // biome.jsonc is JSONC (comments); assert the plugin path substring is present —
+        // this covers both the top-level `plugins` array and any `overrides[].plugins`.
+        const biomeConfig = yield* fs.readFileString(path.join(repoRoot, "biome.jsonc"));
+        for (const name of RULE_NAMES) {
+          const pluginRef = `rules/${name}.grit`;
+          expect(biomeConfig.includes(pluginRef), `${name} must be registered in biome.jsonc (${pluginRef})`).toBe(
+            true
+          );
+        }
+      })
+    ));
 });


### PR DESCRIPTION
## fix(lint-rules): address PR #270 review-bot findings

Follow-up to the merged lint-toolchain-modernization P1 PR (#270): LICENSE -> Apache-2.0
(match package.json); preset plugin paths ./rules -> ../rules (resolve relative to
configs/); remove mis-scoped no-native-error from the services preset; scope
no-bigint-literals to **/src/** (was repo-wide, 446 hits mostly test/LiteralKit data);
noConsole allowlist adds **/__tests__/**; rule-inventory.md + SPEC acceptance + exception
ledger record effect-fn/effect-imports as ts-morph (non-viable in GritQL); CLAUDE.md
checklist points at inline test/sources.ts; harness/parity temp dirs moved into the
acquireUseRelease bracket + parity spawn-failure guards; new test asserts every rule is
registered in biome.jsonc. Internal tooling/config; no package releases.

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- full:pre-push: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/fix_lint-rules-p1-review-022c49882773/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/273"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784622780&installation_id=141092090&pr_number=273&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F273&signature=7070239971ba47c4dc80db95de44d042d13848373d5d931012b21541225a6d63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated license from MIT to Apache License 2.0
  * Refined linting configuration and plugin paths for better clarity
  * Improved test infrastructure for policy rules

* **Tests**
  * Added registry consistency verification to ensure all lint rules are properly configured

* **Documentation**
  * Updated contributor guidelines for adding new lint rules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->