### PR TITLE
docs(goals): harness-otel-adoption P0-P1 shipped, P2 verification live

### DIFF
--- a/goals/INDEX.md
+++ b/goals/INDEX.md
@@ -14,7 +14,7 @@ drifts from the manifests, and merge conflicts are resolved by regenerating.
 | [ai-metrics-stack](./ai-metrics-stack/README.md) | AI Metrics Stack | 6/8 | 2026-07-14 | — |
 | [file-processing-capability](./file-processing-capability/README.md) | File Processing Capability | 3/7 | 2026-07-14 | Define and implement a product-neutral schema-first file processing capability with driver-backed extraction and repo C… |
 | [harness-hygiene-mechanical](./harness-hygiene-mechanical/README.md) | Harness Hygiene Mechanical | 0/4 | 2026-07-14 | Delete the four zero-signal skills, evict volatile state from AGENTS.md's cache prefix, add the three agent-requested l… |
-| [harness-otel-adoption](./harness-otel-adoption/README.md) | Harness OTel Adoption | 0/4 | 2026-07-14 | Native Claude Code + Codex OTLP into dankserver's monitoring collector (traces to Phoenix, metrics to Prometheus/Grafan… |
+| [harness-otel-adoption](./harness-otel-adoption/README.md) | Harness OTel Adoption | 2/4 | 2026-07-14 | Native Claude Code + Codex OTLP into dankserver's monitoring collector (traces to Phoenix, metrics to Prometheus/Grafan… |
 | [legal-document-intake](./legal-document-intake/README.md) | Legal Document Intake | 4/8 | 2026-07-14 | — |
 | [professional-desktop-adversarial-qa](./professional-desktop-adversarial-qa/README.md) | Professional Desktop Adversarial QA | 1/5 | 2026-07-12 | Run adversarial QA and repair loops over the professional desktop surface until two consecutive rounds are clean. |
 | [semantic-foundation](./semantic-foundation/README.md) | Semantic Foundation | 0/6 | 2026-07-08 | — |

--- a/goals/harness-otel-adoption/README.md
+++ b/goals/harness-otel-adoption/README.md
@@ -34,12 +34,20 @@ Use this command for execution-capable sessions:
 
 ## Current Phase
 
-P0 Research — verify current Claude Code/Codex OTel config surfaces and the
-dankserver collector pipeline; decide the dual-ingestion precedence rule.
+P2 Verify — instrumentation is LIVE (2026-07-14): both harnesses export to
+the dankserver collector; traces land in Phoenix, attributed metrics in
+Prometheus. Remaining: one-day coverage-verification note vs transcripts,
+trace-payload content spot-check, then P3 close.
 
 ## Latest Evidence
 
-Not started. Graduated 2026-07-14 from
+[`history/p1-rollout-evidence.md`](./history/p1-rollout-evidence.md) —
+end-to-end live 2026-07-14: dankserver commit 3b22cac, tailnet route :8448,
+attributed metrics verified (`beep_goal_slug="harness-otel-adoption"` on
+real cost series). P0 research in
+[`research/p0-config-surfaces.md`](./research/p0-config-surfaces.md) +
+[`research/p0-attribute-contract.md`](./research/p0-attribute-contract.md).
+Graduated 2026-07-14 from
 [`explorations/agent-effectiveness-pulse`](../../explorations/agent-effectiveness-pulse/README.md)
 (pulse report: `research/pulse-report.md`; landscape:
 `research/2026-07-13-external-landscape.md`; decisions: DECISIONS.md

--- a/goals/harness-otel-adoption/SPEC.md
+++ b/goals/harness-otel-adoption/SPEC.md
@@ -74,13 +74,20 @@ Higher sources outrank lower sources when they conflict.
 - [ ] Slice 1: a real Claude Code session on this workstation produces traces
       visible in Phoenix carrying `repo` and `goal-slug` attributes, routed
       through the dankserver collector (not direct-to-Phoenix).
-- [ ] Codex sessions produce metrics visible in Grafana/Prometheus with the
-      same attribution attributes, for every execution mode in use.
+- [ ] Codex sessions produce metrics visible in Grafana/Prometheus
+      (service-level identity; per-repo/goal attribution on codex METRICS is
+      an accepted v1 gap — codex `span_attributes` is traces-only and static;
+      see `research/p0-attribute-contract.md` "Known gap"), for every
+      execution mode in use.
 - [ ] A written coverage-verification note compares one day of native
       telemetry against local transcripts (session counts, token totals
       within tolerance) and records gaps.
-- [ ] Attribute schema documented in `packages/tooling/library/ai-metrics`
-      with pinned semconv versions and the dual-ingestion precedence rule.
+- [ ] Attribute schema v1 documented with pinned emitter versions and the
+      dual-ingestion precedence rule (`research/p0-attribute-contract.md`;
+      amended 2026-07-14: the typed schema in
+      `packages/tooling/library/ai-metrics` is deliberately deferred until
+      the first in-code consumer — contract-by-documentation is the v1
+      deliverable).
 - [ ] Payload privacy check evidenced: emitted spans/metrics contain no
       prompt/response content.
 - [ ] No unrelated refactors or formatting churn.

--- a/goals/harness-otel-adoption/history/p1-rollout-evidence.md
+++ b/goals/harness-otel-adoption/history/p1-rollout-evidence.md
@@ -1,0 +1,59 @@
+# P1 rollout evidence — 2026-07-14
+
+## What shipped
+
+1. **dankserver repo** commit `3b22cac` (`kriegcloud/dankserver`, pushed to
+   main): `ansible/roles/monitoring/templates/otel-config.yaml.j2` gains an
+   `otlphttp/phoenix` traces exporter + traces pipeline and
+   `resource_to_telemetry_conversion` on the prometheus exporter;
+   `compose.yaml.j2` joins the collector to the external
+   `beep-ai-metrics-dankserver_default` network. Live host files were
+   hand-converged to the identical rendered content (backups:
+   `config.yaml.bak-20260714`, `compose.yaml.bak-20260714`) because the
+   ansible inventory targets the YubiKey-gated `dankserver-yubi` alias,
+   which cannot sign non-interactively. Next ansible run is a no-op
+   convergence.
+2. **Tailnet route**: `tailscale serve --bg --https=8448 http://127.0.0.1:4318`
+   on dankserver (tailnet-only). Verified: empty-POST to
+   `https://dankserver.tailc7c348.ts.net:8448/v1/traces` → 200.
+3. **Workstation** (backups `settings.json.bak-otel-20260714`,
+   `config.toml.bak-otel-20260714`):
+   - `~/.claude/settings.json` env: telemetry + enhanced-beta on, metrics +
+     traces OTLP → :8448, logs `none`, all four `OTEL_LOG_*` content flags
+     pinned `0`. `OTEL_RESOURCE_ATTRIBUTES` deliberately NOT set here — the
+     launcher wrapper owns it (avoids precedence conflicts).
+   - `~/.codex/config.toml` `[otel]`: metrics + trace otlp-http → :8448,
+     `exporter = "none"` (logs deferred), `log_user_prompt = false`, static
+     `span_attributes` (host + schema version). Config parse verified.
+   - `~/.zshrc` `claude()` wrapper (`beep-otel-attribution` block): stamps
+     `OTEL_RESOURCE_ATTRIBUTES` per session from git state
+     (`beep.repo/branch/task_class/goal_slug`, schema v1).
+
+## P2 verification (same day)
+
+- Claude Code live probe (`claude -p`, haiku): Phoenix `default` project
+  traceCount 1264 → 1300, endTime advanced to probe time; collector logs
+  clean.
+- Codex live probe (`codex exec`): codex metrics present — **exec-mode
+  coverage confirmed** on 0.144.4 (the mode flagged as a gap in older
+  versions).
+- Collector prometheus exporter serving **1,129** `claude_*`/`codex_*`
+  series; dankserver Prometheus scraping it (`up{job="openclaw"} == 1`).
+- **Attribution verified on real data**:
+  `claude_code_cost_usage_USD_total{beep_branch="goals/harness-otel-adoption-impl",
+  beep_goal_slug="harness-otel-adoption", beep_repo="beep-effect",
+  beep_task_class="goals", model="claude-haiku-4-5-20251001", ...}`.
+- Metric label sample contains no prompt/content fields.
+
+## Open P2 items (goal stays active)
+
+- One-day coverage-verification note: native telemetry vs local transcripts
+  (session counts, token totals) across interactive/companion codex modes
+  and normal Claude sessions — needs a day of real traffic.
+- Trace-payload content spot-check via Phoenix UI (GraphQL span-attribute
+  query shape differs on Phoenix 15.5; metric-label check was clean and all
+  content flags are off).
+- Polish: Phoenix project name for harness traces (currently lands in
+  `default`; a project header would separate it).
+- Polish: grafana dashboard for the new metrics; prometheus scrape job
+  rename from `openclaw` to something harness-neutral (cosmetic).

--- a/goals/harness-otel-adoption/ops/manifest.json
+++ b/goals/harness-otel-adoption/ops/manifest.json
@@ -47,17 +47,17 @@
     {
       "id": "P0",
       "name": "Research",
-      "status": "pending"
+      "status": "complete"
     },
     {
       "id": "P1",
       "name": "Implement",
-      "status": "pending"
+      "status": "complete"
     },
     {
       "id": "P2",
       "name": "Verify",
-      "status": "pending"
+      "status": "in-progress"
     },
     {
       "id": "P3",

--- a/goals/harness-otel-adoption/research/p0-attribute-contract.md
+++ b/goals/harness-otel-adoption/research/p0-attribute-contract.md
@@ -1,0 +1,84 @@
+# P0: beep attribute contract v1 + dual-ingestion precedence
+
+> Decided 2026-07-14 during P0. Companion to
+> [`p0-config-surfaces.md`](./p0-config-surfaces.md). This is the beep-owned
+> schema the SPEC requires; the eventual typed home is
+> `packages/tooling/library/ai-metrics` (added when the first consumer needs
+> it in code — v1 is contract-by-documentation).
+
+## Attribute schema v1 (pinned)
+
+Emitted as OTel resource attributes (Claude Code) / span attributes (Codex —
+see gap below). Namespaced under `beep.` to survive upstream GenAI-semconv
+churn; upstream conventions are development-stage, so nothing downstream may
+depend on non-`beep.` attribute names.
+
+| Attribute | Values | Source |
+|---|---|---|
+| `beep.repo` | checkout family (`beep-effect`, `beep-effect2`, …) | launcher wrapper, from `basename $(git rev-parse --show-toplevel)` |
+| `beep.branch` | current git branch | launcher wrapper |
+| `beep.task_class` | `feat` \| `fix` \| `goals` \| `chore` \| `explore` \| `other` | launcher wrapper, from branch prefix |
+| `beep.goal_slug` | `goals/<slug>` branch slug or empty | launcher wrapper, from branch |
+| `beep.schema_version` | `1` | static |
+| `host.name` | machine name | static (standard semconv) |
+
+Harness identity rides the standard `service.name` (Claude Code and Codex
+set their own); `environment` (Codex `[otel] environment`) stays `dev`.
+
+Cardinality rule: NO session ids, paths, or prompt-derived values in metric
+labels. `resource_to_telemetry_conversion` on the Prometheus exporter copies
+resource attributes onto datapoints — the table above is the complete
+allowed set.
+
+Emitter version pins (recorded at adoption): Claude Code 2.1.209 (traces
+beta), Codex CLI 0.144.4, otelcol-contrib 0.154.0.
+
+## Dynamic injection
+
+Static user-level config cannot know repo/branch/goal. A thin launcher
+wrapper (shell function) computes `OTEL_RESOURCE_ATTRIBUTES` from git state
+at invocation time for Claude Code. Codex: `span_attributes` is static
+user-level TOML — see gap.
+
+## Known gap: Codex metric/dynamic attribution
+
+Codex `span_attributes` (a) applies to traces only — metrics carry no custom
+attribution — and (b) is static user-scope config, so even trace attribution
+cannot vary per session/checkout without rewriting config.toml. v1 accepts:
+
+- Codex metrics: identified by `service.name` + `environment` only.
+- Codex traces: static machine-level attrs only.
+- Repo-level codex attribution continues to come from the transcript
+  pipeline (`session_meta.cwd`), which already does this well.
+
+Follow-up (recorded, not v1): upstream feature request for
+resource-attribute env passthrough, or collector-side enrichment keyed on
+something codex does emit.
+
+## Dual-ingestion precedence rule (decided)
+
+Two paths now produce overlapping data (native OTel vs transcript pipeline).
+Consumers are partitioned so nothing double-counts:
+
+| Consumer | Source of truth |
+|---|---|
+| Live dashboards (Grafana metrics, Phoenix traces) | **native OTel only** |
+| Weekly config-impact scorecards, DuckDB analytics, archives | **transcript pipeline only** (unchanged) |
+| Coverage verification (P2) | compares the two, reports drift — the only place both appear together |
+
+The transcript pipeline remains the analytical system of record (content
+depth, historical backfill, privacy-proofed archive). Native OTel is
+operational visibility. A future migration of scorecard inputs onto OTel
+data is explicitly out of scope for this goal (SPEC non-goal: no scorecard
+redesign).
+
+## Deployment note (discovered in P0)
+
+The dankserver monitoring stack is Ansible-managed from the `dankserver`
+repo (`ansible/roles/monitoring/templates/{otel-config.yaml.j2,
+compose.yaml.j2}`). Collector changes MUST land there and deploy through
+that repo's flow — hand-editing `/home/elpresidank/monitoring/otel/config.yaml`
+creates drift that the next ansible run erases. Traces fan-out additionally
+requires the collector container to join the external
+`beep-ai-metrics-dankserver_default` network, because Phoenix publishes
+6006 on host loopback only.

--- a/goals/harness-otel-adoption/research/p0-attribute-contract.md
+++ b/goals/harness-otel-adoption/research/p0-attribute-contract.md
@@ -18,7 +18,7 @@ depend on non-`beep.` attribute names.
 | `beep.repo` | checkout family (`beep-effect`, `beep-effect2`, …) | launcher wrapper, from `basename $(git rev-parse --show-toplevel)` |
 | `beep.branch` | current git branch | launcher wrapper |
 | `beep.task_class` | `feat` \| `fix` \| `goals` \| `chore` \| `explore` \| `other` | launcher wrapper, from branch prefix |
-| `beep.goal_slug` | `goals/<slug>` branch slug or empty | launcher wrapper, from branch |
+| `beep.goal_slug` | the branch path AFTER the `goals/` prefix, verbatim (e.g. branch `goals/harness-otel-adoption-impl` -> `harness-otel-adoption-impl`); empty for non-goals branches | launcher wrapper, from branch |
 | `beep.schema_version` | `1` | static |
 | `host.name` | machine name | static (standard semconv) |
 
@@ -29,6 +29,12 @@ Cardinality rule: NO session ids, paths, or prompt-derived values in metric
 labels. `resource_to_telemetry_conversion` on the Prometheus exporter copies
 resource attributes onto datapoints — the table above is the complete
 allowed set.
+
+Consumers should prefix-match goal slugs
+(`beep_goal_slug=~"<goal>.*"`) because implementation branches may carry
+suffixes. The 2026-07-14 live probe exported a manually normalized value
+(`harness-otel-adoption`); wrapper-emitted values are verbatim branch
+remainders.
 
 Emitter version pins (recorded at adoption): Claude Code 2.1.209 (traces
 beta), Codex CLI 0.144.4, otelcol-contrib 0.154.0.

--- a/goals/harness-otel-adoption/research/p0-config-surfaces.md
+++ b/goals/harness-otel-adoption/research/p0-config-surfaces.md
@@ -4,6 +4,11 @@ Verified against Claude Code 2.1.209 and Codex CLI 0.144.4 installed on this wor
 
 ## A. Claude Code config ready to paste
 
+> NOTE (post-review): in the deployed setup `OTEL_RESOURCE_ATTRIBUTES` is
+> NOT placed in settings.json — the `claude()` launcher wrapper computes and
+> exports it per session (see `p0-attribute-contract.md`). The line below
+> shows the canonical `beep.*` names for reference.
+
 Put this `env` object in user-level `~/.claude/settings.json`; user settings apply across projects. Project/local settings can override it, so `/status` should be checked during rollout. [Claude settings scopes](https://code.claude.com/docs/en/settings)
 
 ```json
@@ -17,7 +22,7 @@ Put this `env` object in user-level `~/.claude/settings.json`; user settings app
     "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
     "OTEL_EXPORTER_OTLP_ENDPOINT": "https://dankserver.tailc7c348.ts.net:<HTTPS_PORT>",
     "OTEL_EXPORTER_OTLP_HEADERS": "<key>=<value>",
-    "OTEL_RESOURCE_ATTRIBUTES": "repo=<repo>,branch=<branch>,goal-slug=<goal>,task-class=<class>,host.name=<machine>",
+    "OTEL_RESOURCE_ATTRIBUTES": "beep.repo=<repo>,beep.branch=<branch>,beep.goal_slug=<goal>,beep.task_class=<class>,beep.schema_version=1,host.name=<machine>",
     "OTEL_METRICS_INCLUDE_RESOURCE_ATTRIBUTES": "true",
     "OTEL_LOG_USER_PROMPTS": "0",
     "OTEL_LOG_TOOL_DETAILS": "0",
@@ -42,7 +47,7 @@ log_user_prompt = false
 exporter = "none" # logs deferred by this goal
 metrics_exporter = { otlp-http = { endpoint = "https://dankserver.tailc7c348.ts.net:<HTTPS_PORT>/v1/metrics", protocol = "binary", headers = {} } }
 trace_exporter = { otlp-http = { endpoint = "https://dankserver.tailc7c348.ts.net:<HTTPS_PORT>/v1/traces", protocol = "binary", headers = {} } }
-span_attributes = { repo = "<repo>", branch = "<branch>", "goal-slug" = "<goal>", "task-class" = "<class>", "host.name" = "<machine>" }
+span_attributes = { "host.name" = "<machine>", "beep.schema_version" = "1" } # static only; see p0-attribute-contract.md codex gap
 ```
 
 `otlp-http` requires an endpoint and `protocol = "binary"` or `"json"`; `otlp-grpc` is the alternative and has no `protocol` field. Headers are static literal TOML strings (no environment interpolation), with optional CA/client-certificate/client-key paths under `tls`. `environment` defaults to `dev`; `metrics_exporter` otherwise defaults to `statsig`. [Codex reference](https://learn.chatgpt.com/docs/config-file/config-reference) [Codex schema](https://github.com/openai/codex/blob/main/codex-rs/core/config.schema.json) [header interpolation limitation](https://github.com/openai/codex/issues/14465)

--- a/goals/harness-otel-adoption/research/p0-config-surfaces.md
+++ b/goals/harness-otel-adoption/research/p0-config-surfaces.md
@@ -1,0 +1,119 @@
+# P0: native harness OTel configuration surfaces (2026-07-14)
+
+Verified against Claude Code 2.1.209 and Codex CLI 0.144.4 installed on this workstation. The upstream references are the current Claude monitoring documentation, OpenAI configuration reference, and Codex `main` configuration schema. Pin at least these locally verified versions for rollout; upstream does not publish a single minimum version covering every surface below. Claude tracing remains beta even on 2.1.209. [Claude monitoring](https://code.claude.com/docs/en/monitoring-usage) [Codex reference](https://learn.chatgpt.com/docs/config-file/config-reference) [Codex schema](https://github.com/openai/codex/blob/main/codex-rs/core/config.schema.json)
+
+## A. Claude Code config ready to paste
+
+Put this `env` object in user-level `~/.claude/settings.json`; user settings apply across projects. Project/local settings can override it, so `/status` should be checked during rollout. [Claude settings scopes](https://code.claude.com/docs/en/settings)
+
+```json
+{
+  "env": {
+    "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
+    "CLAUDE_CODE_ENHANCED_TELEMETRY_BETA": "1",
+    "OTEL_METRICS_EXPORTER": "otlp",
+    "OTEL_LOGS_EXPORTER": "none",
+    "OTEL_TRACES_EXPORTER": "otlp",
+    "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
+    "OTEL_EXPORTER_OTLP_ENDPOINT": "https://dankserver.tailc7c348.ts.net:<HTTPS_PORT>",
+    "OTEL_EXPORTER_OTLP_HEADERS": "<key>=<value>",
+    "OTEL_RESOURCE_ATTRIBUTES": "repo=<repo>,branch=<branch>,goal-slug=<goal>,task-class=<class>,host.name=<machine>",
+    "OTEL_METRICS_INCLUDE_RESOURCE_ATTRIBUTES": "true",
+    "OTEL_LOG_USER_PROMPTS": "0",
+    "OTEL_LOG_TOOL_DETAILS": "0",
+    "OTEL_LOG_TOOL_CONTENT": "0",
+    "OTEL_LOG_RAW_API_BODIES": "0"
+  }
+}
+```
+
+Delete `OTEL_EXPORTER_OTLP_HEADERS` when Tailnet ACLs are the only authorization; otherwise its format is comma-separated `key=value`. A base OTLP/HTTP endpoint is correct: the SDK appends `/v1/traces`, `/v1/metrics`, and `/v1/logs`. `OTEL_RESOURCE_ATTRIBUTES` accepts custom comma-separated pairs, propagates them in the resource block, and by default copies them onto metric datapoints; high-cardinality values increase Prometheus cost. [Claude variables and attributes](https://code.claude.com/docs/en/monitoring-usage) [OTLP endpoint rules](https://opentelemetry.io/docs/specs/otel/protocol/exporter/)
+
+The static user block cannot discover repo/branch/goal/task. A launcher must compute and override `OTEL_RESOURCE_ATTRIBUTES` per session, or project-local Claude settings must provide fixed repo metadata. Otherwise a global placeholder/fixed value misattributes other checkouts. Claude supports project and local settings; the user file itself is machine-wide. [Claude configuration scopes](https://code.claude.com/docs/en/configuration)
+
+## B. Codex `config.toml` ready to paste
+
+Place this only in `~/.codex/config.toml`. Current Codex explicitly ignores `otel` in project `.codex/config.toml`, so telemetry routing is user/machine scoped. [Codex config scope](https://learn.chatgpt.com/docs/config-file/config-reference#configtoml)
+
+```toml
+[otel]
+environment = "dev"
+log_user_prompt = false
+exporter = "none" # logs deferred by this goal
+metrics_exporter = { otlp-http = { endpoint = "https://dankserver.tailc7c348.ts.net:<HTTPS_PORT>/v1/metrics", protocol = "binary", headers = {} } }
+trace_exporter = { otlp-http = { endpoint = "https://dankserver.tailc7c348.ts.net:<HTTPS_PORT>/v1/traces", protocol = "binary", headers = {} } }
+span_attributes = { repo = "<repo>", branch = "<branch>", "goal-slug" = "<goal>", "task-class" = "<class>", "host.name" = "<machine>" }
+```
+
+`otlp-http` requires an endpoint and `protocol = "binary"` or `"json"`; `otlp-grpc` is the alternative and has no `protocol` field. Headers are static literal TOML strings (no environment interpolation), with optional CA/client-certificate/client-key paths under `tls`. `environment` defaults to `dev`; `metrics_exporter` otherwise defaults to `statsig`. [Codex reference](https://learn.chatgpt.com/docs/config-file/config-reference) [Codex schema](https://github.com/openai/codex/blob/main/codex-rs/core/config.schema.json) [header interpolation limitation](https://github.com/openai/codex/issues/14465)
+
+Critical gap: `span_attributes` annotates every exported **trace span only**. The current schema has no general user-defined resource/metric-attribute map, so native Codex metrics cannot satisfy repo/branch/goal/task attribution from this block alone. Collector-side enrichment can add machine/static attributes, but dynamic per-session values require an upstream Codex feature or another correlation mechanism. [Codex schema](https://github.com/openai/codex/blob/main/codex-rs/core/config.schema.json)
+
+## C. Signals matrix
+
+| Harness | Metrics | Logs/events | Traces |
+|---|---|---|---|
+| Claude Code 2.1.209 | Supported | Supported; intentionally `none` here | **Beta**; requires both telemetry flags plus `OTEL_TRACES_EXPORTER` |
+| Codex CLI 0.144.4 | Supported via `metrics_exporter` | Supported via `exporter`; intentionally `none` here | Supported via `trace_exporter`; not marked experimental |
+
+Claude documents metrics, logs/events, and opt-in beta spans. Codex’s current reference/schema exposes independent exporters for all three. [Claude monitoring](https://code.claude.com/docs/en/monitoring-usage) [Codex reference](https://learn.chatgpt.com/docs/config-file/config-reference) [Codex schema](https://github.com/openai/codex/blob/main/codex-rs/core/config.schema.json)
+
+Codex 0.105.0 had confirmed mode gaps (`exec`: no metrics; `mcp-server`: no OTel). That issue is closed, but contains no linked fix; therefore 0.144.4 interactive, `exec`, resume, app-server/Desktop, and companion/background modes still require payload-level coverage tests before acceptance. [Codex issue #12913](https://github.com/openai/codex/issues/12913)
+
+## D. Content-capture flags and defaults
+
+Claude prompt, tool detail/content, and raw API body capture are all disabled by default; explicitly keeping all four flags at `0` makes the privacy intent auditable. Prompt text is redacted unless `OTEL_LOG_USER_PROMPTS=1`; tool arguments require `OTEL_LOG_TOOL_DETAILS=1`; trace tool bodies require `OTEL_LOG_TOOL_CONTENT=1`; full conversation bodies require `OTEL_LOG_RAW_API_BODIES=1` or `file:<dir>`. [Claude security/privacy](https://code.claude.com/docs/en/monitoring-usage#security-and-privacy)
+
+Codex `otel.log_user_prompt` is opt-in and defaults false in runtime behavior; set it explicitly false. No current Codex OTel setting offers response/tool-body capture, but sample payloads must still be inspected for event attributes before trust. [Codex reference](https://learn.chatgpt.com/docs/config-file/config-reference) [Codex schema](https://github.com/openai/codex/blob/main/codex-rs/core/config.schema.json)
+
+## E. Failure modes and scope
+
+Both configurations export this workstation’s local harness processes; neither filters telemetry by repository at the routing layer. Claude can override env per project/session, while Codex intentionally rejects project-local `otel`. Tailnet ACLs and collector processors are therefore the reliable machine/source boundary. [Claude scopes](https://code.claude.com/docs/en/configuration) [Codex scope](https://learn.chatgpt.com/docs/config-file/config-reference#configtoml)
+
+OTLP transient failures must retry with exponential backoff and jitter, and OTel exporters must not throw merely because the endpoint is unreachable. The client API should not block by default and should bound memory, which permits dropping telemetry under sustained outage; shutdown flushes may briefly block. Neither harness documents a durable disk spool or exact queue/retry horizon, so assume offline data can be lost and prove that an unavailable collector does not stall each pinned binary. Invalid startup configuration may still fail fast. [OTLP retry](https://opentelemetry.io/docs/specs/otel/protocol/exporter/#retry) [OTel error handling](https://opentelemetry.io/docs/specs/otel/error-handling/) [OTel performance](https://opentelemetry.io/docs/specs/otel/performance/)
+
+Claude defaults to 60 s metric and 5 s log/trace batch intervals. Avoid short debug intervals in steady state and control metric cardinality, especially session IDs and copied resource attributes. [Claude monitoring](https://code.claude.com/docs/en/monitoring-usage)
+
+## F. Collector fan-out sketch (otelcol-contrib 0.154.0)
+
+Tailscale Serve terminates the public Tailnet HTTPS connection and reverse-proxies plain HTTP to `127.0.0.1:4318`; the collector receiver therefore needs no TLS block. Use `tailscale serve --https=<HTTPS_PORT> http://127.0.0.1:4318`. Serve owns the certificate and adds protected Tailscale identity headers; normal OTLP headers still reach the HTTP backend. [Tailscale Serve CLI](https://tailscale.com/docs/reference/tailscale-cli/serve) [Serve identity headers](https://tailscale.com/docs/features/tailscale-serve#identity-headers)
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+processors:
+  batch: {}
+exporters:
+  otlphttp/phoenix:
+    traces_endpoint: http://127.0.0.1:6006/v1/traces
+  prometheus:
+    endpoint: 0.0.0.0:9464
+    send_timestamps: true
+    resource_to_telemetry_conversion:
+      enabled: true
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlphttp/phoenix]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheus]
+```
+
+OTLP/HTTP receiver paths default to `/v1/{traces,metrics,logs}`. [OTLP receiver](https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/README.md) The current dankserver topology already has Prometheus scrape the collector exporter on 9464, so `prometheus` is the minimal path. [managed collector template](https://github.com/kriegcloud/dankserver/blob/6459ab5a9f68802e357af4dc7d1dd5000fc2061c/ansible/roles/monitoring/templates/otel-config.yaml.j2) [managed Prometheus template](https://github.com/kriegcloud/dankserver/blob/6459ab5a9f68802e357af4dc7d1dd5000fc2061c/ansible/roles/monitoring/templates/prometheus.yml.j2)
+
+Alternative: `prometheus_remote_write` pushes to `http://prometheus:9090/api/v1/write`, but Prometheus must enable its remote-write receiver. It has its own queued retry (default queue 10,000) and optional WAL; delta/non-cumulative monotonic, histogram, and summary OTLP metrics can be dropped, so Claude’s default delta temporality makes the existing scrape exporter safer. [remote-write exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/prometheusremotewriteexporter/README.md)
+
+## G. Open questions
+
+1. Is Phoenix reachable from the collector container at `127.0.0.1:6006`? In Docker that normally means the collector container itself; verify host networking or replace it with a resolvable host/container address.
+2. What versioned beep attribute names and allowed values replace the provisional `repo`, `branch`, `goal-slug`, and `task-class` keys?
+3. How will Codex metrics receive dynamic attribution given the missing metric/resource attribute surface?
+4. Does Tailnet ACL identity alone suffice, allowing all static OTLP headers to be removed?
+5. Empirically record loss, shutdown delay, and mode coverage for both pinned binaries with the endpoint offline and restored.


### PR DESCRIPTION
## docs(goals): harness-otel-adoption P0-P1 shipped, P2 verification live

Native Claude Code + Codex OTel now flows to dankserver's monitoring
collector (traces to Phoenix, attributed metrics to Prometheus). Records P0
config-surface research and the beep attribute contract v1 with the
dual-ingestion precedence rule, plus P1 rollout evidence: dankserver
monitoring commit 3b22cac, tailscale route :8448, workstation harness
configs and the claude launcher wrapper. Live verification captured
attributed cost metrics (beep_goal_slug=harness-otel-adoption). Goal stays
active: one-day coverage note and trace-payload spot-check remain in P2.

## Local proof

- publish:git:push: passed

Verdict: .beep/yeet/runs/goals_harness-otel-adoption-impl-b976a11e50bd/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786619479&installation_id=141092090&pr_number=404&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F404&signature=d7083f4b13933d68bd05c8b3a6fcc410c8dbf448bb3590c4bc6b86d408d956ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->