### PR TITLE
feat(one-round-loop): relocate fcRuns to @beep/fc-runs leaf so schema/utils/pglite property tests env-raise

### DIFF
--- a/.changeset/fc-runs-leaf-extraction.md
+++ b/.changeset/fc-runs-leaf-extraction.md
@@ -1,0 +1,9 @@
+---
+"@beep/fc-runs": patch
+"@beep/test-utils": patch
+"@beep/schema": patch
+"@beep/utils": patch
+"@beep/pglite": patch
+---
+
+one-round-loop P1: relocate the env-max `fcRuns` helper (with `DEFAULT_FC_NUM_RUNS`, `parseFcNumRunsFloor`, `envFcNumRunsFloor`) out of `@beep/test-utils` into a new leaf package `@beep/fc-runs`, upstream of the whole `@beep/test-utils` dependency closure. `@beep/test-utils` re-exports it, so existing `import { fcRuns } from "@beep/test-utils"` sites are unchanged. This lets `@beep/schema`, `@beep/utils`, and `@beep/pglite` — which `@beep/test-utils` depends on — import `fcRuns` directly from the leaf without forming a package cycle, closing the codemod carve-out that had left the schema property suite (the repo's most property-heavy package) opted out of the `BEEP_FC_NUM_RUNS` env-max floor. The numRuns→fcRuns codemod now routes closure files to `@beep/fc-runs` instead of skipping them.

--- a/bun.lock
+++ b/bun.lock
@@ -780,6 +780,7 @@
         "effect": "catalog:",
       },
       "devDependencies": {
+        "@beep/fc-runs": "workspace:^",
         "@effect/platform-node": "catalog:",
         "@effect/vitest": "catalog:",
         "@types/node": "catalog:",
@@ -1342,6 +1343,7 @@
         "yaml": "catalog:",
       },
       "devDependencies": {
+        "@beep/fc-runs": "workspace:^",
         "@beep/types": "workspace:^",
         "@effect/platform-bun": "catalog:",
         "@effect/vitest": "catalog:",
@@ -1358,6 +1360,7 @@
         "picomatch": "catalog:",
       },
       "devDependencies": {
+        "@beep/fc-runs": "workspace:^",
         "@beep/types": "workspace:^",
         "@effect/platform-node": "catalog:",
         "@effect/vitest": "catalog:",
@@ -1710,10 +1713,22 @@
         "next": "catalog:",
       },
     },
+    "packages/tooling/test-kit/fc-runs": {
+      "name": "@beep/fc-runs",
+      "version": "0.0.0",
+      "dependencies": {
+        "effect": "catalog:",
+      },
+      "devDependencies": {
+        "@effect/vitest": "catalog:",
+        "@types/node": "catalog:",
+      },
+    },
     "packages/tooling/test-kit/test-utils": {
       "name": "@beep/test-utils",
       "version": "0.0.2",
       "dependencies": {
+        "@beep/fc-runs": "workspace:^",
         "@beep/identity": "workspace:^",
         "@beep/schema": "workspace:^",
         "@beep/utils": "workspace:^",
@@ -2325,6 +2340,8 @@
     "@beep/epistemic-use-cases": ["@beep/epistemic-use-cases@workspace:packages/epistemic/use-cases"],
 
     "@beep/face-detection": ["@beep/face-detection@workspace:packages/drivers/face-detection"],
+
+    "@beep/fc-runs": ["@beep/fc-runs@workspace:packages/tooling/test-kit/fc-runs"],
 
     "@beep/federal-register": ["@beep/federal-register@workspace:packages/drivers/federal-register"],
 

--- a/goals/one-round-loop/ops/codemods/numruns-fcruns.codemod.ts
+++ b/goals/one-round-loop/ops/codemods/numruns-fcruns.codemod.ts
@@ -41,15 +41,18 @@ import type { CallExpression, ObjectLiteralExpression, SourceFile } from "ts-mor
 
 const FAST_CHECK_MODULE = "effect/testing";
 const TEST_UTILS_MODULE = "@beep/test-utils";
+const FC_RUNS_MODULE = "@beep/fc-runs";
 const HELPER_NAME = "fcRuns";
 
 /**
  * Packages inside `@beep/test-utils`' own dependency closure. `@beep/test-utils`
- * depends on `@beep/schema`, `@beep/utils`, and `@beep/pglite`, so migrating
- * their test files to `fcRuns` would make them import the helper back out of a
- * package that depends on them — a package cycle (greptile: "Cyclic Helper
- * Import"). The codemod leaves their inline `numRuns` untouched; lift this
- * carve-out by relocating `fcRuns` to a leaf package upstream of the closure.
+ * depends on `@beep/schema`, `@beep/utils`, and `@beep/pglite`, so importing
+ * `fcRuns` from `@beep/test-utils` in their test files would make them import
+ * the helper back out of a package that depends on them — a package cycle
+ * (greptile: "Cyclic Helper Import"). `fcRuns` therefore lives in the leaf
+ * `@beep/fc-runs`, upstream of the whole closure: these files import it from
+ * the leaf directly, while every other file keeps importing from
+ * `@beep/test-utils` (which re-exports the leaf).
  */
 const TEST_UTILS_CLOSURE_MARKERS: ReadonlyArray<string> = [
   "/foundation/modeling/schema/",
@@ -59,6 +62,15 @@ const TEST_UTILS_CLOSURE_MARKERS: ReadonlyArray<string> = [
 
 const isTestUtilsClosureFile = (filePath: string): boolean =>
   A.some(TEST_UTILS_CLOSURE_MARKERS, (marker) => Str.includes(marker)(filePath));
+
+/**
+ * Resolve which module a file imports `fcRuns` from. Closure files
+ * (schema/utils/pglite) import the upstream leaf `@beep/fc-runs` to avoid a
+ * package cycle; every other file imports `@beep/test-utils`, which re-exports
+ * the leaf.
+ */
+const resolveFcRunsModule = (filePath: string): string =>
+  isTestUtilsClosureFile(filePath) ? FC_RUNS_MODULE : TEST_UTILS_MODULE;
 
 /**
  * Per-file codemod outcome.
@@ -134,16 +146,16 @@ const rewriteOptionsObject = (options: ObjectLiteralExpression): boolean => {
   return true;
 };
 
-const ensureFcRunsImport = (sourceFile: SourceFile): void => {
+const ensureFcRunsImport = (sourceFile: SourceFile, moduleSpecifier: string): void => {
   const existing = A.findFirst(
     sourceFile.getImportDeclarations(),
-    (declaration) => declaration.getModuleSpecifierValue() === TEST_UTILS_MODULE && !declaration.isTypeOnly()
+    (declaration) => declaration.getModuleSpecifierValue() === moduleSpecifier && !declaration.isTypeOnly()
   );
 
   O.match(existing, {
     onNone: () => {
       sourceFile.addImportDeclaration({
-        moduleSpecifier: TEST_UTILS_MODULE,
+        moduleSpecifier,
         namedImports: [HELPER_NAME],
       });
     },
@@ -157,10 +169,6 @@ const ensureFcRunsImport = (sourceFile: SourceFile): void => {
 };
 
 const rewriteNumRunsToFcRuns = (sourceFile: SourceFile): boolean => {
-  if (isTestUtilsClosureFile(sourceFile.getFilePath())) {
-    return false;
-  }
-
   const fcAlias = resolveFastCheckAlias(sourceFile);
   if (O.isNone(fcAlias)) {
     return false;
@@ -182,7 +190,7 @@ const rewriteNumRunsToFcRuns = (sourceFile: SourceFile): boolean => {
     return false;
   }
 
-  ensureFcRunsImport(sourceFile);
+  ensureFcRunsImport(sourceFile, resolveFcRunsModule(sourceFile.getFilePath()));
   return true;
 };
 

--- a/goals/one-round-loop/ops/codemods/numruns-fcruns.test.ts
+++ b/goals/one-round-loop/ops/codemods/numruns-fcruns.test.ts
@@ -116,12 +116,14 @@ layer(TestLayer, { timeout: 300_000 })("numruns-fcruns codemod", (it) => {
     );
   });
 
-  describe("closure carve-out", () => {
+  describe("closure routing", () => {
     // The subject is the SAME fixture the golden test rewrites; placing it under
-    // a `@beep/test-utils` closure path (/drivers/pglite/) must make the codemod
-    // skip it — proving `changed: false` is the guard, not an empty diff.
+    // a `@beep/test-utils` closure path (/drivers/pglite/) must still rewrite it
+    // — but route the `fcRuns` import to the upstream leaf `@beep/fc-runs`, never
+    // back out of `@beep/test-utils` (which depends on this package), so the
+    // migration never forms a package cycle.
     it.effect(
-      "skips files inside @beep/test-utils' dependency closure (would-be cyclic import)",
+      "routes closure files to the @beep/fc-runs leaf import (no cyclic @beep/test-utils import)",
       Effect.fn(function* () {
         const fs = yield* FileSystem.FileSystem;
         const path = yield* Path.Path;
@@ -137,9 +139,15 @@ layer(TestLayer, { timeout: 300_000 })("numruns-fcruns codemod", (it) => {
         yield* Effect.ensuring(
           Effect.gen(function* () {
             const results = yield* runNumRunsFcRunsCodemod([subjectPath]);
-            expect(results).toEqual([{ filePath: subjectPath, changed: false }]);
+            expect(results).toEqual([{ filePath: subjectPath, changed: true }]);
             const actual = yield* fs.readFileString(subjectPath);
-            expect(actual).toBe(before);
+            // The literal numRuns options were rewritten to the helper...
+            expect(actual).toContain("fcRuns(40)");
+            expect(actual).toContain("{ ...fcRuns(25), endOnFailure: true }");
+            // ...importing `fcRuns` from the upstream leaf, and never importing
+            // it out of `@beep/test-utils` (which depends on this package).
+            expect(actual).toContain('import { fcRuns } from "@beep/fc-runs"');
+            expect(actual).not.toContain('fcRuns } from "@beep/test-utils"');
           }),
           fs.remove(dir, { recursive: true }).pipe(Effect.orElseSucceed(() => undefined))
         );

--- a/packages/drivers/pglite/docgen.json
+++ b/packages/drivers/pglite/docgen.json
@@ -31,6 +31,12 @@
     "paths": {
       "@beep/pglite": ["../../../packages/drivers/pglite/src/index.ts"],
       "@beep/pglite/*": ["../../../packages/drivers/pglite/src/*.ts"],
+      "@beep/fc-runs": [
+        "../../../packages/tooling/test-kit/fc-runs/src/index.ts"
+      ],
+      "@beep/fc-runs/*": [
+        "../../../packages/tooling/test-kit/fc-runs/src/*.ts"
+      ],
       "@beep/identity": [
         "../../../packages/foundation/modeling/identity/src/index.ts"
       ],

--- a/packages/drivers/pglite/test/PgliteClient.test.ts
+++ b/packages/drivers/pglite/test/PgliteClient.test.ts
@@ -1,3 +1,4 @@
+import { fcRuns } from "@beep/fc-runs";
 import { makeLayer, PgliteClient, PgliteError, PgliteTestLayer } from "@beep/pglite";
 import * as Pg from "@effect/sql-pg/PgClient";
 import { describe, expect, it, layer } from "@effect/vitest";
@@ -29,7 +30,7 @@ describe("PgliteError", () => {
 
         expect(decoded).toEqual(error);
       }),
-      { numRuns: 50 }
+      fcRuns(50)
     ));
 });
 

--- a/packages/drivers/pglite/tsconfig.json
+++ b/packages/drivers/pglite/tsconfig.json
@@ -16,6 +16,9 @@
     },
     {
       "path": "../../foundation/modeling/utils/tsconfig.json"
+    },
+    {
+      "path": "../../tooling/test-kit/fc-runs/tsconfig.json"
     }
   ]
 }

--- a/packages/foundation/modeling/identity/src/packages.ts
+++ b/packages/foundation/modeling/identity/src/packages.ts
@@ -145,7 +145,8 @@ const generatedComposers = $I.compose(
   "api-transport",
   "mcp-kit",
   "uspto-mcp",
-  "pacer"
+  "pacer",
+  "fc-runs"
 );
 
 const composers = {
@@ -1647,3 +1648,19 @@ export const $UsptoMcpId: Identity.IdentityComposer<"@beep/uspto-mcp"> = compose
  * @category configuration
  */
 export const $PacerId: Identity.IdentityComposer<"@beep/pacer"> = composers.$PacerId;
+
+/**
+ * Identity composer for `@beep/fc-runs`.
+ *
+ * @example
+ * ```typescript
+ * import { $FcRunsId } from "@beep/identity"
+ *
+ * const id = $FcRunsId.make("FcRuns")
+ * void id
+ * ```
+ *
+ * @since 0.0.0
+ * @category configuration
+ */
+export const $FcRunsId: Identity.IdentityComposer<"@beep/fc-runs"> = composers.$FcRunsId;

--- a/packages/foundation/modeling/schema/docgen.json
+++ b/packages/foundation/modeling/schema/docgen.json
@@ -401,6 +401,12 @@
       "@beep/data/*": [
         "../../../../packages/foundation/primitive/data/src/*.ts"
       ],
+      "@beep/fc-runs": [
+        "../../../../packages/tooling/test-kit/fc-runs/src/index.ts"
+      ],
+      "@beep/fc-runs/*": [
+        "../../../../packages/tooling/test-kit/fc-runs/src/*.ts"
+      ],
       "@beep/identity": [
         "../../../../packages/foundation/modeling/identity/src/index.ts"
       ],

--- a/packages/foundation/modeling/schema/package.json
+++ b/packages/foundation/modeling/schema/package.json
@@ -40,6 +40,7 @@
     "yaml": "catalog:"
   },
   "devDependencies": {
+    "@beep/fc-runs": "workspace:^",
     "@beep/types": "workspace:^",
     "@effect/platform-bun": "catalog:",
     "@effect/vitest": "catalog:",

--- a/packages/foundation/modeling/schema/test/AtURI.test.ts
+++ b/packages/foundation/modeling/schema/test/AtURI.test.ts
@@ -1,3 +1,4 @@
+import { fcRuns } from "@beep/fc-runs";
 import { AtUri } from "@beep/schema/AtURI";
 import { describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
@@ -84,7 +85,7 @@ describe("AtUri", () => {
         expect(pathSegments.length).toBeLessThanOrEqual(3);
         expect(pathSegments.every((segment) => segment.length > 0)).toBe(true);
       }),
-      { numRuns: 100 }
+      fcRuns(100)
     );
   });
 });

--- a/packages/foundation/modeling/schema/test/BlockchainRedacted.test.ts
+++ b/packages/foundation/modeling/schema/test/BlockchainRedacted.test.ts
@@ -1,3 +1,4 @@
+import { fcRuns } from "@beep/fc-runs";
 import { CryptoTxnHashRedacted } from "@beep/schema/CryptoTxnHash";
 import { CryptoWalletAddressRedacted } from "@beep/schema/CryptoWalletAddress";
 import {
@@ -41,7 +42,7 @@ describe("blockchain redacted schemas", () => {
       fc.property(validatorPublicKeyArbitrary, (value) => {
         expect(decodeValidatorPublicKey(value)).toBe(value);
       }),
-      { numRuns: 50 }
+      fcRuns(50)
     );
   });
 });

--- a/packages/foundation/modeling/schema/test/CaseStr.test.ts
+++ b/packages/foundation/modeling/schema/test/CaseStr.test.ts
@@ -1,3 +1,4 @@
+import { fcRuns } from "@beep/fc-runs";
 import { KebabCaseStr, PascalCaseStr, SnakeCaseStr } from "@beep/schema";
 import { describe, expect, it } from "@effect/vitest";
 import * as S from "effect/Schema";
@@ -25,7 +26,7 @@ describe("KebabCaseStr", () => {
         expect(decode(value)).toBe(value);
         expect(value).toMatch(/^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/);
       }),
-      { numRuns: 50 }
+      fcRuns(50)
     );
   });
 });
@@ -52,7 +53,7 @@ describe("PascalCaseStr", () => {
         expect(decode(value)).toBe(value);
         expect(value).toMatch(/^[A-Z][a-z0-9]*(?:[A-Z][a-z0-9]*)*$/);
       }),
-      { numRuns: 50 }
+      fcRuns(50)
     );
   });
 });
@@ -77,7 +78,7 @@ describe("SnakeCaseStr", () => {
         expect(decode(value)).toBe(value);
         expect(value).toMatch(/^[a-z][a-z0-9]*(_[a-z0-9]+)*$/);
       }),
-      { numRuns: 50 }
+      fcRuns(50)
     );
   });
 });

--- a/packages/foundation/modeling/schema/test/Color.test.ts
+++ b/packages/foundation/modeling/schema/test/Color.test.ts
@@ -1,3 +1,4 @@
+import { fcRuns } from "@beep/fc-runs";
 import * as Color from "@beep/schema/Color";
 import { describe, expect, it } from "@effect/vitest";
 import * as S from "effect/Schema";
@@ -59,7 +60,7 @@ describe("Color", () => {
         const rgb = decodeRgb(hex);
         expect(encodeHex({ r: rgb.r, g: rgb.g, b: rgb.b })).toBe(hex);
       }),
-      { numRuns: 50 }
+      fcRuns(50)
     );
   });
 
@@ -74,7 +75,7 @@ describe("Color", () => {
         expect(amount).toBeLessThanOrEqual(1);
         expect(decode(encode(amount))).toBe(amount);
       }),
-      { numRuns: 25 }
+      fcRuns(25)
     );
   });
 });

--- a/packages/foundation/modeling/schema/test/Csv.test.ts
+++ b/packages/foundation/modeling/schema/test/Csv.test.ts
@@ -1,3 +1,4 @@
+import { fcRuns } from "@beep/fc-runs";
 import { $SchemaId } from "@beep/identity";
 import { CSV } from "@beep/schema/Csv";
 import { describe, expect, it } from "@effect/vitest";
@@ -160,7 +161,7 @@ describe("CSV", () => {
 
         expect(decoded).toEqual(rows);
       }),
-      { numRuns: 25 }
+      fcRuns(25)
     );
   });
 

--- a/packages/foundation/modeling/schema/test/Cuid.test.ts
+++ b/packages/foundation/modeling/schema/test/Cuid.test.ts
@@ -1,3 +1,4 @@
+import { fcRuns } from "@beep/fc-runs";
 import { Cuid, CuidSeed, CuidState, cuid, sha512 } from "@beep/schema/Cuid";
 import * as BunCrypto from "@effect/platform-bun/BunCrypto";
 import { describe, expect, it } from "@effect/vitest";
@@ -35,7 +36,7 @@ describe("Cuid", () => {
         expect(Cuid.is(id)).toBe(true);
         expect(S.encodeSync(Cuid)(id)).toBe(id);
       }),
-      { numRuns: 25 }
+      fcRuns(25)
     );
   });
 

--- a/packages/foundation/modeling/schema/test/DateTimeUtcFromValid.test.ts
+++ b/packages/foundation/modeling/schema/test/DateTimeUtcFromValid.test.ts
@@ -1,3 +1,4 @@
+import { fcRuns } from "@beep/fc-runs";
 import {
   applyTimezone,
   createDateTimeWithTimezone,
@@ -247,7 +248,7 @@ describe("DateTimeUtcFromValid", () => {
         expect(Equal.equals(encode(roundTripped), encoded)).toBe(true);
         expect(DateTime.toEpochMillis(roundTripped)).toBe(DateTime.toEpochMillis(utc));
       }),
-      { numRuns: 50 }
+      fcRuns(50)
     );
   });
 });

--- a/packages/foundation/modeling/schema/test/Did.test.ts
+++ b/packages/foundation/modeling/schema/test/Did.test.ts
@@ -1,3 +1,4 @@
+import { fcRuns } from "@beep/fc-runs";
 import { Did } from "@beep/schema/Did";
 import { describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
@@ -59,7 +60,7 @@ describe("Did", () => {
         expect(did).toMatch(/^did:[a-z0-9]+:/u);
         expect(did).not.toMatch(/[/?#\s]/u);
       }),
-      { numRuns: 100 }
+      fcRuns(100)
     );
   });
 });

--- a/packages/foundation/modeling/schema/test/Duration.test.ts
+++ b/packages/foundation/modeling/schema/test/Duration.test.ts
@@ -1,3 +1,4 @@
+import { fcRuns } from "@beep/fc-runs";
 import * as Duration from "@beep/schema/Duration";
 import { describe, expect, it } from "@effect/vitest";
 import * as D from "effect/Duration";
@@ -90,7 +91,7 @@ describe("DurationFromInput", () => {
 
     fc.assert(
       fc.property(arbitrary, (value) => D.isDuration(value) && isDuration(value)),
-      { numRuns: 50 }
+      fcRuns(50)
     );
   });
 });

--- a/packages/foundation/modeling/schema/test/FileName.test.ts
+++ b/packages/foundation/modeling/schema/test/FileName.test.ts
@@ -1,3 +1,4 @@
+import { fcRuns } from "@beep/fc-runs";
 import { FileName } from "@beep/schema/FileName";
 import { describe, expect, it } from "@effect/vitest";
 import * as S from "effect/Schema";
@@ -71,7 +72,7 @@ describe("FileName", () => {
         expect(isFileName(name)).toBe(true);
         expect(decode(name)).toBe(name);
       }),
-      { numRuns: 50 }
+      fcRuns(50)
     );
   });
 });

--- a/packages/foundation/modeling/schema/test/FilePath.test.ts
+++ b/packages/foundation/modeling/schema/test/FilePath.test.ts
@@ -1,3 +1,4 @@
+import { fcRuns } from "@beep/fc-runs";
 import * as FilePathSchema from "@beep/schema/FilePath";
 import { describe, expect, it } from "@effect/vitest";
 import * as S from "effect/Schema";
@@ -60,7 +61,7 @@ describe("FilePath part schemas", () => {
         expect(decode(value)).toBe(value);
         expect(value).toMatch(/^[A-Za-z]:[\\/]?$/);
       }),
-      { numRuns: 50 }
+      fcRuns(50)
     );
   });
 

--- a/packages/foundation/modeling/schema/test/Glob.test.ts
+++ b/packages/foundation/modeling/schema/test/Glob.test.ts
@@ -1,3 +1,4 @@
+import { fcRuns } from "@beep/fc-runs";
 import * as GlobModule from "@beep/schema/Glob";
 import { Glob } from "@beep/schema/Glob";
 import { describe, expect, it } from "@effect/vitest";
@@ -54,7 +55,7 @@ describe("Glob", () => {
         expect(isGlob(pattern)).toBe(true);
         expect(decode(pattern)).toBe(pattern);
       }),
-      { numRuns: 25 }
+      fcRuns(25)
     );
   });
 

--- a/packages/foundation/modeling/schema/test/Graph.test.ts
+++ b/packages/foundation/modeling/schema/test/Graph.test.ts
@@ -1,3 +1,4 @@
+import { fcRuns } from "@beep/fc-runs";
 import * as GraphSchema from "@beep/schema/Graph";
 import { A } from "@beep/utils";
 import { describe, expect, it } from "@effect/vitest";
@@ -38,7 +39,7 @@ describe("Graph indices", () => {
         expect(S.is(GraphSchema.EdgeIndex)(edgeIndex)).toBe(true);
         expect(S.is(GraphSchema.GraphKind)(graphKind)).toBe(true);
       }),
-      { numRuns: 50 }
+      fcRuns(50)
     );
   });
 });

--- a/packages/foundation/modeling/schema/test/HttpHeaders.test.ts
+++ b/packages/foundation/modeling/schema/test/HttpHeaders.test.ts
@@ -1,3 +1,4 @@
+import { fcRuns } from "@beep/fc-runs";
 import {
   CrossOriginEmbedderPolicyHeader,
   CrossOriginEmbedderPolicyOption,
@@ -121,7 +122,7 @@ describe("Secure header schemas", () => {
           P.isString(option) ? option : undefined
         );
       }),
-      { numRuns: 25 }
+      fcRuns(25)
     );
   });
 
@@ -150,7 +151,7 @@ describe("Secure header schemas", () => {
           fc.property(testCase.optionArbitrary, (option) => {
             expectHeader(testCase.decodeOption(option), testCase.headerName, P.isString(option) ? option : undefined);
           }),
-          { numRuns: 25 }
+          fcRuns(25)
         );
       });
 

--- a/packages/foundation/modeling/schema/test/HttpStatus.test.ts
+++ b/packages/foundation/modeling/schema/test/HttpStatus.test.ts
@@ -1,3 +1,4 @@
+import { fcRuns } from "@beep/fc-runs";
 import * as HttpStatus from "@beep/schema/HttpStatus";
 import { describe, expect, it } from "@effect/vitest";
 import * as S from "effect/Schema";
@@ -20,7 +21,7 @@ describe("HttpStatus", () => {
         expect(typeof name).toBe("string");
         expect(decode(name)).toBe(code);
       }),
-      { numRuns: 50 }
+      fcRuns(50)
     );
   });
 

--- a/packages/foundation/modeling/schema/test/Int.test.ts
+++ b/packages/foundation/modeling/schema/test/Int.test.ts
@@ -1,3 +1,4 @@
+import { fcRuns } from "@beep/fc-runs";
 import { Int64, Int64FromString, isInt64 } from "@beep/schema/Int";
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, Exit } from "effect";
@@ -56,7 +57,7 @@ describe("Int64", () => {
         expect(value >= int64Minimum).toBe(true);
         expect(value <= int64Maximum).toBe(true);
       }),
-      { numRuns: 100 }
+      fcRuns(100)
     );
   });
 });

--- a/packages/foundation/modeling/schema/test/LiteralKit.test.ts
+++ b/packages/foundation/modeling/schema/test/LiteralKit.test.ts
@@ -1,3 +1,4 @@
+import { fcRuns } from "@beep/fc-runs";
 import { $RepoCliId, $SchemaId } from "@beep/identity";
 import {
   LiteralKit,
@@ -32,7 +33,7 @@ describe("LiteralKit", () => {
         expect(Status.Options).toContain(literal);
         expect(decode(encode(literal))).toBe(literal);
       }),
-      { numRuns: 25 }
+      fcRuns(25)
     );
   });
 

--- a/packages/foundation/modeling/schema/test/LocalDate.test.ts
+++ b/packages/foundation/modeling/schema/test/LocalDate.test.ts
@@ -1,3 +1,4 @@
+import { fcRuns } from "@beep/fc-runs";
 import {
   addDays,
   addMonths,
@@ -556,7 +557,7 @@ describe("LocalDate", () => {
           expect(decoded).toBeInstanceOf(LocalDate);
           expect(equals(decoded, date)).toBe(true);
         }),
-        { numRuns: 50 }
+        fcRuns(50)
       ));
 
     it.effect(

--- a/packages/foundation/modeling/schema/test/MappedLiteralKit.test.ts
+++ b/packages/foundation/modeling/schema/test/MappedLiteralKit.test.ts
@@ -1,3 +1,4 @@
+import { fcRuns } from "@beep/fc-runs";
 import { LiteralKitKeyCollisionError } from "@beep/schema/LiteralKit";
 import { MappedLiteralDuplicateError, MappedLiteralKit } from "@beep/schema/MappedLiteralKit";
 import { describe, expect, it } from "@effect/vitest";
@@ -30,7 +31,7 @@ describe("MappedLiteralKit", () => {
         expect(SqlState.To.Options).toContain(literal);
         expect(decode(encode(literal))).toBe(literal);
       }),
-      { numRuns: 25 }
+      fcRuns(25)
     );
   });
 

--- a/packages/foundation/modeling/schema/test/Markdown.test.ts
+++ b/packages/foundation/modeling/schema/test/Markdown.test.ts
@@ -1,3 +1,4 @@
+import { fcRuns } from "@beep/fc-runs";
 import { decodeMarkdownTextAs, Markdown, MarkdownTextToHtml } from "@beep/schema/Markdown";
 import { loadMarkdownGfmModule, loadMarkdownModule, makeParseMarkdownForSchema } from "@beep/schema/test/Markdown";
 import { describe, expect, it } from "@effect/vitest";
@@ -53,7 +54,7 @@ describe("Markdown", () => {
       fc.property(markdownArbitrary, (document) => {
         expect(decodeMarkdown(document)).toBe(document);
       }),
-      { numRuns: 25 }
+      fcRuns(25)
     );
   });
 

--- a/packages/foundation/modeling/schema/test/Model.test.ts
+++ b/packages/foundation/modeling/schema/test/Model.test.ts
@@ -1,3 +1,4 @@
+import { fcRuns } from "@beep/fc-runs";
 import * as Model from "@beep/schema/Model";
 import { describe, expect, it } from "@effect/vitest";
 import { DateTime, Effect, SchemaParser } from "effect";
@@ -33,7 +34,7 @@ describe("Model optional helpers", () => {
       fc.property(arbitrary, (value) => {
         expect(decode(encode(value))).toEqual(value);
       }),
-      { numRuns: 50 }
+      fcRuns(50)
     );
   });
 });

--- a/packages/foundation/modeling/schema/test/MutableHashMap.test.ts
+++ b/packages/foundation/modeling/schema/test/MutableHashMap.test.ts
@@ -1,3 +1,4 @@
+import { fcRuns } from "@beep/fc-runs";
 import { isMutableHashMap, MutableHashMap, MutableHashMapFromSelf } from "@beep/schema/MutableHashMap";
 import { A } from "@beep/utils";
 import { describe, expect, it } from "@effect/vitest";
@@ -126,7 +127,7 @@ describe("MutableHashMap", () => {
         const decoded = decode(encoded);
         expect(equivalence(decoded, value)).toBe(true);
       }),
-      { numRuns: 50 }
+      fcRuns(50)
     );
   });
 });

--- a/packages/foundation/modeling/schema/test/MutableHashSet.test.ts
+++ b/packages/foundation/modeling/schema/test/MutableHashSet.test.ts
@@ -1,3 +1,4 @@
+import { fcRuns } from "@beep/fc-runs";
 import { isMutableHashSet, MutableHashSet, MutableHashSetFromSelf } from "@beep/schema/MutableHashSet";
 import { withKeyDefaults } from "@beep/schema/SchemaUtils/withKeyDefaults";
 import { A } from "@beep/utils";
@@ -54,7 +55,7 @@ describe("MutableHashSetFromSelf", () => {
         const decoded = decode(encoded);
         expect(equivalence(decoded, set)).toBe(true);
       }),
-      { numRuns: 50 }
+      fcRuns(50)
     );
   });
 });

--- a/packages/foundation/modeling/schema/test/Options.test.ts
+++ b/packages/foundation/modeling/schema/test/Options.test.ts
@@ -1,3 +1,4 @@
+import { fcRuns } from "@beep/fc-runs";
 import { OptionFromOptionalNullishKey } from "@beep/schema/Options";
 import { describe, expect, it } from "@effect/vitest";
 import * as O from "effect/Option";
@@ -63,7 +64,7 @@ describe("OptionFromOptionalNullishKey", () => {
       fc.property(arbitrary, (payload) => {
         expect(decode(encode(payload))).toEqual(payload);
       }),
-      { numRuns: 50 }
+      fcRuns(50)
     );
   });
 });

--- a/packages/foundation/modeling/schema/test/Port.test.ts
+++ b/packages/foundation/modeling/schema/test/Port.test.ts
@@ -1,3 +1,4 @@
+import { fcRuns } from "@beep/fc-runs";
 import { Port, PortFromString } from "@beep/schema/Port";
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, Exit } from "effect";
@@ -54,7 +55,7 @@ describe("Port", () => {
         expect(value).toBeGreaterThanOrEqual(portMinimum);
         expect(value).toBeLessThanOrEqual(portMaximum);
       }),
-      { numRuns: 100 }
+      fcRuns(100)
     );
   });
 });

--- a/packages/foundation/modeling/schema/test/RegExp.test.ts
+++ b/packages/foundation/modeling/schema/test/RegExp.test.ts
@@ -1,3 +1,4 @@
+import { fcRuns } from "@beep/fc-runs";
 import { RegExpFromStr, RegExpStr } from "@beep/schema/RegExp";
 import { describe, expect, it } from "@effect/vitest";
 import * as S from "effect/Schema";
@@ -25,7 +26,7 @@ describe("RegExpStr", () => {
         new globalThis.RegExp(value);
         return S.is(RegExpStr)(value) && decode(value) === value;
       }),
-      { numRuns: 50 }
+      fcRuns(50)
     );
   });
 });
@@ -60,7 +61,7 @@ describe("RegExpFromStr", () => {
 
     fc.assert(
       fc.property(arbitrary, (value) => value instanceof RegExp && S.is(S.RegExp)(value)),
-      { numRuns: 50 }
+      fcRuns(50)
     );
   });
 });

--- a/packages/foundation/modeling/schema/test/SchemaUtils.test.ts
+++ b/packages/foundation/modeling/schema/test/SchemaUtils.test.ts
@@ -1,3 +1,4 @@
+import { fcRuns } from "@beep/fc-runs";
 import { $SchemaId } from "@beep/identity/packages";
 import * as SchemaUtils from "@beep/schema/SchemaUtils/index";
 import { optional } from "@beep/schema/SchemaUtils/optional";
@@ -220,7 +221,7 @@ describe("withCodecStatics", () => {
         expect(Slug.fromUnknown(sampled)).toBe(sampled);
         expect(O.isSome(Slug.decodeOption(sampled))).toBe(true);
       }),
-      { numRuns: 50 }
+      fcRuns(50)
     );
   });
 

--- a/packages/foundation/modeling/schema/test/Sha256.test.ts
+++ b/packages/foundation/modeling/schema/test/Sha256.test.ts
@@ -1,3 +1,4 @@
+import { fcRuns } from "@beep/fc-runs";
 import { Sha256Hex, Sha256HexFromBytes, Sha256HexFromHexBytes } from "@beep/schema/Sha256";
 import { Str } from "@beep/utils";
 import * as BunCrypto from "@effect/platform-bun/BunCrypto";
@@ -31,7 +32,7 @@ describe("Sha256Hex", () => {
         expect(digest).toHaveLength(64);
         expect(digest).toMatch(/^[0-9a-f]{64}$/);
       }),
-      { numRuns: 25 }
+      fcRuns(25)
     );
   });
 

--- a/packages/foundation/modeling/schema/test/TypedArrays.test.ts
+++ b/packages/foundation/modeling/schema/test/TypedArrays.test.ts
@@ -1,3 +1,4 @@
+import { fcRuns } from "@beep/fc-runs";
 import { Float16Arr, Float16ArrayFromArray } from "@beep/schema/Float16Array";
 import { Float32Arr, Float32ArrayFromArray } from "@beep/schema/Float32Array";
 import { Float64Arr, Float64ArrayFromArray } from "@beep/schema/Float64Array";
@@ -32,7 +33,7 @@ describe("Float16Array schemas", () => {
         expect(value).toBeInstanceOf(Float16Array);
         expect(decode(encode(value))).toBeInstanceOf(Float16Array);
       }),
-      { numRuns: 25 }
+      fcRuns(25)
     );
   });
 });
@@ -63,7 +64,7 @@ describe("Float32Array schemas", () => {
         expect(value).toBeInstanceOf(Float32Array);
         expect(decode(encode(value))).toBeInstanceOf(Float32Array);
       }),
-      { numRuns: 25 }
+      fcRuns(25)
     );
   });
 });
@@ -94,7 +95,7 @@ describe("Float64Array schemas", () => {
         expect(value).toBeInstanceOf(Float64Array);
         expect(decode(encode(value))).toBeInstanceOf(Float64Array);
       }),
-      { numRuns: 25 }
+      fcRuns(25)
     );
   });
 });

--- a/packages/foundation/modeling/schema/tsconfig.json
+++ b/packages/foundation/modeling/schema/tsconfig.json
@@ -19,6 +19,9 @@
     },
     {
       "path": "../../primitive/types/tsconfig.json"
+    },
+    {
+      "path": "../../../tooling/test-kit/fc-runs/tsconfig.json"
     }
   ]
 }

--- a/packages/foundation/modeling/utils/package.json
+++ b/packages/foundation/modeling/utils/package.json
@@ -36,6 +36,7 @@
     "picomatch": "catalog:"
   },
   "devDependencies": {
+    "@beep/fc-runs": "workspace:^",
     "@beep/types": "workspace:^",
     "@effect/platform-node": "catalog:",
     "@effect/vitest": "catalog:",

--- a/packages/foundation/modeling/utils/test/SchemaParity.test.ts
+++ b/packages/foundation/modeling/utils/test/SchemaParity.test.ts
@@ -1,3 +1,4 @@
+import { fcRuns } from "@beep/fc-runs";
 import { AppendFileSyncOptions, ReaddirSyncOptions, RmSyncOptions } from "@beep/utils/FileSystem";
 import { GlobOptions, Pattern } from "@beep/utils/Glob";
 import { PathInput } from "@beep/utils/Struct";
@@ -25,7 +26,7 @@ const expectSchemaRoundTrips = <C extends S.Codec<unknown, unknown>>(schema: C):
     fc.property(arbitrary, (value) => {
       expectRoundTrip(schema, value);
     }),
-    { numRuns: 50 }
+    fcRuns(50)
   );
 };
 

--- a/packages/foundation/modeling/utils/tsconfig.json
+++ b/packages/foundation/modeling/utils/tsconfig.json
@@ -13,6 +13,9 @@
     },
     {
       "path": "../../primitive/types/tsconfig.json"
+    },
+    {
+      "path": "../../../tooling/test-kit/fc-runs/tsconfig.json"
     }
   ]
 }

--- a/packages/tooling/test-kit/fc-runs/AGENTS.md
+++ b/packages/tooling/test-kit/fc-runs/AGENTS.md
@@ -1,0 +1,11 @@
+# @beep/fc-runs
+
+Env-max fast-check run-count helpers (property-law lane floor)
+
+## Surface
+
+- See `src/index.ts` barrel — do not hand-maintain inventory tables here.
+
+## Laws
+
+- Root `AGENTS.md` and `standards/ARCHITECTURE.md` govern this package; record only genuinely package-specific deltas here.

--- a/packages/tooling/test-kit/fc-runs/CLAUDE.md
+++ b/packages/tooling/test-kit/fc-runs/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/tooling/test-kit/fc-runs/LICENSE
+++ b/packages/tooling/test-kit/fc-runs/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 beep-effect
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/tooling/test-kit/fc-runs/README.md
+++ b/packages/tooling/test-kit/fc-runs/README.md
@@ -1,0 +1,43 @@
+# @beep/fc-runs
+
+Env-max fast-check run-count helpers (property-law lane floor)
+
+## Installation
+
+```bash
+bun add @beep/fc-runs
+```
+
+## Usage
+
+```ts
+import { fcRuns } from "@beep/fc-runs"
+
+// Inline value is a floor; BEEP_FC_NUM_RUNS can only raise it, never lower it.
+const options = fcRuns(40) // { numRuns: max(40, BEEP_FC_NUM_RUNS) }
+```
+
+## Development
+
+```bash
+# Build
+bun run build
+
+# Type check
+bun run check
+
+# Test
+bun run test
+
+# Integration test
+bun run test:integration
+
+# Lint
+bun run lint:fix
+```
+
+Unit tests stay outside `test/integration`; package integration tests live under `test/integration` and use `bun run test:integration`. Tests and dtslint files import package source through `@beep/fc-runs` or other `@beep/*` aliases. Use relative imports only for local helpers, fixtures, and snapshots.
+
+## License
+
+MIT

--- a/packages/tooling/test-kit/fc-runs/docgen.json
+++ b/packages/tooling/test-kit/fc-runs/docgen.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../../packages/tooling/tool/docgen/schema.json",
   "exclude": ["src/internal/**/*.ts"],
-  "srcLink": "https://github.com/beep-effect/beep-effect/tree/main/packages/foundation/modeling/utils/src/",
+  "srcLink": "https://github.com/beep-effect/beep-effect/tree/main/packages/tooling/test-kit/fc-runs/src/",
   "examplesCompilerOptions": {
     "noEmit": true,
     "strict": true,
@@ -26,35 +26,14 @@
     "noFallthroughCasesInSwitch": true,
     "stripInternal": false,
     "noErrorTruncation": true,
-    "types": ["node", "bun"],
+    "types": [],
     "jsx": "react-jsx",
     "paths": {
-      "@beep/utils": [
-        "../../../../packages/foundation/modeling/utils/src/index.ts"
-      ],
-      "@beep/utils/*": [
-        "../../../../packages/foundation/modeling/utils/src/*.ts"
-      ],
       "@beep/fc-runs": [
         "../../../../packages/tooling/test-kit/fc-runs/src/index.ts"
       ],
       "@beep/fc-runs/*": [
         "../../../../packages/tooling/test-kit/fc-runs/src/*.ts"
-      ],
-      "@beep/identity": [
-        "../../../../packages/foundation/modeling/identity/src/index.ts"
-      ],
-      "@beep/identity/*": [
-        "../../../../packages/foundation/modeling/identity/src/*.ts"
-      ],
-      "@beep/identity/packages": [
-        "../../../../packages/foundation/modeling/identity/src/packages.ts"
-      ],
-      "@beep/types": [
-        "../../../../packages/foundation/primitive/types/src/index.ts"
-      ],
-      "@beep/types/*": [
-        "../../../../packages/foundation/primitive/types/src/*.ts"
       ]
     }
   }

--- a/packages/tooling/test-kit/fc-runs/package.json
+++ b/packages/tooling/test-kit/fc-runs/package.json
@@ -1,18 +1,19 @@
 {
-  "name": "@beep/pglite",
+  "name": "@beep/fc-runs",
   "version": "0.0.0",
-  "description": "Driver-level PGlite (embedded PostgreSQL) runtime via @effect/sql-pglite.",
+  "description": "Env-max fast-check run-count helpers (property-law lane floor)",
   "license": "MIT",
   "private": true,
   "type": "module",
-  "homepage": "https://github.com/beep-effect/beep-effect/tree/main/packages/drivers/pglite",
+  "homepage": "https://github.com/beep-effect/beep-effect/tree/main/packages/tooling/test-kit/fc-runs",
   "repository": {
     "type": "git",
     "url": "git@github.com:beep-effect/beep-effect.git",
-    "directory": "packages/drivers/pglite"
+    "directory": "packages/tooling/test-kit/fc-runs"
   },
   "beep": {
-    "family": "drivers"
+    "family": "tooling",
+    "kind": "test-kit"
   },
   "scripts": {
     "audit": "bun run --if-present beep:audit",
@@ -28,11 +29,10 @@
     "build": "bun run beep:build",
     "check": "bun run beep:check",
     "coverage": "bunx vitest run --coverage --exclude=test/integration/**",
-    "docgen": "bun run ../../../packages/tooling/tool/docgen/src/bin.ts",
+    "docgen": "bun run ../../../../packages/tooling/tool/docgen/src/bin.ts",
     "lint": "bun run beep:lint",
     "lint:fix": "bun run beep:lint:fix",
     "test": "bun run beep:test",
-    "test:property": "bun run beep:test",
     "test:integration": "bun run beep:test:integration"
   },
   "exports": {
@@ -53,25 +53,17 @@
     "access": "public",
     "provenance": true,
     "exports": {
-      ".": "./dist/index.js",
+      ".": "./dist/index.ts",
       "./*": "./dist/*.js",
       "./internal/*": null,
       "./package.json": "./package.json"
     }
   },
   "dependencies": {
-    "@beep/identity": "workspace:^",
-    "@beep/schema": "workspace:^",
-    "@beep/utils": "workspace:^",
-    "@effect/sql-pg": "catalog:",
-    "@effect/sql-pglite": "catalog:",
     "effect": "catalog:"
   },
   "devDependencies": {
-    "@beep/fc-runs": "workspace:^",
-    "@effect/platform-node": "catalog:",
     "@effect/vitest": "catalog:",
-    "@types/node": "catalog:",
-    "drizzle-orm": "catalog:"
+    "@types/node": "catalog:"
   }
 }

--- a/packages/tooling/test-kit/fc-runs/src/FastCheckRuns.ts
+++ b/packages/tooling/test-kit/fc-runs/src/FastCheckRuns.ts
@@ -1,0 +1,116 @@
+/**
+ * Env-max fast-check run-count helpers (one-round-loop P1).
+ *
+ * Inline `numRuns` values override `fc.configureGlobal`, so a global
+ * floor alone cannot raise property-law depth across the repo. These
+ * helpers make every migrated site env-raisable: the effective run
+ * count is `max(inline ?? default, BEEP_FC_NUM_RUNS)` — inline values
+ * are floors and can never be lowered by the environment.
+ *
+ * Lives in this leaf package (upstream of the entire `@beep/test-utils`
+ * dependency closure) so that `@beep/schema`, `@beep/utils`, and
+ * `@beep/pglite` — which `@beep/test-utils` itself depends on — can
+ * import `fcRuns` without forming a package cycle. `@beep/test-utils`
+ * re-exports these helpers so existing `@beep/test-utils` imports keep
+ * working unchanged.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { Config, Effect, pipe } from "effect";
+import * as O from "effect/Option";
+
+/**
+ * fast-check's own default run count, used when a site passes no inline value.
+ *
+ * @example
+ * ```ts
+ * import { DEFAULT_FC_NUM_RUNS } from "@beep/fc-runs"
+ *
+ * console.log(DEFAULT_FC_NUM_RUNS) // 100
+ * ```
+ * @category testing
+ * @since 0.0.0
+ */
+export const DEFAULT_FC_NUM_RUNS = 100;
+
+/**
+ * Parse a raw `BEEP_FC_NUM_RUNS` value into a usable floor.
+ *
+ * Non-integers, non-positives, and absent values collapse to 0 so the
+ * result can feed the environment side of a `max()` directly.
+ *
+ * @param raw - Raw environment value, if any.
+ * @returns The parsed positive-integer floor, or 0.
+ * @example
+ * ```ts
+ * import { parseFcNumRunsFloor } from "@beep/fc-runs"
+ *
+ * console.log(parseFcNumRunsFloor("400")) // 400
+ * console.log(parseFcNumRunsFloor("2.5")) // 0
+ * console.log(parseFcNumRunsFloor(undefined)) // 0
+ * ```
+ * @category testing
+ * @since 0.0.0
+ */
+export const parseFcNumRunsFloor = (raw: string | undefined): number =>
+  O.match(O.flatMap(O.fromNullishOr(raw), parsePositiveInteger), {
+    onNone: () => 0,
+    onSome: (floor) => floor,
+  });
+
+const parsePositiveInteger = (raw: string): O.Option<number> => {
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed > 0 ? O.some(parsed) : O.none();
+};
+
+// Effect's default ConfigProvider snapshots the environment at process
+// boot — exactly the lane semantics (CI exports BEEP_FC_NUM_RUNS before
+// vitest starts). Runtime mutation is deliberately NOT observed.
+const fcNumRunsConfig = Config.option(Config.string("BEEP_FC_NUM_RUNS"));
+
+/**
+ * Read the `BEEP_FC_NUM_RUNS` environment floor.
+ *
+ * Returns 0 when the variable is unset or not a positive integer, so it
+ * can be used directly as the environment side of a `max()`.
+ *
+ * @returns The configured floor, or 0 when absent or invalid.
+ * @example
+ * ```ts
+ * import { envFcNumRunsFloor } from "@beep/fc-runs"
+ *
+ * const floor = envFcNumRunsFloor()
+ * console.log(floor >= 0) // true
+ * ```
+ * @category testing
+ * @since 0.0.0
+ */
+export const envFcNumRunsFloor = (): number =>
+  pipe(Effect.runSync(fcNumRunsConfig), O.getOrUndefined, parseFcNumRunsFloor);
+
+/**
+ * Build fast-check run options whose effective `numRuns` is
+ * `max(inline ?? DEFAULT_FC_NUM_RUNS, BEEP_FC_NUM_RUNS)`.
+ *
+ * Inline values are floors: the environment can raise the run count for
+ * a deep sweep (the nightly property lane runs with
+ * `BEEP_FC_NUM_RUNS=1000`), but can never lower a site below the value
+ * it declares (one-round-loop fence 3).
+ *
+ * @param inline - The site's own run count; defaults to fast-check's 100.
+ * @returns Options bag spreadable into `fc.assert` parameters.
+ * @example
+ * ```ts
+ * import { fcRuns } from "@beep/fc-runs"
+ *
+ * const options = fcRuns(40)
+ * console.log(options.numRuns >= 40) // true; higher when BEEP_FC_NUM_RUNS is set
+ * ```
+ * @category testing
+ * @since 0.0.0
+ */
+export const fcRuns = (inline?: number): { readonly numRuns: number } => ({
+  numRuns: Math.max(inline ?? DEFAULT_FC_NUM_RUNS, envFcNumRunsFloor()),
+});

--- a/packages/tooling/test-kit/fc-runs/src/index.ts
+++ b/packages/tooling/test-kit/fc-runs/src/index.ts
@@ -7,15 +7,13 @@
  * depth without importing back out of a package that depends on them.
  * `@beep/test-utils` re-exports everything here.
  *
+ * @packageDocumentation
  * @example
  * ```ts
  * import { fcRuns } from "@beep/fc-runs"
- *
  * const options = fcRuns(40)
  * console.log(options.numRuns >= 40) // true; higher when BEEP_FC_NUM_RUNS is set
  * ```
- *
- * @packageDocumentation
  * @since 0.0.0
  */
 

--- a/packages/tooling/test-kit/fc-runs/src/index.ts
+++ b/packages/tooling/test-kit/fc-runs/src/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Env-max fast-check run-count helpers for the property-law lane.
+ *
+ * A leaf package upstream of the entire `@beep/test-utils` dependency
+ * closure. It holds the `fcRuns` env-floor helper so closure packages
+ * (`@beep/schema`, `@beep/utils`, `@beep/pglite`) can raise property-test
+ * depth without importing back out of a package that depends on them.
+ * `@beep/test-utils` re-exports everything here.
+ *
+ * @example
+ * ```ts
+ * import { fcRuns } from "@beep/fc-runs"
+ *
+ * const options = fcRuns(40)
+ * console.log(options.numRuns >= 40) // true; higher when BEEP_FC_NUM_RUNS is set
+ * ```
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+/**
+ * Fast-check run-count helper exports.
+ *
+ * @example
+ * ```ts
+ * import { fcRuns } from "@beep/fc-runs"
+ *
+ * console.log(fcRuns(40).numRuns >= 40) // true
+ * ```
+ * @category testing
+ * @since 0.0.0
+ */
+export * from "./FastCheckRuns.js";

--- a/packages/tooling/test-kit/fc-runs/test/FastCheckRuns.test.ts
+++ b/packages/tooling/test-kit/fc-runs/test/FastCheckRuns.test.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_FC_NUM_RUNS, fcRuns, parseFcNumRunsFloor } from "@beep/test-utils";
+import { DEFAULT_FC_NUM_RUNS, fcRuns, parseFcNumRunsFloor } from "@beep/fc-runs";
 import { FastCheck as fc } from "effect/testing";
 import { describe, expect, it } from "vitest";
 
@@ -32,7 +32,7 @@ describe("fcRuns (one-round-loop P1 env-max helper)", () => {
     // starts), so the end-to-end raise/never-lower semantics need a fresh
     // subprocess with the variable present at spawn.
     const probe = [
-      'const { fcRuns } = await import("@beep/test-utils");',
+      'const { fcRuns } = await import("@beep/fc-runs");',
       "const raised = fcRuns(40).numRuns;",
       "const floored = fcRuns(9000).numRuns;",
       "process.stdout.write(`${raised}/${floored}`);",

--- a/packages/tooling/test-kit/fc-runs/tsconfig.json
+++ b/packages/tooling/test-kit/fc-runs/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../../../tsconfig.base.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "types": ["node"],
+    "outDir": "dist",
+    "rootDir": "src"
+  }
+}

--- a/packages/tooling/test-kit/fc-runs/tsconfig.test.json
+++ b/packages/tooling/test-kit/fc-runs/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../../../tsconfig.base.json",
+  "include": ["src", "test", "dtslint"],
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "incremental": false,
+    "noEmit": true,
+    "outDir": "dist-test",
+    "rootDir": ".",
+    "sourceMap": false,
+    "types": ["node", "bun-types"]
+  }
+}

--- a/packages/tooling/test-kit/fc-runs/vitest.config.ts
+++ b/packages/tooling/test-kit/fc-runs/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig, mergeConfig } from "vitest/config";
+import shared from "../../../../vitest.shared.ts";
+
+export default mergeConfig(
+  shared,
+  defineConfig({
+    test: {
+      // Package-specific overrides
+    },
+  })
+);

--- a/packages/tooling/test-kit/test-utils/docgen.json
+++ b/packages/tooling/test-kit/test-utils/docgen.json
@@ -35,6 +35,12 @@
       "@beep/test-utils/*": [
         "../../../../packages/tooling/test-kit/test-utils/src/*.ts"
       ],
+      "@beep/fc-runs": [
+        "../../../../packages/tooling/test-kit/fc-runs/src/index.ts"
+      ],
+      "@beep/fc-runs/*": [
+        "../../../../packages/tooling/test-kit/fc-runs/src/*.ts"
+      ],
       "@beep/identity": [
         "../../../../packages/foundation/modeling/identity/src/index.ts"
       ],

--- a/packages/tooling/test-kit/test-utils/package.json
+++ b/packages/tooling/test-kit/test-utils/package.json
@@ -48,6 +48,7 @@
     "audit": "bun run --if-present beep:audit"
   },
   "dependencies": {
+    "@beep/fc-runs": "workspace:^",
     "@beep/identity": "workspace:^",
     "@beep/schema": "workspace:^",
     "@beep/utils": "workspace:^",

--- a/packages/tooling/test-kit/test-utils/src/FastCheckRuns.ts
+++ b/packages/tooling/test-kit/test-utils/src/FastCheckRuns.ts
@@ -1,109 +1,28 @@
 /**
- * Env-max fast-check run-count helpers (one-round-loop P1).
+ * Re-exports the env-max fast-check run-count helpers from `@beep/fc-runs`.
  *
- * Inline `numRuns` values override `fc.configureGlobal`, so a global
- * floor alone cannot raise property-law depth across the repo. These
- * helpers make every migrated site env-raisable: the effective run
- * count is `max(inline ?? default, BEEP_FC_NUM_RUNS)` — inline values
- * are floors and can never be lowered by the environment.
+ * The helpers live in `@beep/fc-runs` — a leaf package upstream of this
+ * package's dependency closure — so that `@beep/schema`, `@beep/utils`,
+ * and `@beep/pglite` (which `@beep/test-utils` itself depends on) can
+ * import `fcRuns` without forming a package cycle. This module keeps the
+ * historical `@beep/test-utils` import path working for every other
+ * consumer.
  *
  * @packageDocumentation
  * @since 0.0.0
  */
 
-import { Config, Effect, pipe } from "effect";
-import * as O from "effect/Option";
-
 /**
- * fast-check's own default run count, used when a site passes no inline value.
+ * Re-exported env-max fast-check run-count helpers (`fcRuns`,
+ * `envFcNumRunsFloor`, `parseFcNumRunsFloor`, `DEFAULT_FC_NUM_RUNS`).
  *
- * @example
- * ```ts
- * import { DEFAULT_FC_NUM_RUNS } from "@beep/test-utils"
- *
- * console.log(DEFAULT_FC_NUM_RUNS) // 100
- * ```
- * @category testing
- * @since 0.0.0
- */
-export const DEFAULT_FC_NUM_RUNS = 100;
-
-/**
- * Parse a raw `BEEP_FC_NUM_RUNS` value into a usable floor.
- *
- * Non-integers, non-positives, and absent values collapse to 0 so the
- * result can feed the environment side of a `max()` directly.
- *
- * @param raw - Raw environment value, if any.
- * @returns The parsed positive-integer floor, or 0.
- * @example
- * ```ts
- * import { parseFcNumRunsFloor } from "@beep/test-utils"
- *
- * console.log(parseFcNumRunsFloor("400")) // 400
- * console.log(parseFcNumRunsFloor("2.5")) // 0
- * console.log(parseFcNumRunsFloor(undefined)) // 0
- * ```
- * @category testing
- * @since 0.0.0
- */
-export const parseFcNumRunsFloor = (raw: string | undefined): number =>
-  O.match(O.flatMap(O.fromNullishOr(raw), parsePositiveInteger), {
-    onNone: () => 0,
-    onSome: (floor) => floor,
-  });
-
-const parsePositiveInteger = (raw: string): O.Option<number> => {
-  const parsed = Number(raw);
-  return Number.isInteger(parsed) && parsed > 0 ? O.some(parsed) : O.none();
-};
-
-// Effect's default ConfigProvider snapshots the environment at process
-// boot — exactly the lane semantics (CI exports BEEP_FC_NUM_RUNS before
-// vitest starts). Runtime mutation is deliberately NOT observed.
-const fcNumRunsConfig = Config.option(Config.string("BEEP_FC_NUM_RUNS"));
-
-/**
- * Read the `BEEP_FC_NUM_RUNS` environment floor.
- *
- * Returns 0 when the variable is unset or not a positive integer, so it
- * can be used directly as the environment side of a `max()`.
- *
- * @returns The configured floor, or 0 when absent or invalid.
- * @example
- * ```ts
- * import { envFcNumRunsFloor } from "@beep/test-utils"
- *
- * const floor = envFcNumRunsFloor()
- * console.log(floor >= 0) // true
- * ```
- * @category testing
- * @since 0.0.0
- */
-export const envFcNumRunsFloor = (): number =>
-  pipe(Effect.runSync(fcNumRunsConfig), O.getOrUndefined, parseFcNumRunsFloor);
-
-/**
- * Build fast-check run options whose effective `numRuns` is
- * `max(inline ?? DEFAULT_FC_NUM_RUNS, BEEP_FC_NUM_RUNS)`.
- *
- * Inline values are floors: the environment can raise the run count for
- * a deep sweep (the nightly property lane runs with
- * `BEEP_FC_NUM_RUNS=1000`), but can never lower a site below the value
- * it declares (one-round-loop fence 3).
- *
- * @param inline - The site's own run count; defaults to fast-check's 100.
- * @returns Options bag spreadable into `fc.assert` parameters.
  * @example
  * ```ts
  * import { fcRuns } from "@beep/test-utils"
  *
- * const options = fcRuns(40)
- * console.log(options.numRuns >= 40) // true; higher when BEEP_FC_NUM_RUNS is set
+ * console.log(fcRuns(40).numRuns >= 40) // true; higher when BEEP_FC_NUM_RUNS is set
  * ```
  * @category testing
  * @since 0.0.0
  */
-export const fcRuns = (inline?: number): { readonly numRuns: number } => ({
-  numRuns: Math.max(inline ?? DEFAULT_FC_NUM_RUNS, envFcNumRunsFloor()),
-});
+export * from "@beep/fc-runs";

--- a/packages/tooling/test-kit/test-utils/tsconfig.json
+++ b/packages/tooling/test-kit/test-utils/tsconfig.json
@@ -16,6 +16,9 @@
     },
     {
       "path": "../../../foundation/modeling/utils/tsconfig.json"
+    },
+    {
+      "path": "../fc-runs/tsconfig.json"
     }
   ]
 }

--- a/standards/fallow.boundaries.generated.jsonc
+++ b/standards/fallow.boundaries.generated.jsonc
@@ -210,6 +210,12 @@
         ]
       },
       {
+        "name": "@beep/fc-runs",
+        "patterns": [
+          "packages/tooling/test-kit/fc-runs/src/**"
+        ]
+      },
+      {
         "name": "@beep/federal-register",
         "patterns": [
           "packages/drivers/federal-register/src/**"
@@ -1194,6 +1200,15 @@
         ]
       },
       {
+        "from": "@beep/fc-runs",
+        "allow": [
+          "@beep/fc-runs"
+        ],
+        "allowTypeOnly": [
+          "@beep/fc-runs"
+        ]
+      },
+      {
         "from": "@beep/federal-register",
         "allow": [
           "@beep/federal-register"
@@ -1755,12 +1770,14 @@
       {
         "from": "@beep/pglite",
         "allow": [
+          "@beep/fc-runs",
           "@beep/identity",
           "@beep/pglite",
           "@beep/schema",
           "@beep/utils"
         ],
         "allowTypeOnly": [
+          "@beep/fc-runs",
           "@beep/identity",
           "@beep/pglite",
           "@beep/schema",
@@ -2066,6 +2083,7 @@
         "from": "@beep/schema",
         "allow": [
           "@beep/data",
+          "@beep/fc-runs",
           "@beep/identity",
           "@beep/schema",
           "@beep/types",
@@ -2073,6 +2091,7 @@
         ],
         "allowTypeOnly": [
           "@beep/data",
+          "@beep/fc-runs",
           "@beep/identity",
           "@beep/schema",
           "@beep/types",
@@ -2165,12 +2184,14 @@
       {
         "from": "@beep/test-utils",
         "allow": [
+          "@beep/fc-runs",
           "@beep/identity",
           "@beep/schema",
           "@beep/test-utils",
           "@beep/utils"
         ],
         "allowTypeOnly": [
+          "@beep/fc-runs",
           "@beep/identity",
           "@beep/schema",
           "@beep/test-utils",
@@ -2259,11 +2280,13 @@
       {
         "from": "@beep/utils",
         "allow": [
+          "@beep/fc-runs",
           "@beep/identity",
           "@beep/types",
           "@beep/utils"
         ],
         "allowTypeOnly": [
+          "@beep/fc-runs",
           "@beep/identity",
           "@beep/types",
           "@beep/utils"

--- a/standards/jsdoc-documentation.inventory.jsonc
+++ b/standards/jsdoc-documentation.inventory.jsonc
@@ -1,7 +1,7 @@
 {
   "standard": "jsdoc-documentation",
   "version": 1,
-  "generatedAt": "2026-07-08T13:42:54.093Z",
+  "generatedAt": "2026-07-08T16:21:44.466Z",
   "source": {
     "packageUniverseCommand": "bun run topo-sort",
     "generator": "bun run beep quality jsdoc-inventory",
@@ -61,12 +61,12 @@
     "status": "resolved"
   },
   "totals": {
-    "packages": 104,
-    "cleanPackages": 20,
+    "packages": 105,
+    "cleanPackages": 21,
     "packagesWithoutPublicSrcSurface": 3,
-    "packagesNeedingRemediation": 78,
-    "publicModules": 1620,
-    "publicExports": 14484,
+    "packagesNeedingRemediation": 77,
+    "publicModules": 1622,
+    "publicExports": 14497,
     "openModules": 129,
     "openExports": 2207,
     "missingExportExamples": 2013,
@@ -5228,8 +5228,8 @@
           "exportKind": "class",
           "filePath": "src/PclClient.service.ts",
           "repoPath": "packages/drivers/pacer/src/PclClient.service.ts",
-          "line": 175,
-          "anchor": "packages-drivers-pacer-src-pclclient-service-ts-175-pclclient",
+          "line": 194,
+          "anchor": "packages-drivers-pacer-src-pclclient-service-ts-194-pclclient",
           "currentTags": [
             "@example",
             "@category",
@@ -58616,7 +58616,7 @@
         "srcDir": "src",
         "sourceFileCount": 6,
         "publicModuleCount": 6,
-        "publicExportCount": 37
+        "publicExportCount": 34
       },
       "docgenCoverage": {
         "hasDocgenConfig": true,
@@ -58677,7 +58677,7 @@
           "unsafeExampleViolations": [],
           "schemaAnnotationGaps": [],
           "categoryViolations": [],
-          "exportCount": 4,
+          "exportCount": 1,
           "remediationStatus": "resolved"
         },
         {
@@ -58813,84 +58813,13 @@
           "remediationStatus": "resolved"
         },
         {
-          "symbolName": "DEFAULT_FC_NUM_RUNS",
-          "exportKind": "const",
+          "symbolName": "export * from \"@beep/fc-runs\";",
+          "exportKind": "re-export",
           "filePath": "src/FastCheckRuns.ts",
           "repoPath": "packages/tooling/test-kit/test-utils/src/FastCheckRuns.ts",
-          "line": 29,
-          "anchor": "packages-tooling-test-kit-test-utils-src-fastcheckruns-ts-29-default-fc-num-runs",
+          "line": 28,
+          "anchor": "packages-tooling-test-kit-test-utils-src-fastcheckruns-ts-28-export-from-beep-fc-runs",
           "currentTags": [
-            "@example",
-            "@category",
-            "@since"
-          ],
-          "missingRequiredTags": [],
-          "forbiddenTags": [],
-          "missingSummary": false,
-          "malformedConditionalTags": [],
-          "exampleImportViolations": [],
-          "unsafeExampleViolations": [],
-          "schemaAnnotationGaps": [],
-          "categoryViolations": [],
-          "remediationStatus": "resolved"
-        },
-        {
-          "symbolName": "parseFcNumRunsFloor",
-          "exportKind": "const",
-          "filePath": "src/FastCheckRuns.ts",
-          "repoPath": "packages/tooling/test-kit/test-utils/src/FastCheckRuns.ts",
-          "line": 50,
-          "anchor": "packages-tooling-test-kit-test-utils-src-fastcheckruns-ts-50-parsefcnumrunsfloor",
-          "currentTags": [
-            "@param",
-            "@returns",
-            "@example",
-            "@category",
-            "@since"
-          ],
-          "missingRequiredTags": [],
-          "forbiddenTags": [],
-          "missingSummary": false,
-          "malformedConditionalTags": [],
-          "exampleImportViolations": [],
-          "unsafeExampleViolations": [],
-          "schemaAnnotationGaps": [],
-          "categoryViolations": [],
-          "remediationStatus": "resolved"
-        },
-        {
-          "symbolName": "envFcNumRunsFloor",
-          "exportKind": "const",
-          "filePath": "src/FastCheckRuns.ts",
-          "repoPath": "packages/tooling/test-kit/test-utils/src/FastCheckRuns.ts",
-          "line": 83,
-          "anchor": "packages-tooling-test-kit-test-utils-src-fastcheckruns-ts-83-envfcnumrunsfloor",
-          "currentTags": [
-            "@returns",
-            "@example",
-            "@category",
-            "@since"
-          ],
-          "missingRequiredTags": [],
-          "forbiddenTags": [],
-          "missingSummary": false,
-          "malformedConditionalTags": [],
-          "exampleImportViolations": [],
-          "unsafeExampleViolations": [],
-          "schemaAnnotationGaps": [],
-          "categoryViolations": [],
-          "remediationStatus": "resolved"
-        },
-        {
-          "symbolName": "fcRuns",
-          "exportKind": "const",
-          "filePath": "src/FastCheckRuns.ts",
-          "repoPath": "packages/tooling/test-kit/test-utils/src/FastCheckRuns.ts",
-          "line": 107,
-          "anchor": "packages-tooling-test-kit-test-utils-src-fastcheckruns-ts-107-fcruns",
-          "currentTags": [
-            "@param",
-            "@returns",
             "@example",
             "@category",
             "@since"
@@ -93998,7 +93927,7 @@
         "srcDir": "src",
         "sourceFileCount": 6,
         "publicModuleCount": 6,
-        "publicExportCount": 169
+        "publicExportCount": 170
       },
       "docgenCoverage": {
         "hasDocgenConfig": true,
@@ -94146,7 +94075,7 @@
           "unsafeExampleViolations": [],
           "schemaAnnotationGaps": [],
           "categoryViolations": [],
-          "exportCount": 95,
+          "exportCount": 96,
           "remediationStatus": "resolved"
         }
       ],
@@ -95846,8 +95775,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 171,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-171-dataid",
+          "line": 172,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-172-dataid",
           "currentTags": [
             "@example",
             "@since",
@@ -95868,8 +95797,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 186,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-186-identityid",
+          "line": 187,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-187-identityid",
           "currentTags": [
             "@example",
             "@since",
@@ -95890,8 +95819,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 201,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-201-schemaid",
+          "line": 202,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-202-schemaid",
           "currentTags": [
             "@example",
             "@since",
@@ -95912,8 +95841,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 216,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-216-provenanceid",
+          "line": 217,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-217-provenanceid",
           "currentTags": [
             "@example",
             "@since",
@@ -95934,8 +95863,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 231,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-231-rdfid",
+          "line": 232,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-232-rdfid",
           "currentTags": [
             "@example",
             "@since",
@@ -95956,8 +95885,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 246,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-246-ontologyid",
+          "line": 247,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-247-ontologyid",
           "currentTags": [
             "@example",
             "@since",
@@ -95978,8 +95907,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 261,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-261-typesid",
+          "line": 262,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-262-typesid",
           "currentTags": [
             "@example",
             "@since",
@@ -96000,8 +95929,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 276,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-276-utilsid",
+          "line": 277,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-277-utilsid",
           "currentTags": [
             "@example",
             "@since",
@@ -96022,8 +95951,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 293,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-293-uiid",
+          "line": 294,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-294-uiid",
           "currentTags": [
             "@example",
             "@since",
@@ -96044,8 +95973,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 310,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-310-repoaimetricsid",
+          "line": 311,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-311-repoaimetricsid",
           "currentTags": [
             "@example",
             "@since",
@@ -96066,8 +95995,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 325,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-325-repocliid",
+          "line": 326,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-326-repocliid",
           "currentTags": [
             "@example",
             "@since",
@@ -96088,8 +96017,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 340,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-340-repoconfigsid",
+          "line": 341,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-341-repoconfigsid",
           "currentTags": [
             "@example",
             "@since",
@@ -96110,8 +96039,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 355,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-355-repoutilsid",
+          "line": 356,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-356-repoutilsid",
           "currentTags": [
             "@example",
             "@since",
@@ -96132,8 +96061,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 370,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-370-testutilsid",
+          "line": 371,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-371-testutilsid",
           "currentTags": [
             "@example",
             "@since",
@@ -96154,8 +96083,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 387,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-387-shareddomainid",
+          "line": 388,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-388-shareddomainid",
           "currentTags": [
             "@example",
             "@since",
@@ -96176,8 +96105,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 402,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-402-sharedtablesid",
+          "line": 403,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-403-sharedtablesid",
           "currentTags": [
             "@example",
             "@since",
@@ -96198,8 +96127,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 417,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-417-semanticwebid",
+          "line": 418,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-418-semanticwebid",
           "currentTags": [
             "@example",
             "@since",
@@ -96220,8 +96149,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 432,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-432-nlpid",
+          "line": 433,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-433-nlpid",
           "currentTags": [
             "@example",
             "@since",
@@ -96242,8 +96171,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 447,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-447-nlpprocessingid",
+          "line": 448,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-448-nlpprocessingid",
           "currentTags": [
             "@example",
             "@since",
@@ -96264,8 +96193,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 462,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-462-langextractid",
+          "line": 463,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-463-langextractid",
           "currentTags": [
             "@example",
             "@since",
@@ -96286,8 +96215,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 477,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-477-observabilityid",
+          "line": 478,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-478-observabilityid",
           "currentTags": [
             "@example",
             "@since",
@@ -96308,8 +96237,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 492,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-492-colorsid",
+          "line": 493,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-493-colorsid",
           "currentTags": [
             "@example",
             "@since",
@@ -96330,8 +96259,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 507,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-507-chalkid",
+          "line": 508,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-508-chalkid",
           "currentTags": [
             "@example",
             "@since",
@@ -96352,8 +96281,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 522,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-522-repodocgenid",
+          "line": 523,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-523-repodocgenid",
           "currentTags": [
             "@example",
             "@since",
@@ -96374,8 +96303,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 537,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-537-infraid",
+          "line": 538,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-538-infraid",
           "currentTags": [
             "@example",
             "@since",
@@ -96396,8 +96325,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 554,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-554-workspacedomainid",
+          "line": 555,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-555-workspacedomainid",
           "currentTags": [
             "@example",
             "@category",
@@ -96418,8 +96347,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 569,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-569-epistemicdomainid",
+          "line": 570,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-570-epistemicdomainid",
           "currentTags": [
             "@example",
             "@category",
@@ -96440,8 +96369,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 585,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-585-epistemicusecasesid",
+          "line": 586,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-586-epistemicusecasesid",
           "currentTags": [
             "@example",
             "@category",
@@ -96462,8 +96391,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 601,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-601-agentsdomainid",
+          "line": 602,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-602-agentsdomainid",
           "currentTags": [
             "@example",
             "@category",
@@ -96484,8 +96413,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 616,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-616-agentsserverid",
+          "line": 617,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-617-agentsserverid",
           "currentTags": [
             "@example",
             "@category",
@@ -96506,8 +96435,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 631,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-631-agentsusecasesid",
+          "line": 632,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-632-agentsusecasesid",
           "currentTags": [
             "@example",
             "@category",
@@ -96528,8 +96457,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 646,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-646-lawpracticedomainid",
+          "line": 647,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-647-lawpracticedomainid",
           "currentTags": [
             "@example",
             "@category",
@@ -96550,8 +96479,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 663,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-663-lawpracticeusecasesid",
+          "line": 664,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-664-lawpracticeusecasesid",
           "currentTags": [
             "@example",
             "@category",
@@ -96572,8 +96501,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 680,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-680-lawpracticeserverid",
+          "line": 681,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-681-lawpracticeserverid",
           "currentTags": [
             "@example",
             "@category",
@@ -96594,8 +96523,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 696,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-696-professionaldesktopid",
+          "line": 697,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-697-professionaldesktopid",
           "currentTags": [
             "@example",
             "@category",
@@ -96616,8 +96545,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 712,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-712-repopkgs",
+          "line": 713,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-713-repopkgs",
           "currentTags": [
             "@example",
             "@category",
@@ -96638,8 +96567,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 728,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-728-mdid",
+          "line": 729,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-729-mdid",
           "currentTags": [
             "@since",
             "@example",
@@ -96660,8 +96589,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 744,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-744-oipwebid",
+          "line": 745,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-745-oipwebid",
           "currentTags": [
             "@since",
             "@example",
@@ -96682,8 +96611,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 760,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-760-drizzleid",
+          "line": 761,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-761-drizzleid",
           "currentTags": [
             "@since",
             "@example",
@@ -96704,8 +96633,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 776,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-776-duckdbid",
+          "line": 777,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-777-duckdbid",
           "currentTags": [
             "@since",
             "@example",
@@ -96726,8 +96655,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 792,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-792-facedetectionid",
+          "line": 793,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-793-facedetectionid",
           "currentTags": [
             "@since",
             "@example",
@@ -96748,8 +96677,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 808,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-808-ffmpegid",
+          "line": 809,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-809-ffmpegid",
           "currentTags": [
             "@since",
             "@example",
@@ -96770,8 +96699,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 824,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-824-postgresid",
+          "line": 825,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-825-postgresid",
           "currentTags": [
             "@since",
             "@example",
@@ -96792,8 +96721,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 840,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-840-anthropicid",
+          "line": 841,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-841-anthropicid",
           "currentTags": [
             "@example",
             "@since",
@@ -96814,8 +96743,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 856,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-856-veniceaiid",
+          "line": 857,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-857-veniceaiid",
           "currentTags": [
             "@since",
             "@example",
@@ -96836,8 +96765,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 872,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-872-xaiid",
+          "line": 873,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-873-xaiid",
           "currentTags": [
             "@since",
             "@example",
@@ -96858,8 +96787,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 888,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-888-acpid",
+          "line": 889,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-889-acpid",
           "currentTags": [
             "@example",
             "@since",
@@ -96880,8 +96809,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 904,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-904-openaicompatid",
+          "line": 905,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-905-openaicompatid",
           "currentTags": [
             "@example",
             "@since",
@@ -96902,8 +96831,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 920,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-920-workspacetablesid",
+          "line": 921,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-921-workspacetablesid",
           "currentTags": [
             "@example",
             "@since",
@@ -96924,8 +96853,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 936,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-936-workspaceusecasesid",
+          "line": 937,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-937-workspaceusecasesid",
           "currentTags": [
             "@example",
             "@since",
@@ -96946,8 +96875,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 953,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-953-workspaceserverid",
+          "line": 954,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-954-workspaceserverid",
           "currentTags": [
             "@example",
             "@since",
@@ -96968,8 +96897,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 969,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-969-architecturelabdomainid",
+          "line": 970,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-970-architecturelabdomainid",
           "currentTags": [
             "@example",
             "@since",
@@ -96990,8 +96919,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 986,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-986-architecturelabusecasesid",
+          "line": 987,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-987-architecturelabusecasesid",
           "currentTags": [
             "@example",
             "@since",
@@ -97012,8 +96941,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1003,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1003-architecturelabconfigid",
+          "line": 1004,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1004-architecturelabconfigid",
           "currentTags": [
             "@example",
             "@since",
@@ -97034,8 +96963,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1020,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1020-architecturelabserverid",
+          "line": 1021,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1021-architecturelabserverid",
           "currentTags": [
             "@example",
             "@since",
@@ -97056,8 +96985,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1037,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1037-architecturelabtablesid",
+          "line": 1038,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1038-architecturelabtablesid",
           "currentTags": [
             "@example",
             "@since",
@@ -97078,8 +97007,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1054,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1054-architecturelabclientid",
+          "line": 1055,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1055-architecturelabclientid",
           "currentTags": [
             "@example",
             "@since",
@@ -97100,8 +97029,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1071,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1071-architecturelabuiid",
+          "line": 1072,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1072-architecturelabuiid",
           "currentTags": [
             "@example",
             "@since",
@@ -97122,8 +97051,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1088,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1088-architecturelabproofid",
+          "line": 1089,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1089-architecturelabproofid",
           "currentTags": [
             "@example",
             "@since",
@@ -97144,8 +97073,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1105,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1105-runpodid",
+          "line": 1106,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1106-runpodid",
           "currentTags": [
             "@example",
             "@since",
@@ -97166,8 +97095,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1121,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1121-onepasswordcliid",
+          "line": 1122,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1122-onepasswordcliid",
           "currentTags": [
             "@example",
             "@since",
@@ -97188,8 +97117,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1137,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1137-discordid",
+          "line": 1138,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1138-discordid",
           "currentTags": [
             "@example",
             "@since",
@@ -97210,8 +97139,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1153,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1153-aiprovidercliid",
+          "line": 1154,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1154-aiprovidercliid",
           "currentTags": [
             "@example",
             "@since",
@@ -97232,8 +97161,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1169,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1169-sanityid",
+          "line": 1170,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1170-sanityid",
           "currentTags": [
             "@example",
             "@since",
@@ -97254,8 +97183,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1185,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1185-hubspotid",
+          "line": 1186,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1186-hubspotid",
           "currentTags": [
             "@example",
             "@since",
@@ -97276,8 +97205,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1201,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1201-phoenixid",
+          "line": 1202,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1202-phoenixid",
           "currentTags": [
             "@example",
             "@since",
@@ -97298,8 +97227,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1217,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1217-aisyncid",
+          "line": 1218,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1218-aisyncid",
           "currentTags": [
             "@example",
             "@since",
@@ -97320,8 +97249,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1233,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1233-boxid",
+          "line": 1234,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1234-boxid",
           "currentTags": [
             "@example",
             "@since",
@@ -97342,8 +97271,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1249,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1249-nlpmcpid",
+          "line": 1250,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1250-nlpmcpid",
           "currentTags": [
             "@example",
             "@since",
@@ -97364,8 +97293,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1265,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1265-rdfcanonizeid",
+          "line": 1266,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1266-rdfcanonizeid",
           "currentTags": [
             "@example",
             "@since",
@@ -97386,8 +97315,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1281,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1281-winkid",
+          "line": 1282,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1282-winkid",
           "currentTags": [
             "@example",
             "@since",
@@ -97408,8 +97337,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1297,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1297-fileprocessingid",
+          "line": 1298,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1298-fileprocessingid",
           "currentTags": [
             "@example",
             "@since",
@@ -97430,8 +97359,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1313,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1313-tikaid",
+          "line": 1314,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1314-tikaid",
           "currentTags": [
             "@example",
             "@since",
@@ -97452,8 +97381,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1329,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1329-libpffid",
+          "line": 1330,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1330-libpffid",
           "currentTags": [
             "@example",
             "@since",
@@ -97474,8 +97403,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1345,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1345-firecrawlid",
+          "line": 1346,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1346-firecrawlid",
           "currentTags": [
             "@example",
             "@since",
@@ -97496,8 +97425,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1361,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1361-usptoid",
+          "line": 1362,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1362-usptoid",
           "currentTags": [
             "@example",
             "@since",
@@ -97518,8 +97447,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1377,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1377-lexicalschemaid",
+          "line": 1378,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1378-lexicalschemaid",
           "currentTags": [
             "@example",
             "@since",
@@ -97540,8 +97469,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1393,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1393-editorid",
+          "line": 1394,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1394-editorid",
           "currentTags": [
             "@example",
             "@since",
@@ -97562,8 +97491,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1409,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1409-scratchpadid",
+          "line": 1410,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1410-scratchpadid",
           "currentTags": [
             "@example",
             "@since",
@@ -97584,8 +97513,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1425,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1425-htmlid",
+          "line": 1426,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1426-htmlid",
           "currentTags": [
             "@example",
             "@since",
@@ -97606,8 +97535,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1441,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1441-pandocastid",
+          "line": 1442,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1442-pandocastid",
           "currentTags": [
             "@example",
             "@since",
@@ -97628,8 +97557,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1457,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1457-formid",
+          "line": 1458,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1458-formid",
           "currentTags": [
             "@example",
             "@since",
@@ -97650,8 +97579,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1473,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1473-pgliteid",
+          "line": 1474,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1474-pgliteid",
           "currentTags": [
             "@example",
             "@since",
@@ -97672,8 +97601,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1489,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1489-m365id",
+          "line": 1490,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1490-m365id",
           "currentTags": [
             "@example",
             "@since",
@@ -97694,8 +97623,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1505,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1505-m365mcpid",
+          "line": 1506,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1506-m365mcpid",
           "currentTags": [
             "@example",
             "@since",
@@ -97716,8 +97645,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1521,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1521-govinfoid",
+          "line": 1522,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1522-govinfoid",
           "currentTags": [
             "@example",
             "@since",
@@ -97738,8 +97667,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1537,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1537-federalregisterid",
+          "line": 1538,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1538-federalregisterid",
           "currentTags": [
             "@example",
             "@since",
@@ -97760,8 +97689,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1553,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1553-ecfrid",
+          "line": 1554,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1554-ecfrid",
           "currentTags": [
             "@example",
             "@since",
@@ -97782,8 +97711,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1569,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1569-dolid",
+          "line": 1570,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1570-dolid",
           "currentTags": [
             "@example",
             "@since",
@@ -97804,8 +97733,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1585,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1585-courtlistenerid",
+          "line": 1586,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1586-courtlistenerid",
           "currentTags": [
             "@example",
             "@since",
@@ -97826,8 +97755,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1601,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1601-apitransportid",
+          "line": 1602,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1602-apitransportid",
           "currentTags": [
             "@example",
             "@since",
@@ -97848,8 +97777,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1617,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1617-mcpkitid",
+          "line": 1618,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1618-mcpkitid",
           "currentTags": [
             "@example",
             "@since",
@@ -97870,8 +97799,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1633,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1633-usptomcpid",
+          "line": 1634,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1634-usptomcpid",
           "currentTags": [
             "@example",
             "@since",
@@ -97892,8 +97821,30 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1649,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1649-pacerid",
+          "line": 1650,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1650-pacerid",
+          "currentTags": [
+            "@example",
+            "@since",
+            "@category"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "$FcRunsId",
+          "exportKind": "const",
+          "filePath": "src/packages.ts",
+          "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
+          "line": 1666,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1666-fcrunsid",
           "currentTags": [
             "@example",
             "@since",
@@ -211330,8 +211281,8 @@
           "exportKind": "const",
           "filePath": "src/runtime/Pglite.ts",
           "repoPath": "apps/professional-desktop/src/runtime/Pglite.ts",
-          "line": 73,
-          "anchor": "apps-professional-desktop-src-runtime-pglite-ts-73-chatdbcompatibilitymarker",
+          "line": 72,
+          "anchor": "apps-professional-desktop-src-runtime-pglite-ts-72-chatdbcompatibilitymarker",
           "currentTags": [
             "@category",
             "@since"
@@ -211353,8 +211304,8 @@
           "exportKind": "const",
           "filePath": "src/runtime/Pglite.ts",
           "repoPath": "apps/professional-desktop/src/runtime/Pglite.ts",
-          "line": 113,
-          "anchor": "apps-professional-desktop-src-runtime-pglite-ts-113-markcompatiblechatdbdatadir",
+          "line": 112,
+          "anchor": "apps-professional-desktop-src-runtime-pglite-ts-112-markcompatiblechatdbdatadir",
           "currentTags": [
             "@category",
             "@since"
@@ -211376,8 +211327,8 @@
           "exportKind": "const",
           "filePath": "src/runtime/Pglite.ts",
           "repoPath": "apps/professional-desktop/src/runtime/Pglite.ts",
-          "line": 173,
-          "anchor": "apps-professional-desktop-src-runtime-pglite-ts-173-ensurecompatiblechatdbdatadir",
+          "line": 172,
+          "anchor": "apps-professional-desktop-src-runtime-pglite-ts-172-ensurecompatiblechatdbdatadir",
           "currentTags": [
             "@category",
             "@since"
@@ -211399,8 +211350,8 @@
           "exportKind": "const",
           "filePath": "src/runtime/Pglite.ts",
           "repoPath": "apps/professional-desktop/src/runtime/Pglite.ts",
-          "line": 255,
-          "anchor": "apps-professional-desktop-src-runtime-pglite-ts-255-makebundledpglitelayer",
+          "line": 252,
+          "anchor": "apps-professional-desktop-src-runtime-pglite-ts-252-makebundledpglitelayer",
           "currentTags": [
             "@category",
             "@since"
@@ -211422,8 +211373,8 @@
           "exportKind": "const",
           "filePath": "src/runtime/Pglite.ts",
           "repoPath": "apps/professional-desktop/src/runtime/Pglite.ts",
-          "line": 276,
-          "anchor": "apps-professional-desktop-src-runtime-pglite-ts-276-pglitedrizzlelive",
+          "line": 266,
+          "anchor": "apps-professional-desktop-src-runtime-pglite-ts-266-pglitedrizzlelive",
           "currentTags": [
             "@category",
             "@since"
@@ -243478,9 +243429,202 @@
       ]
     },
     {
+      "packageName": "@beep/fc-runs",
+      "packagePath": "packages/tooling/test-kit/fc-runs",
+      "topoOrder": 76,
+      "status": "clean",
+      "sourceCoverage": {
+        "srcDir": "src",
+        "sourceFileCount": 2,
+        "publicModuleCount": 2,
+        "publicExportCount": 5
+      },
+      "docgenCoverage": {
+        "hasDocgenConfig": true,
+        "enforceDescriptions": false,
+        "enforceExamples": false,
+        "enforceVersion": true
+      },
+      "counts": {
+        "openModules": 0,
+        "openExports": 0,
+        "missingExportExamples": 0,
+        "missingExportCategories": 0,
+        "missingExportSince": 0,
+        "missingExportSummaries": 0,
+        "forbiddenTagFindings": 0,
+        "malformedConditionalTagFindings": 0,
+        "exampleImportFindings": 0,
+        "unsafeExampleFindings": 0,
+        "schemaAnnotationFindings": 0
+      },
+      "modules": [
+        {
+          "docKind": "packageDocumentation",
+          "filePath": "src/FastCheckRuns.ts",
+          "repoPath": "packages/tooling/test-kit/fc-runs/src/FastCheckRuns.ts",
+          "line": 1,
+          "anchor": "packages-tooling-test-kit-fc-runs-src-fastcheckruns-ts-1-module",
+          "currentTags": [
+            "@packageDocumentation",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "exportCount": 4,
+          "remediationStatus": "resolved"
+        },
+        {
+          "docKind": "packageDocumentation",
+          "filePath": "src/index.ts",
+          "repoPath": "packages/tooling/test-kit/fc-runs/src/index.ts",
+          "line": 1,
+          "anchor": "packages-tooling-test-kit-fc-runs-src-index-ts-1-module",
+          "currentTags": [
+            "@packageDocumentation",
+            "@example",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "exportCount": 1,
+          "remediationStatus": "resolved"
+        }
+      ],
+      "exports": [
+        {
+          "symbolName": "DEFAULT_FC_NUM_RUNS",
+          "exportKind": "const",
+          "filePath": "src/FastCheckRuns.ts",
+          "repoPath": "packages/tooling/test-kit/fc-runs/src/FastCheckRuns.ts",
+          "line": 36,
+          "anchor": "packages-tooling-test-kit-fc-runs-src-fastcheckruns-ts-36-default-fc-num-runs",
+          "currentTags": [
+            "@example",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "parseFcNumRunsFloor",
+          "exportKind": "const",
+          "filePath": "src/FastCheckRuns.ts",
+          "repoPath": "packages/tooling/test-kit/fc-runs/src/FastCheckRuns.ts",
+          "line": 57,
+          "anchor": "packages-tooling-test-kit-fc-runs-src-fastcheckruns-ts-57-parsefcnumrunsfloor",
+          "currentTags": [
+            "@param",
+            "@returns",
+            "@example",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "envFcNumRunsFloor",
+          "exportKind": "const",
+          "filePath": "src/FastCheckRuns.ts",
+          "repoPath": "packages/tooling/test-kit/fc-runs/src/FastCheckRuns.ts",
+          "line": 90,
+          "anchor": "packages-tooling-test-kit-fc-runs-src-fastcheckruns-ts-90-envfcnumrunsfloor",
+          "currentTags": [
+            "@returns",
+            "@example",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "fcRuns",
+          "exportKind": "const",
+          "filePath": "src/FastCheckRuns.ts",
+          "repoPath": "packages/tooling/test-kit/fc-runs/src/FastCheckRuns.ts",
+          "line": 114,
+          "anchor": "packages-tooling-test-kit-fc-runs-src-fastcheckruns-ts-114-fcruns",
+          "currentTags": [
+            "@param",
+            "@returns",
+            "@example",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "export * from \"./FastCheckRuns.js\";",
+          "exportKind": "re-export",
+          "filePath": "src/index.ts",
+          "repoPath": "packages/tooling/test-kit/fc-runs/src/index.ts",
+          "line": 32,
+          "anchor": "packages-tooling-test-kit-fc-runs-src-index-ts-32-export-from-fastcheckruns-js",
+          "currentTags": [
+            "@example",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "remediationStatus": "resolved"
+        }
+      ]
+    },
+    {
       "packageName": "@beep/repo-utils",
       "packagePath": "packages/tooling/library/repo-utils",
-      "topoOrder": 76,
+      "topoOrder": 77,
       "status": "needs-remediation",
       "sourceCoverage": {
         "srcDir": "src",
@@ -259446,7 +259590,7 @@
     {
       "packageName": "@beep/schema",
       "packagePath": "packages/foundation/modeling/schema",
-      "topoOrder": 77,
+      "topoOrder": 78,
       "status": "needs-remediation",
       "sourceCoverage": {
         "srcDir": "src",
@@ -300180,7 +300324,7 @@
     {
       "packageName": "@beep/epistemic-server",
       "packagePath": "packages/epistemic/server",
-      "topoOrder": 78,
+      "topoOrder": 79,
       "status": "needs-remediation",
       "sourceCoverage": {
         "srcDir": "src",
@@ -300326,7 +300470,7 @@
     {
       "packageName": "@beep/rdf",
       "packagePath": "packages/foundation/modeling/rdf",
-      "topoOrder": 79,
+      "topoOrder": 80,
       "status": "needs-remediation",
       "sourceCoverage": {
         "srcDir": "src",
@@ -305346,7 +305490,7 @@
     {
       "packageName": "@beep/onepassword-cli",
       "packagePath": "packages/drivers/onepassword-cli",
-      "topoOrder": 80,
+      "topoOrder": 81,
       "status": "needs-remediation",
       "sourceCoverage": {
         "srcDir": "src",
@@ -305827,7 +305971,7 @@
     {
       "packageName": "@beep/architecture-lab-config",
       "packagePath": "packages/architecture-lab/config",
-      "topoOrder": 81,
+      "topoOrder": 82,
       "status": "needs-remediation",
       "sourceCoverage": {
         "srcDir": "src",
@@ -306523,7 +306667,7 @@
     {
       "packageName": "@beep/govinfo",
       "packagePath": "packages/drivers/govinfo",
-      "topoOrder": 82,
+      "topoOrder": 83,
       "status": "needs-remediation",
       "sourceCoverage": {
         "srcDir": "src",
@@ -309169,7 +309313,7 @@
     {
       "packageName": "@beep/data",
       "packagePath": "packages/foundation/primitive/data",
-      "topoOrder": 83,
+      "topoOrder": 84,
       "status": "needs-remediation",
       "sourceCoverage": {
         "srcDir": "src",
@@ -312660,7 +312804,7 @@
     {
       "packageName": "@beep/xai",
       "packagePath": "packages/drivers/xai",
-      "topoOrder": 84,
+      "topoOrder": 85,
       "status": "clean",
       "sourceCoverage": {
         "srcDir": "src",
@@ -314385,7 +314529,7 @@
     {
       "packageName": "@beep/architecture-lab-server",
       "packagePath": "packages/architecture-lab/server",
-      "topoOrder": 85,
+      "topoOrder": 86,
       "status": "needs-remediation",
       "sourceCoverage": {
         "srcDir": "src",
@@ -315478,7 +315622,7 @@
     {
       "packageName": "@beep/duckdb",
       "packagePath": "packages/drivers/duckdb",
-      "topoOrder": 86,
+      "topoOrder": 87,
       "status": "needs-remediation",
       "sourceCoverage": {
         "srcDir": "src",
@@ -315915,8 +316059,8 @@
           "exportKind": "interface",
           "filePath": "src/DuckDb.service.ts",
           "repoPath": "packages/drivers/duckdb/src/DuckDb.service.ts",
-          "line": 166,
-          "anchor": "packages-drivers-duckdb-src-duckdb-service-ts-166-duckdbshape",
+          "line": 171,
+          "anchor": "packages-drivers-duckdb-src-duckdb-service-ts-171-duckdbshape",
           "currentTags": [
             "@remarks",
             "@example",
@@ -315938,8 +316082,8 @@
           "exportKind": "class",
           "filePath": "src/DuckDb.service.ts",
           "repoPath": "packages/drivers/duckdb/src/DuckDb.service.ts",
-          "line": 468,
-          "anchor": "packages-drivers-duckdb-src-duckdb-service-ts-468-duckdb",
+          "line": 484,
+          "anchor": "packages-drivers-duckdb-src-duckdb-service-ts-484-duckdb",
           "currentTags": [
             "@remarks",
             "@example",
@@ -316009,8 +316153,8 @@
           "exportKind": "const",
           "filePath": "src/DuckDbSqlClient.service.ts",
           "repoPath": "packages/drivers/duckdb/src/DuckDbSqlClient.service.ts",
-          "line": 60,
-          "anchor": "packages-drivers-duckdb-src-duckdbsqlclient-service-ts-60-duckdbsqlclienttypeid",
+          "line": 64,
+          "anchor": "packages-drivers-duckdb-src-duckdbsqlclient-service-ts-64-duckdbsqlclienttypeid",
           "currentTags": [
             "@example",
             "@category",
@@ -316031,8 +316175,8 @@
           "exportKind": "type",
           "filePath": "src/DuckDbSqlClient.service.ts",
           "repoPath": "packages/drivers/duckdb/src/DuckDbSqlClient.service.ts",
-          "line": 76,
-          "anchor": "packages-drivers-duckdb-src-duckdbsqlclient-service-ts-76-duckdbsqlclienttypeid",
+          "line": 80,
+          "anchor": "packages-drivers-duckdb-src-duckdbsqlclient-service-ts-80-duckdbsqlclienttypeid",
           "currentTags": [
             "@example",
             "@category",
@@ -316053,8 +316197,8 @@
           "exportKind": "type",
           "filePath": "src/DuckDbSqlClient.service.ts",
           "repoPath": "packages/drivers/duckdb/src/DuckDbSqlClient.service.ts",
-          "line": 92,
-          "anchor": "packages-drivers-duckdb-src-duckdbsqlclient-service-ts-92-duckdbsqlclientoptions",
+          "line": 96,
+          "anchor": "packages-drivers-duckdb-src-duckdbsqlclient-service-ts-96-duckdbsqlclientoptions",
           "currentTags": [
             "@example",
             "@category",
@@ -316075,8 +316219,8 @@
           "exportKind": "type",
           "filePath": "src/DuckDbSqlClient.service.ts",
           "repoPath": "packages/drivers/duckdb/src/DuckDbSqlClient.service.ts",
-          "line": 114,
-          "anchor": "packages-drivers-duckdb-src-duckdbsqlclient-service-ts-114-duckdbsqlclientvalue",
+          "line": 118,
+          "anchor": "packages-drivers-duckdb-src-duckdbsqlclient-service-ts-118-duckdbsqlclientvalue",
           "currentTags": [
             "@example",
             "@category",
@@ -316097,8 +316241,8 @@
           "exportKind": "const",
           "filePath": "src/DuckDbSqlClient.service.ts",
           "repoPath": "packages/drivers/duckdb/src/DuckDbSqlClient.service.ts",
-          "line": 363,
-          "anchor": "packages-drivers-duckdb-src-duckdbsqlclient-service-ts-363-fromclient",
+          "line": 503,
+          "anchor": "packages-drivers-duckdb-src-duckdbsqlclient-service-ts-503-fromclient",
           "currentTags": [
             "@example",
             "@effects",
@@ -316120,8 +316264,8 @@
           "exportKind": "const",
           "filePath": "src/DuckDbSqlClient.service.ts",
           "repoPath": "packages/drivers/duckdb/src/DuckDbSqlClient.service.ts",
-          "line": 387,
-          "anchor": "packages-drivers-duckdb-src-duckdbsqlclient-service-ts-387-make",
+          "line": 527,
+          "anchor": "packages-drivers-duckdb-src-duckdbsqlclient-service-ts-527-make",
           "currentTags": [
             "@example",
             "@effects",
@@ -316143,8 +316287,8 @@
           "exportKind": "const",
           "filePath": "src/DuckDbSqlClient.service.ts",
           "repoPath": "packages/drivers/duckdb/src/DuckDbSqlClient.service.ts",
-          "line": 408,
-          "anchor": "packages-drivers-duckdb-src-duckdbsqlclient-service-ts-408-makelayer",
+          "line": 548,
+          "anchor": "packages-drivers-duckdb-src-duckdbsqlclient-service-ts-548-makelayer",
           "currentTags": [
             "@example",
             "@category",
@@ -316165,8 +316309,8 @@
           "exportKind": "class",
           "filePath": "src/DuckDbSqlClient.service.ts",
           "repoPath": "packages/drivers/duckdb/src/DuckDbSqlClient.service.ts",
-          "line": 431,
-          "anchor": "packages-drivers-duckdb-src-duckdbsqlclient-service-ts-431-duckdbsqlclient",
+          "line": 571,
+          "anchor": "packages-drivers-duckdb-src-duckdbsqlclient-service-ts-571-duckdbsqlclient",
           "currentTags": [
             "@example",
             "@category",
@@ -316279,7 +316423,7 @@
     {
       "packageName": "@beep/ffmpeg",
       "packagePath": "packages/drivers/ffmpeg",
-      "topoOrder": 87,
+      "topoOrder": 88,
       "status": "needs-remediation",
       "sourceCoverage": {
         "srcDir": "src",
@@ -317607,7 +317751,7 @@
     {
       "packageName": "@beep/agents-client",
       "packagePath": "packages/agents/client",
-      "topoOrder": 88,
+      "topoOrder": 89,
       "status": "needs-remediation",
       "sourceCoverage": {
         "srcDir": "src",
@@ -318262,7 +318406,7 @@
     {
       "packageName": "@beep/uspto-mcp",
       "packagePath": "packages/drivers/uspto-mcp",
-      "topoOrder": 89,
+      "topoOrder": 90,
       "status": "needs-remediation",
       "sourceCoverage": {
         "srcDir": "src",
@@ -319119,7 +319263,7 @@
     {
       "packageName": "@beep/architecture-lab-proof",
       "packagePath": "apps/architecture-lab-proof",
-      "topoOrder": 90,
+      "topoOrder": 91,
       "status": "clean",
       "sourceCoverage": {
         "srcDir": "src",
@@ -319221,7 +319365,7 @@
     {
       "packageName": "@beep/epistemic-use-cases",
       "packagePath": "packages/epistemic/use-cases",
-      "topoOrder": 91,
+      "topoOrder": 92,
       "status": "needs-remediation",
       "sourceCoverage": {
         "srcDir": "src",
@@ -319888,7 +320032,7 @@
     {
       "packageName": "@beep/m365",
       "packagePath": "packages/drivers/m365",
-      "topoOrder": 92,
+      "topoOrder": 93,
       "status": "needs-remediation",
       "sourceCoverage": {
         "srcDir": "src",
@@ -321683,7 +321827,7 @@
     {
       "packageName": "@beep/observability",
       "packagePath": "packages/foundation/capability/observability",
-      "topoOrder": 93,
+      "topoOrder": 94,
       "status": "needs-remediation",
       "sourceCoverage": {
         "srcDir": "src",
@@ -325770,7 +325914,7 @@
     {
       "packageName": "@beep/html",
       "packagePath": "packages/foundation/modeling/html",
-      "topoOrder": 94,
+      "topoOrder": 95,
       "status": "needs-remediation",
       "sourceCoverage": {
         "srcDir": "src",
@@ -333781,7 +333925,7 @@
     {
       "packageName": "@beep/ui",
       "packagePath": "packages/foundation/ui-system/ui",
-      "topoOrder": 95,
+      "topoOrder": 96,
       "status": "needs-remediation",
       "sourceCoverage": {
         "srcDir": "src",
@@ -349373,7 +349517,7 @@
     {
       "packageName": "@beep/pandoc-ast",
       "packagePath": "packages/foundation/modeling/pandoc-ast",
-      "topoOrder": 96,
+      "topoOrder": 97,
       "status": "needs-remediation",
       "sourceCoverage": {
         "srcDir": "src",
@@ -352233,7 +352377,7 @@
     {
       "packageName": "@beep/repo-configs",
       "packagePath": "packages/tooling/policy-pack/repo-configs",
-      "topoOrder": 97,
+      "topoOrder": 98,
       "status": "needs-remediation",
       "sourceCoverage": {
         "srcDir": "src",
@@ -355881,7 +356025,7 @@
     {
       "packageName": "@beep/wink",
       "packagePath": "packages/drivers/wink",
-      "topoOrder": 98,
+      "topoOrder": 99,
       "status": "needs-remediation",
       "sourceCoverage": {
         "srcDir": "src",
@@ -357789,7 +357933,7 @@
     {
       "packageName": "@beep/postgres",
       "packagePath": "packages/drivers/postgres",
-      "topoOrder": 99,
+      "topoOrder": 100,
       "status": "needs-remediation",
       "sourceCoverage": {
         "srcDir": "src",
@@ -358771,7 +358915,7 @@
     {
       "packageName": "@beep/architecture-lab-domain",
       "packagePath": "packages/architecture-lab/domain",
-      "topoOrder": 100,
+      "topoOrder": 101,
       "status": "needs-remediation",
       "sourceCoverage": {
         "srcDir": "src",
@@ -360303,7 +360447,7 @@
     {
       "packageName": "@beep/provenance",
       "packagePath": "packages/foundation/modeling/provenance",
-      "topoOrder": 101,
+      "topoOrder": 102,
       "status": "needs-remediation",
       "sourceCoverage": {
         "srcDir": "src",
@@ -360491,7 +360635,7 @@
     {
       "packageName": "@beep/epistemic-tables",
       "packagePath": "packages/epistemic/tables",
-      "topoOrder": 102,
+      "topoOrder": 103,
       "status": "needs-remediation",
       "sourceCoverage": {
         "srcDir": "src",
@@ -360918,7 +361062,7 @@
     {
       "packageName": "@beep/federal-register",
       "packagePath": "packages/drivers/federal-register",
-      "topoOrder": 103,
+      "topoOrder": 104,
       "status": "clean",
       "sourceCoverage": {
         "srcDir": "src",
@@ -360999,7 +361143,7 @@
     {
       "packageName": "@beep/sanity",
       "packagePath": "packages/drivers/sanity",
-      "topoOrder": 104,
+      "topoOrder": 105,
       "status": "needs-remediation",
       "sourceCoverage": {
         "srcDir": "src",

--- a/standards/jsdoc-documentation.inventory.md
+++ b/standards/jsdoc-documentation.inventory.md
@@ -1,6 +1,6 @@
 # JSDoc Documentation Compliance Inventory
 
-Generated: 2026-07-08T13:42:54.093Z
+Generated: 2026-07-08T16:21:44.466Z
 
 ## Scope
 
@@ -10,12 +10,12 @@ The package universe is the current `bun run topo-sort` output. This inventory c
 
 | Metric | Count |
 |---|---:|
-| packages | 104 |
-| cleanPackages | 20 |
+| packages | 105 |
+| cleanPackages | 21 |
 | packagesWithoutPublicSrcSurface | 3 |
-| packagesNeedingRemediation | 78 |
-| publicModules | 1620 |
-| publicExports | 14484 |
+| packagesNeedingRemediation | 77 |
+| publicModules | 1622 |
+| publicExports | 14497 |
 | openModules | 129 |
 | openExports | 2207 |
 | missingExportExamples | 2013 |
@@ -81,7 +81,7 @@ The package universe is the current `bun run topo-sort` output. This inventory c
 | 38 | `@beep/chalk` | `packages/foundation/capability/chalk` | clean | 1 | 35 | 0 | 0 |
 | 39 | `@beep/uspto` | `packages/drivers/uspto` | needs-remediation | 5 | 24 | 0 | 9 |
 | 40 | `@beep/phoenix` | `packages/drivers/phoenix` | needs-remediation | 5 | 50 | 0 | 10 |
-| 41 | `@beep/test-utils` | `packages/tooling/test-kit/test-utils` | needs-remediation | 6 | 37 | 0 | 9 |
+| 41 | `@beep/test-utils` | `packages/tooling/test-kit/test-utils` | needs-remediation | 6 | 34 | 0 | 9 |
 | 42 | `@beep/types` | `packages/foundation/primitive/types` | clean | 5 | 10 | 0 | 0 |
 | 43 | `@beep/oip-web` | `apps/oip-web` | needs-remediation | 31 | 84 | 1 | 11 |
 | 44 | `@beep/storybook` | `apps/storybook` | no-public-src-surface | 0 | 0 | 0 | 0 |
@@ -100,7 +100,7 @@ The package universe is the current `bun run topo-sort` output. This inventory c
 | 57 | `@beep/libpff` | `packages/drivers/libpff` | needs-remediation | 4 | 19 | 0 | 5 |
 | 58 | `@beep/venice-ai` | `packages/drivers/venice-ai` | clean | 3 | 35 | 0 | 0 |
 | 59 | `@beep/form` | `packages/foundation/ui-system/form` | needs-remediation | 42 | 114 | 0 | 1 |
-| 60 | `@beep/identity` | `packages/foundation/modeling/identity` | needs-remediation | 6 | 169 | 0 | 21 |
+| 60 | `@beep/identity` | `packages/foundation/modeling/identity` | needs-remediation | 6 | 170 | 0 | 21 |
 | 61 | `@beep/drizzle` | `packages/drivers/drizzle` | needs-remediation | 4 | 17 | 0 | 3 |
 | 62 | `@beep/api-transport` | `packages/foundation/capability/api-transport` | needs-remediation | 2 | 8 | 0 | 1 |
 | 63 | `@beep/box` | `packages/drivers/box` | needs-remediation | 103 | 4497 | 0 | 53 |
@@ -116,35 +116,36 @@ The package universe is the current `bun run topo-sort` output. This inventory c
 | 73 | `@beep/nlp` | `packages/foundation/modeling/nlp` | needs-remediation | 28 | 312 | 0 | 34 |
 | 74 | `@beep/infra` | `infra` | clean | 5 | 34 | 0 | 0 |
 | 75 | `@beep/runpod` | `packages/drivers/runpod` | needs-remediation | 6 | 178 | 0 | 7 |
-| 76 | `@beep/repo-utils` | `packages/tooling/library/repo-utils` | needs-remediation | 63 | 649 | 2 | 73 |
-| 77 | `@beep/schema` | `packages/foundation/modeling/schema` | needs-remediation | 241 | 1566 | 0 | 640 |
-| 78 | `@beep/epistemic-server` | `packages/epistemic/server` | needs-remediation | 2 | 3 | 0 | 1 |
-| 79 | `@beep/rdf` | `packages/foundation/modeling/rdf` | needs-remediation | 17 | 208 | 0 | 8 |
-| 80 | `@beep/onepassword-cli` | `packages/drivers/onepassword-cli` | needs-remediation | 4 | 16 | 0 | 5 |
-| 81 | `@beep/architecture-lab-config` | `packages/architecture-lab/config` | needs-remediation | 9 | 21 | 0 | 7 |
-| 82 | `@beep/govinfo` | `packages/drivers/govinfo` | needs-remediation | 32 | 85 | 0 | 45 |
-| 83 | `@beep/data` | `packages/foundation/primitive/data` | needs-remediation | 12 | 144 | 0 | 36 |
-| 84 | `@beep/xai` | `packages/drivers/xai` | clean | 7 | 70 | 0 | 0 |
-| 85 | `@beep/architecture-lab-server` | `packages/architecture-lab/server` | needs-remediation | 13 | 34 | 0 | 12 |
-| 86 | `@beep/duckdb` | `packages/drivers/duckdb` | needs-remediation | 6 | 28 | 0 | 6 |
-| 87 | `@beep/ffmpeg` | `packages/drivers/ffmpeg` | needs-remediation | 4 | 54 | 0 | 6 |
-| 88 | `@beep/agents-client` | `packages/agents/client` | needs-remediation | 3 | 24 | 0 | 3 |
-| 89 | `@beep/uspto-mcp` | `packages/drivers/uspto-mcp` | needs-remediation | 7 | 30 | 0 | 15 |
-| 90 | `@beep/architecture-lab-proof` | `apps/architecture-lab-proof` | clean | 1 | 2 | 0 | 0 |
-| 91 | `@beep/epistemic-use-cases` | `packages/epistemic/use-cases` | needs-remediation | 10 | 19 | 0 | 1 |
-| 92 | `@beep/m365` | `packages/drivers/m365` | needs-remediation | 6 | 74 | 0 | 5 |
-| 93 | `@beep/observability` | `packages/foundation/capability/observability` | needs-remediation | 24 | 159 | 3 | 31 |
-| 94 | `@beep/html` | `packages/foundation/modeling/html` | needs-remediation | 5 | 339 | 0 | 333 |
-| 95 | `@beep/ui` | `packages/foundation/ui-system/ui` | needs-remediation | 132 | 578 | 114 | 64 |
-| 96 | `@beep/pandoc-ast` | `packages/foundation/modeling/pandoc-ast` | needs-remediation | 5 | 119 | 0 | 92 |
-| 97 | `@beep/repo-configs` | `packages/tooling/policy-pack/repo-configs` | needs-remediation | 25 | 138 | 0 | 6 |
-| 98 | `@beep/wink` | `packages/drivers/wink` | needs-remediation | 14 | 71 | 0 | 13 |
-| 99 | `@beep/postgres` | `packages/drivers/postgres` | needs-remediation | 7 | 36 | 0 | 6 |
-| 100 | `@beep/architecture-lab-domain` | `packages/architecture-lab/domain` | needs-remediation | 15 | 52 | 0 | 18 |
-| 101 | `@beep/provenance` | `packages/foundation/modeling/provenance` | needs-remediation | 2 | 5 | 0 | 1 |
-| 102 | `@beep/epistemic-tables` | `packages/epistemic/tables` | needs-remediation | 6 | 12 | 0 | 1 |
-| 103 | `@beep/federal-register` | `packages/drivers/federal-register` | clean | 1 | 1 | 0 | 0 |
-| 104 | `@beep/sanity` | `packages/drivers/sanity` | needs-remediation | 4 | 16 | 0 | 3 |
+| 76 | `@beep/fc-runs` | `packages/tooling/test-kit/fc-runs` | clean | 2 | 5 | 0 | 0 |
+| 77 | `@beep/repo-utils` | `packages/tooling/library/repo-utils` | needs-remediation | 63 | 649 | 2 | 73 |
+| 78 | `@beep/schema` | `packages/foundation/modeling/schema` | needs-remediation | 241 | 1566 | 0 | 640 |
+| 79 | `@beep/epistemic-server` | `packages/epistemic/server` | needs-remediation | 2 | 3 | 0 | 1 |
+| 80 | `@beep/rdf` | `packages/foundation/modeling/rdf` | needs-remediation | 17 | 208 | 0 | 8 |
+| 81 | `@beep/onepassword-cli` | `packages/drivers/onepassword-cli` | needs-remediation | 4 | 16 | 0 | 5 |
+| 82 | `@beep/architecture-lab-config` | `packages/architecture-lab/config` | needs-remediation | 9 | 21 | 0 | 7 |
+| 83 | `@beep/govinfo` | `packages/drivers/govinfo` | needs-remediation | 32 | 85 | 0 | 45 |
+| 84 | `@beep/data` | `packages/foundation/primitive/data` | needs-remediation | 12 | 144 | 0 | 36 |
+| 85 | `@beep/xai` | `packages/drivers/xai` | clean | 7 | 70 | 0 | 0 |
+| 86 | `@beep/architecture-lab-server` | `packages/architecture-lab/server` | needs-remediation | 13 | 34 | 0 | 12 |
+| 87 | `@beep/duckdb` | `packages/drivers/duckdb` | needs-remediation | 6 | 28 | 0 | 6 |
+| 88 | `@beep/ffmpeg` | `packages/drivers/ffmpeg` | needs-remediation | 4 | 54 | 0 | 6 |
+| 89 | `@beep/agents-client` | `packages/agents/client` | needs-remediation | 3 | 24 | 0 | 3 |
+| 90 | `@beep/uspto-mcp` | `packages/drivers/uspto-mcp` | needs-remediation | 7 | 30 | 0 | 15 |
+| 91 | `@beep/architecture-lab-proof` | `apps/architecture-lab-proof` | clean | 1 | 2 | 0 | 0 |
+| 92 | `@beep/epistemic-use-cases` | `packages/epistemic/use-cases` | needs-remediation | 10 | 19 | 0 | 1 |
+| 93 | `@beep/m365` | `packages/drivers/m365` | needs-remediation | 6 | 74 | 0 | 5 |
+| 94 | `@beep/observability` | `packages/foundation/capability/observability` | needs-remediation | 24 | 159 | 3 | 31 |
+| 95 | `@beep/html` | `packages/foundation/modeling/html` | needs-remediation | 5 | 339 | 0 | 333 |
+| 96 | `@beep/ui` | `packages/foundation/ui-system/ui` | needs-remediation | 132 | 578 | 114 | 64 |
+| 97 | `@beep/pandoc-ast` | `packages/foundation/modeling/pandoc-ast` | needs-remediation | 5 | 119 | 0 | 92 |
+| 98 | `@beep/repo-configs` | `packages/tooling/policy-pack/repo-configs` | needs-remediation | 25 | 138 | 0 | 6 |
+| 99 | `@beep/wink` | `packages/drivers/wink` | needs-remediation | 14 | 71 | 0 | 13 |
+| 100 | `@beep/postgres` | `packages/drivers/postgres` | needs-remediation | 7 | 36 | 0 | 6 |
+| 101 | `@beep/architecture-lab-domain` | `packages/architecture-lab/domain` | needs-remediation | 15 | 52 | 0 | 18 |
+| 102 | `@beep/provenance` | `packages/foundation/modeling/provenance` | needs-remediation | 2 | 5 | 0 | 1 |
+| 103 | `@beep/epistemic-tables` | `packages/epistemic/tables` | needs-remediation | 6 | 12 | 0 | 1 |
+| 104 | `@beep/federal-register` | `packages/drivers/federal-register` | clean | 1 | 1 | 0 | 0 |
+| 105 | `@beep/sanity` | `packages/drivers/sanity` | needs-remediation | 4 | 16 | 0 | 3 |
 
 ## Open Findings
 
@@ -1346,11 +1347,11 @@ Export findings:
 - `src/runtime/Layer.ts:97` `RuntimeTest` (const) - missing @example
 - `src/runtime/Migrations.ts:269` `SidecarReadyMarker` (const) - missing @example
 - `src/runtime/Observability.ts:97` `ObservabilityLive` (const) - missing @example
-- `src/runtime/Pglite.ts:73` `ChatDbCompatibilityMarker` (const) - missing @example
-- `src/runtime/Pglite.ts:113` `markCompatibleChatDbDataDir` (const) - missing @example
-- `src/runtime/Pglite.ts:173` `ensureCompatibleChatDbDataDir` (const) - missing @example
-- `src/runtime/Pglite.ts:255` `makeBundledPgliteLayer` (const) - missing @example
-- `src/runtime/Pglite.ts:276` `PgliteDrizzleLive` (const) - missing @example
+- `src/runtime/Pglite.ts:72` `ChatDbCompatibilityMarker` (const) - missing @example
+- `src/runtime/Pglite.ts:112` `markCompatibleChatDbDataDir` (const) - missing @example
+- `src/runtime/Pglite.ts:172` `ensureCompatibleChatDbDataDir` (const) - missing @example
+- `src/runtime/Pglite.ts:252` `makeBundledPgliteLayer` (const) - missing @example
+- `src/runtime/Pglite.ts:266` `PgliteDrizzleLive` (const) - missing @example
 
 ### @beep/architecture-lab-use-cases
 

--- a/standards/knip.regression-baseline.jsonc
+++ b/standards/knip.regression-baseline.jsonc
@@ -11,7 +11,7 @@
     "omitted_fields": ["line", "col", "pos"]
   },
   "check": {
-    "total_findings": 73,
+    "total_findings": 74,
     "binaries": 3,
     "dependencies": 4,
     "devDependencies": 13,
@@ -22,7 +22,7 @@
     "optionalPeerDependencies": 0,
     "types": 1,
     "unlisted": 0,
-    "unresolved": 26
+    "unresolved": 27
   },
   "findings": [
     {
@@ -388,6 +388,11 @@
     {
       "kind": "unresolved",
       "file": "packages/tooling/library/ai-sync/tsconfig.test.json",
+      "name": "bun-types"
+    },
+    {
+      "kind": "unresolved",
+      "file": "packages/tooling/test-kit/fc-runs/tsconfig.test.json",
       "name": "bun-types"
     }
   ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1359,7 +1359,9 @@
       "@beep/pacer/*": ["./packages/drivers/pacer/src/*"],
       "@beep/epistemic-domain/values/EpistemicFixtureKey": [
         "./packages/epistemic/domain/src/values/EpistemicFixtureKey/index.ts"
-      ]
+      ],
+      "@beep/fc-runs": ["./packages/tooling/test-kit/fc-runs/src/index.ts"],
+      "@beep/fc-runs/*": ["./packages/tooling/test-kit/fc-runs/src/*"]
     }
   }
 }

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -280,6 +280,9 @@
       "path": "packages/tooling/policy-pack/repo-configs"
     },
     {
+      "path": "packages/tooling/test-kit/fc-runs"
+    },
+    {
       "path": "packages/tooling/test-kit/test-utils"
     },
     {


### PR DESCRIPTION
## Summary

Follow-up to #327 (the P1 property-law lane). That PR added the env-max `fcRuns` helper to `@beep/test-utils`, but because `@beep/test-utils` depends on `@beep/schema`, `@beep/utils`, and `@beep/pglite`, those three packages could not import `fcRuns` without forming a package cycle. Their inline `numRuns:` sites were therefore carved out of the migration (skipped by `isTestUtilsClosureFile` in the codemod) — leaving the **schema property suite, the repo's most property-heavy package, opted out of the `BEEP_FC_NUM_RUNS` env-max floor**.

This PR closes that gap:

- **New leaf package `@beep/fc-runs`** (`packages/tooling/test-kit/fc-runs`) — holds `fcRuns` + `DEFAULT_FC_NUM_RUNS` / `parseFcNumRunsFloor` / `envFcNumRunsFloor`. It is `effect`-only and upstream of the entire `@beep/test-utils` dependency closure, so schema/utils/pglite can import it without a cycle.
- **`@beep/test-utils` re-exports it** via a thin shim, so all existing `import { fcRuns } from "@beep/test-utils"` sites (60 packages) are unchanged.
- **Dependency wiring** — `@beep/fc-runs` is a runtime dep of `test-utils` (re-exported from src) and a devDep of schema/utils/pglite.
- **Codemod** — the `numRuns`→`fcRuns` codemod now *routes* closure files to `@beep/fc-runs` instead of skipping them; its test asserts the routing.
- **Migrated 31 carved-out test files** (schema 29, utils 1, pglite 1) back to `fcRuns()`.

## Verification

- No dependency cycle: turbo graph resolves; 0 closure→test-utils imports; `@beep/fc-runs` is a leaf.
- `config-sync:check` clean; `fallow:boundaries:check` up to date + layer-legality passed; `jsdoc-ratchet` green (increased=0).
- Typecheck + tests pass: fc-runs (4), codemod (4), schema (614), utils (157), pglite (5), test-utils (17).
- **Env-raise proof**: `fcRuns(40)=1000` resolved from schema's own `node_modules` at `BEEP_FC_NUM_RUNS=1000`; a schema property file runs at the raised count and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786096267&installation_id=141092090&pr_number=335&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F335&signature=fe72c43ccff3b9e5fd55e42ee1ffd313df4487c947ba7efdbeb62b060f349724"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->