### PR TITLE
feat(identity): literal-typed IRI/CURIE composer (identity-iri-core)

### DIFF
--- a/explorations/identity-as-iri/DECISIONS.md
+++ b/explorations/identity-as-iri/DECISIONS.md
@@ -127,14 +127,22 @@ fiber source among several (annotations, docs, provenance). Rejected:
 `OntologyRegistry` (names one use case, reads narrower than the interface),
 bare `Registry` (leans entirely on package namespace).
 
-## 2026-07-02 — authority host (DEFERRED)
+## 2026-07-02 — authority host (RESOLVED)
 
 **Question:** What real authority host replaces the `https://ns.beep.sh/`
 placeholder?
 
-**Answer:** DEFERRED by elpresidank (2026-07-01): keep the placeholder;
-decide before the composer-binding phase merges. `rebase` makes this safe to
-defer — the default just should be right before it ships.
+**Answer:** `https://ns.beep.sh/` CONFIRMED as the real authority
+(elpresidank, 2026-07-02, at `goals/identity-iri-core` P0). Every beep
+identity derives its IRI from this root; published vocabularies may still
+`rebase` per-module (e.g. opip.law namespaces).
+
+**Rationale:** Purpose-built `ns.` subdomain on a beep-owned domain; matches
+the handoff, prototype, and spec examples; slash-style per-term dereference
+remains servable there. Rejected: oip.law namespace (anchors repo-wide
+identity to one client vertical); deciding at PR review (no new information
+would arrive). Originally DEFERRED 2026-07-01; resolved when the core packet
+launched.
 
 ## 2026-07-02 — apply goals supersession now
 

--- a/explorations/identity-as-iri/ops/manifest.json
+++ b/explorations/identity-as-iri/ops/manifest.json
@@ -5,9 +5,7 @@
     "title": "Identity as IRI",
     "status": "active",
     "stage": "graduate",
-    "openQuestions": [
-      "DEFERRED — authority host: https://ns.beep.sh/ placeholder stands; confirm before goals/identity-iri-core merges (DECISIONS 2026-07-02)"
-    ],
+    "openQuestions": [],
     "sources": ["research/SOURCES.md"],
     "links": {
       "goals": ["goals/identity-iri-core"],

--- a/goals/identity-iri-core/README.md
+++ b/goals/identity-iri-core/README.md
@@ -37,14 +37,17 @@ Use this command for execution-capable sessions:
 
 ## Current Phase
 
-P0 Research — next concrete action: confirm the authority host with
-elpresidank (blocking input; `https://ns.beep.sh/` is a placeholder), then
-build the audit-B shape-stable harness before touching `Id.ts`.
+P3 Yeet: PR to mergeable — [PR #289](https://github.com/beep-effect/beep-effect/pull/289)
+open; monitoring checks. Inherited main-red lanes are documented in the SPEC
+Exception Ledger and the PR body. Then P4 Close (reflection + status flip).
 
 ## Latest Evidence
 
-Not started. Design proof: `scratchpad/identity/` prototype (27/27 tests,
-effect-only) at checkpoint `61160e1baf`.
+[PR #289](https://github.com/beep-effect/beep-effect/pull/289). Local gates:
+identity 51 tests (incl. shape-stable harness) + rdf 26, check/docgen/biome
+green. Blast radius: [`history/p2-blast-radius.md`](./history/p2-blast-radius.md)
+(+6% in-package instantiations, ~noise downstream). Full phase evidence under
+[`history/`](./history/).
 
 ## Notes
 

--- a/goals/identity-iri-core/history/p0-harness-evidence.md
+++ b/goals/identity-iri-core/history/p0-harness-evidence.md
@@ -1,0 +1,77 @@
+# P0 Shape-Stable Harness Evidence
+
+Date: 2026-07-02
+
+## Audit Currency
+
+Verdict: drifted, but still usable as the preserve-exactly baseline.
+
+I spot-checked `explorations/identity-as-iri/research/11-audit-identity-coupling.md`
+against HEAD with a TypeScript AST scan of named imports from `@beep/identity`
+and `@beep/identity/packages` across `apps`, `packages`, `infra`, `goals`,
+`scratchpad`, and `explorations`.
+
+- Current `@beep/identity` named imports: 56 runtime names and 9 type-only names.
+- Current `@beep/identity/packages` named imports: 41 runtime names.
+- Drift found: `$UsptoMcpId` is now imported from `@beep/identity/packages` and
+  was not present in the audit list.
+- Audit-only names not currently imported as named imports: `$DataId` and
+  `$IdentityId`; `$BeepId` is an alias of the imported `$I`, not an imported
+  name.
+
+## Harness Coverage
+
+Added `packages/foundation/modeling/identity/test/shape-stable.test.ts`.
+
+The harness pins:
+
+- Current runtime named imports from `@beep/identity`.
+- Current runtime named imports from `@beep/identity/packages`.
+- Current type-only import inventory from `@beep/identity` as a sentinel next to
+  the existing package dtslint coverage.
+- Every generated composer export from `src/packages.ts`, including `$I`, with
+  exact current `.string()`, `.identifier`, `.value`, and `Symbol.for(...)`
+  behavior.
+- Composer callable/function shape and method presence for `create`, `compose`,
+  `annote`, `annoteHttp`, `annoteSchema`, `annoteKey`, `make`, `string`, and
+  `symbol`.
+- Current `make()` one-argument forms for `beep`, `@beep`, `schema`, `@schema`,
+  `@beep/schema`, and `repo-cli`.
+- Representative `Symbol.for` round trips for root, package, nested, and new
+  `$UsptoMcpId` identities.
+- Existing `annote`, `annoteSchema`, and `annoteKey` metadata keys and values
+  while allowing future additive keys such as `iri` and `curie`.
+- Create-package identity registration coupling in
+  `packages/tooling/tool/cli/src/commands/CreatePackage/Handler.ts`: root import
+  emission, typed export emission, accessor naming, and registration against
+  `generatedComposers` or `composers`.
+
+## How To Run
+
+Required lane:
+
+```sh
+bunx turbo run test --filter @beep/identity
+```
+
+Fallback Vitest lane when Bun-backed Vitest workers time out before test import:
+
+```sh
+cd packages/foundation/modeling/identity
+bunx vitest run
+```
+
+Package check:
+
+```sh
+cd packages/foundation/modeling/identity
+bun run check
+```
+
+## Gate Results
+
+- `bunx turbo run test --filter @beep/identity`: failed before test execution;
+  `bunx --bun vitest run` timed out starting Vitest fork workers for both
+  `Identity.test.ts` and `shape-stable.test.ts`.
+- Fallback `bunx vitest run`: passed, 2 files and 29 tests.
+- `bun run check`: passed.

--- a/goals/identity-iri-core/history/p1a-vocab-codecs-evidence.md
+++ b/goals/identity-iri-core/history/p1a-vocab-codecs-evidence.md
@@ -1,0 +1,53 @@
+# P1A Vocab / CURIE / PN_LOCAL Evidence
+
+## Files Touched
+
+- `packages/foundation/modeling/identity/src/Vocab.ts`
+- `packages/foundation/modeling/identity/src/Curie.ts`
+- `packages/foundation/modeling/identity/src/PnLocal.ts`
+- `packages/foundation/modeling/identity/src/index.ts`
+- `packages/foundation/modeling/identity/test/Vocab.test.ts`
+- `packages/foundation/modeling/identity/test/Curie.test.ts`
+- `packages/foundation/modeling/identity/test/PnLocal.test.ts`
+- `packages/foundation/modeling/rdf/src/Vocab/Dcterms.ts`
+- `packages/foundation/modeling/rdf/src/Vocab/Owl.ts`
+- `packages/foundation/modeling/rdf/src/Vocab/Rdf.ts`
+- `packages/foundation/modeling/rdf/src/Vocab/Rdfs.ts`
+- `packages/foundation/modeling/rdf/src/Vocab/Skos.ts`
+- `packages/foundation/modeling/rdf/test/VocabDrift.test.ts`
+- `goals/identity-iri-core/history/p1a-vocab-codecs-evidence.md`
+
+## Gate Summary
+
+- `bunx turbo run check --filter @beep/identity --filter @beep/rdf`: green.
+  - Turbo summary: 6 successful, 6 total.
+- `bunx turbo run docgen --filter @beep/identity --filter @beep/rdf --concurrency=1`: green.
+  - `@beep/identity`: 6 modules, 144 examples, docs generation succeeded.
+  - `@beep/rdf`: 17 modules, 196 examples, docs generation succeeded.
+  - Turbo summary: 6 successful, 6 total.
+- `bunx biome check <touched files>`: green.
+  - 13 files checked, no fixes applied.
+- `bunx vitest run` in `packages/foundation/modeling/identity`: green.
+  - 5 test files, 47 tests passed.
+- `bunx vitest run test/VocabDrift.test.ts` in `packages/foundation/modeling/rdf`: green.
+  - 1 test file, 1 test passed.
+- `bunx vitest run` in `packages/foundation/modeling/rdf`: not used as proof.
+  - The new `test/VocabDrift.test.ts` passed, but the existing `test/Rdf.test.ts` failed on an unrelated `SemanticSchemaMetadata` error-message assertion: expected text containing `Expected SemanticSchemaMetadataKind`, received text containing `Expected @beep/rdf/semantic-schema-metadata/SemanticSchemaMetadataKind`.
+
+## Blocked / External Gate Notes
+
+- `bunx turbo run test --filter @beep/identity --filter @beep/rdf`: blocked by the package scripts' Bun-backed Vitest worker startup.
+  - Both package scripts run `bunx --bun vitest run`.
+  - Vitest reported `Failed to start forks worker` and `Timeout waiting for worker to respond`.
+  - It failed before loading tests: `Test Files no tests`, `transform 0ms`, `import 0ms`.
+  - The same worker timeout reproduced on a single identity test file with `bunx --bun vitest run test/Vocab.test.ts --pool=forks --maxWorkers=1`.
+  - The same identity tests pass under the Node-backed runner (`bunx vitest run`), and the new RDF drift test passes under the Node-backed runner.
+- `bun run docgen:local`: blocked by unrelated repo-wide docgen metadata debt after selecting the touched packages.
+  - It reported unrelated failures in `packages/drivers/box`, `packages/drivers/ecfr`, `packages/drivers/govinfo`, `packages/foundation/capability/api-transport`, UI/editor packages, `packages/law-practice/domain`, and `packages/tooling/policy-pack/repo-configs`.
+  - The package-scoped docgen fallback for `@beep/identity` and `@beep/rdf` is green.
+
+## Deviations From Donor Prototype
+
+- `CoreVocab` uses the full `03-vocabularies.md` registry for `rdf`, `rdfs`, `skos`, `owl`, and `dcterms`; the scratchpad donor carried only the smaller proof subset.
+- RDF vocabulary modules now expose static term-list constants, plus a new `Dcterms.ts`, so the drift test can compare namespace and term inventories without making `@beep/identity` depend on `@beep/rdf`.
+- No composer behavior was ported in part A, and `packages/foundation/modeling/identity/src/Id.ts` plus `src/packages.ts` were not edited.

--- a/goals/identity-iri-core/history/p1b-composer-evidence.md
+++ b/goals/identity-iri-core/history/p1b-composer-evidence.md
@@ -1,0 +1,91 @@
+# P1b Composer Evidence
+
+## Implementation
+
+- `packages/foundation/modeling/identity/src/Id.ts`
+  - Added exported `IriFromIdentity`, `CurieFromIdentity`, and `SlugFromIdentifier` type transforms beside the existing `TitleFromIdentifier` family.
+  - Extended `IdentityComposer` with binding-aware type parameters, `.iri`, `.curie`, `.slug`, and `rebase(...)`.
+  - Kept one-argument `make(...)` compatible and explicitly unbound. Added an optional second binding argument `{ authority, prefix, vocab? }`.
+  - Threaded binding type parameters through `create(...)`, `compose(...)`, and annotation helpers.
+  - Added bound-only `iri` / `curie` annotation fields for `annote`, `annoteSchema`, `annoteHttp`, and `annoteKey` via the shared `annote(...)` path.
+  - Preserved identity strings and `Symbol.for(...)` interning under `rebase(...)`.
+
+- `packages/foundation/modeling/identity/src/packages.ts`
+  - Bound the root `$I` composer with `{ authority: "https://ns.beep.sh/", prefix: "beep" }`.
+  - No other package composer call sites changed; generated composers inherit from the bound root.
+
+- New modules
+  - No new source module was added. The integration stayed in `Id.ts` because the projection helpers are tightly coupled to the existing composer generics and annotation result shapes.
+  - Existing P1a modules `Vocab.ts`, `Curie.ts`, and `PnLocal.ts` were read/imported by type only where needed and not modified.
+
+- Test runner note
+  - `@beep/identity` package-local `beep:test` now uses `bunx vitest run` instead of `bunx --bun vitest run`. On this host, `bunx --bun vitest run` failed before test import with Vitest worker-pool startup timeouts / stdout pipe errors. The Node-run Vitest path passes the same package tests and lets the required turbo gate complete.
+
+## Unbound Composer Semantics
+
+One-argument `make(...)` returns an unbound composer. Its `.iri` and `.curie` properties are present and typed as `undefined`; `.slug` is always derived from the identity path. This keeps the API type-safe without throwing from property access, and it preserves existing callers that use `make("beep")` only for identity strings, symbols, and annotations.
+
+Unbound `annote(...)` records do not gain own `iri` / `curie` fields. Bound composers add those fields as owned-channel metadata. Existing `identifier`, `schemaId`, and `title` values remain unchanged.
+
+## Type-Level Notes
+
+`SlugFromIdentifier` is implemented at the type level for static strings and at runtime for composer values. Widened `string` inputs widen to `string`, matching `IriFromIdentity` and `CurieFromIdentity`. The slug transform mirrors runtime behavior for separators and lower-to-upper word boundaries; acronym runs stay joined the same way the runtime regex handles them.
+
+## Gate Evidence
+
+```sh
+bunx turbo run test --filter @beep/identity --filter @beep/rdf --concurrency=1
+```
+
+Result: pass.
+
+Key lines:
+
+```text
+@beep/identity:test: Test Files  6 passed (6)
+@beep/identity:test: Tests  51 passed (51)
+@beep/identity:test: ✓ test/shape-stable.test.ts (10 tests)
+@beep/rdf:test: Test Files 2 passed (2)
+@beep/rdf:test: Tests 26 passed (26)
+Tasks: 2 successful, 2 total
+```
+
+```sh
+bunx turbo run check --filter @beep/identity --filter @beep/rdf
+```
+
+Result: pass.
+
+Key lines:
+
+```text
+@beep/identity:check: $ tsgo -b tsconfig.json
+@beep/rdf:check: $ tsgo -b tsconfig.json
+Tasks: 6 successful, 6 total
+```
+
+```sh
+bunx turbo run docgen --filter @beep/identity --concurrency=1
+```
+
+Result: pass.
+
+Key lines:
+
+```text
+@beep/identity:docgen: 6 module(s) found
+@beep/identity:docgen: 147 example(s) found
+@beep/identity:docgen: Typechecking examples...
+@beep/identity:docgen: ✓ Docs generation succeeded!
+Tasks: 2 successful, 2 total
+```
+
+Diff scope checked after implementation and before final gate rerun:
+
+```text
+packages/foundation/modeling/identity/package.json
+packages/foundation/modeling/identity/src/Id.ts
+packages/foundation/modeling/identity/src/packages.ts
+packages/foundation/modeling/identity/test/IriBinding.test.ts
+goals/identity-iri-core/history/p1b-composer-evidence.md
+```

--- a/goals/identity-iri-core/history/p2-blast-radius.md
+++ b/goals/identity-iri-core/history/p2-blast-radius.md
@@ -1,0 +1,24 @@
+# P2 Compile Blast-Radius Measurement
+
+Date: 2026-07-02. Method: `tsc -p tsconfig.json --extendedDiagnostics` on
+`@beep/identity` (tsbuildinfo cleared) and wall-clock `tsc -b --force` on the
+direct dependent `@beep/schema`, at HEAD (P1a+P1b, `811733b62c`) vs baseline
+(`647093884d`, pre-P1a) via in-place package checkout.
+
+| Metric | Baseline | HEAD | Delta |
+| --- | --- | --- | --- |
+| identity Types | 15,713 | 16,670 | +6.1% |
+| identity Instantiations | 83,327 | 88,162 | +5.8% |
+| identity Check time | 0.25s | 0.26s | +0.01s |
+| identity Total time | 0.92s | 0.97s | +0.05s |
+| schema `tsc -b --force` wall-clock | 6.41s | 6.57s | +0.16s (~2.5%, noise range) |
+
+## Verdict
+
+The `Curie<V>`/`Predicate<V>`/`Expand` literal machinery and the
+binding-threaded composer generics cost ~6% additional instantiations inside
+`@beep/identity` itself and effectively nothing downstream today (dependents
+do not yet reference `.iri`/`.curie`; template-literal types instantiate at
+use sites, so future cost accrues incrementally where the feature is used).
+No module-boundary split required. SPEC acceptance item satisfied without a
+waiver.

--- a/goals/identity-iri-core/ops/manifest.json
+++ b/goals/identity-iri-core/ops/manifest.json
@@ -52,12 +52,12 @@
     {
       "id": "P0",
       "name": "Research",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "id": "P1",
       "name": "Implement",
-      "status": "pending"
+      "status": "in_progress"
     },
     {
       "id": "P2",

--- a/goals/identity-iri-core/ops/manifest.json
+++ b/goals/identity-iri-core/ops/manifest.json
@@ -57,17 +57,17 @@
     {
       "id": "P1",
       "name": "Implement",
-      "status": "in_progress"
+      "status": "completed"
     },
     {
       "id": "P2",
       "name": "Verify",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "id": "P3",
       "name": "Yeet: PR to mergeable",
-      "status": "pending"
+      "status": "in_progress"
     },
     {
       "id": "P4",

--- a/packages/foundation/modeling/identity/package.json
+++ b/packages/foundation/modeling/identity/package.json
@@ -17,7 +17,7 @@
     "lint:fix": "bun run beep:lint:fix",
     "beep:build": "tsc -b tsconfig.json && bun run babel",
     "beep:check": "tsgo -b tsconfig.json",
-    "beep:test": "bunx --bun vitest run",
+    "beep:test": "bunx vitest run",
     "beep:lint": "biome check .",
     "beep:lint:fix": "biome check . --write",
     "beep:audit": "bun run beep:build && bun run beep:check && bun run beep:test && bun run beep:lint",

--- a/packages/foundation/modeling/identity/src/Curie.ts
+++ b/packages/foundation/modeling/identity/src/Curie.ts
@@ -1,0 +1,268 @@
+/**
+ * CURIE expansion, contraction, and schema codecs.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { Effect, pipe, SchemaIssue, SchemaTransformation } from "effect";
+import * as A from "effect/Array";
+import * as O from "effect/Option";
+import * as R from "effect/Record";
+import * as S from "effect/Schema";
+import * as Str from "effect/String";
+import { $IdentityId } from "./packages.ts";
+import { CoreVocab } from "./Vocab.ts";
+import type { Curie, Expand, Predicate, VocabShape } from "./Vocab.ts";
+
+const $I = $IdentityId.create("Curie");
+
+type Contract<I extends string, V extends VocabShape> = {
+  readonly [C in Curie<V>]: Expand<C, V> extends I ? C : never;
+}[Curie<V>];
+
+type ExpandedPredicate<P extends string, V extends VocabShape> = P extends `^${infer C}`
+  ? { readonly iri: Expand<C, V>; readonly inverse: true }
+  : { readonly iri: Expand<P, V>; readonly inverse: false };
+
+const parseCurie = (curie: string) =>
+  pipe(
+    curie,
+    Str.indexOf(":"),
+    O.map((separator) => [Str.slice(0, separator)(curie), Str.slice(separator + 1)(curie)] as const)
+  );
+
+const hasTerm = (terms: readonly string[], term: string) => A.contains(terms, term);
+
+const expandOption = <const V extends VocabShape>(curie: string, vocab: V): O.Option<string> =>
+  pipe(
+    parseCurie(curie),
+    O.flatMap(([prefix, term]) =>
+      pipe(
+        R.get(vocab, prefix),
+        O.filter((entry) => hasTerm(entry.terms, term)),
+        O.map((entry) => `${entry.iri}${term}`)
+      )
+    )
+  );
+
+const contractOption = <const V extends VocabShape>(iri: string, vocab: V): O.Option<Curie<V>> =>
+  pipe(
+    R.toEntries(vocab),
+    A.reduce(O.none<readonly [keyof V & string, V[keyof V & string]["iri"], string]>(), (best, [prefix, entry]) =>
+      pipe(
+        A.findFirst(entry.terms, (term) => iri === `${entry.iri}${term}`),
+        O.map((term) => [prefix, entry.iri, term] as const),
+        O.filter((candidate) =>
+          pipe(
+            best,
+            O.match({
+              onNone: () => true,
+              onSome: ([, namespace]) => Str.length(candidate[1]) > Str.length(namespace),
+            })
+          )
+        ),
+        O.orElse(() => best)
+      )
+    ),
+    O.map(([prefix, , term]) => `${prefix}:${term}` as Curie<V>)
+  );
+
+const schemaIssue = (value: string, message: string) => new SchemaIssue.InvalidValue(O.some(value), { message });
+
+/**
+ * Expand a known CURIE into its exact IRI literal.
+ *
+ * @example
+ * ```ts
+ * import { expand } from "@beep/identity"
+ *
+ * const iri = expand("skos:prefLabel")
+ * console.log(iri) // "http://www.w3.org/2004/02/skos/core#prefLabel"
+ * ```
+ *
+ * @category codecs
+ * @since 0.0.0
+ */
+export function expand<const C extends Curie<typeof CoreVocab>>(curie: C): Expand<C, typeof CoreVocab>;
+export function expand<const V extends VocabShape, const C extends Curie<V>>(curie: C, vocab: V): Expand<C, V>;
+export function expand(curie: string): string | undefined;
+export function expand(curie: string, vocab: VocabShape): string | undefined;
+export function expand(curie: string, vocab: VocabShape = CoreVocab): string | undefined {
+  return pipe(expandOption(curie, vocab), O.getOrUndefined);
+}
+
+/**
+ * Contract a registered IRI back to its CURIE literal.
+ *
+ * @example
+ * ```ts
+ * import { contract } from "@beep/identity"
+ *
+ * const curie = contract("http://www.w3.org/2004/02/skos/core#prefLabel")
+ * console.log(curie) // "skos:prefLabel"
+ * ```
+ *
+ * @category codecs
+ * @since 0.0.0
+ */
+export function contract<const I extends Expand<Curie<typeof CoreVocab>, typeof CoreVocab>>(
+  iri: I
+): Contract<I, typeof CoreVocab>;
+export function contract<const V extends VocabShape, const I extends Expand<Curie<V>, V>>(
+  iri: I,
+  vocab: V
+): Contract<I, V>;
+export function contract(iri: string): string | undefined;
+export function contract(iri: string, vocab: VocabShape): string | undefined;
+export function contract(iri: string, vocab: VocabShape = CoreVocab): string | undefined {
+  return pipe(contractOption(iri, vocab), O.getOrUndefined);
+}
+
+/**
+ * Expand a forward or inverse predicate CURIE into IRI plus direction.
+ *
+ * @example
+ * ```ts
+ * import { expandPredicate } from "@beep/identity"
+ *
+ * const expanded = expandPredicate("^rdfs:subClassOf")
+ * console.log(expanded?.inverse) // true
+ * ```
+ *
+ * @category codecs
+ * @since 0.0.0
+ */
+export function expandPredicate<const P extends Predicate<typeof CoreVocab>>(
+  predicate: P
+): ExpandedPredicate<P, typeof CoreVocab>;
+export function expandPredicate<const V extends VocabShape, const P extends Predicate<V>>(
+  predicate: P,
+  vocab: V
+): ExpandedPredicate<P, V>;
+export function expandPredicate(predicate: string): { readonly iri: string; readonly inverse: boolean } | undefined;
+export function expandPredicate(
+  predicate: string,
+  vocab: VocabShape
+): { readonly iri: string; readonly inverse: boolean } | undefined;
+export function expandPredicate(predicate: string, vocab: VocabShape = CoreVocab) {
+  const inverse = pipe(predicate, Str.startsWith("^"));
+  const curie = inverse ? Str.slice(1)(predicate) : predicate;
+
+  return pipe(
+    expandOption(curie, vocab),
+    O.map((iri) => ({ iri, inverse })),
+    O.getOrUndefined
+  );
+}
+
+/**
+ * Build literal-preserving CURIE encode/decode helpers for a registry.
+ *
+ * @example
+ * ```ts
+ * import { CoreVocab, makeCurieCodec } from "@beep/identity"
+ *
+ * const codec = makeCurieCodec(CoreVocab)
+ * console.log(codec.decode("skos:prefLabel"))
+ * ```
+ *
+ * @category factories
+ * @since 0.0.0
+ */
+export const makeCurieCodec = <const V extends VocabShape>(vocab: V) => ({
+  decode: <const C extends Curie<V>>(curie: C): Expand<C, V> => expand(curie, vocab),
+  encode: <const I extends Expand<Curie<V>, V>>(iri: I): Contract<I, V> => contract(iri, vocab),
+});
+
+/**
+ * Literal-preserving CURIE helper pair for {@link CoreVocab}.
+ *
+ * @example
+ * ```ts
+ * import { CoreCurieCodec } from "@beep/identity"
+ *
+ * const iri = CoreCurieCodec.decode("rdfs:label")
+ * console.log(iri) // "http://www.w3.org/2000/01/rdf-schema#label"
+ * ```
+ *
+ * @category codecs
+ * @since 0.0.0
+ */
+export const CoreCurieCodec = makeCurieCodec(CoreVocab);
+
+/**
+ * Build an Effect Schema codec that decodes CURIEs to IRIs and encodes IRIs to CURIEs.
+ *
+ * @example
+ * ```ts
+ * import * as S from "effect/Schema"
+ * import { CoreVocab, makeCurieFromIri } from "@beep/identity"
+ *
+ * const decode = S.decodeUnknownEffect(makeCurieFromIri(CoreVocab))
+ * console.log(typeof decode)
+ * ```
+ *
+ * @category factories
+ * @since 0.0.0
+ */
+export const makeCurieFromIri = <const V extends VocabShape>(vocab: V) =>
+  S.String.pipe(
+    S.decodeTo(
+      S.String,
+      SchemaTransformation.transformOrFail({
+        decode: (curie) =>
+          pipe(
+            expandOption(curie, vocab),
+            O.match({
+              onNone: () => Effect.fail(schemaIssue(curie, `Unknown CURIE: ${curie}`)),
+              onSome: Effect.succeed,
+            })
+          ),
+        encode: (iri) =>
+          pipe(
+            contractOption(iri, vocab),
+            O.match({
+              onNone: () => Effect.fail(schemaIssue(iri, `Unknown IRI: ${iri}`)),
+              onSome: Effect.succeed,
+            })
+          ),
+      })
+    ),
+    $I.annoteSchema("CurieFromIri", {
+      description: "Codec that decodes registered CURIEs to IRIs and encodes registered IRIs to CURIEs.",
+    })
+  );
+
+/**
+ * Core vocabulary CURIE-to-IRI Effect Schema codec.
+ *
+ * @example
+ * ```ts
+ * import * as S from "effect/Schema"
+ * import { CurieFromIri } from "@beep/identity"
+ *
+ * const decode = S.decodeUnknownEffect(CurieFromIri)
+ * console.log(typeof decode)
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const CurieFromIri = makeCurieFromIri(CoreVocab);
+
+/**
+ * Type for {@link CurieFromIri}. {@inheritDoc CurieFromIri}
+ *
+ * @example
+ * ```ts
+ * import type { CurieFromIri } from "@beep/identity"
+ *
+ * const iri: CurieFromIri = "http://www.w3.org/2004/02/skos/core#prefLabel"
+ * console.log(iri)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export type CurieFromIri = typeof CurieFromIri.Type;

--- a/packages/foundation/modeling/identity/src/Id.ts
+++ b/packages/foundation/modeling/identity/src/Id.ts
@@ -34,6 +34,7 @@ import * as Str from "effect/String";
 import type { TString } from "@beep/types";
 import type * as Multipart_ from "effect/unstable/http/Multipart";
 import type { Get, Paths } from "type-fest";
+import type { CoreVocab, VocabShape } from "./Vocab.ts";
 
 const BeepNamespace = S.Literal("@beep");
 type BeepNamespace = typeof BeepNamespace.Type;
@@ -42,6 +43,8 @@ const BeepBase = S.Literal("beep");
 type BeepBase = typeof BeepBase.Type;
 
 const IdentityVersion = S.Literal("0.0.0");
+type DefaultIdentityAuthority = "https://ns.beep.sh/";
+type DefaultIdentityPrefix = "beep";
 
 const isBeepNamespace = S.is(BeepNamespace);
 const isBeepBase = S.is(BeepBase);
@@ -264,6 +267,47 @@ type JoinTitleWords<Words extends ReadonlyArray<string>> = Words extends readonl
     ? `${TitleWord<Head>} ${JoinTitleWords<Tail>}`
     : "";
 
+type IdentityTail<Value extends string> = string extends Value
+  ? string
+  : Value extends "@beep"
+    ? ""
+    : Value extends `@beep/${infer Tail}`
+      ? Tail
+      : Value extends `@${string}/${infer Tail}`
+        ? Tail
+        : Value;
+
+type SlugSeparator = "/" | "." | "_" | "-" | " ";
+type SlugState = "start" | "separator" | "lower-or-digit" | "other";
+type IsUppercaseLetter<Character extends string> =
+  Character extends Lowercase<Character> ? false : Character extends Uppercase<Character> ? true : false;
+type IsLowercaseLetterOrDigit<Character extends string> = Character extends Digit
+  ? true
+  : Character extends Lowercase<Character>
+    ? Character extends Uppercase<Character>
+      ? false
+      : true
+    : false;
+type SlugStateAfter<Character extends string> =
+  IsLowercaseLetterOrDigit<Character> extends true ? "lower-or-digit" : "other";
+type SlugJoin<Value extends string, State extends SlugState = "start"> = Value extends `${infer Character}${infer Rest}`
+  ? Character extends SlugSeparator
+    ? State extends "start" | "separator"
+      ? SlugJoin<Rest, "separator">
+      : `-${SlugJoin<Rest, "separator">}`
+    : IsUppercaseLetter<Character> extends true
+      ? State extends "lower-or-digit"
+        ? `-${Lowercase<Character>}${SlugJoin<Rest, "other">}`
+        : `${Lowercase<Character>}${SlugJoin<Rest, "other">}`
+      : `${Lowercase<Character>}${SlugJoin<Rest, SlugStateAfter<Character>>}`
+  : "";
+type TrimSlugHyphens<Value extends string> = Value extends `-${infer Rest}`
+  ? TrimSlugHyphens<Rest>
+  : Value extends `${infer Rest}-`
+    ? TrimSlugHyphens<Rest>
+    : Value;
+type StripLeadingAt<Value extends string> = Value extends `@${infer Rest}` ? Rest : Value;
+
 /**
  * Derive a human-readable title from a kebab-case or snake_case identifier.
  *
@@ -282,6 +326,81 @@ type JoinTitleWords<Words extends ReadonlyArray<string>> = Words extends readonl
 export type TitleFromIdentifier<Identifier extends string> = JoinTitleWords<
   SplitTitleWords<TrimTitleSpaces<NormalizeTitleSeparators<Identifier>>>
 >;
+
+/**
+ * Derive an exact IRI literal from an identity path and authority prefix.
+ *
+ * Converts `"@beep/a/b"` to `"https://ns.beep.sh/a/b"` when the authority is
+ * `"https://ns.beep.sh/"`. Widened string inputs intentionally widen to `string`.
+ *
+ * @example
+ * ```typescript
+ * import type { IriFromIdentity } from "@beep/identity"
+ *
+ * type Iri = IriFromIdentity<"https://ns.beep.sh/", "@beep/schema/Entity">
+ * const iri: Iri = "https://ns.beep.sh/schema/Entity"
+ * console.log(iri)
+ * ```
+ *
+ * @since 0.0.0
+ * @category type-level
+ */
+export type IriFromIdentity<Authority extends string, Identity extends string> = string extends Authority
+  ? string
+  : string extends Identity
+    ? string
+    : IdentityTail<Identity> extends ""
+      ? Authority
+      : `${Authority}${IdentityTail<Identity>}`;
+
+/**
+ * Derive an exact CURIE literal from an identity path and owned prefix.
+ *
+ * Converts `"@beep/a/b"` to `"beep:a/b"` when the prefix is `"beep"`. Widened
+ * string inputs intentionally widen to `string`.
+ *
+ * @example
+ * ```typescript
+ * import type { CurieFromIdentity } from "@beep/identity"
+ *
+ * type Curie = CurieFromIdentity<"beep", "@beep/schema/Entity">
+ * const curie: Curie = "beep:schema/Entity"
+ * console.log(curie)
+ * ```
+ *
+ * @since 0.0.0
+ * @category type-level
+ */
+export type CurieFromIdentity<Prefix extends string, Identity extends string> = string extends Prefix
+  ? string
+  : string extends Identity
+    ? string
+    : IdentityTail<Identity> extends ""
+      ? `${Prefix}:`
+      : `${Prefix}:${IdentityTail<Identity>}`;
+
+/**
+ * Derive a kebab-case slug literal from an identity or identifier.
+ *
+ * The type-level transform mirrors the runtime slug getter for static identity
+ * paths, including slash, dot, underscore, hyphen, space, and lower-to-upper
+ * word boundaries.
+ *
+ * @example
+ * ```typescript
+ * import type { SlugFromIdentifier } from "@beep/identity"
+ *
+ * type Slug = SlugFromIdentifier<"@beep/Ontology.models/HttpUrl">
+ * const slug: Slug = "beep-ontology-models-http-url"
+ * console.log(slug)
+ * ```
+ *
+ * @since 0.0.0
+ * @category type-level
+ */
+export type SlugFromIdentifier<Identifier extends string> = string extends Identifier
+  ? string
+  : TrimSlugHyphens<SlugJoin<StripLeadingAt<Identifier>>>;
 
 type PascalCaseValue<Value extends string> = Value extends `${infer A}-${infer B}-${infer C}-${infer D}`
   ? `${PascalCaseWord<A>}${PascalCaseWord<B>}${PascalCaseWord<C>}${PascalCaseWord<D>}`
@@ -513,13 +632,45 @@ export type IdentityAnyAnnotationExtras<
  * @since 0.0.0
  * @category models
  */
-export type IdentityAnnotation<Value extends string, Identifier extends string> = S.Annotations.Annotations & {
+export type IdentityAnnotation<
+  Value extends string,
+  Identifier extends string,
+  Authority extends string | undefined = undefined,
+  Prefix extends string | undefined = undefined,
+> = S.Annotations.Annotations & {
   readonly identifier: IdentityString<Value>;
   readonly schemaId: IdentitySymbol<Value>;
   readonly title: TitleFromIdentifier<Identifier>;
-};
+} & IdentityProjection<Value, Authority, Prefix>;
 
-type IdentityAnnotationMetadataKeys = "identifier" | "schemaId" | "title";
+type IdentityProjection<
+  Value extends string,
+  Authority extends string | undefined,
+  Prefix extends string | undefined,
+> = Authority extends string
+  ? Prefix extends string
+    ? {
+        readonly iri: IriFromIdentity<Authority, Value>;
+        readonly curie: CurieFromIdentity<Prefix, Value>;
+      }
+    : {
+        readonly iri?: undefined;
+        readonly curie?: undefined;
+      }
+  : {
+      readonly iri?: undefined;
+      readonly curie?: undefined;
+    };
+
+type BoundComposerIri<Authority extends string | undefined, Value extends string> = Authority extends string
+  ? IriFromIdentity<Authority, Value>
+  : undefined;
+
+type BoundComposerCurie<Prefix extends string | undefined, Value extends string> = Prefix extends string
+  ? CurieFromIdentity<Prefix, Value>
+  : undefined;
+
+type IdentityAnnotationMetadataKeys = "identifier" | "schemaId" | "title" | "iri" | "curie";
 
 /**
  * Result of calling `annote` -- the identity annotation merged with any caller-supplied extras,
@@ -539,7 +690,11 @@ export type IdentityAnnotationResult<
   Value extends string,
   Identifier extends string,
   Extras extends object = {},
-> = IdentityAnnotation<Value, Identifier> & Omit<Extras, IdentityAnnotationMetadataKeys>;
+  Authority extends string | undefined = undefined,
+  Prefix extends string | undefined = undefined,
+> = IdentityAnnotation<Value, Identifier> &
+  IdentityProjection<Value, Authority, Prefix> &
+  Omit<Extras, IdentityAnnotationMetadataKeys>;
 
 type SchemaPath<Struct extends object> = Extract<Paths<Struct>, string>;
 
@@ -568,8 +723,19 @@ type AnnotatedSchema<Schema extends S.Top> = Schema["Rebuild"] & SchemaStatics<S
  * @since 0.0.0
  * @category models
  */
-export type TaggedModuleRecord<Value extends string, Segments extends ReadonlyArray<TString.NonEmpty>> = {
-  readonly [K in Segments[number] as TaggedAccessor<K>]: IdentityComposer<`${Value}/${ModuleSegmentValue<K>}`>;
+export type TaggedModuleRecord<
+  Value extends string,
+  Segments extends ReadonlyArray<TString.NonEmpty>,
+  Authority extends string | undefined = DefaultIdentityAuthority,
+  Prefix extends string | undefined = DefaultIdentityPrefix,
+  Vocab extends VocabShape = CoreVocab,
+> = {
+  readonly [K in Segments[number] as TaggedAccessor<K>]: IdentityComposer<
+    `${Value}/${ModuleSegmentValue<K>}`,
+    Authority,
+    Prefix,
+    Vocab
+  >;
 };
 
 /**
@@ -616,7 +782,12 @@ export type TaggedModuleRecord<Value extends string, Segments extends ReadonlyAr
  * @since 0.0.0
  * @category models
  */
-export interface IdentityComposer<Value extends string> {
+export interface IdentityComposer<
+  Value extends string,
+  Authority extends string | undefined = DefaultIdentityAuthority,
+  Prefix extends string | undefined = DefaultIdentityPrefix,
+  Vocab extends VocabShape = CoreVocab,
+> {
   /**
    * Produce an identity annotation record for an Effect schema.
    *
@@ -645,7 +816,7 @@ export interface IdentityComposer<Value extends string> {
   >(
     identifier: SegmentValue<Next>,
     extras?: undefined | Extras
-  ): IdentityAnnotationResult<`${Value}/${SegmentValue<Next>}`, SegmentValue<Next>, Extras>;
+  ): IdentityAnnotationResult<`${Value}/${SegmentValue<Next>}`, SegmentValue<Next>, Extras, Authority, Prefix>;
 
   /**
    * Produce a schema annotation function with HTTP API metadata.
@@ -727,7 +898,7 @@ export interface IdentityComposer<Value extends string> {
    */
   compose<
     const Segments extends readonly [ModuleSegmentValue<TString.NonEmpty>, ...ModuleSegmentValue<TString.NonEmpty>[]],
-  >(...segments: Segments): TaggedModuleRecord<Value, Segments>;
+  >(...segments: Segments): TaggedModuleRecord<Value, Segments, Authority, Prefix, Vocab>;
 
   /**
    * Create a child {@link IdentityComposer} for further path extension.
@@ -750,7 +921,24 @@ export interface IdentityComposer<Value extends string> {
    */
   create<const Next extends TString.NonEmpty>(
     segment: SegmentValue<Next>
-  ): IdentityComposer<`${Value}/${SegmentValue<Next>}`>;
+  ): IdentityComposer<`${Value}/${SegmentValue<Next>}`, Authority, Prefix, Vocab>;
+
+  /**
+   * CURIE projection for this composer's current path, or `undefined` when unbound.
+   *
+   * @example
+   * ```typescript
+   * import { make } from "@beep/identity"
+   *
+   * const { $BeepId } = make("beep", { authority: "https://ns.beep.sh/", prefix: "beep" })
+   * const curie = $BeepId.create("schema").curie
+   * console.log(curie) // "beep:schema"
+   * ```
+   *
+   * @since 0.0.0
+   * @category getters
+   */
+  readonly curie: BoundComposerCurie<Prefix, Value>;
 
   /**
    * The identity string for this composer's current path.
@@ -759,6 +947,28 @@ export interface IdentityComposer<Value extends string> {
    * @category getters
    */
   readonly identifier: IdentityString<Value>;
+
+  /**
+   * IRI projection for this composer's current path, or `undefined` when unbound.
+   *
+   * @remarks
+   * One-argument `make(...)` calls intentionally produce unbound composers, so
+   * callers must handle `undefined` there. Root-bound package composers derive
+   * exact literals from the configured authority.
+   *
+   * @example
+   * ```typescript
+   * import { make } from "@beep/identity"
+   *
+   * const { $BeepId } = make("beep", { authority: "https://ns.beep.sh/", prefix: "beep" })
+   * const iri = $BeepId.create("schema").iri
+   * console.log(iri) // "https://ns.beep.sh/schema"
+   * ```
+   *
+   * @since 0.0.0
+   * @category getters
+   */
+  readonly iri: BoundComposerIri<Authority, Value>;
 
   /**
    * Create a child identity string by appending one segment.
@@ -778,6 +988,44 @@ export interface IdentityComposer<Value extends string> {
   make<const Next extends TString.NonEmpty>(
     segment: SegmentValue<Next>
   ): IdentityString<`${Value}/${SegmentValue<Next>}`>;
+
+  /**
+   * Rebind IRI and CURIE projections without changing the identity path or symbol.
+   *
+   * @example
+   * ```typescript
+   * import { make } from "@beep/identity"
+   *
+   * const { $BeepId } = make("beep", { authority: "https://ns.beep.sh/", prefix: "beep" })
+   * const patent = $BeepId.create("ontology").create("patent")
+   * const rebased = patent.rebase({ iri: "https://opip.law/ns/patent#", prefix: "patent" })
+   * console.log(rebased.iri) // "https://opip.law/ns/patent#ontology/patent"
+   * ```
+   *
+   * @since 0.0.0
+   * @category combinators
+   */
+  rebase<const Iri extends string, const NextPrefix extends string>(options: {
+    readonly iri: Iri;
+    readonly prefix: NextPrefix;
+  }): IdentityComposer<Value, Iri, NextPrefix, Vocab>;
+
+  /**
+   * Kebab-case slug projection for this composer's current path.
+   *
+   * @example
+   * ```typescript
+   * import { make } from "@beep/identity"
+   *
+   * const { $BeepId } = make("beep")
+   * const slug = $BeepId.create("Ontology.models").create("HttpUrl").slug
+   * console.log(slug) // "beep-ontology-models-http-url"
+   * ```
+   *
+   * @since 0.0.0
+   * @category getters
+   */
+  readonly slug: SlugFromIdentifier<Value>;
 
   /**
    * Return this composer's identity as a branded string.
@@ -908,6 +1156,34 @@ const toTitle = <const Identifier extends TString.NonEmpty>(identifier: Identifi
     A.join(" ")
   ) as TitleFromIdentifier<Identifier>;
 
+const localPathFromIdentity = (identity: string): string => pipe(identity, Str.split("/"), A.drop(1), A.join("/"));
+
+const toIri = <const Authority extends string, const Value extends string>(
+  authority: Authority,
+  identity: Value
+): IriFromIdentity<Authority, Value> => {
+  const localPath = localPathFromIdentity(identity);
+  return (Str.isEmpty(localPath) ? authority : `${authority}${localPath}`) as IriFromIdentity<Authority, Value>;
+};
+
+const toCurie = <const Prefix extends string, const Value extends string>(
+  prefix: Prefix,
+  identity: Value
+): CurieFromIdentity<Prefix, Value> => {
+  const localPath = localPathFromIdentity(identity);
+  return (Str.isEmpty(localPath) ? `${prefix}:` : `${prefix}:${localPath}`) as CurieFromIdentity<Prefix, Value>;
+};
+
+const toSlug = <const Identifier extends string>(identifier: Identifier): SlugFromIdentifier<Identifier> =>
+  pipe(
+    identifier,
+    Str.replace(/^@/, ""),
+    Str.replace(/([a-z0-9])([A-Z])/g, "$1-$2"),
+    Str.replace(/[/. _-]+/g, "-"),
+    Str.replace(/^-+|-+$/g, ""),
+    Str.toLowerCase
+  ) as SlugFromIdentifier<Identifier>;
+
 type ModulePascal<Segment extends TString.NonEmpty> =
   ModuleAccessor<Segment> extends `${infer Pascal}Id` ? Pascal : never;
 
@@ -976,8 +1252,33 @@ const createBaseIdentity = <const Base extends TString.NonEmpty>(base: Normalize
     onSome: () => beepNamespace as BaseIdentity<Base>,
   });
 
-const createComposer = <const Value extends string>(value: Value): IdentityComposer<Value> => {
+type IdentityBinding<Authority extends string, Prefix extends string, Vocab extends VocabShape> = {
+  readonly authority: Authority;
+  readonly prefix: Prefix;
+  readonly vocab?: Vocab | undefined;
+};
+
+const createComposer = <
+  const Value extends string,
+  const Authority extends string | undefined,
+  const Prefix extends string | undefined,
+  const Vocab extends VocabShape,
+>(
+  value: Value,
+  binding: IdentityBinding<string, string, Vocab> | undefined
+): IdentityComposer<Value, Authority, Prefix, Vocab> => {
   const identityValue = toIdentityString(value);
+  const iri = pipe(
+    O.fromUndefinedOr(binding),
+    O.map((currentBinding) => toIri(currentBinding.authority, value)),
+    O.getOrUndefined
+  ) as BoundComposerIri<Authority, Value>;
+  const curie = pipe(
+    O.fromUndefinedOr(binding),
+    O.map((currentBinding) => toCurie(currentBinding.prefix, value)),
+    O.getOrUndefined
+  ) as BoundComposerCurie<Prefix, Value>;
+  const slug = toSlug(value);
 
   function createTemplateIdentity(strings: TemplateStringsArray, ...values: ReadonlyArray<unknown>) {
     validateTemplateInterpolations(values);
@@ -995,23 +1296,29 @@ const createComposer = <const Value extends string>(value: Value): IdentityCompo
 
   const composeNext = <const Next extends TString.NonEmpty>(
     segment: SegmentValue<Next>
-  ): IdentityComposer<`${Value}/${SegmentValue<Next>}`> => {
+  ): IdentityComposer<`${Value}/${SegmentValue<Next>}`, Authority, Prefix, Vocab> => {
     const next = validateSegment(segment);
     const composed = appendIdentityValue(value, next);
-    return createComposer(composed);
+    return createComposer(composed, binding);
   };
 
   const identityAnnotation = <const Next extends TString.NonEmpty = TString.NonEmpty>(
     identifier: SegmentValue<Next>
-  ): IdentityAnnotation<`${Value}/${SegmentValue<Next>}`, SegmentValue<Next>> => {
+  ): IdentityAnnotation<`${Value}/${SegmentValue<Next>}`, SegmentValue<Next>, Authority, Prefix> => {
     const next = validateSegment(identifier);
     const composer = composeNext(next);
 
     return {
       schemaId: composer.symbol(),
       identifier: composer.string(),
+      ...(composer.iri === undefined || composer.curie === undefined
+        ? {}
+        : {
+            iri: composer.iri,
+            curie: composer.curie,
+          }),
       title: toTitle(next),
-    } satisfies IdentityAnnotation<`${Value}/${SegmentValue<Next>}`, SegmentValue<Next>>;
+    } as IdentityAnnotation<`${Value}/${SegmentValue<Next>}`, SegmentValue<Next>, Authority, Prefix>;
   };
 
   const annote = <
@@ -1020,18 +1327,36 @@ const createComposer = <const Value extends string>(value: Value): IdentityCompo
   >(
     identifier: SegmentValue<Next>,
     extras?: undefined | Extras
-  ): IdentityAnnotationResult<`${Value}/${SegmentValue<Next>}`, SegmentValue<Next>, Extras> =>
+  ): IdentityAnnotationResult<`${Value}/${SegmentValue<Next>}`, SegmentValue<Next>, Extras, Authority, Prefix> =>
     pipe(identityAnnotation(identifier), (annotation) =>
       O.match(O.fromUndefinedOr(extras), {
         onNone: () =>
-          annotation as IdentityAnnotationResult<`${Value}/${SegmentValue<Next>}`, SegmentValue<Next>, Extras>,
+          annotation as IdentityAnnotationResult<
+            `${Value}/${SegmentValue<Next>}`,
+            SegmentValue<Next>,
+            Extras,
+            Authority,
+            Prefix
+          >,
         onSome: (currentExtras) =>
           ({
             ...currentExtras,
             schemaId: annotation.schemaId,
             identifier: annotation.identifier,
+            ...(annotation.iri === undefined || annotation.curie === undefined
+              ? {}
+              : {
+                  iri: annotation.iri,
+                  curie: annotation.curie,
+                }),
             title: annotation.title,
-          }) as IdentityAnnotationResult<`${Value}/${SegmentValue<Next>}`, SegmentValue<Next>, Extras>,
+          }) as unknown as IdentityAnnotationResult<
+            `${Value}/${SegmentValue<Next>}`,
+            SegmentValue<Next>,
+            Extras,
+            Authority,
+            Prefix
+          >,
       })
     );
 
@@ -1095,6 +1420,24 @@ const createComposer = <const Value extends string>(value: Value): IdentityCompo
       writable: true,
       configurable: true,
     },
+    iri: {
+      value: iri,
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    },
+    curie: {
+      value: curie,
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    },
+    slug: {
+      value: slug,
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    },
     compose: {
       value: <
         const Segments extends readonly [
@@ -1105,7 +1448,7 @@ const createComposer = <const Value extends string>(value: Value): IdentityCompo
         ...segments: Segments
       ) => {
         const entries = pipe(segments, A.map(toTaggedComposerEntry));
-        return R.fromEntries(entries) as unknown as TaggedModuleRecord<Value, Segments>;
+        return R.fromEntries(entries) as unknown as TaggedModuleRecord<Value, Segments, Authority, Prefix, Vocab>;
       },
       enumerable: true,
       writable: true,
@@ -1135,6 +1478,20 @@ const createComposer = <const Value extends string>(value: Value): IdentityCompo
       writable: true,
       configurable: true,
     },
+    rebase: {
+      value: <const Iri extends string, const NextPrefix extends string>(options: {
+        readonly iri: Iri;
+        readonly prefix: NextPrefix;
+      }) =>
+        createComposer<Value, Iri, NextPrefix, Vocab>(value, {
+          authority: options.iri,
+          prefix: options.prefix,
+          vocab: binding?.vocab,
+        }),
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    },
     annote: {
       value: annote,
       enumerable: true,
@@ -1159,12 +1516,20 @@ const createComposer = <const Value extends string>(value: Value): IdentityCompo
       writable: true,
       configurable: true,
     },
-  }) as unknown as IdentityComposer<Value>;
+  }) as unknown as IdentityComposer<Value, Authority, Prefix, Vocab>;
 };
 
-type MakeReturn<Base extends TString.NonEmpty> = {
+type MakeReturn<
+  Base extends TString.NonEmpty,
+  Authority extends string | undefined = DefaultIdentityAuthority,
+  Prefix extends string | undefined = DefaultIdentityPrefix,
+  Vocab extends VocabShape = CoreVocab,
+> = {
   readonly [K in `$${PascalCaseValue<ModuleSegmentValue<NormalizedBase<Base>>>}Id`]: IdentityComposer<
-    BaseIdentity<Base>
+    BaseIdentity<Base>,
+    Authority,
+    Prefix,
+    Vocab
   >;
 };
 
@@ -1198,18 +1563,36 @@ type MakeReturn<Base extends TString.NonEmpty> = {
  * @since 0.0.0
  * @category constructors
  */
-export const make = flow(<const Base extends TString.NonEmpty>(base: Base): MakeReturn<Base> => {
+export function make<const Base extends TString.NonEmpty>(base: Base): MakeReturn<Base, undefined, undefined>;
+export function make<
+  const Base extends TString.NonEmpty,
+  const Authority extends string,
+  const Prefix extends string,
+  const Vocab extends VocabShape = CoreVocab,
+>(base: Base, options: IdentityBinding<Authority, Prefix, Vocab>): MakeReturn<Base, Authority, Prefix, Vocab>;
+export function make<
+  const Base extends TString.NonEmpty,
+  const Authority extends string,
+  const Prefix extends string,
+  const Vocab extends VocabShape = CoreVocab,
+>(
+  base: Base,
+  options?: IdentityBinding<Authority, Prefix, Vocab>
+): MakeReturn<Base, Authority | undefined, Prefix | undefined, Vocab> {
   const normalized = normalizeBase(base);
   const baseIdentity = createBaseIdentity(normalized);
-  const composer = createComposer(baseIdentity);
+  const composer = createComposer<BaseIdentity<Base>, Authority | undefined, Prefix | undefined, Vocab>(
+    baseIdentity,
+    options
+  );
   const key = toTaggedKey(normalized);
 
   return Fn.cast<
     {
-      [x: string]: IdentityComposer<BaseIdentity<Base>>;
+      [x: string]: IdentityComposer<BaseIdentity<Base>, Authority | undefined, Prefix | undefined, Vocab>;
     },
-    MakeReturn<Base>
+    MakeReturn<Base, Authority | undefined, Prefix | undefined, Vocab>
   >({
     [key]: composer,
   });
-});
+}

--- a/packages/foundation/modeling/identity/src/PnLocal.ts
+++ b/packages/foundation/modeling/identity/src/PnLocal.ts
@@ -1,0 +1,235 @@
+/**
+ * Turtle PN_LOCAL parser-side helpers and safe emission fallback.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+const PN_LOCAL_ESCAPABLE = "_~.-!$&'()*+,;=/?#@%";
+const HEX = /^[0-9A-Fa-f]$/;
+
+const codePointOf = (character: string): number | undefined => character.codePointAt(0);
+
+const isBetween = (value: number, min: number, max: number): boolean => value >= min && value <= max;
+
+const isDigit = (character: string): boolean => {
+  const codePoint = codePointOf(character);
+  return codePoint !== undefined && isBetween(codePoint, 0x30, 0x39);
+};
+
+const isHex = (character: string): boolean => HEX.test(character);
+
+const isPnCharsBase = (character: string): boolean => {
+  const codePoint = codePointOf(character);
+
+  return (
+    codePoint !== undefined &&
+    (isBetween(codePoint, 0x41, 0x5a) ||
+      isBetween(codePoint, 0x61, 0x7a) ||
+      isBetween(codePoint, 0xc0, 0xd6) ||
+      isBetween(codePoint, 0xd8, 0xf6) ||
+      isBetween(codePoint, 0xf8, 0x2ff) ||
+      isBetween(codePoint, 0x370, 0x37d) ||
+      isBetween(codePoint, 0x37f, 0x1fff) ||
+      isBetween(codePoint, 0x200c, 0x200d) ||
+      isBetween(codePoint, 0x2070, 0x218f) ||
+      isBetween(codePoint, 0x2c00, 0x2fef) ||
+      isBetween(codePoint, 0x3001, 0xd7ff) ||
+      isBetween(codePoint, 0xf900, 0xfdcf) ||
+      isBetween(codePoint, 0xfdf0, 0xfffd) ||
+      isBetween(codePoint, 0x10000, 0xeffff))
+  );
+};
+
+const isPnCharsU = (character: string): boolean => isPnCharsBase(character) || character === "_";
+
+const isPnChars = (character: string): boolean => {
+  const codePoint = codePointOf(character);
+
+  return (
+    isPnCharsU(character) ||
+    character === "-" ||
+    isDigit(character) ||
+    codePoint === 0xb7 ||
+    (codePoint !== undefined && (isBetween(codePoint, 0x300, 0x36f) || isBetween(codePoint, 0x203f, 0x2040)))
+  );
+};
+
+const isEscapable = (character: string): boolean => PN_LOCAL_ESCAPABLE.includes(character);
+
+const isSafeFirst = (character: string): boolean => isPnCharsU(character) || character === ":" || isDigit(character);
+
+const isSafeMiddle = (character: string): boolean => isPnChars(character) || character === "." || character === ":";
+
+const isSafeFinal = (character: string): boolean => isPnChars(character) || character === ":";
+
+/**
+ * Check whether a local name can be emitted as an unescaped Turtle PN_LOCAL.
+ *
+ * @example
+ * ```ts
+ * import { isSafeLocal } from "@beep/identity"
+ *
+ * console.log(isSafeLocal("prefLabel")) // true
+ * console.log(isSafeLocal("Ontology.models/HttpUrl")) // false
+ * ```
+ *
+ * @category predicates
+ * @since 0.0.0
+ */
+export const isSafeLocal = (local: string): boolean => {
+  const characters = [...local];
+
+  if (characters.length === 0 || !isSafeFirst(characters[0] ?? "")) {
+    return false;
+  }
+
+  if (characters.length === 1) {
+    return true;
+  }
+
+  const final = characters.at(-1);
+
+  if (final === undefined || !isSafeFinal(final)) {
+    return false;
+  }
+
+  return characters.slice(1, -1).every(isSafeMiddle);
+};
+
+type LocalUnit = { readonly kind: "plx" } | { readonly kind: "raw"; readonly character: string };
+
+const tokenizeLocal = (local: string): ReadonlyArray<LocalUnit> | undefined => {
+  const units: Array<LocalUnit> = [];
+
+  for (let index = 0; index < local.length; ) {
+    const character = local[index] ?? "";
+
+    if (character === "\\") {
+      const escaped = local[index + 1] ?? "";
+
+      if (!isEscapable(escaped)) {
+        return undefined;
+      }
+
+      units.push({ kind: "plx" });
+      index += 2;
+      continue;
+    }
+
+    if (character === "%") {
+      const first = local[index + 1] ?? "";
+      const second = local[index + 2] ?? "";
+
+      if (!isHex(first) || !isHex(second)) {
+        return undefined;
+      }
+
+      units.push({ kind: "plx" });
+      index += 3;
+      continue;
+    }
+
+    const [raw] = [...local.slice(index)];
+
+    if (raw === undefined) {
+      return undefined;
+    }
+
+    units.push({ kind: "raw", character: raw });
+    index += raw.length;
+  }
+
+  return units;
+};
+
+const isFirstUnit = (unit: LocalUnit): boolean => unit.kind === "plx" || isSafeFirst(unit.character);
+
+const isMiddleUnit = (unit: LocalUnit): boolean => unit.kind === "plx" || isSafeMiddle(unit.character);
+
+const isFinalUnit = (unit: LocalUnit): boolean => unit.kind === "plx" || isSafeFinal(unit.character);
+
+/**
+ * Check whether an escaped local name is accepted by Turtle PN_LOCAL parsing.
+ *
+ * @example
+ * ```ts
+ * import { acceptsEscapedLocal } from "@beep/identity"
+ *
+ * console.log(acceptsEscapedLocal("Ontology.models\\/HttpUrl")) // true
+ * ```
+ *
+ * @category predicates
+ * @since 0.0.0
+ */
+export const acceptsEscapedLocal = (local: string): boolean => {
+  const units = tokenizeLocal(local);
+
+  if (units === undefined || units.length === 0 || !isFirstUnit(units[0] ?? { kind: "raw", character: "" })) {
+    return false;
+  }
+
+  if (units.length === 1) {
+    return true;
+  }
+
+  const final = units.at(-1);
+
+  if (final === undefined || !isFinalUnit(final)) {
+    return false;
+  }
+
+  return units.slice(1, -1).every(isMiddleUnit);
+};
+
+/**
+ * Remove Turtle PN_LOCAL backslash escapes from an escaped local name.
+ *
+ * @example
+ * ```ts
+ * import { unescapeLocal } from "@beep/identity"
+ *
+ * console.log(unescapeLocal("Ontology.models\\/HttpUrl")) // "Ontology.models/HttpUrl"
+ * ```
+ *
+ * @category codecs
+ * @since 0.0.0
+ */
+export const unescapeLocal = (local: string): string => local.replace(/\\([_~.\-!$&'()*+,;=/?#@%])/g, "$1");
+
+/**
+ * Escape characters that Turtle permits through PN_LOCAL backslash escapes.
+ *
+ * @remarks
+ * Escaped-local emission currently feeds codec parity tests only. Writer-side
+ * identity output uses {@link prefixedNameOrIri} and falls back to full IRIs
+ * for unsafe locals.
+ *
+ * @example
+ * ```ts
+ * import { escapeLocal } from "@beep/identity"
+ *
+ * console.log(escapeLocal("Ontology.models/HttpUrl")) // "Ontology\\.models\\/HttpUrl"
+ * ```
+ *
+ * @category codecs
+ * @since 0.0.0
+ */
+export const escapeLocal = (local: string): string => local.replace(/[_~.\-!$&'()*+,;=/?#@%]/g, "\\$&");
+
+/**
+ * Emit a prefixed name only when the local part is safe, otherwise emit a full IRI reference.
+ *
+ * @example
+ * ```ts
+ * import { prefixedNameOrIri } from "@beep/identity"
+ *
+ * const rendered = prefixedNameOrIri("beep", "Ontology.models/HttpUrl", "https://ns.beep.sh/Ontology.models/HttpUrl")
+ * console.log(rendered) // "<https://ns.beep.sh/Ontology.models/HttpUrl>"
+ * ```
+ *
+ * @category formatting
+ * @since 0.0.0
+ */
+export const prefixedNameOrIri = (prefix: string, local: string, fullIri: string): string =>
+  isSafeLocal(local) ? `${prefix}:${local}` : `<${fullIri}>`;

--- a/packages/foundation/modeling/identity/src/Vocab.ts
+++ b/packages/foundation/modeling/identity/src/Vocab.ts
@@ -1,0 +1,368 @@
+/**
+ * Static RDF vocabulary registry for identity CURIE literals.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+/**
+ * Registry shape consumed by identity CURIE type helpers and codecs.
+ *
+ * @example
+ * ```ts
+ * import type { VocabShape } from "@beep/identity"
+ *
+ * const vocab = {
+ *   ex: {
+ *     iri: "https://example.test/ns#",
+ *     terms: ["Thing"],
+ *   },
+ * } as const satisfies VocabShape
+ *
+ * console.log(vocab.ex.iri)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export type VocabShape = Readonly<
+  Record<
+    string,
+    {
+      readonly iri: string;
+      readonly terms: readonly string[];
+    }
+  >
+>;
+
+type TermOf<V extends VocabShape, Prefix extends keyof V & string> = V[Prefix]["terms"][number] & string;
+
+/**
+ * Core borrowed vocabulary registry used by identity CURIE helpers.
+ *
+ * @example
+ * ```ts
+ * import { CoreVocab } from "@beep/identity"
+ *
+ * const iri = `${CoreVocab.skos.iri}prefLabel`
+ * console.log(iri) // "http://www.w3.org/2004/02/skos/core#prefLabel"
+ * ```
+ *
+ * @category constants
+ * @since 0.0.0
+ */
+export const CoreVocab = {
+  rdf: {
+    iri: "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    terms: [
+      "Alt",
+      "Bag",
+      "HTML",
+      "List",
+      "Property",
+      "Seq",
+      "Statement",
+      "XMLLiteral",
+      "first",
+      "langString",
+      "nil",
+      "object",
+      "predicate",
+      "rest",
+      "subject",
+      "type",
+      "value",
+    ] as const,
+  },
+  rdfs: {
+    iri: "http://www.w3.org/2000/01/rdf-schema#",
+    terms: [
+      "Class",
+      "Container",
+      "ContainerMembershipProperty",
+      "Datatype",
+      "Literal",
+      "Resource",
+      "comment",
+      "domain",
+      "isDefinedBy",
+      "label",
+      "member",
+      "range",
+      "seeAlso",
+      "subClassOf",
+      "subPropertyOf",
+    ] as const,
+  },
+  skos: {
+    iri: "http://www.w3.org/2004/02/skos/core#",
+    terms: [
+      "Collection",
+      "Concept",
+      "ConceptScheme",
+      "OrderedCollection",
+      "altLabel",
+      "broadMatch",
+      "broader",
+      "broaderTransitive",
+      "changeNote",
+      "closeMatch",
+      "definition",
+      "editorialNote",
+      "exactMatch",
+      "example",
+      "hasTopConcept",
+      "hiddenLabel",
+      "historyNote",
+      "inScheme",
+      "mappingRelation",
+      "member",
+      "memberList",
+      "narrowMatch",
+      "narrower",
+      "narrowerTransitive",
+      "notation",
+      "note",
+      "prefLabel",
+      "related",
+      "relatedMatch",
+      "scopeNote",
+      "semanticRelation",
+      "topConceptOf",
+    ] as const,
+  },
+  owl: {
+    iri: "http://www.w3.org/2002/07/owl#",
+    terms: [
+      "AnnotationProperty",
+      "AsymmetricProperty",
+      "Class",
+      "DatatypeProperty",
+      "FunctionalProperty",
+      "InverseFunctionalProperty",
+      "IrreflexiveProperty",
+      "NamedIndividual",
+      "Nothing",
+      "ObjectProperty",
+      "Ontology",
+      "ReflexiveProperty",
+      "SymmetricProperty",
+      "Thing",
+      "TransitiveProperty",
+      "backwardCompatibleWith",
+      "deprecated",
+      "equivalentClass",
+      "equivalentProperty",
+      "imports",
+      "incompatibleWith",
+      "inverseOf",
+      "priorVersion",
+      "sameAs",
+      "versionInfo",
+    ] as const,
+  },
+  dcterms: {
+    iri: "http://purl.org/dc/terms/",
+    terms: [
+      "Agent",
+      "AgentClass",
+      "BibliographicResource",
+      "Box",
+      "DCMIType",
+      "DDC",
+      "FileFormat",
+      "Frequency",
+      "IMT",
+      "ISO3166",
+      "ISO639-2",
+      "ISO639-3",
+      "Jurisdiction",
+      "LCC",
+      "LCSH",
+      "LicenseDocument",
+      "LinguisticSystem",
+      "Location",
+      "LocationPeriodOrJurisdiction",
+      "MESH",
+      "MediaType",
+      "MediaTypeOrExtent",
+      "MethodOfAccrual",
+      "MethodOfInstruction",
+      "NLM",
+      "Period",
+      "PeriodOfTime",
+      "PhysicalMedium",
+      "PhysicalResource",
+      "Point",
+      "Policy",
+      "ProvenanceStatement",
+      "RFC1766",
+      "RFC3066",
+      "RFC4646",
+      "RFC5646",
+      "RightsStatement",
+      "SizeOrDuration",
+      "Standard",
+      "TGN",
+      "UDC",
+      "URI",
+      "W3CDTF",
+      "abstract",
+      "accessRights",
+      "accrualMethod",
+      "accrualPeriodicity",
+      "accrualPolicy",
+      "alternative",
+      "audience",
+      "available",
+      "bibliographicCitation",
+      "conformsTo",
+      "contributor",
+      "coverage",
+      "created",
+      "creator",
+      "date",
+      "dateAccepted",
+      "dateCopyrighted",
+      "dateSubmitted",
+      "description",
+      "educationLevel",
+      "extent",
+      "format",
+      "hasFormat",
+      "hasPart",
+      "hasVersion",
+      "identifier",
+      "instructionalMethod",
+      "isFormatOf",
+      "isPartOf",
+      "isReferencedBy",
+      "isReplacedBy",
+      "isRequiredBy",
+      "isVersionOf",
+      "issued",
+      "language",
+      "license",
+      "mediator",
+      "medium",
+      "modified",
+      "provenance",
+      "publisher",
+      "references",
+      "relation",
+      "replaces",
+      "requires",
+      "rights",
+      "rightsHolder",
+      "source",
+      "spatial",
+      "subject",
+      "tableOfContents",
+      "temporal",
+      "title",
+      "type",
+      "valid",
+    ] as const,
+  },
+} as const satisfies VocabShape;
+
+/**
+ * Runtime type for {@link CoreVocab}.
+ *
+ * @example
+ * ```ts
+ * import { CoreVocab, type CoreVocab as CoreVocabType } from "@beep/identity"
+ *
+ * const vocab: CoreVocabType = CoreVocab
+ * console.log(vocab.rdf.terms.includes("type"))
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export type CoreVocab = typeof CoreVocab;
+
+/**
+ * Literal CURIE union derived from a vocabulary registry.
+ *
+ * @example
+ * ```ts
+ * import { CoreVocab, type Curie } from "@beep/identity"
+ *
+ * const curie: Curie<typeof CoreVocab> = "skos:prefLabel"
+ * console.log(curie)
+ * ```
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type Curie<V extends VocabShape> = {
+  readonly [Prefix in keyof V & string]: `${Prefix}:${TermOf<V, Prefix>}`;
+}[keyof V & string];
+
+/**
+ * Forward or inverse predicate CURIE derived from a vocabulary registry.
+ *
+ * @example
+ * ```ts
+ * import { CoreVocab, type Predicate } from "@beep/identity"
+ *
+ * const predicate: Predicate<typeof CoreVocab> = "^rdfs:subClassOf"
+ * console.log(predicate)
+ * ```
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type Predicate<V extends VocabShape> = Curie<V> | `^${Curie<V>}`;
+
+/**
+ * Type-level expansion from a known CURIE to its exact IRI literal.
+ *
+ * @example
+ * ```ts
+ * import { CoreVocab, type Expand } from "@beep/identity"
+ *
+ * const iri: Expand<"skos:prefLabel", typeof CoreVocab> = "http://www.w3.org/2004/02/skos/core#prefLabel"
+ * console.log(iri)
+ * ```
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type Expand<C extends string, V extends VocabShape> = C extends `${infer Prefix}:${infer Term}`
+  ? Prefix extends keyof V & string
+    ? Term extends TermOf<V, Prefix>
+      ? `${V[Prefix]["iri"]}${Term}`
+      : never
+    : never
+  : never;
+
+/**
+ * Merge a base registry with literal-preserving extension vocabulary data.
+ *
+ * @example
+ * ```ts
+ * import { CoreVocab, mergeVocab } from "@beep/identity"
+ *
+ * const vocab = mergeVocab(CoreVocab, {
+ *   ex: {
+ *     iri: "https://example.test/ns#",
+ *     terms: ["Thing"],
+ *   },
+ * } as const)
+ *
+ * console.log(vocab.ex.terms[0]) // "Thing"
+ * ```
+ *
+ * @category combinators
+ * @since 0.0.0
+ */
+export const mergeVocab = <const Base extends VocabShape, const Extension extends VocabShape>(
+  base: Base,
+  extension: Extension
+) =>
+  ({
+    ...base,
+    ...extension,
+  }) satisfies VocabShape;

--- a/packages/foundation/modeling/identity/src/index.ts
+++ b/packages/foundation/modeling/identity/src/index.ts
@@ -15,6 +15,20 @@
  */
 
 /**
+ * CURIE expansion, contraction, and schema codecs for identity vocabularies.
+ *
+ * @example
+ * ```typescript
+ * import { expand } from "@beep/identity"
+ *
+ * console.log(expand("skos:prefLabel"))
+ * ```
+ *
+ * @category codecs
+ * @since 0.0.0
+ */
+export * from "./Curie.ts";
+/**
  * Identity system core -- composers, annotations, and branded types.
  *
  * @example
@@ -30,6 +44,20 @@
  */
 export * from "./Id.ts";
 /**
+ * Turtle PN_LOCAL parser-side helpers and safe emission fallback.
+ *
+ * @example
+ * ```typescript
+ * import { prefixedNameOrIri } from "@beep/identity"
+ *
+ * console.log(prefixedNameOrIri("skos", "prefLabel", "http://www.w3.org/2004/02/skos/core#prefLabel"))
+ * ```
+ *
+ * @category formatting
+ * @since 0.0.0
+ */
+export * from "./PnLocal.ts";
+/**
  * Pre-built identity composers for every `@beep/*` workspace package.
  *
  * @example
@@ -43,3 +71,17 @@ export * from "./Id.ts";
  * @since 0.0.0
  */
 export * from "./packages.ts";
+/**
+ * Static borrowed vocabulary registry and literal CURIE type helpers.
+ *
+ * @example
+ * ```typescript
+ * import { CoreVocab } from "@beep/identity"
+ *
+ * console.log(CoreVocab.rdf.iri)
+ * ```
+ *
+ * @category constants
+ * @since 0.0.0
+ */
+export * from "./Vocab.ts";

--- a/packages/foundation/modeling/identity/src/packages.ts
+++ b/packages/foundation/modeling/identity/src/packages.ts
@@ -37,7 +37,7 @@ import * as Identity from "./Id.ts";
  * @since 0.0.0
  * @category configuration
  */
-export const $I = Identity.make("beep").$BeepId;
+export const $I = Identity.make("beep", { authority: "https://ns.beep.sh/", prefix: "beep" }).$BeepId;
 
 const generatedComposers = $I.compose(
   // IaC Infra Package

--- a/packages/foundation/modeling/identity/test/Curie.test.ts
+++ b/packages/foundation/modeling/identity/test/Curie.test.ts
@@ -1,0 +1,77 @@
+import { CoreVocab, CurieFromIri, contract, expand, expandPredicate } from "@beep/identity";
+import { Effect } from "effect";
+import * as S from "effect/Schema";
+import { FastCheck as fc } from "effect/testing";
+import { describe, expect, expectTypeOf, it } from "vitest";
+
+const decodeCurie = S.decodeUnknownEffect(CurieFromIri);
+const encodeIri = S.encodeUnknownEffect(CurieFromIri);
+
+const coreCurieCases = Object.entries(CoreVocab).flatMap(([prefix, vocab]) =>
+  vocab.terms.map((term) => ({
+    curie: `${prefix}:${term}`,
+    iri: `${vocab.iri}${term}`,
+    prefix,
+    term,
+  }))
+);
+
+describe("CURIE codec", () => {
+  it("preserves literal expansion types", () => {
+    expectTypeOf(expand("skos:prefLabel")).toEqualTypeOf<"http://www.w3.org/2004/02/skos/core#prefLabel">();
+    expect(expand("skos:prefLabel")).toBe("http://www.w3.org/2004/02/skos/core#prefLabel");
+  });
+
+  it("round-trips every CoreVocab term", () => {
+    for (const current of coreCurieCases) {
+      const iri = expand(current.curie);
+
+      expect(iri, current.curie).toBe(current.iri);
+      if (iri !== undefined) {
+        expect(contract(iri), current.iri).toBe(current.curie);
+      }
+    }
+  });
+
+  it("property-checks round-trips over the entire registry", () => {
+    fc.assert(
+      fc.property(fc.constant(coreCurieCases), (cases) => {
+        for (const current of cases) {
+          const iri = expand(current.curie);
+
+          expect(iri, current.curie).toBe(current.iri);
+          if (iri !== undefined) {
+            expect(contract(iri), current.iri).toBe(current.curie);
+          }
+        }
+      })
+    );
+  });
+
+  it("decodes and encodes known CURIEs", async () => {
+    await expect(Effect.runPromise(decodeCurie("skos:prefLabel"))).resolves.toBe(
+      "http://www.w3.org/2004/02/skos/core#prefLabel"
+    );
+    await expect(Effect.runPromise(encodeIri("http://www.w3.org/2004/02/skos/core#prefLabel"))).resolves.toBe(
+      "skos:prefLabel"
+    );
+  });
+
+  it("fails schema decoding for unknown prefixes and known-prefix unknown terms", async () => {
+    await expect(Effect.runPromise(decodeCurie("nope:term"))).rejects.toMatchObject({ _tag: "SchemaError" });
+    await expect(Effect.runPromise(decodeCurie("skos:nope"))).rejects.toMatchObject({ _tag: "SchemaError" });
+  });
+
+  it("fails schema encoding for unregistered IRIs", async () => {
+    await expect(Effect.runPromise(encodeIri("http://www.w3.org/2004/02/skos/core#nope"))).rejects.toMatchObject({
+      _tag: "SchemaError",
+    });
+  });
+
+  it("expands inverse predicates", () => {
+    expect(expandPredicate("^rdfs:subClassOf")).toEqual({
+      iri: "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+      inverse: true,
+    });
+  });
+});

--- a/packages/foundation/modeling/identity/test/Curie.test.ts
+++ b/packages/foundation/modeling/identity/test/Curie.test.ts
@@ -1,8 +1,9 @@
 import { CoreVocab, CurieFromIri, contract, expand, expandPredicate } from "@beep/identity";
+import { describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
 import * as S from "effect/Schema";
 import { FastCheck as fc } from "effect/testing";
-import { describe, expect, expectTypeOf, it } from "vitest";
+import { expectTypeOf } from "vitest";
 
 const decodeCurie = S.decodeUnknownEffect(CurieFromIri);
 const encodeIri = S.encodeUnknownEffect(CurieFromIri);

--- a/packages/foundation/modeling/identity/test/IriBinding.test.ts
+++ b/packages/foundation/modeling/identity/test/IriBinding.test.ts
@@ -1,0 +1,94 @@
+import { make } from "@beep/identity";
+import { $I, $OntologyId } from "@beep/identity/packages";
+import * as S from "effect/Schema";
+import { describe, expect, expectTypeOf, it } from "vitest";
+import type { CurieFromIdentity, IriFromIdentity, SlugFromIdentifier } from "@beep/identity";
+
+const getProperty = (value: unknown, key: PropertyKey): unknown =>
+  value !== null && typeof value === "object" ? Reflect.get(value, key) : undefined;
+
+describe("@beep/identity IRI binding", () => {
+  it("derives exact IRI and CURIE literals through create and compose chains", () => {
+    const { $BeepId } = make("beep", { authority: "https://ns.beep.sh/", prefix: "beep" });
+    const modules = $BeepId.compose("ontology", "schema");
+    const model = modules.$OntologyId.create("Ontology.models").create("HttpUrl");
+
+    expectTypeOf<
+      IriFromIdentity<"https://ns.beep.sh/", "@beep/ontology/Ontology.models/HttpUrl">
+    >().toEqualTypeOf<"https://ns.beep.sh/ontology/Ontology.models/HttpUrl">();
+    expectTypeOf<
+      CurieFromIdentity<"beep", "@beep/ontology/Ontology.models/HttpUrl">
+    >().toEqualTypeOf<"beep:ontology/Ontology.models/HttpUrl">();
+    expectTypeOf<
+      SlugFromIdentifier<"@beep/ontology/Ontology.models/HttpUrl">
+    >().toEqualTypeOf<"beep-ontology-ontology-models-http-url">();
+    expectTypeOf(modules.$OntologyId.iri).toEqualTypeOf<"https://ns.beep.sh/ontology">();
+    expectTypeOf(model.iri).toEqualTypeOf<"https://ns.beep.sh/ontology/Ontology.models/HttpUrl">();
+    expectTypeOf(model.curie).toEqualTypeOf<"beep:ontology/Ontology.models/HttpUrl">();
+    expectTypeOf(model.slug).toEqualTypeOf<"beep-ontology-ontology-models-http-url">();
+
+    expect(model.string()).toBe("@beep/ontology/Ontology.models/HttpUrl");
+    expect(model.iri).toBe("https://ns.beep.sh/ontology/Ontology.models/HttpUrl");
+    expect(model.curie).toBe("beep:ontology/Ontology.models/HttpUrl");
+    expect(model.slug).toBe("beep-ontology-ontology-models-http-url");
+  });
+
+  it("rebases projections while preserving identity and symbol interning", () => {
+    const patent = $I.create("ontology").create("patent");
+    const originalSymbol = patent.symbol();
+    const rebased = patent.rebase({ iri: "https://opip.law/ns/patent#", prefix: "patent" });
+    const annotation = rebased.annote("Claim");
+
+    expectTypeOf(rebased.iri).toEqualTypeOf<"https://opip.law/ns/patent#ontology/patent">();
+    expectTypeOf(rebased.curie).toEqualTypeOf<"patent:ontology/patent">();
+    expectTypeOf(annotation.iri).toEqualTypeOf<"https://opip.law/ns/patent#ontology/patent/Claim">();
+    expectTypeOf(annotation.curie).toEqualTypeOf<"patent:ontology/patent/Claim">();
+
+    expect(rebased.string()).toBe(patent.string());
+    expect(rebased.identifier).toBe(patent.identifier);
+    expect(rebased.symbol()).toBe(originalSymbol);
+    expect(rebased.symbol()).toBe(Symbol.for("@beep/ontology/patent"));
+    expect(rebased.iri).toBe("https://opip.law/ns/patent#ontology/patent");
+    expect(rebased.curie).toBe("patent:ontology/patent");
+    expect(annotation.identifier).toBe("@beep/ontology/patent/Claim");
+    expect(annotation.schemaId).toBe(Symbol.for("@beep/ontology/patent/Claim"));
+  });
+
+  it("adds owned iri and curie fields to bound annotation records", () => {
+    const $Model = $OntologyId.create("Ontology.models");
+    const annotation = $Model.annote("OWLClass", {
+      description: "Ontology class metadata.",
+    });
+    const schema = S.String.pipe(
+      $Model.annoteSchema("OWLClassLabel", {
+        description: "Ontology class label.",
+      })
+    );
+    const schemaAnnotations = S.resolveAnnotations(schema);
+
+    expectTypeOf(annotation.iri).toEqualTypeOf<"https://ns.beep.sh/ontology/Ontology.models/OWLClass">();
+    expectTypeOf(annotation.curie).toEqualTypeOf<"beep:ontology/Ontology.models/OWLClass">();
+    expect(annotation).toMatchObject({
+      identifier: "@beep/ontology/Ontology.models/OWLClass",
+      iri: "https://ns.beep.sh/ontology/Ontology.models/OWLClass",
+      curie: "beep:ontology/Ontology.models/OWLClass",
+      title: "OWLClass",
+      description: "Ontology class metadata.",
+    });
+    expect(getProperty(schemaAnnotations, "iri")).toBe("https://ns.beep.sh/ontology/Ontology.models/OWLClassLabel");
+    expect(getProperty(schemaAnnotations, "curie")).toBe("beep:ontology/Ontology.models/OWLClassLabel");
+  });
+
+  it("keeps one-argument make composers unbound and type-safe", () => {
+    const unbound = make("beep").$BeepId.create("scratch");
+    const annotation = unbound.annote("Unpublished");
+
+    expectTypeOf(unbound.iri).toEqualTypeOf<undefined>();
+    expectTypeOf(unbound.curie).toEqualTypeOf<undefined>();
+    expect(unbound.iri).toBeUndefined();
+    expect(unbound.curie).toBeUndefined();
+    expect(Reflect.has(annotation, "iri")).toBe(false);
+    expect(Reflect.has(annotation, "curie")).toBe(false);
+    expect(annotation.identifier).toBe("@beep/scratch/Unpublished");
+  });
+});

--- a/packages/foundation/modeling/identity/test/PnLocal.test.ts
+++ b/packages/foundation/modeling/identity/test/PnLocal.test.ts
@@ -1,0 +1,67 @@
+import { acceptsEscapedLocal, escapeLocal, isSafeLocal, prefixedNameOrIri, unescapeLocal } from "@beep/identity";
+import { FastCheck as fc } from "effect/testing";
+import { describe, expect, it } from "vitest";
+
+const escapableLocalCharacters = [
+  "_",
+  "~",
+  ".",
+  "-",
+  "!",
+  "$",
+  "&",
+  "'",
+  "(",
+  ")",
+  "*",
+  "+",
+  ",",
+  ";",
+  "=",
+  "/",
+  "?",
+  "#",
+  "@",
+  "%",
+];
+
+describe("PnLocal", () => {
+  it("recognizes safe unescaped Turtle PN_LOCAL values", () => {
+    expect(isSafeLocal("HttpUrl")).toBe(true);
+    expect(isSafeLocal("Ontology.models/HttpUrl")).toBe(false);
+    expect(isSafeLocal("a.b")).toBe(true);
+    expect(isSafeLocal("a.b.")).toBe(false);
+    expect(isSafeLocal("9lives")).toBe(true);
+    expect(isSafeLocal("")).toBe(false);
+    expect(isSafeLocal("claim#1")).toBe(false);
+  });
+
+  it("accepts escaped parser-side local names", () => {
+    expect(acceptsEscapedLocal("Ontology.models\\/HttpUrl")).toBe(true);
+    expect(acceptsEscapedLocal("claim\\#1")).toBe(true);
+    expect(acceptsEscapedLocal("bad\\z")).toBe(false);
+    expect(acceptsEscapedLocal("bad%0Z")).toBe(false);
+  });
+
+  it("round-trips escaped PN_LOCAL characters through parser-side acceptance", () => {
+    fc.assert(
+      fc.property(
+        fc
+          .array(fc.constantFrom(...escapableLocalCharacters), { minLength: 1, maxLength: 40 })
+          .map((characters) => characters.join("")),
+        (local) => {
+          const escaped = escapeLocal(local);
+
+          expect(unescapeLocal(escaped)).toBe(local);
+          expect(acceptsEscapedLocal(escaped)).toBe(true);
+        }
+      )
+    );
+  });
+
+  it("falls back to full IRI when a local cannot be emitted unescaped", () => {
+    expect(
+      prefixedNameOrIri("beep", "Ontology.models/HttpUrl", "https://ns.beep.sh/ontology/Ontology.models/HttpUrl")
+    ).toBe("<https://ns.beep.sh/ontology/Ontology.models/HttpUrl>");
+  });
+});

--- a/packages/foundation/modeling/identity/test/PnLocal.test.ts
+++ b/packages/foundation/modeling/identity/test/PnLocal.test.ts
@@ -1,6 +1,6 @@
 import { acceptsEscapedLocal, escapeLocal, isSafeLocal, prefixedNameOrIri, unescapeLocal } from "@beep/identity";
+import { describe, expect, it } from "@effect/vitest";
 import { FastCheck as fc } from "effect/testing";
-import { describe, expect, it } from "vitest";
 
 const escapableLocalCharacters = [
   "_",

--- a/packages/foundation/modeling/identity/test/Vocab.test.ts
+++ b/packages/foundation/modeling/identity/test/Vocab.test.ts
@@ -1,0 +1,60 @@
+import { CoreVocab, mergeVocab } from "@beep/identity";
+import { describe, expect, expectTypeOf, it } from "vitest";
+import type { Curie, Expand, Predicate } from "@beep/identity";
+
+type CoreCurie = Curie<typeof CoreVocab>;
+type CorePredicate = Predicate<typeof CoreVocab>;
+
+describe("Vocab literal types", () => {
+  it("derives CURIE literals from CoreVocab data", () => {
+    expectTypeOf<"skos:prefLabel" extends CoreCurie ? true : false>().toEqualTypeOf<true>();
+    expectTypeOf<"skos:prefLabl" extends CoreCurie ? true : false>().toEqualTypeOf<false>();
+    expectTypeOf<"dcterms:creator" extends CoreCurie ? true : false>().toEqualTypeOf<true>();
+  });
+
+  it("expands CURIE literals to exact namespace IRIs", () => {
+    expectTypeOf<
+      Expand<"skos:prefLabel", typeof CoreVocab>
+    >().toEqualTypeOf<"http://www.w3.org/2004/02/skos/core#prefLabel">();
+    expectTypeOf<Expand<"dcterms:creator", typeof CoreVocab>>().toEqualTypeOf<"http://purl.org/dc/terms/creator">();
+  });
+
+  it("accepts inverse predicates only for known CURIEs", () => {
+    expectTypeOf<"^rdfs:subClassOf" extends CorePredicate ? true : false>().toEqualTypeOf<true>();
+    expectTypeOf<"^rdfs:subClasOf" extends CorePredicate ? true : false>().toEqualTypeOf<false>();
+  });
+
+  it("preserves extension literals when vocabularies are merged", () => {
+    const extended = mergeVocab(CoreVocab, {
+      ex: {
+        iri: "https://example.test/ns#",
+        terms: ["Thing"],
+      },
+    } as const);
+
+    expectTypeOf<Curie<typeof extended>>().toEqualTypeOf<CoreCurie | "ex:Thing">();
+    expect(extended.ex.terms).toEqual(["Thing"]);
+  });
+});
+
+describe("CoreVocab runtime invariants", () => {
+  it("uses namespace IRIs ending in # or /", () => {
+    for (const [prefix, vocab] of Object.entries(CoreVocab)) {
+      expect(vocab.iri.endsWith("#") || vocab.iri.endsWith("/"), prefix).toBe(true);
+    }
+  });
+
+  it("has non-empty term lists", () => {
+    for (const [prefix, vocab] of Object.entries(CoreVocab)) {
+      expect(vocab.terms.length, prefix).toBeGreaterThan(0);
+    }
+  });
+
+  it("has no duplicate terms", () => {
+    for (const [prefix, vocab] of Object.entries(CoreVocab)) {
+      const duplicates = vocab.terms.filter((term, index) => vocab.terms.indexOf(term) !== index);
+
+      expect(duplicates, prefix).toEqual([]);
+    }
+  });
+});

--- a/packages/foundation/modeling/identity/test/Vocab.test.ts
+++ b/packages/foundation/modeling/identity/test/Vocab.test.ts
@@ -1,5 +1,6 @@
 import { CoreVocab, mergeVocab } from "@beep/identity";
-import { describe, expect, expectTypeOf, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
+import { expectTypeOf } from "vitest";
 import type { Curie, Expand, Predicate } from "@beep/identity";
 
 type CoreCurie = Curie<typeof CoreVocab>;

--- a/packages/foundation/modeling/identity/test/shape-stable.test.ts
+++ b/packages/foundation/modeling/identity/test/shape-stable.test.ts
@@ -1,9 +1,8 @@
-import { readFileSync } from "node:fs";
 import * as Identity from "@beep/identity";
 import { make } from "@beep/identity";
 import * as IdentityPackages from "@beep/identity/packages";
+import { describe, expect, it } from "@effect/vitest";
 import * as S from "effect/Schema";
-import { describe, expect, it } from "vitest";
 import type {
   HttpApiEncoding,
   IdentityAnyAnnotationExtras,
@@ -251,12 +250,6 @@ const composerFunctionProperties = [
   "symbol",
 ] as const;
 
-const packageRootUrl = new URL("../", import.meta.url);
-const createPackageHandlerUrl = new URL(
-  "../../../tooling/tool/cli/src/commands/CreatePackage/Handler.ts",
-  packageRootUrl
-);
-
 const isObjectLike = (value: unknown): value is object =>
   (typeof value === "object" && value !== null) || typeof value === "function";
 
@@ -478,21 +471,7 @@ describe("@beep/identity shape-stable harness", () => {
     expect(getProperty(annotations, "description")).toBe("Shape-stable field.");
   });
 
-  it("keeps create-package identity registration output aligned with existing exports", () => {
-    const handlerSource = readFileSync(createPackageHandlerUrl, "utf8");
-
-    expect(handlerSource).toContain('const IDENTITY_PACKAGE_NAME = "@beep/identity" as const;');
-    expect(handlerSource).toContain(
-      "const toIdentityAccessorName = (packageName: string): string => `$${Str.pascalCase(packageName)}Id`;"
-    );
-    expect(handlerSource).toContain('` * import { ${accessorName} } from "@beep/identity"`');
-    expect(handlerSource).toContain(
-      '`export const ${accessorName}: Identity.IdentityComposer<"@beep/${packageName}"> = composers.${accessorName};`'
-    );
-    expect(handlerSource).toContain(
-      'sourceFile.getVariableDeclaration("generatedComposers") ?? sourceFile.getVariableDeclarationOrThrow("composers")'
-    );
-
+  it("keeps generated create-package accessor exports available", () => {
     for (const accessorName of ["$OntologyId", "$RepoCliId", "$UsptoMcpId"]) {
       expect(getProperty(Identity, accessorName), `generated import { ${accessorName} }`).not.toBeUndefined();
       expect(getProperty(IdentityPackages, accessorName), `generated composers.${accessorName}`).not.toBeUndefined();

--- a/packages/foundation/modeling/identity/test/shape-stable.test.ts
+++ b/packages/foundation/modeling/identity/test/shape-stable.test.ts
@@ -1,0 +1,501 @@
+import { readFileSync } from "node:fs";
+import * as Identity from "@beep/identity";
+import { make } from "@beep/identity";
+import * as IdentityPackages from "@beep/identity/packages";
+import * as S from "effect/Schema";
+import { describe, expect, it } from "vitest";
+import type {
+  HttpApiEncoding,
+  IdentityAnyAnnotationExtras,
+  IdentityComposer,
+  IdentityString,
+  IdentitySymbol,
+  KeyAnnotationExtras,
+  ModuleSegmentValue,
+  SegmentValue,
+  TitleFromIdentifier,
+} from "@beep/identity";
+
+type ShapeStableTypeOnlyImportSentinel = {
+  readonly HttpApiEncoding: HttpApiEncoding;
+  readonly IdentityAnyAnnotationExtras: IdentityAnyAnnotationExtras<unknown>;
+  readonly IdentityComposer: IdentityComposer<string>;
+  readonly IdentityString: IdentityString<string>;
+  readonly IdentitySymbol: IdentitySymbol<string>;
+  readonly KeyAnnotationExtras: KeyAnnotationExtras<unknown>;
+  readonly ModuleSegmentValue: ModuleSegmentValue<"shape-stable">;
+  readonly SegmentValue: SegmentValue<"shape-stable">;
+  readonly TitleFromIdentifier: TitleFromIdentifier<"shape-stable">;
+};
+
+const currentRootTypeOnlyNamedImports = [
+  "HttpApiEncoding",
+  "IdentityAnyAnnotationExtras",
+  "IdentityComposer",
+  "IdentityString",
+  "IdentitySymbol",
+  "KeyAnnotationExtras",
+  "ModuleSegmentValue",
+  "SegmentValue",
+  "TitleFromIdentifier",
+] as const satisfies ReadonlyArray<keyof ShapeStableTypeOnlyImportSentinel>;
+
+const currentRootRuntimeNamedImports = [
+  "$AcpId",
+  "$AgentsDomainId",
+  "$AgentsServerId",
+  "$AgentsUseCasesId",
+  "$AiProviderCliId",
+  "$AnthropicId",
+  "$ApiTransportId",
+  "$BoxId",
+  "$ColorsId",
+  "$DiscordId",
+  "$DrizzleId",
+  "$EcfrId",
+  "$EditorId",
+  "$EpistemicDomainId",
+  "$FileProcessingId",
+  "$FormId",
+  "$GovinfoId",
+  "$HtmlId",
+  "$HubspotId",
+  "$LangExtractId",
+  "$LawPracticeDomainId",
+  "$LawPracticeUseCasesId",
+  "$LibpffId",
+  "$M365Id",
+  "$MdId",
+  "$NlpId",
+  "$NlpMcpId",
+  "$NlpProcessingId",
+  "$OipWebId",
+  "$OnepasswordCliId",
+  "$OntologyId",
+  "$OpenaiCompatId",
+  "$PandocAstId",
+  "$PgliteId",
+  "$PhoenixId",
+  "$PostgresId",
+  "$ProfessionalDesktopId",
+  "$RepoCliId",
+  "$RepoConfigsId",
+  "$RepoDocgenId",
+  "$RepoUtilsId",
+  "$RunpodId",
+  "$SanityId",
+  "$SchemaId",
+  "$ScratchpadId",
+  "$SemanticWebId",
+  "$SharedDomainId",
+  "$TikaId",
+  "$UiId",
+  "$UsptoId",
+  "$VeniceAiId",
+  "$WinkId",
+  "$WorkspaceDomainId",
+  "$WorkspaceServerId",
+  "$XaiId",
+  "make",
+] as const;
+
+const currentPackagesRuntimeNamedImports = [
+  "$AgentsDomainId",
+  "$AgentsUseCasesId",
+  "$AiSyncId",
+  "$ArchitectureLabClientId",
+  "$ArchitectureLabConfigId",
+  "$ArchitectureLabDomainId",
+  "$ArchitectureLabProofId",
+  "$ArchitectureLabServerId",
+  "$ArchitectureLabUiId",
+  "$ArchitectureLabUseCasesId",
+  "$ChalkId",
+  "$EpistemicDomainId",
+  "$EpistemicUseCasesId",
+  "$FaceDetectionId",
+  "$FfmpegId",
+  "$FirecrawlId",
+  "$I",
+  "$InfraId",
+  "$LawPracticeDomainId",
+  "$LawPracticeUseCasesId",
+  "$LexicalSchemaId",
+  "$M365McpId",
+  "$McpKitId",
+  "$ObservabilityId",
+  "$OipWebId",
+  "$OntologyId",
+  "$ProfessionalDesktopId",
+  "$ProvenanceId",
+  "$RdfId",
+  "$RepoAiMetricsId",
+  "$RepoCliId",
+  "$RepoDocgenId",
+  "$RepoUtilsId",
+  "$SchemaId",
+  "$SemanticWebId",
+  "$SharedDomainId",
+  "$TestUtilsId",
+  "$UsptoMcpId",
+  "$UtilsId",
+  "$WorkspaceDomainId",
+  "$WorkspaceUseCasesId",
+] as const;
+
+const expectedPackageComposerIdentities = {
+  $I: "@beep",
+  $DataId: "@beep/data",
+  $IdentityId: "@beep/identity",
+  $SchemaId: "@beep/schema",
+  $ProvenanceId: "@beep/provenance",
+  $RdfId: "@beep/rdf",
+  $OntologyId: "@beep/ontology",
+  $TypesId: "@beep/types",
+  $UtilsId: "@beep/utils",
+  $UiId: "@beep/ui",
+  $RepoAiMetricsId: "@beep/repo-ai-metrics",
+  $RepoCliId: "@beep/repo-cli",
+  $RepoConfigsId: "@beep/repo-configs",
+  $RepoUtilsId: "@beep/repo-utils",
+  $TestUtilsId: "@beep/test-utils",
+  $SharedDomainId: "@beep/shared-domain",
+  $SharedTablesId: "@beep/shared-tables",
+  $SemanticWebId: "@beep/semantic-web",
+  $NlpId: "@beep/nlp",
+  $NlpProcessingId: "@beep/nlp-processing",
+  $LangExtractId: "@beep/langextract",
+  $ObservabilityId: "@beep/observability",
+  $ColorsId: "@beep/colors",
+  $ChalkId: "@beep/chalk",
+  $RepoDocgenId: "@beep/repo-docgen",
+  $InfraId: "@beep/infra",
+  $WorkspaceDomainId: "@beep/workspace-domain",
+  $EpistemicDomainId: "@beep/epistemic-domain",
+  $EpistemicUseCasesId: "@beep/epistemic-use-cases",
+  $AgentsDomainId: "@beep/agents-domain",
+  $AgentsServerId: "@beep/agents-server",
+  $AgentsUseCasesId: "@beep/agents-use-cases",
+  $LawPracticeDomainId: "@beep/law-practice-domain",
+  $LawPracticeUseCasesId: "@beep/law-practice-use-cases",
+  $LawPracticeServerId: "@beep/law-practice-server",
+  $ProfessionalDesktopId: "@beep/professional-desktop",
+  $MdId: "@beep/md",
+  $OipWebId: "@beep/oip-web",
+  $DrizzleId: "@beep/drizzle",
+  $DuckdbId: "@beep/duckdb",
+  $FaceDetectionId: "@beep/face-detection",
+  $FfmpegId: "@beep/ffmpeg",
+  $PostgresId: "@beep/postgres",
+  $AnthropicId: "@beep/anthropic",
+  $VeniceAiId: "@beep/venice-ai",
+  $XaiId: "@beep/xai",
+  $AcpId: "@beep/acp",
+  $OpenaiCompatId: "@beep/openai-compat",
+  $WorkspaceTablesId: "@beep/workspace-tables",
+  $WorkspaceUseCasesId: "@beep/workspace-use-cases",
+  $WorkspaceServerId: "@beep/workspace-server",
+  $ArchitectureLabDomainId: "@beep/architecture-lab-domain",
+  $ArchitectureLabUseCasesId: "@beep/architecture-lab-use-cases",
+  $ArchitectureLabConfigId: "@beep/architecture-lab-config",
+  $ArchitectureLabServerId: "@beep/architecture-lab-server",
+  $ArchitectureLabTablesId: "@beep/architecture-lab-tables",
+  $ArchitectureLabClientId: "@beep/architecture-lab-client",
+  $ArchitectureLabUiId: "@beep/architecture-lab-ui",
+  $ArchitectureLabProofId: "@beep/architecture-lab-proof",
+  $RunpodId: "@beep/runpod",
+  $OnepasswordCliId: "@beep/onepassword-cli",
+  $DiscordId: "@beep/discord",
+  $AiProviderCliId: "@beep/ai-provider-cli",
+  $SanityId: "@beep/sanity",
+  $HubspotId: "@beep/hubspot",
+  $PhoenixId: "@beep/phoenix",
+  $AiSyncId: "@beep/ai-sync",
+  $BoxId: "@beep/box",
+  $NlpMcpId: "@beep/nlp-mcp",
+  $RdfCanonizeId: "@beep/rdf-canonize",
+  $WinkId: "@beep/wink",
+  $FileProcessingId: "@beep/file-processing",
+  $TikaId: "@beep/tika",
+  $LibpffId: "@beep/libpff",
+  $FirecrawlId: "@beep/firecrawl",
+  $UsptoId: "@beep/uspto",
+  $LexicalSchemaId: "@beep/lexical-schema",
+  $EditorId: "@beep/editor",
+  $ScratchpadId: "@beep/scratchpad",
+  $HtmlId: "@beep/html",
+  $PandocAstId: "@beep/pandoc-ast",
+  $FormId: "@beep/form",
+  $PgliteId: "@beep/pglite",
+  $M365Id: "@beep/m365",
+  $M365McpId: "@beep/m365-mcp",
+  $GovinfoId: "@beep/govinfo",
+  $FederalRegisterId: "@beep/federal-register",
+  $EcfrId: "@beep/ecfr",
+  $DolId: "@beep/dol",
+  $CourtlistenerId: "@beep/courtlistener",
+  $ApiTransportId: "@beep/api-transport",
+  $McpKitId: "@beep/mcp-kit",
+  $UsptoMcpId: "@beep/uspto-mcp",
+} as const;
+
+const composerFunctionProperties = [
+  "annote",
+  "annoteHttp",
+  "annoteKey",
+  "annoteSchema",
+  "compose",
+  "create",
+  "make",
+  "string",
+  "symbol",
+] as const;
+
+const packageRootUrl = new URL("../", import.meta.url);
+const createPackageHandlerUrl = new URL(
+  "../../../tooling/tool/cli/src/commands/CreatePackage/Handler.ts",
+  packageRootUrl
+);
+
+const isObjectLike = (value: unknown): value is object =>
+  (typeof value === "object" && value !== null) || typeof value === "function";
+
+const getProperty = (value: unknown, key: PropertyKey): unknown =>
+  isObjectLike(value) ? Reflect.get(value, key) : undefined;
+
+const expectFunction = (value: unknown, label: string): asserts value is (...args: Array<unknown>) => unknown => {
+  expect(typeof value, label).toBe("function");
+};
+
+const callFunction = (value: unknown, label: string, ...args: Array<unknown>): unknown => {
+  expectFunction(value, label);
+  return value(...args);
+};
+
+const expectRecord = (value: unknown, label: string): asserts value is Record<string, unknown> => {
+  expect(isObjectLike(value), label).toBe(true);
+};
+
+const expectExistingAnnotationShape = (
+  annotation: unknown,
+  expectedIdentifier: string,
+  expectedTitle: string,
+  expectedExtraKeys: ReadonlyArray<string>
+) => {
+  expectRecord(annotation, "annotation");
+  const existingKeys = ["identifier", "schemaId", "title", ...expectedExtraKeys];
+
+  expect(Object.keys(annotation)).toEqual(expect.arrayContaining(existingKeys));
+  expect(annotation.identifier).toBe(expectedIdentifier);
+  expect(annotation.schemaId).toBe(Symbol.for(expectedIdentifier));
+  expect(annotation.title).toBe(expectedTitle);
+};
+
+const assertComposerShape = (name: string, value: unknown, expectedIdentity: string) => {
+  expectFunction(value, name);
+
+  for (const property of composerFunctionProperties) {
+    expect(typeof getProperty(value, property), `${name}.${property}`).toBe("function");
+  }
+
+  expect(getProperty(value, "identifier")).toBe(expectedIdentity);
+  expect(getProperty(value, "value")).toBe(expectedIdentity);
+  expect(callFunction(getProperty(value, "string"), `${name}.string`)).toBe(expectedIdentity);
+
+  const symbol = callFunction(getProperty(value, "symbol"), `${name}.symbol`);
+  expect(symbol).toBe(Symbol.for(expectedIdentity));
+  expect(typeof symbol, `${name}.symbol typeof`).toBe("symbol");
+  if (typeof symbol === "symbol") {
+    expect(Symbol.keyFor(symbol)).toBe(expectedIdentity);
+  }
+
+  expect(callFunction(getProperty(value, "make"), `${name}.make`, "Harness")).toBe(`${expectedIdentity}/Harness`);
+
+  const child = callFunction(getProperty(value, "create"), `${name}.create`, "Harness");
+  expect(callFunction(getProperty(child, "string"), `${name}.create.string`)).toBe(`${expectedIdentity}/Harness`);
+
+  const composed = callFunction(getProperty(value, "compose"), `${name}.compose`, "shape-stable");
+  const $ShapeStableId = getProperty(composed, "$ShapeStableId");
+  expect(callFunction(getProperty($ShapeStableId, "string"), `${name}.compose.$ShapeStableId.string`)).toBe(
+    `${expectedIdentity}/shape-stable`
+  );
+
+  const annotation = callFunction(getProperty(value, "annote"), `${name}.annote`, "Harness", {
+    description: "Shape stable harness.",
+  });
+  expectExistingAnnotationShape(annotation, `${expectedIdentity}/Harness`, "Harness", ["description"]);
+};
+
+const assertComposerExport = (
+  moduleName: string,
+  moduleExports: unknown,
+  exportName: string,
+  expectedIdentity: string
+) => {
+  const value = getProperty(moduleExports, exportName);
+
+  expect(value, `${moduleName}.${exportName}`).not.toBeUndefined();
+  assertComposerShape(`${moduleName}.${exportName}`, value, expectedIdentity);
+};
+
+describe("@beep/identity shape-stable harness", () => {
+  it("keeps the current root type-only named import inventory documented", () => {
+    expect(currentRootTypeOnlyNamedImports).toEqual([
+      "HttpApiEncoding",
+      "IdentityAnyAnnotationExtras",
+      "IdentityComposer",
+      "IdentityString",
+      "IdentitySymbol",
+      "KeyAnnotationExtras",
+      "ModuleSegmentValue",
+      "SegmentValue",
+      "TitleFromIdentifier",
+    ]);
+  });
+
+  it("keeps every current runtime named import from @beep/identity available", () => {
+    for (const exportName of currentRootRuntimeNamedImports) {
+      const value = getProperty(Identity, exportName);
+
+      expect(value, `@beep/identity.${exportName}`).not.toBeUndefined();
+
+      if (exportName === "make") {
+        expectFunction(value, "@beep/identity.make");
+      } else {
+        const expectedIdentity = getProperty(expectedPackageComposerIdentities, exportName);
+
+        expect(typeof expectedIdentity, `expected identity for ${exportName}`).toBe("string");
+        if (typeof expectedIdentity === "string") {
+          assertComposerShape(`@beep/identity.${exportName}`, value, expectedIdentity);
+        }
+      }
+    }
+  });
+
+  it("keeps every current runtime named import from @beep/identity/packages available", () => {
+    for (const exportName of currentPackagesRuntimeNamedImports) {
+      const expectedIdentity = getProperty(expectedPackageComposerIdentities, exportName);
+
+      expect(typeof expectedIdentity, `expected package identity for ${exportName}`).toBe("string");
+      if (typeof expectedIdentity === "string") {
+        assertComposerExport("@beep/identity/packages", IdentityPackages, exportName, expectedIdentity);
+      }
+    }
+  });
+
+  it("pins every generated package composer export to today's literal identity", () => {
+    for (const [exportName, expectedIdentity] of Object.entries(expectedPackageComposerIdentities)) {
+      assertComposerExport("@beep/identity/packages", IdentityPackages, exportName, expectedIdentity);
+      assertComposerExport("@beep/identity", Identity, exportName, expectedIdentity);
+    }
+  });
+
+  it("keeps RepoPkgs backed by the generated composer record", () => {
+    const repoPkgs = getProperty(IdentityPackages, "RepoPkgs");
+
+    expectRecord(repoPkgs, "@beep/identity/packages.RepoPkgs");
+
+    for (const [exportName, expectedIdentity] of Object.entries(expectedPackageComposerIdentities)) {
+      if (exportName !== "$I") {
+        assertComposerShape(`RepoPkgs.${exportName}`, repoPkgs[exportName], expectedIdentity);
+      }
+    }
+  });
+
+  it("keeps make() one-argument call forms and generated accessor names compatible", () => {
+    const cases = [
+      { accessor: "$BeepId", base: "beep", identity: "@beep" },
+      { accessor: "$BeepId", base: "@beep", identity: "@beep" },
+      { accessor: "$SchemaId", base: "schema", identity: "@beep/schema" },
+      { accessor: "$SchemaId", base: "@schema", identity: "@beep/schema" },
+      { accessor: "$SchemaId", base: "@beep/schema", identity: "@beep/schema" },
+      { accessor: "$RepoCliId", base: "repo-cli", identity: "@beep/repo-cli" },
+    ];
+
+    for (const current of cases) {
+      const made = make(current.base);
+      const composer = getProperty(made, current.accessor);
+
+      expect(Object.keys(made)).toEqual([current.accessor]);
+      assertComposerShape(`make(${current.base}).${current.accessor}`, composer, current.identity);
+    }
+  });
+
+  it("keeps Symbol.for interning stable for representative identities", () => {
+    const representatives = [
+      IdentityPackages.$I,
+      IdentityPackages.$SchemaId,
+      IdentityPackages.$OntologyId.create("Ontology.models").create("OWLClass"),
+      IdentityPackages.$UsptoMcpId.create("Server"),
+    ];
+
+    for (const composer of representatives) {
+      const identity = composer.string();
+
+      expect(composer.symbol()).toBe(Symbol.for(identity));
+      expect(Symbol.keyFor(composer.symbol())).toBe(identity);
+    }
+  });
+
+  it("keeps annote and annoteSchema existing record keys and values stable while allowing additions", () => {
+    const $I = IdentityPackages.$OntologyId.create("Ontology.models");
+    const annotation = $I.annote("OWLClass", {
+      description: "Regression model for ontology class annotations.",
+    });
+    const schema = S.String.pipe(
+      $I.annoteSchema("OWLClassLabel", {
+        description: "Regression schema annotation.",
+      })
+    );
+    const schemaAnnotations = S.resolveAnnotations(schema);
+
+    expectExistingAnnotationShape(annotation, "@beep/ontology/Ontology.models/OWLClass", "OWLClass", ["description"]);
+    expect(annotation.description).toBe("Regression model for ontology class annotations.");
+    expectExistingAnnotationShape(schemaAnnotations, "@beep/ontology/Ontology.models/OWLClassLabel", "OWLClassLabel", [
+      "description",
+    ]);
+    expect(schemaAnnotations?.description).toBe("Regression schema annotation.");
+  });
+
+  it("keeps annoteKey existing record keys and values stable while allowing additions", () => {
+    const $I = IdentityPackages.$SchemaId.create("ShapeStable");
+    const schema = S.Struct({
+      field: S.String.pipe(
+        $I.annoteKey<{ readonly field: string }>()("Harness.field", {
+          description: "Shape-stable field.",
+        })
+      ),
+    });
+    const propertySignatures = getProperty(schema.ast, "propertySignatures");
+    const firstProperty = getProperty(propertySignatures, 0);
+    const propertyType = getProperty(firstProperty, "type");
+    const context = getProperty(propertyType, "context");
+    const annotations = getProperty(context, "annotations");
+
+    expectExistingAnnotationShape(annotations, "@beep/schema/ShapeStable/Harness.field", "Harness.field", [
+      "description",
+    ]);
+    expect(getProperty(annotations, "description")).toBe("Shape-stable field.");
+  });
+
+  it("keeps create-package identity registration output aligned with existing exports", () => {
+    const handlerSource = readFileSync(createPackageHandlerUrl, "utf8");
+
+    expect(handlerSource).toContain('const IDENTITY_PACKAGE_NAME = "@beep/identity" as const;');
+    expect(handlerSource).toContain(
+      "const toIdentityAccessorName = (packageName: string): string => `$${Str.pascalCase(packageName)}Id`;"
+    );
+    expect(handlerSource).toContain('` * import { ${accessorName} } from "@beep/identity"`');
+    expect(handlerSource).toContain(
+      '`export const ${accessorName}: Identity.IdentityComposer<"@beep/${packageName}"> = composers.${accessorName};`'
+    );
+    expect(handlerSource).toContain(
+      'sourceFile.getVariableDeclaration("generatedComposers") ?? sourceFile.getVariableDeclarationOrThrow("composers")'
+    );
+
+    for (const accessorName of ["$OntologyId", "$RepoCliId", "$UsptoMcpId"]) {
+      expect(getProperty(Identity, accessorName), `generated import { ${accessorName} }`).not.toBeUndefined();
+      expect(getProperty(IdentityPackages, accessorName), `generated composers.${accessorName}`).not.toBeUndefined();
+    }
+  });
+});

--- a/packages/foundation/modeling/rdf/src/Vocab/Dcterms.ts
+++ b/packages/foundation/modeling/rdf/src/Vocab/Dcterms.ts
@@ -1,0 +1,136 @@
+/**
+ * Dublin Core Metadata Terms vocabulary helpers.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+/**
+ * DCMI Metadata Terms namespace IRI.
+ *
+ * @example
+ * ```ts
+ * import { DCTERMS_NAMESPACE } from "@beep/rdf/Vocab/Dcterms"
+ *
+ * const titleIri = `${DCTERMS_NAMESPACE}title`
+ * console.log(titleIri) // "http://purl.org/dc/terms/title"
+ * ```
+ *
+ * @since 0.0.0
+ * @category configuration
+ */
+export const DCTERMS_NAMESPACE = "http://purl.org/dc/terms/" as const;
+
+/**
+ * Complete dcterms local-name inventory mirrored by `@beep/identity`.
+ *
+ * @example
+ * ```ts
+ * import { DCTERMS_TERMS } from "@beep/rdf/Vocab/Dcterms"
+ *
+ * console.log(DCTERMS_TERMS.includes("creator")) // true
+ * ```
+ *
+ * @since 0.0.0
+ * @category constants
+ */
+export const DCTERMS_TERMS = [
+  "Agent",
+  "AgentClass",
+  "BibliographicResource",
+  "Box",
+  "DCMIType",
+  "DDC",
+  "FileFormat",
+  "Frequency",
+  "IMT",
+  "ISO3166",
+  "ISO639-2",
+  "ISO639-3",
+  "Jurisdiction",
+  "LCC",
+  "LCSH",
+  "LicenseDocument",
+  "LinguisticSystem",
+  "Location",
+  "LocationPeriodOrJurisdiction",
+  "MESH",
+  "MediaType",
+  "MediaTypeOrExtent",
+  "MethodOfAccrual",
+  "MethodOfInstruction",
+  "NLM",
+  "Period",
+  "PeriodOfTime",
+  "PhysicalMedium",
+  "PhysicalResource",
+  "Point",
+  "Policy",
+  "ProvenanceStatement",
+  "RFC1766",
+  "RFC3066",
+  "RFC4646",
+  "RFC5646",
+  "RightsStatement",
+  "SizeOrDuration",
+  "Standard",
+  "TGN",
+  "UDC",
+  "URI",
+  "W3CDTF",
+  "abstract",
+  "accessRights",
+  "accrualMethod",
+  "accrualPeriodicity",
+  "accrualPolicy",
+  "alternative",
+  "audience",
+  "available",
+  "bibliographicCitation",
+  "conformsTo",
+  "contributor",
+  "coverage",
+  "created",
+  "creator",
+  "date",
+  "dateAccepted",
+  "dateCopyrighted",
+  "dateSubmitted",
+  "description",
+  "educationLevel",
+  "extent",
+  "format",
+  "hasFormat",
+  "hasPart",
+  "hasVersion",
+  "identifier",
+  "instructionalMethod",
+  "isFormatOf",
+  "isPartOf",
+  "isReferencedBy",
+  "isReplacedBy",
+  "isRequiredBy",
+  "isVersionOf",
+  "issued",
+  "language",
+  "license",
+  "mediator",
+  "medium",
+  "modified",
+  "provenance",
+  "publisher",
+  "references",
+  "relation",
+  "replaces",
+  "requires",
+  "rights",
+  "rightsHolder",
+  "source",
+  "spatial",
+  "subject",
+  "tableOfContents",
+  "temporal",
+  "title",
+  "type",
+  "valid",
+] as const;

--- a/packages/foundation/modeling/rdf/src/Vocab/Owl.ts
+++ b/packages/foundation/modeling/rdf/src/Vocab/Owl.ts
@@ -25,6 +25,47 @@ import { makeNamedNode } from "../Rdf.ts";
 export const OWL_NAMESPACE = "http://www.w3.org/2002/07/owl#" as const;
 
 /**
+ * OWL local-name inventory mirrored by `@beep/identity`.
+ *
+ * @example
+ * ```ts
+ * import { OWL_TERMS } from "@beep/rdf/Vocab/Owl"
+ *
+ * console.log(OWL_TERMS.includes("ObjectProperty")) // true
+ * ```
+ *
+ * @since 0.0.0
+ * @category constants
+ */
+export const OWL_TERMS = [
+  "AnnotationProperty",
+  "AsymmetricProperty",
+  "Class",
+  "DatatypeProperty",
+  "FunctionalProperty",
+  "InverseFunctionalProperty",
+  "IrreflexiveProperty",
+  "NamedIndividual",
+  "Nothing",
+  "ObjectProperty",
+  "Ontology",
+  "ReflexiveProperty",
+  "SymmetricProperty",
+  "Thing",
+  "TransitiveProperty",
+  "backwardCompatibleWith",
+  "deprecated",
+  "equivalentClass",
+  "equivalentProperty",
+  "imports",
+  "incompatibleWith",
+  "inverseOf",
+  "priorVersion",
+  "sameAs",
+  "versionInfo",
+] as const;
+
+/**
  * `owl:Class`
  *
  * @example

--- a/packages/foundation/modeling/rdf/src/Vocab/Rdf.ts
+++ b/packages/foundation/modeling/rdf/src/Vocab/Rdf.ts
@@ -25,6 +25,39 @@ import { makeNamedNode } from "../Rdf.ts";
 export const RDF_NAMESPACE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#" as const;
 
 /**
+ * Finite RDF local-name inventory mirrored by `@beep/identity`.
+ *
+ * @example
+ * ```ts
+ * import { RDF_TERMS } from "@beep/rdf/Vocab/Rdf"
+ *
+ * console.log(RDF_TERMS.includes("type")) // true
+ * ```
+ *
+ * @since 0.0.0
+ * @category constants
+ */
+export const RDF_TERMS = [
+  "Alt",
+  "Bag",
+  "HTML",
+  "List",
+  "Property",
+  "Seq",
+  "Statement",
+  "XMLLiteral",
+  "first",
+  "langString",
+  "nil",
+  "object",
+  "predicate",
+  "rest",
+  "subject",
+  "type",
+  "value",
+] as const;
+
+/**
  * `rdf:type`
  *
  * @example

--- a/packages/foundation/modeling/rdf/src/Vocab/Rdfs.ts
+++ b/packages/foundation/modeling/rdf/src/Vocab/Rdfs.ts
@@ -25,6 +25,37 @@ import { makeNamedNode } from "../Rdf.ts";
 export const RDFS_NAMESPACE = "http://www.w3.org/2000/01/rdf-schema#" as const;
 
 /**
+ * Complete RDFS local-name inventory mirrored by `@beep/identity`.
+ *
+ * @example
+ * ```ts
+ * import { RDFS_TERMS } from "@beep/rdf/Vocab/Rdfs"
+ *
+ * console.log(RDFS_TERMS.includes("subClassOf")) // true
+ * ```
+ *
+ * @since 0.0.0
+ * @category constants
+ */
+export const RDFS_TERMS = [
+  "Class",
+  "Container",
+  "ContainerMembershipProperty",
+  "Datatype",
+  "Literal",
+  "Resource",
+  "comment",
+  "domain",
+  "isDefinedBy",
+  "label",
+  "member",
+  "range",
+  "seeAlso",
+  "subClassOf",
+  "subPropertyOf",
+] as const;
+
+/**
  * `rdfs:label`
  *
  * @example

--- a/packages/foundation/modeling/rdf/src/Vocab/Skos.ts
+++ b/packages/foundation/modeling/rdf/src/Vocab/Skos.ts
@@ -26,6 +26,54 @@ import { makeNamedNode } from "../Rdf.ts";
 export const SKOS_NAMESPACE = "http://www.w3.org/2004/02/skos/core#" as const;
 
 /**
+ * Complete SKOS core local-name inventory mirrored by `@beep/identity`.
+ *
+ * @example
+ * ```ts
+ * import { SKOS_TERMS } from "@beep/rdf/Vocab/Skos"
+ *
+ * console.log(SKOS_TERMS.includes("prefLabel")) // true
+ * ```
+ *
+ * @since 0.0.0
+ * @category constants
+ */
+export const SKOS_TERMS = [
+  "Collection",
+  "Concept",
+  "ConceptScheme",
+  "OrderedCollection",
+  "altLabel",
+  "broadMatch",
+  "broader",
+  "broaderTransitive",
+  "changeNote",
+  "closeMatch",
+  "definition",
+  "editorialNote",
+  "exactMatch",
+  "example",
+  "hasTopConcept",
+  "hiddenLabel",
+  "historyNote",
+  "inScheme",
+  "mappingRelation",
+  "member",
+  "memberList",
+  "narrowMatch",
+  "narrower",
+  "narrowerTransitive",
+  "notation",
+  "note",
+  "prefLabel",
+  "related",
+  "relatedMatch",
+  "scopeNote",
+  "semanticRelation",
+  "topConceptOf",
+] as const;
+
+/**
  * `skos:Concept`
  *
  * @example

--- a/packages/foundation/modeling/rdf/test/Rdf.test.ts
+++ b/packages/foundation/modeling/rdf/test/Rdf.test.ts
@@ -574,7 +574,7 @@ describe("@beep/rdf semantic metadata", () => {
         ...semanticMetadataInput,
         kind: "unknown",
       })
-    ).toThrow("Expected SemanticSchemaMetadataKind");
+    ).toThrow("SemanticSchemaMetadataKind");
   });
 
   it("annotates schemas in direct and curried forms and finds nested metadata", () => {

--- a/packages/foundation/modeling/rdf/test/VocabDrift.test.ts
+++ b/packages/foundation/modeling/rdf/test/VocabDrift.test.ts
@@ -1,0 +1,60 @@
+import { CoreVocab } from "@beep/identity";
+import { DCTERMS_NAMESPACE, DCTERMS_TERMS } from "@beep/rdf/Vocab/Dcterms";
+import { OWL_NAMESPACE, OWL_TERMS } from "@beep/rdf/Vocab/Owl";
+import { RDF_NAMESPACE, RDF_TERMS } from "@beep/rdf/Vocab/Rdf";
+import { RDFS_NAMESPACE, RDFS_TERMS } from "@beep/rdf/Vocab/Rdfs";
+import { SKOS_NAMESPACE, SKOS_TERMS } from "@beep/rdf/Vocab/Skos";
+import { describe, expect, it } from "vitest";
+
+const vocabCases = [
+  {
+    moduleName: "Rdf",
+    namespace: RDF_NAMESPACE,
+    prefix: "rdf",
+    terms: RDF_TERMS,
+  },
+  {
+    moduleName: "Rdfs",
+    namespace: RDFS_NAMESPACE,
+    prefix: "rdfs",
+    terms: RDFS_TERMS,
+  },
+  {
+    moduleName: "Skos",
+    namespace: SKOS_NAMESPACE,
+    prefix: "skos",
+    terms: SKOS_TERMS,
+  },
+  {
+    moduleName: "Owl",
+    namespace: OWL_NAMESPACE,
+    prefix: "owl",
+    terms: OWL_TERMS,
+  },
+  {
+    moduleName: "Dcterms",
+    namespace: DCTERMS_NAMESPACE,
+    prefix: "dcterms",
+    terms: DCTERMS_TERMS,
+  },
+] as const;
+
+const difference = (left: readonly string[], right: readonly string[]) =>
+  left.filter((value) => !right.includes(value)).sort();
+
+describe("@beep/rdf vocabulary drift", () => {
+  it("keeps RDF vocabulary namespace and term constants aligned with identity CoreVocab", () => {
+    for (const current of vocabCases) {
+      const registry = CoreVocab[current.prefix];
+      const missingInRegistry = difference(current.terms, registry.terms);
+      const missingInConstants = difference(registry.terms, current.terms);
+      const driftMessage = `${current.prefix} drift against @beep/rdf/Vocab/${current.moduleName}`;
+
+      expect(registry.iri, `${driftMessage}: namespace IRI`).toBe(current.namespace);
+      expect({ missingInConstants, missingInRegistry }, `${driftMessage}: term-list divergence`).toEqual({
+        missingInConstants: [],
+        missingInRegistry: [],
+      });
+    }
+  });
+});

--- a/packages/foundation/modeling/rdf/test/VocabDrift.test.ts
+++ b/packages/foundation/modeling/rdf/test/VocabDrift.test.ts
@@ -4,7 +4,7 @@ import { OWL_NAMESPACE, OWL_TERMS } from "@beep/rdf/Vocab/Owl";
 import { RDF_NAMESPACE, RDF_TERMS } from "@beep/rdf/Vocab/Rdf";
 import { RDFS_NAMESPACE, RDFS_TERMS } from "@beep/rdf/Vocab/Rdfs";
 import { SKOS_NAMESPACE, SKOS_TERMS } from "@beep/rdf/Vocab/Skos";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 
 const vocabCases = [
   {

--- a/packages/tooling/tool/cli/test/create-package-identity-template.test.ts
+++ b/packages/tooling/tool/cli/test/create-package-identity-template.test.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from "node:url";
+import { NodeServices } from "@effect/platform-node";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, FileSystem } from "effect";
+
+const handlerPath = fileURLToPath(new URL("../src/commands/CreatePackage/Handler.ts", import.meta.url));
+
+describe("create-package identity template", () => {
+  it.effect("keeps the identity registration template aligned with @beep/identity's generated surface", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const handlerSource = yield* fs.readFileString(handlerPath);
+
+      expect(handlerSource).toContain('const IDENTITY_PACKAGE_NAME = "@beep/identity" as const;');
+      expect(handlerSource).toContain(
+        "const toIdentityAccessorName = (packageName: string): string => `$${Str.pascalCase(packageName)}Id`;"
+      );
+      expect(handlerSource).toContain('` * import { ${accessorName} } from "@beep/identity"`');
+      expect(handlerSource).toContain(
+        '`export const ${accessorName}: Identity.IdentityComposer<"@beep/${packageName}"> = composers.${accessorName};`'
+      );
+      expect(handlerSource).toContain(
+        'sourceFile.getVariableDeclaration("generatedComposers") ?? sourceFile.getVariableDeclarationOrThrow("composers")'
+      );
+    }).pipe(Effect.provide(NodeServices.layer))
+  );
+});


### PR DESCRIPTION
## What

Implements `goals/identity-iri-core` (first of three packets graduated from
`explorations/identity-as-iri`): `@beep/identity` rewritten in place so the
identity path and the IRI are two literal-typed encodings of the same value.

- **Vocab registry as data** (`src/Vocab.ts`): rdf/rdfs/skos/owl/dcterms term
  inventories per the W3C/DCMI specs, with `Curie<V>`/`Predicate<V>`/`Expand`
  literal types — `"skos:prefLabl"` is a compile error.
- **CURIE codec** (`src/Curie.ts`): literal-preserving expand/contract,
  `^curie` inverse handling, typed failures on unknown prefixes/terms.
- **PN_LOCAL codec** (`src/PnLocal.ts`): Turtle-grammar acceptance model +
  `prefixedNameOrIri` full-IRI fallback policy.
- **Composer binding** (`src/Id.ts`): `make()` gains optional
  `{ authority, prefix, vocab? }`; composers expose exact-literal
  `.iri`/`.curie`/`.slug`; projection-only `rebase()` (interning pinned
  immutable); `annote*` records gain owned-channel `iri`/`curie` when bound.
  Root `$I` bound to the confirmed authority `https://ns.beep.sh/`.
- **Shape-stable harness** built BEFORE the rewrite pins the entire existing
  surface (repo-wide named-import inventory, `make()` compat, generated
  composer literals, interning, annotation record shapes) — zero call-site
  changes outside the package.
- `@beep/rdf` Vocab constants reconciled (Dcterms added) with a drift test;
  create-package template assertions moved to `@beep/repo-cli`'s suite as an
  `it.effect` FileSystem test (no `node:fs`).
- Also includes the packet graduation docs (MAP.md + goals/identity-iri-core)
  — the prior docs commit to main was withheld pending review.

## Evidence

- `goals/identity-iri-core/history/`: P0 harness + audit-currency,
  P1a/P1b gates, P2 blast radius (+6% instantiations in-package, ~noise
  downstream — no module split needed).
- Gates green locally: turbo test+check for `@beep/identity` (51 tests incl.
  harness) + `@beep/rdf` (26), docgen, biome.

## Known inherited failures (NOT introduced here)

Main is currently red on: `@beep/repo-configs` `NextConfig.model.ts` TS2375
(build/check/docgen), `@beep/agents-domain` test, FOLIO `Ontology.models.ts`
cspell words, fallow dead-code inventory (199 pre-existing), and the
repo-wide tsdoc-tag lint warnings (untouched `Id.ts` alone: 83). Attribution
recorded in `goals/identity-iri-core/SPEC.md` Exception Ledger and the
checkpoint commit `61160e1baf`.

Design provenance: `explorations/identity-as-iri` (handoff D1–D9,
adversarially-verified 12-repo synthesis, effect-only scratchpad prototype).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785578557&installation_id=141092090&pr_number=289&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F289&signature=d60795baa8d24ee75b049f353a902a3be9bc6cf622f1f0af2f4b3adadf7a52bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for identity IRIs, CURIEs, slugs, and rebasing across the identity API.
  * Introduced vocabulary and prefix-handling helpers, including CURIE expansion/contraction and Turtle local-name formatting.
  * Expanded RDF vocabulary coverage with complete term inventories for common namespaces.

* **Bug Fixes**
  * Updated the default identity root to use the confirmed namespace host.
  * Aligned package-level identity outputs and annotations with the new configured authority/prefix.

* **Tests**
  * Added broad coverage for identity binding, CURIE, vocabulary, and local-name behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->