### PR TITLE
fix(box): make BoxError context JSON-round-trippable

### DIFF
--- a/.changeset/box-error-json-context.md
+++ b/.changeset/box-error-json-context.md
@@ -1,0 +1,5 @@
+---
+"@beep/box": patch
+---
+
+Make `BoxApiFailureContext.values` JSON-typed (`JsonObject`) instead of `S.Unknown` so sanitized `BoxError` context round-trips deterministically across the driver boundary. `S.Unknown` allowed non-serializable values (Errors, functions, symbols) into a wire-crossing error, whose encode/decode equivalence depended on host-sensitive structural equality. SDK `contextInfo` that is not JSON now sanitizes to `None` on the error path instead of throwing.

--- a/packages/drivers/box/src/Box.errors.ts
+++ b/packages/drivers/box/src/Box.errors.ts
@@ -6,7 +6,7 @@
  */
 
 import { $BoxId } from "@beep/identity";
-import { LiteralKit, SchemaUtils, TaggedErrorClass } from "@beep/schema";
+import { JsonObject, LiteralKit, SchemaUtils, TaggedErrorClass } from "@beep/schema";
 import * as O from "@beep/utils/Option";
 import { pipe, Result } from "effect";
 import * as P from "effect/Predicate";
@@ -94,10 +94,14 @@ export type BoxErrorReason = typeof BoxErrorReason.Type;
  */
 export class BoxApiFailureContext extends S.Class<BoxApiFailureContext>($I`BoxApiFailureContext`)(
   {
-    values: S.Unknown,
+    // JSON-only so the sanitized context round-trips deterministically across the
+    // driver boundary. `S.Unknown` here let arbitrary non-serializable values
+    // (Errors, functions, symbols) leak into a wire-crossing error, whose
+    // encode/decode equivalence depended on host-sensitive structural `Equal`.
+    values: JsonObject,
   },
   $I.annote("BoxApiFailureContext", {
-    description: "Sanitized key-value context copied from a Box API failure.",
+    description: "Sanitized JSON key-value context copied from a Box API failure.",
   })
 ) {}
 
@@ -311,11 +315,14 @@ const readHttpStatusCode =
 
 const responseInfoFromUnknown = (cause: unknown): O.Option<unknown> => readProperty("responseInfo")(cause);
 
+const decodeApiFailureContext = S.decodeUnknownOption(BoxApiFailureContext);
+
 const readContextInfo = (value: unknown): O.Option<BoxApiFailureContext> =>
   pipe(
     readProperty("contextInfo")(value),
     O.filter(P.isObject),
-    O.map((contextInfo) => BoxApiFailureContext.make({ values: contextInfo }))
+    // Total: non-JSON contextInfo sanitizes to `None` rather than throwing on the error path.
+    O.flatMap((contextInfo) => decodeApiFailureContext({ values: contextInfo }))
   );
 
 // shared driver boundary idiom; no in-family home; future foundation capability candidate.

--- a/packages/drivers/box/test/Box.service.test.ts
+++ b/packages/drivers/box/test/Box.service.test.ts
@@ -240,6 +240,28 @@ describe("@beep/box", () => {
     ).toBe(true);
   });
 
+  it("keeps sanitized JSON context round-trippable and rejects non-JSON context", () => {
+    const withContext = B.BoxError.fromReason("response status", {
+      context: B.BoxApiFailureContext.make({
+        values: { code: "rate_limit", nested: { retries: 3, hints: ["slow down", null] } },
+      }),
+    });
+
+    // Round-trip must preserve equivalence for the JSON-typed context.
+    expectRoundTrip(B.BoxError, withContext);
+
+    // Non-JSON SDK contextInfo sanitizes to `None` instead of throwing on the error path.
+    const nonJson = B.BoxError.fromUnknown("users.getUserMe", {
+      responseInfo: {
+        contextInfo: { retry: () => undefined },
+        statusCode: 429,
+      },
+    });
+
+    expect(nonJson.context).toEqual(O.none());
+    expect(nonJson.status).toEqual(O.some(429));
+  });
+
   it("drops invalid SDK status codes from sanitized errors", () => {
     const error = B.BoxError.fromUnknown("users.getUserMe", {
       responseInfo: {


### PR DESCRIPTION
## fix(box): make BoxError context JSON-round-trippable

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- full:pre-push: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/claude_distracted-proskuriakova-d92d13-ef98f8eaa00c/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786081397&installation_id=141092090&pr_number=331&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F331&signature=69b20c5d93efb2430a2eec7ecdeebffc198e1bbcc6d299e5b8bee3bee3f4e8b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->