### PR TITLE
docs(one-round-loop): mark sast-hardening task resolved (#330)

### DIFF
--- a/goals/one-round-loop/history/p0-parity-evidence.md
+++ b/goals/one-round-loop/history/p0-parity-evidence.md
@@ -127,6 +127,23 @@ fixture branch itself):
   structural identity (the local lane runs the byte-identical CI
   command, per the D9 echo evidence) with expected PASS/PASS.
 
+**SAST-hardening resolution (2026-07-08, PR
+[#330](https://github.com/beep-effect/beep-effect/pull/330), merge
+`57f04df05f`).** The root cause was deeper than rule coverage:
+`semgrep scan` ran without `--error`, so the lane exited 0 even on
+*blocking* findings — the gate could not fail on anything. Empirically
+the community `p/secrets` pack *does* detect a hardcoded private key;
+the RSA-PEM fixture "passed" only because of the missing `--error`, not
+the thin subset. Fix: add `--error` plus a vendored, offline ruleset
+(`.semgrep/first-party.yml`) closing the genuine coverage gaps — dynamic
+`eval`, dynamic `child_process` exec/execSync (named, namespace, and
+default import forms), and hardcoded private keys incl. encrypted
+PKCS#8. Vendored rather than a `SEMGREP_APP_TOKEN` so the lane stays
+verdict-identical between CI and the local replay (a token would exist
+only in CI and break that parity). Locally-constructible failing
+fixtures now exist and fire (exit 1), so the "no-constructible-fixture"
+premise above no longer holds going forward.
+
 **Round-3/4 same-SHA verdict table.** PR A's merge to main made the
 fixture PR CONFLICTING → GitHub cannot build refs/pull/N/merge →
 pull_request runs silently stop triggering (a distinct S4-adjacent


### PR DESCRIPTION
## docs(one-round-loop): mark sast-hardening task resolved (#330)

Add a dated resolution note to p0-parity-evidence.md section 2: the SAST
lane gap filed there is closed by PR #330 (merge 57f04df05f). Corrects the
record — the deeper root cause was semgrep scan running without --error
(exit 0 even on blocking findings), not the thin registry subset; the
community p/secrets pack already detected the RSA PEM. Now gated via
--error plus a vendored offline ruleset.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- full:pre-push: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/claude_sast-hardening-evidence-closeout-1bd4fd558903/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786084400&installation_id=141092090&pr_number=332&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F332&signature=a2ceca4ac312d320a96166cb25b3ab6ad33072bc93fe662781089411b9671f21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->