### PR TITLE
fix(one-round-loop): activate sast gate + vendor semgrep rules

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -781,6 +781,10 @@ jobs:
 
       - name: Run SAST
         run: |
-          # Keep Semgrep parity with the previous semgrep-action packs:
-          # p/typescript, p/javascript, p/security-audit, and p/secrets.
+          # Semgrep runs the four registry packs (p/typescript, p/javascript,
+          # p/security-audit, p/secrets) plus the vendored, offline rules in
+          # .semgrep/first-party.yml, with --error so findings fail the lane.
+          # Config is byte-identical to the local replay (`beep ci lane sast`)
+          # — no SEMGREP_APP_TOKEN, which would only exist in CI and break that
+          # parity. See goals/one-round-loop/history/p0-parity-evidence.md §2.
           bun run beep ci lane sast

--- a/.semgrep/first-party.yml
+++ b/.semgrep/first-party.yml
@@ -46,13 +46,34 @@ rules:
         - https://cwe.mitre.org/data/definitions/78.html
     patterns:
       - pattern-either:
+          # Named import: import { exec, execSync } from "node:child_process".
           - pattern: exec($CMD, ...)
           - pattern: execSync($CMD, ...)
+          # Namespace/default import: cp.exec(...), childProcess.execSync(...).
+          # Scoped to a child_process binding so RegExp.prototype.exec and other
+          # unrelated `.exec` method calls do not match.
+          - patterns:
+              - pattern-either:
+                  - pattern: $CP.exec($CMD, ...)
+                  - pattern: $CP.execSync($CMD, ...)
+              - pattern-either:
+                  - pattern-inside: |
+                      import * as $CP from "$MOD"
+                      ...
+                  - pattern-inside: |
+                      import $CP from "$MOD"
+                      ...
+                  - pattern-inside: |
+                      const $CP = require("$MOD")
+                      ...
+              - metavariable-regex:
+                  metavariable: $MOD
+                  regex: ^(node:)?child_process$
       # Constant string commands are safe; only dynamic arguments are flagged.
       - pattern-not: exec("...", ...)
       - pattern-not: execSync("...", ...)
-      # RegExp.prototype.exec and other method calls are not child_process.
-      - pattern-not: $OBJ.exec($CMD, ...)
+      - pattern-not: $X.exec("...", ...)
+      - pattern-not: $X.execSync("...", ...)
 
   - id: beep-hardcoded-private-key
     languages: [typescript, javascript]
@@ -65,4 +86,4 @@ rules:
       owner: beep-effect
       references:
         - https://cwe.mitre.org/data/definitions/798.html
-    pattern-regex: "-----BEGIN (RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----"
+    pattern-regex: "-----BEGIN (RSA |EC |OPENSSH |DSA |PGP |ENCRYPTED )?PRIVATE KEY-----"

--- a/.semgrep/first-party.yml
+++ b/.semgrep/first-party.yml
@@ -1,0 +1,68 @@
+# Vendored, pinned Semgrep ruleset for the SAST lane (`beep ci lane sast`).
+#
+# Why vendored (not registry auth): the SAST lane must be verdict-identical
+# between CI and the local replay. A `SEMGREP_APP_TOKEN` would give CI the full
+# registry packs while local runs (which lack the token) see only the ~125-rule
+# unauthenticated community subset — breaking that parity. These rules ship in
+# the repo, so both sides read byte-identical config, offline and deterministic,
+# with no secret to manage.
+#
+# Scope: these close the concrete coverage gaps proven in
+# goals/one-round-loop/history/p0-parity-evidence.md §2 (dynamic `eval`, dynamic
+# `child_process` exec) plus a belt-and-suspenders hardcoded-private-key rule.
+# The four `p/*` registry packs still run alongside this file for baseline
+# coverage; `--error` is what makes any finding actually fail the lane.
+#
+# Escape hatches for legitimate matches: a `// nosemgrep: <rule-id>` line
+# comment, or a path entry in `.semgrepignore`.
+rules:
+  - id: beep-no-eval
+    languages: [typescript, javascript]
+    severity: ERROR
+    message: >-
+      eval() executes arbitrary strings as code and is forbidden in first-party
+      source. Remove it or refactor to a data-driven alternative.
+    metadata:
+      category: security
+      owner: beep-effect
+      references:
+        - https://cwe.mitre.org/data/definitions/95.html
+    pattern-either:
+      - pattern: eval(...)
+      - pattern: globalThis.eval(...)
+      - pattern: window.eval(...)
+
+  - id: beep-no-dynamic-shell-exec
+    languages: [typescript, javascript]
+    severity: ERROR
+    message: >-
+      Non-literal command passed to child_process exec/execSync (shell-interpreted)
+      is a command-injection risk. Pass a constant command, or use spawn/execFile
+      with an argument array.
+    metadata:
+      category: security
+      owner: beep-effect
+      references:
+        - https://cwe.mitre.org/data/definitions/78.html
+    patterns:
+      - pattern-either:
+          - pattern: exec($CMD, ...)
+          - pattern: execSync($CMD, ...)
+      # Constant string commands are safe; only dynamic arguments are flagged.
+      - pattern-not: exec("...", ...)
+      - pattern-not: execSync("...", ...)
+      # RegExp.prototype.exec and other method calls are not child_process.
+      - pattern-not: $OBJ.exec($CMD, ...)
+
+  - id: beep-hardcoded-private-key
+    languages: [typescript, javascript]
+    severity: ERROR
+    message: >-
+      Hardcoded private key material detected in source. Store secrets outside the
+      repository (env, secret manager), never as literals.
+    metadata:
+      category: security
+      owner: beep-effect
+      references:
+        - https://cwe.mitre.org/data/definitions/798.html
+    pattern-regex: "-----BEGIN (RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----"

--- a/packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts
@@ -1458,6 +1458,9 @@ const runSastScan = Effect.fn("QualityScriptCommands.runSastScan")(function* (
     "semgrep/semgrep",
     "semgrep",
     "scan",
+    // Fail the lane on findings. Without this, `semgrep scan` exits 0 even on
+    // blocking findings, so every rule below is advisory-only.
+    "--error",
     "--config",
     "p/typescript",
     "--config",
@@ -1466,6 +1469,10 @@ const runSastScan = Effect.fn("QualityScriptCommands.runSastScan")(function* (
     "p/security-audit",
     "--config",
     "p/secrets",
+    // Vendored, offline first-party rules — keep CI and the local replay
+    // verdict-identical without registry auth. See .semgrep/first-party.yml.
+    "--config",
+    "/src/.semgrep/first-party.yml",
     "--disable-version-check",
     "--timeout",
     "20",

--- a/standards/dual-arity.inventory.jsonc
+++ b/standards/dual-arity.inventory.jsonc
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedOn": "2026-07-07",
+  "generatedOn": "2026-07-08",
   "scope": ["apps/**/*.{ts,tsx}", "packages/**/*.{ts,tsx}", "infra/**/*.ts"],
   "enforcedRoots": [
     "packages/tooling/tool/cli/src/commands/Laws/DualArity.ts",


### PR DESCRIPTION
## fix(one-round-loop): activate sast gate + vendor semgrep rules

The SAST lane ran semgrep scan without --error, so it exited 0 even on
blocking findings; the gate could not fail on anything. Add --error and
vendor an offline ruleset (.semgrep/first-party.yml) that closes the proven
coverage gaps (dynamic eval, dynamic child_process exec) plus a
hardcoded-private-key rule.

Vendored rather than a SEMGREP_APP_TOKEN so beep ci lane sast stays
verdict-identical between CI and the local replay: a token would exist only
in CI and break that parity. The four p/* registry packs still run for
baseline coverage; --error is what makes any finding fail the lane.

Closes the SAST-hardening task filed in
goals/one-round-loop/history/p0-parity-evidence.md section 2.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- full:pre-push: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/claude_eloquent-saha-99d9af-fb819ae8b498/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786081312&installation_id=141092090&pr_number=330&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F330&signature=43459fe5702a23aaf6eb72506dcd58cfe6fa8b2b4b000b4f86d497cb921fe1a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->