### PR TITLE
fix(observability): adapt BatchLogRecordProcessor to sdk-logs 2.9.0 constructor

### DIFF
--- a/packages/foundation/capability/observability/src/server/NodeSdk.ts
+++ b/packages/foundation/capability/observability/src/server/NodeSdk.ts
@@ -204,12 +204,12 @@ export const makeNodeSdkServerConfig: {
         options?.logRecordProcessor ??
         (config.otlpEnabled
           ? [
-              new BatchLogRecordProcessor({
-                exporter: new OTLPLogExporter({
+              new BatchLogRecordProcessor(
+                new OTLPLogExporter({
                   url: endpointUrl(config.otlpBaseUrl, "/v1/logs"),
                 }),
-                scheduledDelayMillis: loggerExportInterval,
-              }),
+                { scheduledDelayMillis: loggerExportInterval }
+              ),
             ]
           : undefined),
       loggerMergeWithExisting: options?.loggerMergeWithExisting ?? true,


### PR DESCRIPTION
Repairs the pre-existing main breakage from the OTel 0.220.0/2.9.0 bump (#297): `BatchLogRecordProcessorBase` is now `constructor(exporter, config?)`, so the single-object `{ exporter, scheduledDelayMillis }` argument fails TS2561 at `NodeSdk.ts:208` and cascades into `@beep/firecrawl` and every repo-wide check lane (currently blocking the crispening P2 wave gate). Minimal API adaptation, no dependency or behavior changes; `check`/`lint` green for `@beep/observability`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785920239&installation_id=141092090&pr_number=302&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F302&signature=0b00f691a8141b335feab130f333f781c1608adc0944de91b196ddded2a085ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->