### PR TITLE
fix(runpod): make error options schemas JSON-round-trippable (#331 pattern)

### DIFF
--- a/.changeset/runpod-error-json-context.md
+++ b/.changeset/runpod-error-json-context.md
@@ -1,0 +1,5 @@
+---
+"@beep/runpod": patch
+---
+
+Make the exported Runpod error options schemas (`RunpodErrorOptions`, `RunpodDocsErrorOptions`) round-trip deterministically by holding a sanitized `cause` string (`OptionFromOptionalKey(String)`) instead of `S.Defect`. `S.Defect` allowed non-serializable values (e.g. `new Error("")`, nested objects, functions) into an exported schema whose encode/decode equivalence then depended on host-sensitive structural equality (fast-check seed 948470019 found the counterexample). Raw thrown causes are now accepted through private `*Input` schemas and normalized via `causeFromUnknown` before construction, mirroring the `@beep/box` `BoxErrorOptions` / `BoxErrorOptionsInput` split.

--- a/packages/drivers/runpod/src/Runpod.errors.ts
+++ b/packages/drivers/runpod/src/Runpod.errors.ts
@@ -179,11 +179,14 @@ export class RunpodError extends TaggedErrorClass<RunpodError>($I`RunpodError`)(
    * @since 0.1.0
    */
   static readonly fromDescriptor: {
-    (descriptor: RunpodOperationDescriptor, reason: RunpodErrorReason, options?: RunpodErrorOptions): RunpodError;
-    (reason: RunpodErrorReason, options?: RunpodErrorOptions): (descriptor: RunpodOperationDescriptor) => RunpodError;
+    (descriptor: RunpodOperationDescriptor, reason: RunpodErrorReason, options?: RunpodErrorOptionsInput): RunpodError;
+    (
+      reason: RunpodErrorReason,
+      options?: RunpodErrorOptionsInput
+    ): (descriptor: RunpodOperationDescriptor) => RunpodError;
   } = dual(
     (args) => args.length >= 2 && RunpodOperationDescriptor.is(args[0]),
-    (descriptor: RunpodOperationDescriptor, reason: RunpodErrorReason, options: RunpodErrorOptions = {}) =>
+    (descriptor: RunpodOperationDescriptor, reason: RunpodErrorReason, options: RunpodErrorOptionsInput = {}) =>
       RunpodError.make({
         method: O.some(descriptor.method),
         methodName: O.some(descriptor.methodName),
@@ -255,7 +258,10 @@ export class RunpodDocsError extends TaggedErrorClass<RunpodDocsError>($I`Runpod
    * @category constructors
    * @since 0.1.0
    */
-  static readonly fromReason = (reason: RunpodDocsErrorReason, options: RunpodDocsErrorOptions = {}): RunpodDocsError =>
+  static readonly fromReason = (
+    reason: RunpodDocsErrorReason,
+    options: RunpodDocsErrorOptionsInput = {}
+  ): RunpodDocsError =>
     RunpodDocsError.make({
       cause: causeFromUnknown(options.cause),
       reason,
@@ -270,9 +276,10 @@ export class RunpodDocsError extends TaggedErrorClass<RunpodDocsError>($I`Runpod
  * @example
  * ```ts
  * import { RunpodErrorOptions } from "@beep/runpod"
+ * import * as O from "effect/Option"
  *
- * const options = RunpodErrorOptions.make({ status: 401 })
- * console.log(options.status)
+ * const options = RunpodErrorOptions.make({ cause: O.some("timeout") })
+ * console.log(O.getOrUndefined(options.cause))
  * ```
  *
  * @category models
@@ -280,11 +287,24 @@ export class RunpodDocsError extends TaggedErrorClass<RunpodDocsError>($I`Runpod
  */
 export class RunpodErrorOptions extends S.Class<RunpodErrorOptions>($I`RunpodErrorOptions`)(
   {
+    // Sanitized string label so the exported options schema round-trips
+    // deterministically. Raw thrown causes are accepted via the private
+    // `RunpodErrorOptionsInput` and normalized through `causeFromUnknown`.
+    cause: S.OptionFromOptionalKey(S.String).pipe(SchemaUtils.withNoneDefault),
+    status: S.OptionFromOptionalKey(RunpodHttpStatusCode).pipe(SchemaUtils.withNoneDefault),
+  },
+  $I.annote("RunpodErrorOptions", {
+    description: "Sanitized options for configuring RunpodError instances.",
+  })
+) {}
+
+class RunpodErrorOptionsInput extends S.Class<RunpodErrorOptionsInput>($I`RunpodErrorOptionsInput`)(
+  {
     cause: S.optionalKey(S.Defect({ includeStack: true })),
     status: S.optionalKey(RunpodHttpStatusCode),
   },
-  $I.annote("RunpodErrorOptions", {
-    description: "Options for configuring RunpodError instances.",
+  $I.annote("RunpodErrorOptionsInput", {
+    description: "Raw option input accepted by RunpodError constructors before schema-owned normalization.",
   })
 ) {}
 
@@ -325,11 +345,12 @@ export class RunpodRawErrorOptions extends S.Class<RunpodRawErrorOptions>($I`Run
  * @example
  * ```ts
  * import { RunpodDocsErrorOptions } from "@beep/runpod"
+ * import * as O from "effect/Option"
  *
  * const options = RunpodDocsErrorOptions.make({
- *   url: "https://docs.runpod.io/llms.txt"
+ *   url: O.some("https://docs.runpod.io/llms.txt")
  * })
- * console.log(options.url)
+ * console.log(O.getOrUndefined(options.url))
  * ```
  *
  * @category models
@@ -337,12 +358,26 @@ export class RunpodRawErrorOptions extends S.Class<RunpodRawErrorOptions>($I`Run
  */
 export class RunpodDocsErrorOptions extends S.Class<RunpodDocsErrorOptions>($I`RunpodDocsErrorOptions`)(
   {
+    // Sanitized string label so the exported options schema round-trips
+    // deterministically. Raw thrown causes are accepted via the private
+    // `RunpodDocsErrorOptionsInput` and normalized through `causeFromUnknown`.
+    cause: S.OptionFromOptionalKey(S.String).pipe(SchemaUtils.withNoneDefault),
+    status: S.OptionFromOptionalKey(RunpodHttpStatusCode).pipe(SchemaUtils.withNoneDefault),
+    url: S.OptionFromOptionalKey(S.String).pipe(SchemaUtils.withNoneDefault),
+  },
+  $I.annote("RunpodDocsErrorOptions", {
+    description: "Sanitized options for configuring RunpodDocsError instances.",
+  })
+) {}
+
+class RunpodDocsErrorOptionsInput extends S.Class<RunpodDocsErrorOptionsInput>($I`RunpodDocsErrorOptionsInput`)(
+  {
     cause: S.optionalKey(S.Defect({ includeStack: true })),
     status: S.optionalKey(RunpodHttpStatusCode),
     url: S.optionalKey(S.String),
   },
-  $I.annote("RunpodDocsErrorOptions", {
-    description: "Options for configuring RunpodDocsError instances.",
+  $I.annote("RunpodDocsErrorOptionsInput", {
+    description: "Raw option input accepted by RunpodDocsError constructors before schema-owned normalization.",
   })
 ) {}
 

--- a/packages/drivers/runpod/test/Runpod.service.test.ts
+++ b/packages/drivers/runpod/test/Runpod.service.test.ts
@@ -101,38 +101,6 @@ const RunpodRawRequestArbitrary = S.toArbitrary(RunpodRawRequest).map((request) 
   })
 );
 
-const RunpodErrorOptionsArbitrary = S.toArbitrary(RunpodErrorOptions).map((options) =>
-  RunpodErrorOptions.make(options.status === undefined ? {} : { status: options.status })
-);
-
-const RunpodErrorArbitrary = S.toArbitrary(RunpodError).map((error) =>
-  RunpodError.make({
-    cause: O.none(),
-    method: error.method,
-    methodName: error.methodName,
-    operationId: error.operationId,
-    path: error.path,
-    reason: error.reason,
-    status: error.status,
-  })
-);
-
-const RunpodDocsErrorOptionsArbitrary = S.toArbitrary(RunpodDocsErrorOptions).map((options) =>
-  RunpodDocsErrorOptions.make({
-    ...(options.status === undefined ? {} : { status: options.status }),
-    ...(options.url === undefined ? {} : { url: options.url }),
-  })
-);
-
-const RunpodDocsErrorArbitrary = S.toArbitrary(RunpodDocsError).map((error) =>
-  RunpodDocsError.make({
-    cause: O.none(),
-    reason: error.reason,
-    status: error.status,
-    url: error.url,
-  })
-);
-
 const makeJsonResponse = (body: unknown, status = 200) =>
   Response.json(body, {
     headers: {
@@ -460,10 +428,10 @@ describe("@beep/runpod", () => {
       });
       assertSchemaRoundTrip(RunpodRawRequest, RunpodRawRequestArbitrary);
       assertSchemaRoundTrip(RunpodRawResponse);
-      assertSchemaRoundTrip(RunpodErrorOptions, RunpodErrorOptionsArbitrary);
-      assertSchemaRoundTrip(RunpodError, RunpodErrorArbitrary);
-      assertSchemaRoundTrip(RunpodDocsErrorOptions, RunpodDocsErrorOptionsArbitrary);
-      assertSchemaRoundTrip(RunpodDocsError, RunpodDocsErrorArbitrary);
+      assertSchemaRoundTrip(RunpodErrorOptions);
+      assertSchemaRoundTrip(RunpodError);
+      assertSchemaRoundTrip(RunpodDocsErrorOptions);
+      assertSchemaRoundTrip(RunpodDocsError);
       assertSchemaRoundTrip(RunpodDocsIndexEntry);
       assertSchemaRoundTrip(RunpodDocsIndex);
     })


### PR DESCRIPTION
## fix(runpod): make error options schemas JSON-round-trippable (#331 pattern)

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- full:pre-push: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/claude_focused-mayer-c2ece1-38480b1dea34/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786093428&installation_id=141092090&pr_number=333&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F333&signature=42b369c451a8863da17a859cb305e6039aeb637eb9bdfb7282f6de4837202712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->