### PR TITLE
feat(pretext): pure line-range and line-stats shrinkwrap helpers

### DIFF
--- a/.changeset/pretext-line-stats.md
+++ b/.changeset/pretext-line-stats.md
@@ -1,0 +1,5 @@
+---
+"@beep/pretext": minor
+---
+
+Add pure line-range and line-stats shrinkwrap helpers.

--- a/bun.lock
+++ b/bun.lock
@@ -2302,6 +2302,7 @@
         "@beep/identity": "workspace:^",
         "@beep/md": "workspace:^",
         "@beep/ontology": "workspace:^",
+        "@beep/pretext": "workspace:^",
         "@beep/schema": "workspace:^",
         "@beep/utils": "workspace:^",
         "@effect/platform-bun": "catalog:",

--- a/packages/drivers/pretext/src/Pretext.models.ts
+++ b/packages/drivers/pretext/src/Pretext.models.ts
@@ -208,6 +208,59 @@ export class TextLayoutInput extends S.Class<TextLayoutInput>($I`TextLayoutInput
   })
 ) {}
 
+/**
+ * A word-indexed line range from a greedy text layout. `startWord` is
+ * inclusive, `endWord` is exclusive, and `width` is the line advance.
+ *
+ * @example
+ * ```ts
+ * import { LineRange } from "@beep/pretext"
+ *
+ * const range = LineRange.make({ startWord: 0, endWord: 2, width: 80 })
+ *
+ * console.log(range.endWord)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class LineRange extends S.Class<LineRange>($I`LineRange`)(
+  {
+    startWord: NonNegativeLineCount,
+    endWord: NonNegativeLineCount,
+    width: NonNegativeAdvance,
+  },
+  $I.annote("LineRange", {
+    description: "A word-indexed half-open line range and its measured advance width.",
+  })
+) {}
+
+/**
+ * Aggregate geometry for a greedy text layout: total line count and widest
+ * line advance.
+ *
+ * @example
+ * ```ts
+ * import { LineStats } from "@beep/pretext"
+ *
+ * const stats = LineStats.make({ lineCount: 2, maxLineWidth: 180 })
+ *
+ * console.log(stats.maxLineWidth)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class LineStats extends S.Class<LineStats>($I`LineStats`)(
+  {
+    lineCount: NonNegativeLineCount,
+    maxLineWidth: NonNegativeAdvance,
+  },
+  $I.annote("LineStats", {
+    description: "Aggregate line count and maximum line width from a greedy text layout.",
+  })
+) {}
+
 const wordWidths = (metrics: FontMetrics, text: string): O.Option<ReadonlyArray<number>> =>
   O.all(A.map(Str.split(text, " "), (word) => R.get(metrics.words, word)));
 
@@ -244,6 +297,98 @@ export const naturalWidth: {
   (metrics: FontMetrics, text: string): O.Option<number> =>
     O.map(wordWidths(metrics, text), (widths) =>
       A.reduce(widths, 0, (total, width, index) => (index === 0 ? width : total + metrics.spaceWidth + width))
+    )
+);
+
+/**
+ * Greedy first-fit word ranges for `text` at `maxWidth`, computed purely from
+ * snapshot word widths. Returns `None` when any word is missing from the
+ * snapshot. Ranges use half-open word indices and omit trailing spaces from
+ * each line width.
+ *
+ * @example
+ * ```ts
+ * import { chromeLinuxArial16, lineRanges } from "@beep/pretext"
+ * import { Effect } from "effect"
+ * import * as O from "effect/Option"
+ *
+ * const metrics = Effect.runSync(chromeLinuxArial16).metrics
+ *
+ * const ranges = lineRanges(metrics, { text: "the the", maxWidth: 40 })
+ *
+ * console.log(O.isOption(ranges))
+ * ```
+ *
+ * @category utilities
+ * @since 0.0.0
+ */
+export const lineRanges: {
+  (metrics: FontMetrics, input: TextLayoutInput): O.Option<ReadonlyArray<LineRange>>;
+  (input: TextLayoutInput): (metrics: FontMetrics) => O.Option<ReadonlyArray<LineRange>>;
+} = dual(
+  2,
+  (metrics: FontMetrics, input: TextLayoutInput): O.Option<ReadonlyArray<LineRange>> =>
+    O.map(wordWidths(metrics, input.text), (widths) => {
+      const state = A.reduce(
+        widths,
+        { lines: 0, ranges: A.empty<LineRange>(), startWord: 0, width: 0 },
+        (state, wordWidth, index) => {
+          if (state.lines === 0) {
+            return { ...state, lines: 1, width: wordWidth };
+          }
+          const needed = state.width + metrics.spaceWidth + wordWidth;
+          return needed > input.maxWidth
+            ? {
+                lines: state.lines + 1,
+                ranges: A.append(
+                  state.ranges,
+                  LineRange.make({ startWord: state.startWord, endWord: index, width: state.width })
+                ),
+                startWord: index,
+                width: wordWidth,
+              }
+            : { ...state, width: needed };
+        }
+      );
+      return A.append(
+        state.ranges,
+        LineRange.make({ startWord: state.startWord, endWord: A.length(widths), width: state.width })
+      );
+    })
+);
+
+/**
+ * Aggregate greedy line geometry for `text` at `maxWidth`, derived from
+ * {@link lineRanges}. Returns `None` when any word is missing from the
+ * snapshot.
+ *
+ * @example
+ * ```ts
+ * import { chromeLinuxArial16, lineStats } from "@beep/pretext"
+ * import { Effect } from "effect"
+ * import * as O from "effect/Option"
+ *
+ * const metrics = Effect.runSync(chromeLinuxArial16).metrics
+ *
+ * const stats = lineStats(metrics, { text: "the the", maxWidth: 40 })
+ *
+ * console.log(O.isOption(stats))
+ * ```
+ *
+ * @category utilities
+ * @since 0.0.0
+ */
+export const lineStats: {
+  (metrics: FontMetrics, input: TextLayoutInput): O.Option<LineStats>;
+  (input: TextLayoutInput): (metrics: FontMetrics) => O.Option<LineStats>;
+} = dual(
+  2,
+  (metrics: FontMetrics, input: TextLayoutInput): O.Option<LineStats> =>
+    O.map(lineRanges(metrics, input), (ranges) =>
+      LineStats.make({
+        lineCount: A.length(ranges),
+        maxLineWidth: A.reduce(ranges, 0, (maximum, range) => (range.width > maximum ? range.width : maximum)),
+      })
     )
 );
 

--- a/packages/drivers/pretext/test/Pretext.models.test.ts
+++ b/packages/drivers/pretext/test/Pretext.models.test.ts
@@ -3,6 +3,8 @@ import {
   chromeLinuxArial16Encoded,
   FontMetricsSnapshotV1,
   lineCount,
+  lineRanges,
+  lineStats,
   naturalWidth,
   TextLayoutInput,
   textHeight,
@@ -164,6 +166,58 @@ describe("pure layout helpers", () => {
       const snapshot = yield* chromeLinuxArial16;
 
       expect(lineCount(snapshot.metrics, TextLayoutInput.make({ maxWidth: 1, text: "slithers" }))).toEqual(O.some(1));
+    })
+  );
+
+  it.effect(
+    "lineStats line count matches lineCount across measured and missing words",
+    Effect.fnUntraced(function* () {
+      const snapshot = yield* chromeLinuxArial16;
+      const metrics = snapshot.metrics;
+      const inputs = [
+        TextLayoutInput.make({ maxWidth: 40, text: "The dragon slithers" }),
+        TextLayoutInput.make({ maxWidth: 100_000, text: "The dragon slithers" }),
+        TextLayoutInput.make({ maxWidth: 1, text: "slithers" }),
+      ];
+
+      for (const input of inputs) {
+        expect(O.map(lineStats(metrics, input), (stats) => stats.lineCount)).toEqual(lineCount(metrics, input));
+      }
+
+      const missing = TextLayoutInput.make({ maxWidth: 320, text: "unmeasured" });
+      expect(lineStats(metrics, missing)).toEqual(O.none());
+      expect(lineCount(metrics, missing)).toEqual(O.none());
+    })
+  );
+
+  it.effect(
+    "lineStats max width equals naturalWidth without forced wrapping",
+    Effect.fnUntraced(function* () {
+      const snapshot = yield* chromeLinuxArial16;
+      const text = "The dragon slithers across the page";
+
+      expect(O.map(lineStats(snapshot.metrics, { maxWidth: 100_000, text }), (stats) => stats.maxLineWidth)).toEqual(
+        naturalWidth(snapshot.metrics, text)
+      );
+    })
+  );
+
+  it.effect(
+    "lineRanges reports exact half-open word ranges and advances",
+    Effect.fnUntraced(function* () {
+      const snapshot = yield* chromeLinuxArial16;
+      const metrics = snapshot.metrics;
+
+      expect(lineRanges(metrics, { maxWidth: 90, text: "The dragon slithers" })).toEqual(
+        O.some([
+          {
+            startWord: 0,
+            endWord: 2,
+            width: metrics.words.The + metrics.spaceWidth + metrics.words.dragon,
+          },
+          { startWord: 2, endWord: 3, width: metrics.words.slithers },
+        ])
+      );
     })
   );
 

--- a/scratchpad/bubbles/Bubble.ts
+++ b/scratchpad/bubbles/Bubble.ts
@@ -1,0 +1,63 @@
+/**
+ * Schema-first chat-bubble shrinkwrap proof.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+import { $ScratchpadId } from "@beep/identity/packages";
+import { type FontMetrics, lineStats } from "@beep/pretext";
+import { LiteralKit, SchemaUtils } from "@beep/schema";
+import * as N from "effect/Number";
+import * as O from "effect/Option";
+import * as S from "effect/Schema";
+
+const $I = $ScratchpadId.create("bubbles/Bubble");
+
+const NonNegativeFinite = S.Finite.check(S.isGreaterThanOrEqualTo(0));
+
+/** Author of one chat message. */
+export const BubbleAuthor = LiteralKit(["user", "agent"]).annotate(
+  $I.annote("BubbleAuthor", { description: "Author role for a shrinkwrapped chat message." })
+);
+export type BubbleAuthor = typeof BubbleAuthor.Type;
+
+/** One schema-validated chat message. */
+export class ChatMessage extends S.Class<ChatMessage>($I`ChatMessage`)(
+  {
+    id: S.NonEmptyString,
+    author: BubbleAuthor,
+    text: S.String,
+  },
+  $I.annote("ChatMessage", { description: "A chat message whose text can be measured into a bubble." })
+) {}
+
+/** Width and padding constraints for bubble geometry. */
+export class BubbleConstraints extends S.Class<BubbleConstraints>($I`BubbleConstraints`)(
+  {
+    maxWidth: NonNegativeFinite,
+    padding: NonNegativeFinite.pipe(SchemaUtils.withConstantDefault<number>(0)),
+  },
+  $I.annote("BubbleConstraints", { description: "Maximum content width and surrounding bubble padding." })
+) {}
+
+/** Pure measured outer dimensions of one chat bubble. */
+export class BubbleBox extends S.Class<BubbleBox>($I`BubbleBox`)(
+  {
+    width: NonNegativeFinite,
+    height: NonNegativeFinite,
+  },
+  $I.annote("BubbleBox", { description: "Measured outer width and height of one chat bubble." })
+) {}
+
+/** Measure a chat bubble from a font snapshot, propagating unmeasured text as `None`. */
+export const bubbleBox = (
+  metrics: FontMetrics,
+  message: ChatMessage,
+  constraints: BubbleConstraints
+): O.Option<BubbleBox> =>
+  O.map(lineStats(metrics, { text: message.text, maxWidth: constraints.maxWidth }), (stats) =>
+    BubbleBox.make({
+      width: N.min(constraints.maxWidth, stats.maxLineWidth) + 2 * constraints.padding,
+      height: stats.lineCount * metrics.lineHeight + 2 * constraints.padding,
+    })
+  );

--- a/scratchpad/bubbles/README.md
+++ b/scratchpad/bubbles/README.md
@@ -1,0 +1,17 @@
+# Bubble shrinkwrap proof
+
+This module proves chat-bubble geometry can be computed from schema values.
+
+The checked-in `@beep/pretext` fixture supplies per-word font advances.
+`lineStats` turns those advances into greedy line count and widest-line data.
+`bubbleBox` adds schema-validated width constraints and padding.
+
+Short messages shrinkwrap to their measured content width.
+Long messages clamp to the configured content width and grow vertically.
+Unknown words return `Option.none` instead of guessed geometry.
+Padding defaults live in the schema rather than helper logic.
+Author roles are a `LiteralKit` domain and round-trip through Schema.
+
+Run: `bun test scratchpad/bubbles`
+
+See [`explorations/computable-workspace-geometry`](../../explorations/computable-workspace-geometry/README.md).

--- a/scratchpad/bubbles/bubbles.test.ts
+++ b/scratchpad/bubbles/bubbles.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { chromeLinuxArial16 } from "@beep/pretext";
+import { Effect } from "effect";
+import * as O from "effect/Option";
+import * as S from "effect/Schema";
+import { BubbleAuthor, bubbleBox, BubbleConstraints, ChatMessage } from "./Bubble.ts";
+
+const metrics = Effect.runSync(chromeLinuxArial16).metrics;
+
+describe("schema-first bubble shrinkwrap", () => {
+  test("a short message shrinkwraps below maxWidth from exact fixture arithmetic", () => {
+    const padding = 8;
+    const constraints = BubbleConstraints.make({ maxWidth: 200, padding });
+    const box = O.getOrThrow(
+      bubbleBox(metrics, ChatMessage.make({ id: "short", author: "user", text: "The dragon" }), constraints)
+    );
+    const contentWidth = metrics.words.The + metrics.spaceWidth + metrics.words.dragon;
+
+    expect(box.width).toBe(contentWidth + 2 * padding);
+    expect(box.width).toBeLessThan(constraints.maxWidth + 2 * padding);
+    expect(box.height).toBe(metrics.lineHeight + 2 * padding);
+  });
+
+  test("a long message clamps width and grows height with line count", () => {
+    const padding = 8;
+    const constraints = BubbleConstraints.make({ maxWidth: 40, padding });
+    const box = O.getOrThrow(
+      bubbleBox(
+        metrics,
+        ChatMessage.make({ id: "long", author: "agent", text: "The dragon slithers across the page" }),
+        constraints
+      )
+    );
+
+    expect(box.width).toBe(constraints.maxWidth + 2 * padding);
+    expect(box.height).toBeGreaterThan(metrics.lineHeight + 2 * padding);
+  });
+
+  test("padding defaults to zero", () => {
+    const constraints = BubbleConstraints.make({ maxWidth: 200 });
+    const box = O.getOrThrow(
+      bubbleBox(metrics, ChatMessage.make({ id: "default", author: "user", text: "The" }), constraints)
+    );
+
+    expect(constraints.padding).toBe(0);
+    expect(box.width).toBe(metrics.words.The);
+    expect(box.height).toBe(metrics.lineHeight);
+  });
+
+  test("unmeasured text produces no bubble box", () => {
+    expect(
+      bubbleBox(
+        metrics,
+        ChatMessage.make({ id: "unknown", author: "agent", text: "unmeasured" }),
+        BubbleConstraints.make({ maxWidth: 200 })
+      )
+    ).toEqual(O.none());
+  });
+
+  test("author literals round-trip through the schema", () => {
+    const author = Effect.runSync(S.decodeUnknownEffect(BubbleAuthor)("agent"));
+
+    expect(Effect.runSync(S.encodeEffect(BubbleAuthor)(author))).toBe("agent");
+  });
+});

--- a/scratchpad/package.json
+++ b/scratchpad/package.json
@@ -7,6 +7,7 @@
     "@beep/identity": "workspace:^",
     "@beep/md": "workspace:^",
     "@beep/ontology": "workspace:^",
+    "@beep/pretext": "workspace:^",
     "@beep/schema": "workspace:^",
     "@beep/utils": "workspace:^",
     "@effect/platform-bun": "catalog:",

--- a/scratchpad/tsconfig.json
+++ b/scratchpad/tsconfig.json
@@ -14,6 +14,9 @@
   },
   "references": [
     {
+      "path": "../packages/drivers/pretext/tsconfig.json"
+    },
+    {
       "path": "../packages/foundation/modeling/identity/tsconfig.json"
     },
     {

--- a/standards/fallow.boundaries.generated.jsonc
+++ b/standards/fallow.boundaries.generated.jsonc
@@ -2603,6 +2603,7 @@
           "@beep/identity",
           "@beep/md",
           "@beep/ontology",
+          "@beep/pretext",
           "@beep/schema",
           "@beep/scratchpad",
           "@beep/utils"
@@ -2611,6 +2612,7 @@
           "@beep/identity",
           "@beep/md",
           "@beep/ontology",
+          "@beep/pretext",
           "@beep/schema",
           "@beep/scratchpad",
           "@beep/utils"


### PR DESCRIPTION
## feat(pretext): pure line-range and line-stats shrinkwrap helpers

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- full:pre-push: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/feat_pretext-line-stats-8c70bb7755a1/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786612130&installation_id=141092090&pr_number=399&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F399&signature=c495abba1ca04c5c8ff94aa3c80723d6aee0f0ac429b1434a64d5b0b9d1f6d74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->