### PR TITLE
feat(ontology): semantic foundation m1 - skos seed, taxonomy registry and fail-closed loader

### DIFF
--- a/.changeset/semantic-foundation-m1.md
+++ b/.changeset/semantic-foundation-m1.md
@@ -1,0 +1,8 @@
+---
+"@beep/identity": patch
+"@beep/ontology": patch
+---
+
+Add the identity-backed M1 legal-intake vocabulary, committed SKOS seed,
+schema-first taxonomy registry projections, and fail-closed vendor manifest
+loader with package-local librarian-loop proof.

--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -315,6 +315,7 @@ unasserted
 unbilled
 unbuilt
 Uncheckbox
+uncited
 unconfirmable
 undemonstrated
 Undemonstrated
@@ -342,6 +343,7 @@ unstarted
 unticked
 unticking
 untriaged
+unvetted
 unwired
 USPTO
 UTBMS
@@ -356,4 +358,3 @@ wkcbdgqqo
 Wyner
 yeet
 zazuko
-uncited

--- a/goals/INDEX.md
+++ b/goals/INDEX.md
@@ -31,7 +31,7 @@ drifts from the manifests, and merge conflicts are resolved by regenerating.
 | [professional-desktop-adversarial-qa](./professional-desktop-adversarial-qa/README.md) | Professional Desktop Adversarial QA | 1/5 | 2026-07-12 | Run adversarial QA and repair loops over the professional desktop surface until two consecutive rounds are clean. |
 | [projection-dispatch-core](./projection-dispatch-core/README.md) | Projection Dispatch Core | 0/4 | 2026-07-14 | Deliver one restart-safe accepted-record projection cycle with durable target isolation and a disposable authenticated … |
 | [secure-document-delivery](./secure-document-delivery/README.md) | Secure Document Delivery | 0/4 | 2026-07-14 | Deliver an incubated secure-document-delivery capability and authenticated desktop route, proven by one authorized fixt… |
-| [semantic-foundation](./semantic-foundation/README.md) | Semantic Foundation | 0/6 | 2026-07-08 | — |
+| [semantic-foundation](./semantic-foundation/README.md) | Semantic Foundation | 1/6 | 2026-07-14 | — |
 | [uspto-prosecution-read](./uspto-prosecution-read/README.md) | USPTO Prosecution Read | 0/4 | 2026-07-14 | Deliver the known-application provenance-bearing USPTO prosecution observation and deterministic four-vocabulary genera… |
 | [uspto-ptmnfee2-ingest](./uspto-ptmnfee2-ingest/README.md) | USPTO PTMNFEE2 Ingest | 0/4 | 2026-07-14 | Checksum-pin and atomically full-replace the weekly cumulative PTMNFEE2 release into typed native maintenance events an… |
 | [voice-composer-slice](./voice-composer-slice/README.md) | Voice Composer Slice | 0/4 | 2026-07-14 | Add all-device push-to-talk Moonshine dictation and manual, interruptible Kokoro read-aloud to the professional-desktop… |

--- a/goals/semantic-foundation/PLAN.md
+++ b/goals/semantic-foundation/PLAN.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Status: `pending`
+Status: `active`
 
 ## Sequencing
 
@@ -12,7 +12,7 @@ and which vocabularies deserve constants in `@beep/rdf`.
 
 | Phase | Status | Goal | Exit criteria |
 | --- | --- | --- | --- |
-| M1 Intake-Serving Semantic Seed | pending | Ship the repo-owned SKOS seed, document-class vocabulary, filing-path semantics, and `@beep/ontology` taxonomy registry/loader. | Sample document classification produces taxonomy concept, document class, filing path, and FOLIO-aligned concept IRI; repo proof is green or unrelated failures are documented. |
+| M1 Intake-Serving Semantic Seed | complete | Ship the repo-owned SKOS seed, document-class vocabulary, filing-path semantics, and `@beep/ontology` taxonomy registry/loader. | Sample document classification produces taxonomy concept, document class, filing path, and FOLIO-aligned concept IRI; repo proof is green or unrelated failures are documented. |
 | R1 Research Feed: FOLIO and Legal Vocab Alignment | pending | Decide which FOLIO/vendor slices are vetted for loader support and which alignments are `exactMatch` vs `closeMatch`. | Research report in `explorations/legal-ontology-landscape/research/` names loadable slices, licenses, and alignment confidence. |
 | R2 Research Feed: Classification Schemes | pending | Ground IPC/CPC/Nice edition strategy and constant eligibility. | Research report decides M2 seed boundaries, edition metadata, and whether `@beep/rdf` constants are warranted. |
 | R3 Research Feed: Docketing and Party Roles | pending | Ground deadline and role vocabularies without creating domain entities. | Research report separates enduring party identity from time-bounded legal role vocabulary and names M3 prerequisites. |
@@ -23,21 +23,21 @@ and which vocabularies deserve constants in `@beep/rdf`.
 
 ## M1 Work Items
 
-1. Inspect the current target surfaces and confirm the exact package-local
+1. [x] Inspect the current target surfaces and confirm the exact package-local
    paths for `@beep/rdf`, `@beep/ontology`, `@beep/identity`, and
    `@beep/semantic-web`.
-2. Define the repo-owned M1 taxonomy seed as SKOS TTL/JSON-LD data using
+2. [x] Define the repo-owned M1 taxonomy seed as SKOS TTL/JSON-LD data using
    `https://ns.beep.sh/` IRIs minted by `@beep/identity`.
-3. Model document-class vocabulary for `draft`, `redline`, `filed`,
+3. [x] Model document-class vocabulary for `draft`, `redline`, `filed`,
    `received`, `privileged`, and `extracted-child`.
-4. Add schema-first concept-scheme/taxonomy registry models and a loader
+4. [x] Add schema-first concept-scheme/taxonomy registry models and a loader
    service in `@beep/ontology`.
-5. Load committed seed data plus vetted gitignored vendor slices named by the
+5. [x] Load committed seed data plus vetted gitignored vendor slices named by the
    exploration asset-pack manifest; fail closed when the manifest is missing or
    a vendor slice is unvetted.
-6. Expose filing-path semantics for local vault plus Box mirror as vocabulary
+6. [x] Expose filing-path semantics for local vault plus Box mirror as vocabulary
    data and projection rules for consumers.
-7. Prove a fixture intake librarian classification loop that emits concept IRI,
+7. [x] Prove a fixture intake librarian classification loop that emits concept IRI,
    document class, and filing path without implementing the document slice.
 
 ## P4 Closeout Checklist

--- a/goals/semantic-foundation/README.md
+++ b/goals/semantic-foundation/README.md
@@ -37,14 +37,27 @@ Use this command for execution-capable sessions:
 
 ## Current Phase
 
-M1 Intake-Serving Semantic Seed. Next concrete action: implement the
-repo-owned SKOS taxonomy seed and the `@beep/ontology` taxonomy registry/loader
-surface described in [`SPEC.md`](./SPEC.md), using the legal exploration's
-research directory as feeder input rather than copying it into this packet.
+M1 Intake-Serving Semantic Seed is complete. M2-M4 remain gated; the next
+action is the operator-owned P3 verification and publish flow.
 
 ## Latest Evidence
 
-Not started.
+- `@beep/ontology`: 2 test files and 11 tests pass.
+- `@beep/identity`: 6 test files and 63 tests pass.
+- Ontology source/test and identity TypeScript project checks pass.
+- Effect function/import laws and fallow boundary configuration checks pass.
+- No vendor slice is live-wired: research names no slice `VETTED` for loading,
+  so package-local fixtures prove the fail-closed loader contract.
+- `config-sync:check` is green after the operator applied the single managed
+  change it actually required (`packages/foundation/modeling/ontology/docgen.json`);
+  the implementation lane's repo-wide 110-file sync attempt was a misfire and
+  its invalid blank-file edits were correctly restored.
+- R1 reconciliation caveat: the loader's `VendorManifestEntry` load-manifest
+  shape (`id`/`path`/`format:"jsonld"`/`loadStatus`) is intentionally narrower
+  than the exploration asset pack's fetch-metadata `manifest.jsonl`; pointing
+  the loader at the real manifest today fails closed with a parse error. R1
+  must either extend the asset-pack manifest with load fields or introduce a
+  dedicated load manifest before any live vendor slice is wired.
 
 ## Provenance Notes
 

--- a/goals/semantic-foundation/ops/manifest.json
+++ b/goals/semantic-foundation/ops/manifest.json
@@ -5,7 +5,7 @@
     "title": "Semantic Foundation",
     "status": "active",
     "created": "2026-07-08",
-    "updated": "2026-07-08",
+    "updated": "2026-07-14",
     "packetAnchorDocument": "SPEC.md"
   },
   "packetPath": "goals/semantic-foundation",
@@ -59,7 +59,7 @@
     {
       "id": "M1",
       "name": "Intake-Serving Semantic Seed",
-      "status": "pending"
+      "status": "complete"
     },
     {
       "id": "M2",

--- a/packages/foundation/modeling/identity/src/Vocab.ts
+++ b/packages/foundation/modeling/identity/src/Vocab.ts
@@ -445,3 +445,45 @@ export const mergeVocab: {
     extension: Extension
   ): <const Base extends VocabShape>(base: Base) => ReturnType<typeof mergeVocabImpl<Base, Extension>>;
 } = dual(2, mergeVocabImpl);
+
+/**
+ * Core vocabulary extended with repository-owned semantic-foundation terms.
+ *
+ * @example
+ * ```ts
+ * import { SemanticFoundationVocab } from "@beep/identity"
+ *
+ * console.log(SemanticFoundationVocab.beep.iri) // "https://ns.beep.sh/"
+ * console.log(SemanticFoundationVocab.beep.terms.includes("ontology/semantic-foundation")) // true
+ * ```
+ *
+ * @category constants
+ * @since 0.0.0
+ */
+export const SemanticFoundationVocab = mergeVocab(CoreVocab, {
+  beep: {
+    iri: "https://ns.beep.sh/",
+    terms: [
+      "ontology/semantic-foundation",
+      "ontology/semantic-foundation/taxonomy/legal-intake",
+      "ontology/semantic-foundation/filing-root/local-vault",
+      "ontology/semantic-foundation/filing-root/box-mirror",
+    ],
+  },
+});
+
+/**
+ * Runtime type for {@link SemanticFoundationVocab}.
+ *
+ * @example
+ * ```ts
+ * import { SemanticFoundationVocab, type SemanticFoundationVocab as SemanticFoundationVocabType } from "@beep/identity"
+ *
+ * const vocab: SemanticFoundationVocabType = SemanticFoundationVocab
+ * console.log(vocab.beep.iri)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export type SemanticFoundationVocab = typeof SemanticFoundationVocab;

--- a/packages/foundation/modeling/identity/src/packages.ts
+++ b/packages/foundation/modeling/identity/src/packages.ts
@@ -273,6 +273,21 @@ export const $RdfId: Identity.IdentityComposer<"@beep/rdf"> = composers.$RdfId;
 export const $OntologyId: Identity.IdentityComposer<"@beep/ontology"> = composers.$OntologyId;
 
 /**
+ * Identity composer for the semantic-foundation vocabulary under `@beep/ontology`.
+ *
+ * @example
+ * ```ts
+ * import { $SemanticFoundationId } from "@beep/identity/packages"
+ *
+ * console.log($SemanticFoundationId.iri) // "https://ns.beep.sh/ontology/semantic-foundation"
+ * ```
+ *
+ * @category configuration
+ * @since 0.0.0
+ */
+export const $SemanticFoundationId = $OntologyId.create("semantic-foundation");
+
+/**
  * Identity composer for the `@beep/types` package.
  *
  * @example

--- a/packages/foundation/modeling/identity/test/IriBinding.test.ts
+++ b/packages/foundation/modeling/identity/test/IriBinding.test.ts
@@ -1,5 +1,5 @@
 import { make } from "@beep/identity";
-import { $I, $OntologyId } from "@beep/identity/packages";
+import { $I, $OntologyId, $SemanticFoundationId } from "@beep/identity/packages";
 import * as S from "effect/Schema";
 import { describe, expect, expectTypeOf, it } from "vitest";
 import type { CurieFromIdentity, IriFromIdentity, SlugFromIdentifier } from "@beep/identity";
@@ -8,6 +8,10 @@ const getProperty = (value: unknown, key: PropertyKey): unknown =>
   value !== null && typeof value === "object" ? Reflect.get(value, key) : undefined;
 
 describe("@beep/identity IRI binding", () => {
+  it("binds the semantic foundation to the repository authority", () => {
+    expect($SemanticFoundationId.iri).toBe("https://ns.beep.sh/ontology/semantic-foundation");
+  });
+
   it("derives exact IRI and CURIE literals through create and compose chains", () => {
     const { $BeepId } = make("beep", { authority: "https://ns.beep.sh/", prefix: "beep" });
     const modules = $BeepId.compose("ontology", "schema");

--- a/packages/foundation/modeling/identity/test/Vocab.test.ts
+++ b/packages/foundation/modeling/identity/test/Vocab.test.ts
@@ -1,4 +1,4 @@
-import { CoreVocab, mergeVocab, VocabRegistry } from "@beep/identity";
+import { CoreVocab, mergeVocab, SemanticFoundationVocab, VocabRegistry } from "@beep/identity";
 import { describe, expect, it } from "@effect/vitest";
 import * as Equal from "effect/Equal";
 import * as O from "effect/Option";
@@ -39,6 +39,18 @@ describe("Vocab literal types", () => {
 
     expectTypeOf<Curie<typeof extended>>().toEqualTypeOf<CoreCurie | "ex:Thing">();
     expect(extended.ex.terms).toEqual(["Thing"]);
+  });
+
+  it("extends the core registry with the repository semantic authority", () => {
+    expect(SemanticFoundationVocab.beep).toEqual({
+      iri: "https://ns.beep.sh/",
+      terms: [
+        "ontology/semantic-foundation",
+        "ontology/semantic-foundation/taxonomy/legal-intake",
+        "ontology/semantic-foundation/filing-root/local-vault",
+        "ontology/semantic-foundation/filing-root/box-mirror",
+      ],
+    });
   });
 });
 

--- a/packages/foundation/modeling/ontology/docgen.json
+++ b/packages/foundation/modeling/ontology/docgen.json
@@ -35,6 +35,418 @@
       "@beep/ontology/*": [
         "../../../../packages/foundation/modeling/ontology/src/*.ts"
       ],
+      "@beep/identity": [
+        "../../../../packages/foundation/modeling/identity/src/index.ts"
+      ],
+      "@beep/identity/*": [
+        "../../../../packages/foundation/modeling/identity/src/*.ts"
+      ],
+      "@beep/identity/packages": [
+        "../../../../packages/foundation/modeling/identity/src/packages.ts"
+      ],
+      "@beep/rdf": [
+        "../../../../packages/foundation/modeling/rdf/src/index.ts"
+      ],
+      "@beep/rdf/*": ["../../../../packages/foundation/modeling/rdf/src/*.ts"],
+      "@beep/schema": [
+        "../../../../packages/foundation/modeling/schema/src/index.ts"
+      ],
+      "@beep/schema/AbortSignal": [
+        "../../../../packages/foundation/modeling/schema/src/AbortSignal.ts"
+      ],
+      "@beep/schema/Age": [
+        "../../../../packages/foundation/modeling/schema/src/Age/index.ts"
+      ],
+      "@beep/schema/ArrayOf": [
+        "../../../../packages/foundation/modeling/schema/src/ArrayOf.ts"
+      ],
+      "@beep/schema/AtURI": [
+        "../../../../packages/foundation/modeling/schema/src/AtURI.ts"
+      ],
+      "@beep/schema/BigDecimal": [
+        "../../../../packages/foundation/modeling/schema/src/BigDecimal.ts"
+      ],
+      "@beep/schema/BinaryFileExtension": [
+        "../../../../packages/foundation/modeling/schema/src/BinaryFileExtension.ts"
+      ],
+      "@beep/schema/BufferEncoding": [
+        "../../../../packages/foundation/modeling/schema/src/BufferEncoding.ts"
+      ],
+      "@beep/schema/Bytes": [
+        "../../../../packages/foundation/modeling/schema/src/Bytes.ts"
+      ],
+      "@beep/schema/CardinalDirection": [
+        "../../../../packages/foundation/modeling/schema/src/CardinalDirection/index.ts"
+      ],
+      "@beep/schema/CauseTaggedError": [
+        "../../../../packages/foundation/modeling/schema/src/CauseTaggedError/index.ts"
+      ],
+      "@beep/schema/Color": [
+        "../../../../packages/foundation/modeling/schema/src/Color/index.ts"
+      ],
+      "@beep/schema/CommonTextSchemas": [
+        "../../../../packages/foundation/modeling/schema/src/CommonTextSchemas.ts"
+      ],
+      "@beep/schema/CrossOriginEmbedderPolicy": [
+        "../../../../packages/foundation/modeling/schema/src/CrossOriginEmbedderPolicy/index.ts"
+      ],
+      "@beep/schema/CrossOriginOpenerPolicy": [
+        "../../../../packages/foundation/modeling/schema/src/CrossOriginOpenerPolicy/index.ts"
+      ],
+      "@beep/schema/CrossOriginResourcePolicy": [
+        "../../../../packages/foundation/modeling/schema/src/CrossOriginResourcePolicy/index.ts"
+      ],
+      "@beep/schema/CryptoTxnHash": [
+        "../../../../packages/foundation/modeling/schema/src/CryptoTxnHash/index.ts"
+      ],
+      "@beep/schema/CryptoWalletAddress": [
+        "../../../../packages/foundation/modeling/schema/src/CryptoWalletAddress/index.ts"
+      ],
+      "@beep/schema/Csp": [
+        "../../../../packages/foundation/modeling/schema/src/Csp/index.ts"
+      ],
+      "@beep/schema/Csv": [
+        "../../../../packages/foundation/modeling/schema/src/Csv/index.ts"
+      ],
+      "@beep/schema/CsvCodecOptions": [
+        "../../../../packages/foundation/modeling/schema/src/CsvCodecOptions/index.ts"
+      ],
+      "@beep/schema/CsvError": [
+        "../../../../packages/foundation/modeling/schema/src/CsvError/index.ts"
+      ],
+      "@beep/schema/CsvFormatter": [
+        "../../../../packages/foundation/modeling/schema/src/CsvFormatter/index.ts"
+      ],
+      "@beep/schema/CsvParser": [
+        "../../../../packages/foundation/modeling/schema/src/CsvParser/index.ts"
+      ],
+      "@beep/schema/Cuid": [
+        "../../../../packages/foundation/modeling/schema/src/Cuid.ts"
+      ],
+      "@beep/schema/ContinentCode": [
+        "../../../../packages/foundation/modeling/schema/src/ContinentCode.ts"
+      ],
+      "@beep/schema/ContinentName": [
+        "../../../../packages/foundation/modeling/schema/src/ContinentName.ts"
+      ],
+      "@beep/schema/CountryCode": [
+        "../../../../packages/foundation/modeling/schema/src/CountryCode.ts"
+      ],
+      "@beep/schema/CountryName": [
+        "../../../../packages/foundation/modeling/schema/src/CountryName.ts"
+      ],
+      "@beep/schema/CurrencyCode": [
+        "../../../../packages/foundation/modeling/schema/src/CurrencyCode.ts"
+      ],
+      "@beep/schema/DateTimeUtcFromValid": [
+        "../../../../packages/foundation/modeling/schema/src/DateTimeUtcFromValid/index.ts"
+      ],
+      "@beep/schema/Did": [
+        "../../../../packages/foundation/modeling/schema/src/Did.ts"
+      ],
+      "@beep/schema/Double": [
+        "../../../../packages/foundation/modeling/schema/src/Double.ts"
+      ],
+      "@beep/schema/DomCssProperties": [
+        "../../../../packages/foundation/modeling/schema/src/DomCssProperties/index.ts"
+      ],
+      "@beep/schema/DomDragEvent": [
+        "../../../../packages/foundation/modeling/schema/src/DomDragEvent/index.ts"
+      ],
+      "@beep/schema/DomEvent": [
+        "../../../../packages/foundation/modeling/schema/src/DomEvent/index.ts"
+      ],
+      "@beep/schema/DomHtmlElement": [
+        "../../../../packages/foundation/modeling/schema/src/DomHtmlElement/index.ts"
+      ],
+      "@beep/schema/DomMouseEvent": [
+        "../../../../packages/foundation/modeling/schema/src/DomMouseEvent/index.ts"
+      ],
+      "@beep/schema/DomReactNode": [
+        "../../../../packages/foundation/modeling/schema/src/DomReactNode/index.ts"
+      ],
+      "@beep/schema/DomainModel": [
+        "../../../../packages/foundation/modeling/schema/src/DomainModel.ts"
+      ],
+      "@beep/schema/Duration": [
+        "../../../../packages/foundation/modeling/schema/src/Duration/index.ts"
+      ],
+      "@beep/schema/EffectSchema": [
+        "../../../../packages/foundation/modeling/schema/src/EffectSchema.ts"
+      ],
+      "@beep/schema/Email": [
+        "../../../../packages/foundation/modeling/schema/src/Email.ts"
+      ],
+      "@beep/schema/EntitySchema": [
+        "../../../../packages/foundation/modeling/schema/src/EntitySchema/index.ts"
+      ],
+      "@beep/schema/EthAmount": [
+        "../../../../packages/foundation/modeling/schema/src/EthAmount/index.ts"
+      ],
+      "@beep/schema/EthereumValidatorPublicKey": [
+        "../../../../packages/foundation/modeling/schema/src/EthereumValidatorPublicKey/index.ts"
+      ],
+      "@beep/schema/EvmAddress": [
+        "../../../../packages/foundation/modeling/schema/src/EvmAddress/index.ts"
+      ],
+      "@beep/schema/ExpectCt": [
+        "../../../../packages/foundation/modeling/schema/src/ExpectCt/index.ts"
+      ],
+      "@beep/schema/FileExtension": [
+        "../../../../packages/foundation/modeling/schema/src/FileExtension.ts"
+      ],
+      "@beep/schema/FileName": [
+        "../../../../packages/foundation/modeling/schema/src/FileName.ts"
+      ],
+      "@beep/schema/FilePath": [
+        "../../../../packages/foundation/modeling/schema/src/FilePath/index.ts"
+      ],
+      "@beep/schema/Fixed32": [
+        "../../../../packages/foundation/modeling/schema/src/Fixed32.ts"
+      ],
+      "@beep/schema/Fixed64": [
+        "../../../../packages/foundation/modeling/schema/src/Fixed64.ts"
+      ],
+      "@beep/schema/Float": [
+        "../../../../packages/foundation/modeling/schema/src/Float.ts"
+      ],
+      "@beep/schema/Float16Array": [
+        "../../../../packages/foundation/modeling/schema/src/Float16Array.ts"
+      ],
+      "@beep/schema/Float32Array": [
+        "../../../../packages/foundation/modeling/schema/src/Float32Array.ts"
+      ],
+      "@beep/schema/Float64Array": [
+        "../../../../packages/foundation/modeling/schema/src/Float64Array.ts"
+      ],
+      "@beep/schema/Fn": [
+        "../../../../packages/foundation/modeling/schema/src/Fn/index.ts"
+      ],
+      "@beep/schema/ForceHttpsRedirect": [
+        "../../../../packages/foundation/modeling/schema/src/ForceHttpsRedirect/index.ts"
+      ],
+      "@beep/schema/FrameGuard": [
+        "../../../../packages/foundation/modeling/schema/src/FrameGuard/index.ts"
+      ],
+      "@beep/schema/Glob": [
+        "../../../../packages/foundation/modeling/schema/src/Glob/index.ts"
+      ],
+      "@beep/schema/Graph": [
+        "../../../../packages/foundation/modeling/schema/src/Graph/index.ts"
+      ],
+      "@beep/schema/Html": [
+        "../../../../packages/foundation/modeling/schema/src/Html.ts"
+      ],
+      "@beep/schema/HttpHeaders": [
+        "../../../../packages/foundation/modeling/schema/src/HttpHeaders/index.ts"
+      ],
+      "@beep/schema/HttpMethod": [
+        "../../../../packages/foundation/modeling/schema/src/HttpMethod/index.ts"
+      ],
+      "@beep/schema/HttpProtocol": [
+        "../../../../packages/foundation/modeling/schema/src/HttpProtocol/index.ts"
+      ],
+      "@beep/schema/HttpStatus": [
+        "../../../../packages/foundation/modeling/schema/src/HttpStatus/index.ts"
+      ],
+      "@beep/schema/Int": [
+        "../../../../packages/foundation/modeling/schema/src/Int.ts"
+      ],
+      "@beep/schema/Json": [
+        "../../../../packages/foundation/modeling/schema/src/Json.ts"
+      ],
+      "@beep/schema/Jsonc": [
+        "../../../../packages/foundation/modeling/schema/src/Jsonc.ts"
+      ],
+      "@beep/schema/Jsonl": [
+        "../../../../packages/foundation/modeling/schema/src/Jsonl.ts"
+      ],
+      "@beep/schema/KebabStr": [
+        "../../../../packages/foundation/modeling/schema/src/KebabStr.ts"
+      ],
+      "@beep/schema/LiteralKit": [
+        "../../../../packages/foundation/modeling/schema/src/LiteralKit/index.ts"
+      ],
+      "@beep/schema/LocalDate": [
+        "../../../../packages/foundation/modeling/schema/src/LocalDate/index.ts"
+      ],
+      "@beep/schema/Logs": [
+        "../../../../packages/foundation/modeling/schema/src/Logs.ts"
+      ],
+      "@beep/schema/MappedLiteralKit": [
+        "../../../../packages/foundation/modeling/schema/src/MappedLiteralKit/index.ts"
+      ],
+      "@beep/schema/Markdown": [
+        "../../../../packages/foundation/modeling/schema/src/Markdown.ts"
+      ],
+      "@beep/schema/MimeType": [
+        "../../../../packages/foundation/modeling/schema/src/MimeType.ts"
+      ],
+      "@beep/schema/Model": [
+        "../../../../packages/foundation/modeling/schema/src/Model/index.ts"
+      ],
+      "@beep/schema/MutableHashMap": [
+        "../../../../packages/foundation/modeling/schema/src/MutableHashMap.ts"
+      ],
+      "@beep/schema/MutableHashSet": [
+        "../../../../packages/foundation/modeling/schema/src/MutableHashSet.ts"
+      ],
+      "@beep/schema/NoOpen": [
+        "../../../../packages/foundation/modeling/schema/src/NoOpen/index.ts"
+      ],
+      "@beep/schema/NoSniff": [
+        "../../../../packages/foundation/modeling/schema/src/NoSniff/index.ts"
+      ],
+      "@beep/schema/Number": [
+        "../../../../packages/foundation/modeling/schema/src/Number.ts"
+      ],
+      "@beep/schema/Options": [
+        "../../../../packages/foundation/modeling/schema/src/Options.ts"
+      ],
+      "@beep/schema/ParserOptions": [
+        "../../../../packages/foundation/modeling/schema/src/ParserOptions/index.ts"
+      ],
+      "@beep/schema/PascalStr": [
+        "../../../../packages/foundation/modeling/schema/src/PascalStr.ts"
+      ],
+      "@beep/schema/Percentage": [
+        "../../../../packages/foundation/modeling/schema/src/Percentage.ts"
+      ],
+      "@beep/schema/PermissionsPolicy": [
+        "../../../../packages/foundation/modeling/schema/src/PermissionsPolicy/index.ts"
+      ],
+      "@beep/schema/PermittedCrossDomainPolicies": [
+        "../../../../packages/foundation/modeling/schema/src/PermittedCrossDomainPolicies/index.ts"
+      ],
+      "@beep/schema/Port": [
+        "../../../../packages/foundation/modeling/schema/src/Port.ts"
+      ],
+      "@beep/schema/PosixPath": [
+        "../../../../packages/foundation/modeling/schema/src/PosixPath.ts"
+      ],
+      "@beep/schema/Primitive": [
+        "../../../../packages/foundation/modeling/schema/src/Primitive.ts"
+      ],
+      "@beep/schema/PromiseSchema": [
+        "../../../../packages/foundation/modeling/schema/src/PromiseSchema.ts"
+      ],
+      "@beep/schema/Record": [
+        "../../../../packages/foundation/modeling/schema/src/Record/index.ts"
+      ],
+      "@beep/schema/ReferrerPolicy": [
+        "../../../../packages/foundation/modeling/schema/src/ReferrerPolicy/index.ts"
+      ],
+      "@beep/schema/RegExp": [
+        "../../../../packages/foundation/modeling/schema/src/RegExp.ts"
+      ],
+      "@beep/schema/SchemaUtils": [
+        "../../../../packages/foundation/modeling/schema/src/SchemaUtils/index.ts"
+      ],
+      "@beep/schema/SecureHeader": [
+        "../../../../packages/foundation/modeling/schema/src/SecureHeader/index.ts"
+      ],
+      "@beep/schema/SecureHeaderError": [
+        "../../../../packages/foundation/modeling/schema/src/SecureHeaderError/index.ts"
+      ],
+      "@beep/schema/SecureHeaderOptions": [
+        "../../../../packages/foundation/modeling/schema/src/SecureHeaderOptions/index.ts"
+      ],
+      "@beep/schema/SemanticVersion": [
+        "../../../../packages/foundation/modeling/schema/src/SemanticVersion.ts"
+      ],
+      "@beep/schema/Semver": [
+        "../../../../packages/foundation/modeling/schema/src/Semver.ts"
+      ],
+      "@beep/schema/SeverityLevel": [
+        "../../../../packages/foundation/modeling/schema/src/SeverityLevel.ts"
+      ],
+      "@beep/schema/Sex": [
+        "../../../../packages/foundation/modeling/schema/src/Sex/index.ts"
+      ],
+      "@beep/schema/Sha256": [
+        "../../../../packages/foundation/modeling/schema/src/Sha256.ts"
+      ],
+      "@beep/schema/Sfixed32": [
+        "../../../../packages/foundation/modeling/schema/src/Sfixed32.ts"
+      ],
+      "@beep/schema/Sfixed64": [
+        "../../../../packages/foundation/modeling/schema/src/Sfixed64.ts"
+      ],
+      "@beep/schema/Sint32": [
+        "../../../../packages/foundation/modeling/schema/src/Sint32.ts"
+      ],
+      "@beep/schema/Sint64": [
+        "../../../../packages/foundation/modeling/schema/src/Sint64.ts"
+      ],
+      "@beep/schema/Slug": [
+        "../../../../packages/foundation/modeling/schema/src/Slug.ts"
+      ],
+      "@beep/schema/SnakeStr": [
+        "../../../../packages/foundation/modeling/schema/src/SnakeStr.ts"
+      ],
+      "@beep/schema/StatusCauseError": [
+        "../../../../packages/foundation/modeling/schema/src/StatusCauseError.ts"
+      ],
+      "@beep/schema/StatusCauseTaggedErrorClass": [
+        "../../../../packages/foundation/modeling/schema/src/StatusCauseTaggedErrorClass/index.ts"
+      ],
+      "@beep/schema/String": [
+        "../../../../packages/foundation/modeling/schema/src/String.ts"
+      ],
+      "@beep/schema/TaggedErrorClass": [
+        "../../../../packages/foundation/modeling/schema/src/TaggedErrorClass/index.ts"
+      ],
+      "@beep/schema/Thunk": [
+        "../../../../packages/foundation/modeling/schema/src/Thunk.ts"
+      ],
+      "@beep/schema/TerritoryCode": [
+        "../../../../packages/foundation/modeling/schema/src/TerritoryCode.ts"
+      ],
+      "@beep/schema/TerritoryName": [
+        "../../../../packages/foundation/modeling/schema/src/TerritoryName.ts"
+      ],
+      "@beep/schema/Timestamp": [
+        "../../../../packages/foundation/modeling/schema/src/Timestamp/index.ts"
+      ],
+      "@beep/schema/Timezone": [
+        "../../../../packages/foundation/modeling/schema/src/Timezone.ts"
+      ],
+      "@beep/schema/Toml": [
+        "../../../../packages/foundation/modeling/schema/src/Toml.ts"
+      ],
+      "@beep/schema/Transformations": [
+        "../../../../packages/foundation/modeling/schema/src/Transformations.ts"
+      ],
+      "@beep/schema/URL": [
+        "../../../../packages/foundation/modeling/schema/src/URL.ts"
+      ],
+      "@beep/schema/UnitInterval": [
+        "../../../../packages/foundation/modeling/schema/src/UnitInterval.ts"
+      ],
+      "@beep/schema/Uint32": [
+        "../../../../packages/foundation/modeling/schema/src/Uint32.ts"
+      ],
+      "@beep/schema/Uint64": [
+        "../../../../packages/foundation/modeling/schema/src/Uint64.ts"
+      ],
+      "@beep/schema/VariantSchema": [
+        "../../../../packages/foundation/modeling/schema/src/VariantSchema/index.ts"
+      ],
+      "@beep/schema/Xml": [
+        "../../../../packages/foundation/modeling/schema/src/Xml.ts"
+      ],
+      "@beep/schema/XssProtection": [
+        "../../../../packages/foundation/modeling/schema/src/XssProtection/index.ts"
+      ],
+      "@beep/schema/Yaml": [
+        "../../../../packages/foundation/modeling/schema/src/Yaml.ts"
+      ],
+      "@beep/schema/test/Markdown": [
+        "../../../../packages/foundation/modeling/schema/src/internal/test/Markdown.test-kit.ts"
+      ],
+      "@beep/schema/test/Yaml": [
+        "../../../../packages/foundation/modeling/schema/src/internal/test/Yaml.test-kit.ts"
+      ],
       "@beep/test-utils": [
         "../../../../packages/tooling/test-kit/test-utils/src/index.ts"
       ],

--- a/packages/foundation/modeling/ontology/package.json
+++ b/packages/foundation/modeling/ontology/package.json
@@ -40,6 +40,8 @@
   },
   "files": [
     "src/**/*.ts",
+    "src/**/*.ttl",
+    "src/**/*.jsonld",
     "dist/**/*.js",
     "dist/**/*.js.map",
     "dist/**/*.d.ts",
@@ -57,6 +59,9 @@
     }
   },
   "dependencies": {
+    "@beep/identity": "workspace:^",
+    "@beep/rdf": "workspace:^",
+    "@beep/schema": "workspace:^",
     "effect": "catalog:"
   },
   "devDependencies": {

--- a/packages/foundation/modeling/ontology/src/SemanticFoundation.models.ts
+++ b/packages/foundation/modeling/ontology/src/SemanticFoundation.models.ts
@@ -8,9 +8,79 @@
 import { $OntologyId } from "@beep/identity/packages";
 import { IRIReference } from "@beep/rdf";
 import { LiteralKit } from "@beep/schema";
+import * as P from "effect/Predicate";
 import * as S from "effect/Schema";
+import * as Str from "effect/String";
 
 const $I = $OntologyId.create("SemanticFoundation.models");
+
+const isSafeFilingSegment = (segment: string): boolean =>
+  segment !== "." &&
+  segment !== ".." &&
+  P.not(Str.includes("/"))(segment) &&
+  P.not(Str.includes("\\"))(segment) &&
+  P.not(Str.includes("\u0000"))(segment);
+
+/**
+ * A single safe path component for projected filing paths: no separators,
+ * no dot traversal, no NUL bytes. Every value that is later joined into a
+ * vault or Box mirror path must pass this check, so path traversal is
+ * rejected at decode time instead of reaching a storage adapter.
+ *
+ * @example
+ * ```ts
+ * import { FilingSegment } from "@beep/ontology/SemanticFoundation.models"
+ * import * as S from "effect/Schema"
+ *
+ * console.log(S.decodeUnknownResult(FilingSegment)("../escape")._tag) // "Failure"
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const FilingSegment = S.NonEmptyString.check(
+  S.makeFilter(isSafeFilingSegment, {
+    identifier: $I`FilingSegmentCheck`,
+    title: "Filing Segment",
+    description: "A single path component without separators, dot traversal, or NUL bytes.",
+    message: "Filing segment must be a single safe path component",
+  })
+).pipe(
+  $I.annoteSchema("FilingSegment", {
+    description: "A single safe path component used when projecting filing paths.",
+  })
+);
+
+/**
+ * Runtime type for {@link FilingSegment}.
+ *
+ * @example
+ * ```ts
+ * import type { FilingSegment } from "@beep/ontology/SemanticFoundation.models"
+ *
+ * const segment: FilingSegment = "email-messages"
+ * console.log(segment)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export type FilingSegment = typeof FilingSegment.Type;
+
+/**
+ * Derived guard for {@link FilingSegment}.
+ *
+ * @example
+ * ```ts
+ * import { isFilingSegment } from "@beep/ontology/SemanticFoundation.models"
+ *
+ * console.log(isFilingSegment("received")) // true
+ * ```
+ *
+ * @category guards
+ * @since 0.0.0
+ */
+export const isFilingSegment = S.is(FilingSegment);
 
 /**
  * Exact document-class vocabulary locked by the M1 specification.
@@ -144,7 +214,7 @@ export class TaxonomyConcept extends S.Class<TaxonomyConcept>($I`TaxonomyConcept
     broader: S.Array(IRIReference),
     definition: S.NonEmptyString,
     documentClasses: S.Array(DocumentClass),
-    filingSegment: S.NonEmptyString,
+    filingSegment: FilingSegment,
     iri: IRIReference,
     prefLabel: S.NonEmptyString,
   },
@@ -199,7 +269,7 @@ export type FilingRootKind = typeof FilingRootKind.Type;
  * @since 0.0.0
  */
 export class FilingRoot extends S.Class<FilingRoot>($I`FilingRoot`)(
-  { iri: IRIReference, kind: FilingRootKind, rootSegment: S.NonEmptyString },
+  { iri: IRIReference, kind: FilingRootKind, rootSegment: FilingSegment },
   $I.annote("FilingRoot", { description: "Vocabulary data for a local or mirrored filing root." })
 ) {}
 
@@ -218,7 +288,7 @@ export class TaxonomySeed extends S.Class<TaxonomySeed>($I`TaxonomySeed`)(
   {
     concepts: S.Array(TaxonomyConcept),
     filingRoots: S.Array(FilingRoot),
-    pathTemplateSegments: S.Array(S.NonEmptyString),
+    pathTemplateSegments: S.Array(FilingSegment),
     schemeIri: IRIReference,
     title: S.NonEmptyString,
   },

--- a/packages/foundation/modeling/ontology/src/SemanticFoundation.models.ts
+++ b/packages/foundation/modeling/ontology/src/SemanticFoundation.models.ts
@@ -1,0 +1,226 @@
+/**
+ * Schema-first models for the intake-serving semantic foundation.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $OntologyId } from "@beep/identity/packages";
+import { IRIReference } from "@beep/rdf";
+import { LiteralKit } from "@beep/schema";
+import * as S from "effect/Schema";
+
+const $I = $OntologyId.create("SemanticFoundation.models");
+
+/**
+ * Exact document-class vocabulary locked by the M1 specification.
+ *
+ * @example
+ * ```ts
+ * import { DocumentClass } from "@beep/ontology/SemanticFoundation.models"
+ *
+ * console.log(DocumentClass.is.received("received")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const DocumentClass = LiteralKit([
+  "draft",
+  "redline",
+  "filed",
+  "received",
+  "privileged",
+  "extracted-child",
+]).pipe(
+  $I.annoteSchema("DocumentClass", {
+    description: "Lifecycle and handling class assigned to an intake document.",
+  })
+);
+
+/**
+ * Runtime type for {@link DocumentClass}.
+ *
+ * @example
+ * ```ts
+ * import type { DocumentClass } from "@beep/ontology/SemanticFoundation.models"
+ *
+ * const documentClass: DocumentClass = "received"
+ * console.log(documentClass)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export type DocumentClass = typeof DocumentClass.Type;
+
+/**
+ * Supported SKOS mapping relationship for a vetted external alignment.
+ *
+ * @example
+ * ```ts
+ * import { SkosMappingKind } from "@beep/ontology/SemanticFoundation.models"
+ *
+ * console.log(SkosMappingKind.is.closeMatch("closeMatch")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const SkosMappingKind = LiteralKit(["exactMatch", "closeMatch"]).pipe(
+  $I.annoteSchema("SkosMappingKind", {
+    description: "SKOS mapping predicate used for an externally vetted concept alignment.",
+  })
+);
+
+/**
+ * Runtime type for {@link SkosMappingKind}.
+ *
+ * @example
+ * ```ts
+ * import type { SkosMappingKind } from "@beep/ontology/SemanticFoundation.models"
+ *
+ * const kind: SkosMappingKind = "closeMatch"
+ * console.log(kind)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export type SkosMappingKind = typeof SkosMappingKind.Type;
+
+/**
+ * Vetted external mapping attached to a repo-owned SKOS concept.
+ *
+ * @example
+ * ```ts
+ * import { ConceptAlignment } from "@beep/ontology/SemanticFoundation.models"
+ * import { IRIReference } from "@beep/rdf"
+ *
+ * const alignment = ConceptAlignment.make({
+ *   conceptIri: IRIReference.make("https://folio.openlegalstandard.org/example"),
+ *   kind: "closeMatch",
+ *   sourceIri: IRIReference.make("https://openlegalstandard.org/resources/folio-python-library/taxonomy")
+ * })
+ * console.log(alignment.kind)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class ConceptAlignment extends S.Class<ConceptAlignment>($I`ConceptAlignment`)(
+  {
+    conceptIri: IRIReference,
+    kind: SkosMappingKind,
+    sourceIri: IRIReference,
+  },
+  $I.annote("ConceptAlignment", {
+    description: "Vetted external SKOS mapping metadata for a repo-owned concept.",
+  })
+) {}
+
+/**
+ * One repo-owned concept in an intake taxonomy scheme.
+ *
+ * @example
+ * ```ts
+ * import { TaxonomyConcept } from "@beep/ontology/SemanticFoundation.models"
+ * import { IRIReference } from "@beep/rdf"
+ *
+ * const concept = TaxonomyConcept.make({
+ *   alignments: [], broader: [], definition: "A legal document.", documentClasses: ["received"],
+ *   filingSegment: "legal-documents", iri: IRIReference.make("https://ns.beep.sh/ontology/semantic-foundation/concept/legal-document"),
+ *   prefLabel: "Legal document"
+ * })
+ * console.log(concept.prefLabel)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class TaxonomyConcept extends S.Class<TaxonomyConcept>($I`TaxonomyConcept`)(
+  {
+    alignments: S.Array(ConceptAlignment),
+    broader: S.Array(IRIReference),
+    definition: S.NonEmptyString,
+    documentClasses: S.Array(DocumentClass),
+    filingSegment: S.NonEmptyString,
+    iri: IRIReference,
+    prefLabel: S.NonEmptyString,
+  },
+  $I.annote("TaxonomyConcept", {
+    description: "One repository-owned SKOS concept with filing and document-class metadata.",
+  })
+) {}
+
+/**
+ * Storage root kind exposed as filing vocabulary data.
+ *
+ * @example
+ * ```ts
+ * import { FilingRootKind } from "@beep/ontology/SemanticFoundation.models"
+ *
+ * console.log(FilingRootKind.is["box-mirror"]("box-mirror")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const FilingRootKind = LiteralKit(["local-vault", "box-mirror"]).pipe(
+  $I.annoteSchema("FilingRootKind", {
+    description: "Kind of filing root described by the semantic registry.",
+  })
+);
+
+/** Runtime type for {@link FilingRootKind}.
+ * @example
+ * ```ts
+ * import type { FilingRootKind } from "@beep/ontology/SemanticFoundation.models"
+ * const kind: FilingRootKind = "local-vault"
+ * console.log(kind)
+ * ```
+ * @category models
+ * @since 0.0.0
+ */
+export type FilingRootKind = typeof FilingRootKind.Type;
+
+/**
+ * Filing root and path-template metadata exposed to downstream consumers.
+ *
+ * @example
+ * ```ts
+ * import { FilingRoot } from "@beep/ontology/SemanticFoundation.models"
+ * import { IRIReference } from "@beep/rdf"
+ *
+ * const root = FilingRoot.make({ iri: IRIReference.make("https://ns.beep.sh/ontology/semantic-foundation/filing-root/local-vault"), kind: "local-vault", rootSegment: "vault" })
+ * console.log(root.rootSegment)
+ * ```
+ * @category models
+ * @since 0.0.0
+ */
+export class FilingRoot extends S.Class<FilingRoot>($I`FilingRoot`)(
+  { iri: IRIReference, kind: FilingRootKind, rootSegment: S.NonEmptyString },
+  $I.annote("FilingRoot", { description: "Vocabulary data for a local or mirrored filing root." })
+) {}
+
+/**
+ * Complete schema-first taxonomy registry seed.
+ *
+ * @example
+ * ```ts
+ * import { SemanticFoundationSeed } from "@beep/ontology/SemanticFoundation.seed"
+ * console.log(SemanticFoundationSeed.concepts.length)
+ * ```
+ * @category models
+ * @since 0.0.0
+ */
+export class TaxonomySeed extends S.Class<TaxonomySeed>($I`TaxonomySeed`)(
+  {
+    concepts: S.Array(TaxonomyConcept),
+    filingRoots: S.Array(FilingRoot),
+    pathTemplateSegments: S.Array(S.NonEmptyString),
+    schemeIri: IRIReference,
+    title: S.NonEmptyString,
+  },
+  $I.annote("TaxonomySeed", { description: "A loadable SKOS taxonomy seed and its filing vocabulary metadata." })
+) {}

--- a/packages/foundation/modeling/ontology/src/SemanticFoundation.seed.ts
+++ b/packages/foundation/modeling/ontology/src/SemanticFoundation.seed.ts
@@ -1,0 +1,140 @@
+/**
+ * Repo-owned M1 legal-intake taxonomy seed.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $SemanticFoundationId } from "@beep/identity/packages";
+import { IRIReference } from "@beep/rdf";
+import { FilingRoot, TaxonomyConcept, TaxonomySeed } from "./SemanticFoundation.models.js";
+
+const scheme = $SemanticFoundationId.create("taxonomy/legal-intake");
+const concepts = $SemanticFoundationId.create("concept");
+const documentClasses = $SemanticFoundationId.create("document-class");
+const filingRoots = $SemanticFoundationId.create("filing-root");
+const iri = (value: string) => IRIReference.make(value);
+const legalDocumentIri = iri(concepts.create("legal-document").iri);
+const correspondenceIri = iri(concepts.create("correspondence").iri);
+
+/**
+ * Canonical IRI of the M1 legal-intake concept scheme.
+ *
+ * @example
+ * ```ts
+ * import { SemanticFoundationSchemeIri } from "@beep/ontology/SemanticFoundation.seed"
+ * console.log(SemanticFoundationSchemeIri)
+ * ```
+ * @category constants
+ * @since 0.0.0
+ */
+export const SemanticFoundationSchemeIri = iri(scheme.iri);
+
+/**
+ * Repo-owned semantic seed loaded by the M1 registry.
+ *
+ * @remarks
+ * FOLIO mappings remain empty until a report verifies a term-level semantic
+ * match; the research verifies the namespace and source, but not a matching
+ * concept identifier for these M1 terms.
+ *
+ * @example
+ * ```ts
+ * import { SemanticFoundationSeed } from "@beep/ontology/SemanticFoundation.seed"
+ * console.log(SemanticFoundationSeed.title) // "Legal intake taxonomy"
+ * ```
+ * @category constants
+ * @since 0.0.0
+ */
+export const SemanticFoundationSeed = TaxonomySeed.make({
+  concepts: [
+    TaxonomyConcept.make({
+      alignments: [],
+      broader: [],
+      definition: "Documents received, created, or maintained while delivering legal services.",
+      documentClasses: ["draft", "redline", "filed", "received", "privileged", "extracted-child"],
+      filingSegment: "legal-documents",
+      iri: legalDocumentIri,
+      prefLabel: "Legal document",
+    }),
+    TaxonomyConcept.make({
+      alignments: [],
+      broader: [legalDocumentIri],
+      definition: "Letters, electronic mail, and other messages preserved as matter records.",
+      documentClasses: ["draft", "received", "privileged", "extracted-child"],
+      filingSegment: "correspondence",
+      iri: correspondenceIri,
+      prefLabel: "Correspondence",
+    }),
+    TaxonomyConcept.make({
+      alignments: [],
+      broader: [correspondenceIri],
+      definition: "Electronic-mail messages and their preserved renderings or extracted children.",
+      documentClasses: ["received", "privileged", "extracted-child"],
+      filingSegment: "email-messages",
+      iri: iri(concepts.create("email-message").iri),
+      prefLabel: "Email message",
+    }),
+    TaxonomyConcept.make({
+      alignments: [],
+      broader: [legalDocumentIri],
+      definition: "A document classifying an intake artifact as a draft.",
+      documentClasses: ["draft"],
+      filingSegment: "draft",
+      iri: iri(documentClasses.create("draft").iri),
+      prefLabel: "Draft",
+    }),
+    TaxonomyConcept.make({
+      alignments: [],
+      broader: [legalDocumentIri],
+      definition: "A document showing revisions against another version.",
+      documentClasses: ["redline"],
+      filingSegment: "redline",
+      iri: iri(documentClasses.create("redline").iri),
+      prefLabel: "Redline",
+    }),
+    TaxonomyConcept.make({
+      alignments: [],
+      broader: [legalDocumentIri],
+      definition: "A document submitted to a court, agency, or legal authority.",
+      documentClasses: ["filed"],
+      filingSegment: "filed",
+      iri: iri(documentClasses.create("filed").iri),
+      prefLabel: "Filed",
+    }),
+    TaxonomyConcept.make({
+      alignments: [],
+      broader: [legalDocumentIri],
+      definition: "A document received from an external party or source.",
+      documentClasses: ["received"],
+      filingSegment: "received",
+      iri: iri(documentClasses.create("received").iri),
+      prefLabel: "Received",
+    }),
+    TaxonomyConcept.make({
+      alignments: [],
+      broader: [legalDocumentIri],
+      definition: "A document carrying privileged or protected legal communications.",
+      documentClasses: ["privileged"],
+      filingSegment: "privileged",
+      iri: iri(documentClasses.create("privileged").iri),
+      prefLabel: "Privileged",
+    }),
+    TaxonomyConcept.make({
+      alignments: [],
+      broader: [legalDocumentIri],
+      definition: "A child artifact extracted from a parent intake document.",
+      documentClasses: ["extracted-child"],
+      filingSegment: "extracted-child",
+      iri: iri(documentClasses.create("extracted-child").iri),
+      prefLabel: "Extracted child",
+    }),
+  ],
+  filingRoots: [
+    FilingRoot.make({ iri: iri(filingRoots.create("local-vault").iri), kind: "local-vault", rootSegment: "vault" }),
+    FilingRoot.make({ iri: iri(filingRoots.create("box-mirror").iri), kind: "box-mirror", rootSegment: "box-mirror" }),
+  ],
+  pathTemplateSegments: ["root", "client", "matter", "taxonomy-concept", "document-class", "file-name"],
+  schemeIri: SemanticFoundationSchemeIri,
+  title: "Legal intake taxonomy",
+});

--- a/packages/foundation/modeling/ontology/src/TaxonomyLoader.ts
+++ b/packages/foundation/modeling/ontology/src/TaxonomyLoader.ts
@@ -1,0 +1,235 @@
+/**
+ * Fail-closed manifest loader for semantic-foundation taxonomy slices.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $OntologyId } from "@beep/identity/packages";
+import { LiteralKit, TaggedErrorClass } from "@beep/schema";
+import { Context, Effect, FileSystem, Layer } from "effect";
+import * as A from "effect/Array";
+import * as S from "effect/Schema";
+import * as Str from "effect/String";
+import { TaxonomySeed } from "./SemanticFoundation.models.js";
+import { SemanticFoundationSeed } from "./SemanticFoundation.seed.js";
+
+const $I = $OntologyId.create("TaxonomyLoader");
+
+/** Repository-relative production manifest contract.
+ * @example
+ * ```ts
+ * import { VendorManifestPath } from "@beep/ontology/TaxonomyLoader"
+ * console.log(VendorManifestPath.endsWith("manifest.jsonl")) // true
+ * ```
+ * @category constants
+ * @since 0.0.0
+ */
+export const VendorManifestPath = "explorations/legal-ontology-landscape/assets/manifest.jsonl";
+
+/** Explicit loader-vetting state required in addition to research verification.
+ * @example
+ * ```ts
+ * import { VendorLoadStatus } from "@beep/ontology/TaxonomyLoader"
+ * console.log(VendorLoadStatus.is.VETTED("VETTED")) // true
+ * ```
+ * @category schemas
+ * @since 0.0.0
+ */
+export const VendorLoadStatus = LiteralKit(["VETTED", "UNVETTED"]).pipe(
+  $I.annoteSchema("VendorLoadStatus", { description: "Explicit implementation-loading verdict for a vendor slice." })
+);
+
+/** Runtime type for {@link VendorLoadStatus}.
+ * @example
+ * ```ts
+ * import type { VendorLoadStatus } from "@beep/ontology/TaxonomyLoader"
+ * const status: VendorLoadStatus = "UNVETTED"
+ * console.log(status)
+ * ```
+ * @category models
+ * @since 0.0.0
+ */
+export type VendorLoadStatus = typeof VendorLoadStatus.Type;
+
+/** One manifest row admitted by the package loader.
+ * @example
+ * ```ts
+ * import { VendorManifestEntry } from "@beep/ontology/TaxonomyLoader"
+ * console.log(VendorManifestEntry.make({ format: "jsonld", id: "fixture", loadStatus: "VETTED", path: "fixture.jsonld" }).id)
+ * ```
+ * @category models
+ * @since 0.0.0
+ */
+export class VendorManifestEntry extends S.Class<VendorManifestEntry>($I`VendorManifestEntry`)(
+  { format: S.Literal("jsonld"), id: S.NonEmptyString, loadStatus: VendorLoadStatus, path: S.NonEmptyString },
+  $I.annote("VendorManifestEntry", { description: "Manifest row for one explicitly vetted JSON-LD taxonomy slice." })
+) {}
+
+/** Raised when the manifest cannot be read.
+ * @example
+ * ```ts
+ * import { TaxonomyManifestReadError } from "@beep/ontology/TaxonomyLoader"
+ * console.log(TaxonomyManifestReadError.make({ path: "missing.jsonl" })._tag)
+ * ```
+ * @category errors
+ * @since 0.0.0
+ */
+export class TaxonomyManifestReadError extends TaggedErrorClass<TaxonomyManifestReadError>(
+  $I`TaxonomyManifestReadError`
+)(
+  "TaxonomyManifestReadError",
+  { path: S.NonEmptyString },
+  $I.annote("TaxonomyManifestReadError", { description: "The vendor manifest is missing or unreadable." })
+) {}
+
+/** Raised when a manifest row cannot be parsed.
+ * @example
+ * ```ts
+ * import { TaxonomyManifestParseError } from "@beep/ontology/TaxonomyLoader"
+ * console.log(TaxonomyManifestParseError.make({ line: 1, path: "manifest.jsonl" }).line)
+ * ```
+ * @category errors
+ * @since 0.0.0
+ */
+export class TaxonomyManifestParseError extends TaggedErrorClass<TaxonomyManifestParseError>(
+  $I`TaxonomyManifestParseError`
+)(
+  "TaxonomyManifestParseError",
+  { line: S.Int, path: S.NonEmptyString },
+  $I.annote("TaxonomyManifestParseError", { description: "A vendor manifest JSONL row failed schema decoding." })
+) {}
+
+/** Raised when a manifest slice lacks explicit loading approval.
+ * @example
+ * ```ts
+ * import { VendorSliceUnvetted } from "@beep/ontology/TaxonomyLoader"
+ * console.log(VendorSliceUnvetted.make({ id: "folio" }).id)
+ * ```
+ * @category errors
+ * @since 0.0.0
+ */
+export class VendorSliceUnvetted extends TaggedErrorClass<VendorSliceUnvetted>($I`VendorSliceUnvetted`)(
+  "VendorSliceUnvetted",
+  { id: S.NonEmptyString },
+  $I.annote("VendorSliceUnvetted", { description: "A vendor slice is not explicitly VETTED for loading." })
+) {}
+
+/** Raised when an approved slice cannot be read.
+ * @example
+ * ```ts
+ * import { VendorSliceReadError } from "@beep/ontology/TaxonomyLoader"
+ * console.log(VendorSliceReadError.make({ id: "fixture", path: "missing.jsonld" })._tag)
+ * ```
+ * @category errors
+ * @since 0.0.0
+ */
+export class VendorSliceReadError extends TaggedErrorClass<VendorSliceReadError>($I`VendorSliceReadError`)(
+  "VendorSliceReadError",
+  { id: S.NonEmptyString, path: S.NonEmptyString },
+  $I.annote("VendorSliceReadError", { description: "An explicitly vetted vendor slice is unreadable." })
+) {}
+
+/** Raised when an approved slice cannot be schema-decoded.
+ * @example
+ * ```ts
+ * import { VendorSliceParseError } from "@beep/ontology/TaxonomyLoader"
+ * console.log(VendorSliceParseError.make({ id: "fixture", path: "fixture.jsonld" }).id)
+ * ```
+ * @category errors
+ * @since 0.0.0
+ */
+export class VendorSliceParseError extends TaggedErrorClass<VendorSliceParseError>($I`VendorSliceParseError`)(
+  "VendorSliceParseError",
+  { id: S.NonEmptyString, path: S.NonEmptyString },
+  $I.annote("VendorSliceParseError", { description: "An explicitly vetted vendor taxonomy slice is unparsable." })
+) {}
+
+const decodeManifestEntry = S.decodeUnknownEffect(S.fromJsonString(VendorManifestEntry));
+const decodeTaxonomySeed = S.decodeUnknownEffect(S.fromJsonString(TaxonomySeed));
+
+const parseManifest = Effect.fn("TaxonomyLoader.parseManifest")(function* (path: string, content: string) {
+  const lines = A.filter(A.map(Str.split(content, "\n"), Str.trim), Str.isNonEmpty);
+  return yield* Effect.forEach(
+    lines,
+    (line, index) =>
+      decodeManifestEntry(line).pipe(Effect.mapError(() => TaxonomyManifestParseError.make({ line: index + 1, path }))),
+    { concurrency: 1 }
+  );
+});
+
+const readSlice = Effect.fn("TaxonomyLoader.readSlice")(function* (entry: VendorManifestEntry, vendorRoot: string) {
+  return yield* VendorLoadStatus.$match(entry.loadStatus, {
+    UNVETTED: () => Effect.fail(VendorSliceUnvetted.make({ id: entry.id })),
+    VETTED: Effect.fn("TaxonomyLoader.readVettedSlice")(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = A.join([vendorRoot, entry.path], "/");
+      const content = yield* fs
+        .readFileString(path)
+        .pipe(Effect.mapError(() => VendorSliceReadError.make({ id: entry.id, path })));
+      return yield* decodeTaxonomySeed(content).pipe(
+        Effect.mapError(() => VendorSliceParseError.make({ id: entry.id, path }))
+      );
+    }),
+  });
+});
+
+/** Service contract for loading the committed seed plus explicitly vetted slices.
+ * @example
+ * ```ts
+ * import { TaxonomyLoader } from "@beep/ontology/TaxonomyLoader"
+ * console.log(TaxonomyLoader.key)
+ * ```
+ * @category services
+ * @since 0.0.0
+ */
+export class TaxonomyLoader extends Context.Service<
+  TaxonomyLoader,
+  {
+    readonly load: (
+      manifestPath: string,
+      vendorRoot: string
+    ) => Effect.Effect<
+      TaxonomySeed,
+      | TaxonomyManifestReadError
+      | TaxonomyManifestParseError
+      | VendorSliceUnvetted
+      | VendorSliceReadError
+      | VendorSliceParseError,
+      FileSystem.FileSystem
+    >;
+  }
+>()($I`TaxonomyLoader`) {
+  /** Live loader implementation requiring only the portable FileSystem service.
+   * @example
+   * ```ts
+   * import { TaxonomyLoader } from "@beep/ontology/TaxonomyLoader"
+   * console.log(TaxonomyLoader.layer)
+   * ```
+   * @category layers
+   * @since 0.0.0
+   */
+  static readonly layer = Layer.succeed(this, {
+    load: Effect.fn("TaxonomyLoader.load")(function* (manifestPath: string, vendorRoot: string) {
+      const fs = yield* FileSystem.FileSystem;
+      const content = yield* fs
+        .readFileString(manifestPath)
+        .pipe(Effect.mapError(() => TaxonomyManifestReadError.make({ path: manifestPath })));
+      const entries = yield* parseManifest(manifestPath, content);
+      const slices = yield* Effect.forEach(entries, (entry) => readSlice(entry, vendorRoot), { concurrency: 1 });
+      return TaxonomySeed.make({
+        concepts: A.appendAll(
+          SemanticFoundationSeed.concepts,
+          A.flatMap(slices, (slice) => slice.concepts)
+        ),
+        filingRoots: A.appendAll(
+          SemanticFoundationSeed.filingRoots,
+          A.flatMap(slices, (slice) => slice.filingRoots)
+        ),
+        pathTemplateSegments: SemanticFoundationSeed.pathTemplateSegments,
+        schemeIri: SemanticFoundationSeed.schemeIri,
+        title: SemanticFoundationSeed.title,
+      });
+    }),
+  });
+}

--- a/packages/foundation/modeling/ontology/src/TaxonomyLoader.ts
+++ b/packages/foundation/modeling/ontology/src/TaxonomyLoader.ts
@@ -11,21 +11,40 @@ import { Context, Effect, FileSystem, Layer } from "effect";
 import * as A from "effect/Array";
 import * as S from "effect/Schema";
 import * as Str from "effect/String";
-import { TaxonomySeed } from "./SemanticFoundation.models.js";
+import { isFilingSegment, TaxonomySeed } from "./SemanticFoundation.models.js";
 import { SemanticFoundationSeed } from "./SemanticFoundation.seed.js";
 
 const $I = $OntologyId.create("TaxonomyLoader");
 
-/** Repository-relative production manifest contract.
+/**
+ * Relative path to one vendor slice, contained within the vendor root: one
+ * or more {@link FilingSegment}-safe components joined by `/`, so `..`
+ * traversal, absolute paths, and separator tricks are rejected at decode
+ * time and the loader cannot read outside its configured directory.
+ *
  * @example
  * ```ts
- * import { VendorManifestPath } from "@beep/ontology/TaxonomyLoader"
- * console.log(VendorManifestPath.endsWith("manifest.jsonl")) // true
+ * import { VendorSlicePath } from "@beep/ontology/TaxonomyLoader"
+ * import * as S from "effect/Schema"
+ *
+ * console.log(S.decodeUnknownResult(VendorSlicePath)("../secrets.jsonld")._tag) // "Failure"
  * ```
- * @category constants
+ *
+ * @category schemas
  * @since 0.0.0
  */
-export const VendorManifestPath = "explorations/legal-ontology-landscape/assets/manifest.jsonl";
+export const VendorSlicePath = S.NonEmptyString.check(
+  S.makeFilter((path: string) => A.every(Str.split(path, "/"), isFilingSegment), {
+    identifier: $I`VendorSlicePathCheck`,
+    title: "Vendor Slice Path",
+    description: "A vendor-root-relative path whose every component is a safe filing segment.",
+    message: "Vendor slice path must stay inside the vendor root",
+  })
+).pipe(
+  $I.annoteSchema("VendorSlicePath", {
+    description: "Vendor-root-relative slice path that cannot escape the configured directory.",
+  })
+);
 
 /** Explicit loader-vetting state required in addition to research verification.
  * @example
@@ -62,7 +81,7 @@ export type VendorLoadStatus = typeof VendorLoadStatus.Type;
  * @since 0.0.0
  */
 export class VendorManifestEntry extends S.Class<VendorManifestEntry>($I`VendorManifestEntry`)(
-  { format: S.Literal("jsonld"), id: S.NonEmptyString, loadStatus: VendorLoadStatus, path: S.NonEmptyString },
+  { format: S.Literal("jsonld"), id: S.NonEmptyString, loadStatus: VendorLoadStatus, path: VendorSlicePath },
   $I.annote("VendorManifestEntry", { description: "Manifest row for one explicitly vetted JSON-LD taxonomy slice." })
 ) {}
 

--- a/packages/foundation/modeling/ontology/src/TaxonomyRegistry.ts
+++ b/packages/foundation/modeling/ontology/src/TaxonomyRegistry.ts
@@ -1,0 +1,153 @@
+/**
+ * Pure registry projections for loaded semantic-foundation data.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $OntologyId } from "@beep/identity/packages";
+import { IRIReference } from "@beep/rdf";
+import { TaggedErrorClass } from "@beep/schema";
+import { Effect } from "effect";
+import * as A from "effect/Array";
+import * as O from "effect/Option";
+import * as S from "effect/Schema";
+import { DocumentClass, FilingRootKind } from "./SemanticFoundation.models.js";
+import type { TaxonomyConcept, TaxonomySeed } from "./SemanticFoundation.models.js";
+
+const $I = $OntologyId.create("TaxonomyRegistry");
+const iriEquivalence = S.toEquivalence(IRIReference);
+
+/** Document metadata supplied to the package-local librarian projection.
+ * @example
+ * ```ts
+ * import { LibrarianInput } from "@beep/ontology/TaxonomyRegistry"
+ * import { IRIReference } from "@beep/rdf"
+ * const input = LibrarianInput.make({ client: "acme", conceptIri: IRIReference.make("https://ns.beep.sh/example"), documentClass: "received", fileName: "mail.eml", matter: "aurora" })
+ * console.log(input.documentClass)
+ * ```
+ * @category models
+ * @since 0.0.0
+ */
+export class LibrarianInput extends S.Class<LibrarianInput>($I`LibrarianInput`)(
+  {
+    client: S.NonEmptyString,
+    conceptIri: IRIReference,
+    documentClass: DocumentClass,
+    fileName: S.NonEmptyString,
+    matter: S.NonEmptyString,
+  },
+  $I.annote("LibrarianInput", { description: "Document metadata used to project one registry-backed filing decision." })
+) {}
+
+/** One filing path projected for a semantic storage root.
+ * @example
+ * ```ts
+ * import { FilingPath } from "@beep/ontology/TaxonomyRegistry"
+ * console.log(FilingPath.make({ kind: "local-vault", path: "vault/acme/matter/mail" }).kind)
+ * ```
+ * @category models
+ * @since 0.0.0
+ */
+export class FilingPath extends S.Class<FilingPath>($I`FilingPath`)(
+  { kind: FilingRootKind, path: S.NonEmptyString },
+  $I.annote("FilingPath", { description: "A projected path paired with its semantic filing-root kind." })
+) {}
+
+/** Registry-backed classification and filing-path projection.
+ * @example
+ * ```ts
+ * import type { LibrarianOutput } from "@beep/ontology/TaxonomyRegistry"
+ * const show = (output: LibrarianOutput) => output.filingPaths
+ * console.log(show)
+ * ```
+ * @category models
+ * @since 0.0.0
+ */
+export class LibrarianOutput extends S.Class<LibrarianOutput>($I`LibrarianOutput`)(
+  { conceptIri: IRIReference, documentClass: DocumentClass, filingPaths: S.Array(FilingPath) },
+  $I.annote("LibrarianOutput", {
+    description: "Pure classification output projected from loaded registry vocabulary data.",
+  })
+) {}
+
+/** Raised when a requested concept is absent from loaded registry data.
+ * @example
+ * ```ts
+ * import { TaxonomyConceptNotFound } from "@beep/ontology/TaxonomyRegistry"
+ * import { IRIReference } from "@beep/rdf"
+ * console.log(TaxonomyConceptNotFound.make({ conceptIri: IRIReference.make("https://ns.beep.sh/missing") })._tag)
+ * ```
+ * @category errors
+ * @since 0.0.0
+ */
+export class TaxonomyConceptNotFound extends TaggedErrorClass<TaxonomyConceptNotFound>($I`TaxonomyConceptNotFound`)(
+  "TaxonomyConceptNotFound",
+  { conceptIri: IRIReference },
+  $I.annote("TaxonomyConceptNotFound", {
+    description: "The requested concept IRI is absent from the loaded taxonomy registry.",
+  })
+) {}
+
+/** Raised when a concept does not admit the requested document class.
+ * @example
+ * ```ts
+ * import { UnsupportedDocumentClass } from "@beep/ontology/TaxonomyRegistry"
+ * import { IRIReference } from "@beep/rdf"
+ * console.log(UnsupportedDocumentClass.make({ conceptIri: IRIReference.make("https://ns.beep.sh/example"), documentClass: "filed" }).documentClass)
+ * ```
+ * @category errors
+ * @since 0.0.0
+ */
+export class UnsupportedDocumentClass extends TaggedErrorClass<UnsupportedDocumentClass>($I`UnsupportedDocumentClass`)(
+  "UnsupportedDocumentClass",
+  { conceptIri: IRIReference, documentClass: DocumentClass },
+  $I.annote("UnsupportedDocumentClass", {
+    description: "The selected taxonomy concept does not admit the requested document class.",
+  })
+) {}
+
+const pathFor = (input: LibrarianInput, concept: TaxonomyConcept, rootSegment: string): string =>
+  A.join([rootSegment, input.client, input.matter, concept.filingSegment, input.documentClass, input.fileName], "/");
+
+/** Project document metadata through loaded registry data without placement I/O.
+ * @example
+ * ```ts
+ * import { Effect } from "effect"
+ * import { IRIReference } from "@beep/rdf"
+ * import { SemanticFoundationSeed } from "@beep/ontology/SemanticFoundation.seed"
+ * import { LibrarianInput, runLibrarianLoop } from "@beep/ontology/TaxonomyRegistry"
+ * const result = runLibrarianLoop(SemanticFoundationSeed, LibrarianInput.make({ client: "acme", conceptIri: IRIReference.make("https://ns.beep.sh/ontology/semantic-foundation/concept/correspondence"), documentClass: "received", fileName: "mail.eml", matter: "aurora" }))
+ * console.log(Effect.isEffect(result)) // true
+ * ```
+ * @category workflows
+ * @since 0.0.0
+ */
+export const runLibrarianLoop = Effect.fn("TaxonomyRegistry.runLibrarianLoop")(function* (
+  seed: TaxonomySeed,
+  input: LibrarianInput
+) {
+  const concept = yield* A.findFirst(seed.concepts, (candidate) =>
+    iriEquivalence(candidate.iri, input.conceptIri)
+  ).pipe(
+    O.match({
+      onNone: () => Effect.fail(TaxonomyConceptNotFound.make({ conceptIri: input.conceptIri })),
+      onSome: Effect.succeed,
+    })
+  );
+  yield* Effect.filterOrFail(
+    Effect.succeed(concept),
+    (candidate) => A.contains(candidate.documentClasses, input.documentClass),
+    () => UnsupportedDocumentClass.make({ conceptIri: input.conceptIri, documentClass: input.documentClass })
+  );
+  return LibrarianOutput.make({
+    conceptIri: concept.iri,
+    documentClass: input.documentClass,
+    filingPaths: A.map(seed.filingRoots, (root) =>
+      FilingPath.make({
+        kind: root.kind,
+        path: pathFor(input, concept, root.rootSegment),
+      })
+    ),
+  });
+});

--- a/packages/foundation/modeling/ontology/src/TaxonomyRegistry.ts
+++ b/packages/foundation/modeling/ontology/src/TaxonomyRegistry.ts
@@ -12,7 +12,7 @@ import { Effect } from "effect";
 import * as A from "effect/Array";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
-import { DocumentClass, FilingRootKind } from "./SemanticFoundation.models.js";
+import { DocumentClass, FilingRootKind, FilingSegment } from "./SemanticFoundation.models.js";
 import type { TaxonomyConcept, TaxonomySeed } from "./SemanticFoundation.models.js";
 
 const $I = $OntologyId.create("TaxonomyRegistry");
@@ -31,11 +31,11 @@ const iriEquivalence = S.toEquivalence(IRIReference);
  */
 export class LibrarianInput extends S.Class<LibrarianInput>($I`LibrarianInput`)(
   {
-    client: S.NonEmptyString,
+    client: FilingSegment,
     conceptIri: IRIReference,
     documentClass: DocumentClass,
-    fileName: S.NonEmptyString,
-    matter: S.NonEmptyString,
+    fileName: FilingSegment,
+    matter: FilingSegment,
   },
   $I.annote("LibrarianInput", { description: "Document metadata used to project one registry-backed filing decision." })
 ) {}

--- a/packages/foundation/modeling/ontology/src/index.ts
+++ b/packages/foundation/modeling/ontology/src/index.ts
@@ -9,3 +9,31 @@
  * @category configuration
  */
 export * as Ontology from "./Ontology.models.ts";
+/**
+ * Intake-serving semantic-foundation models and services.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export * from "./SemanticFoundation.models.ts";
+/**
+ * Committed repository-owned taxonomy seed.
+ *
+ * @category constants
+ * @since 0.0.0
+ */
+export * from "./SemanticFoundation.seed.ts";
+/**
+ * Fail-closed taxonomy manifest loader.
+ *
+ * @category services
+ * @since 0.0.0
+ */
+export * from "./TaxonomyLoader.ts";
+/**
+ * Pure registry-backed librarian projections.
+ *
+ * @category workflows
+ * @since 0.0.0
+ */
+export * from "./TaxonomyRegistry.ts";

--- a/packages/foundation/modeling/ontology/src/seed/legal-intake.jsonld
+++ b/packages/foundation/modeling/ontology/src/seed/legal-intake.jsonld
@@ -1,0 +1,87 @@
+{
+  "@context": {
+    "beep": "https://ns.beep.sh/ontology/semantic-foundation/",
+    "dcterms": "http://purl.org/dc/terms/",
+    "skos": "http://www.w3.org/2004/02/skos/core#"
+  },
+  "@id": "beep:taxonomy/legal-intake",
+  "@type": "skos:ConceptScheme",
+  "dcterms:title": "Legal intake taxonomy",
+  "beep:pathTemplateSegment": [
+    "root",
+    "client",
+    "matter",
+    "taxonomy-concept",
+    "document-class",
+    "file-name"
+  ],
+  "@graph": [
+    {
+      "@id": "beep:concept/legal-document",
+      "@type": "skos:Concept",
+      "skos:prefLabel": "Legal document"
+    },
+    {
+      "@id": "beep:concept/correspondence",
+      "@type": "skos:Concept",
+      "skos:broader": { "@id": "beep:concept/legal-document" },
+      "skos:prefLabel": "Correspondence"
+    },
+    {
+      "@id": "beep:concept/email-message",
+      "@type": "skos:Concept",
+      "skos:broader": { "@id": "beep:concept/correspondence" },
+      "skos:prefLabel": "Email message"
+    },
+    {
+      "@id": "beep:document-class/draft",
+      "@type": "skos:Concept",
+      "skos:inScheme": { "@id": "beep:taxonomy/legal-intake" },
+      "skos:prefLabel": "Draft"
+    },
+    {
+      "@id": "beep:document-class/redline",
+      "@type": "skos:Concept",
+      "skos:inScheme": { "@id": "beep:taxonomy/legal-intake" },
+      "skos:prefLabel": "Redline"
+    },
+    {
+      "@id": "beep:document-class/filed",
+      "@type": "skos:Concept",
+      "skos:inScheme": { "@id": "beep:taxonomy/legal-intake" },
+      "skos:prefLabel": "Filed"
+    },
+    {
+      "@id": "beep:document-class/received",
+      "@type": "skos:Concept",
+      "skos:inScheme": { "@id": "beep:taxonomy/legal-intake" },
+      "skos:prefLabel": "Received"
+    },
+    {
+      "@id": "beep:document-class/privileged",
+      "@type": "skos:Concept",
+      "skos:inScheme": { "@id": "beep:taxonomy/legal-intake" },
+      "skos:prefLabel": "Privileged"
+    },
+    {
+      "@id": "beep:document-class/extracted-child",
+      "@type": "skos:Concept",
+      "skos:inScheme": { "@id": "beep:taxonomy/legal-intake" },
+      "skos:prefLabel": "Extracted child"
+    },
+    {
+      "@id": "beep:filing-root/local-vault",
+      "@type": "skos:Concept",
+      "beep:rootSegment": "vault",
+      "skos:inScheme": { "@id": "beep:taxonomy/legal-intake" },
+      "skos:prefLabel": "Local vault"
+    },
+    {
+      "@id": "beep:filing-root/box-mirror",
+      "@type": "skos:Concept",
+      "beep:rootSegment": "box-mirror",
+      "skos:inScheme": { "@id": "beep:taxonomy/legal-intake" },
+      "skos:prefLabel": "Box mirror"
+    }
+  ]
+}

--- a/packages/foundation/modeling/ontology/src/seed/legal-intake.ttl
+++ b/packages/foundation/modeling/ontology/src/seed/legal-intake.ttl
@@ -1,0 +1,33 @@
+@prefix beep: <https://ns.beep.sh/ontology/semantic-foundation/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+beep:taxonomy/legal-intake a skos:ConceptScheme ;
+  dcterms:title "Legal intake taxonomy"@en ;
+  beep:pathTemplateSegment "root", "client", "matter", "taxonomy-concept", "document-class", "file-name" ;
+  skos:hasTopConcept beep:concept/legal-document .
+
+beep:concept/legal-document a skos:Concept ;
+  skos:inScheme beep:taxonomy/legal-intake ;
+  skos:prefLabel "Legal document"@en ;
+  skos:definition "Documents received, created, or maintained while delivering legal services."@en .
+
+beep:concept/correspondence a skos:Concept ;
+  skos:inScheme beep:taxonomy/legal-intake ;
+  skos:broader beep:concept/legal-document ;
+  skos:prefLabel "Correspondence"@en .
+
+beep:concept/email-message a skos:Concept ;
+  skos:inScheme beep:taxonomy/legal-intake ;
+  skos:broader beep:concept/correspondence ;
+  skos:prefLabel "Email message"@en .
+
+beep:document-class/draft a skos:Concept ; skos:inScheme beep:taxonomy/legal-intake ; skos:prefLabel "Draft"@en .
+beep:document-class/redline a skos:Concept ; skos:inScheme beep:taxonomy/legal-intake ; skos:prefLabel "Redline"@en .
+beep:document-class/filed a skos:Concept ; skos:inScheme beep:taxonomy/legal-intake ; skos:prefLabel "Filed"@en .
+beep:document-class/received a skos:Concept ; skos:inScheme beep:taxonomy/legal-intake ; skos:prefLabel "Received"@en .
+beep:document-class/privileged a skos:Concept ; skos:inScheme beep:taxonomy/legal-intake ; skos:prefLabel "Privileged"@en .
+beep:document-class/extracted-child a skos:Concept ; skos:inScheme beep:taxonomy/legal-intake ; skos:prefLabel "Extracted child"@en .
+
+beep:filing-root/local-vault a skos:Concept ; beep:rootSegment "vault" ; skos:inScheme beep:taxonomy/legal-intake ; skos:prefLabel "Local vault"@en .
+beep:filing-root/box-mirror a skos:Concept ; beep:rootSegment "box-mirror" ; skos:inScheme beep:taxonomy/legal-intake ; skos:prefLabel "Box mirror"@en .

--- a/packages/foundation/modeling/ontology/test/SemanticFoundation.test.ts
+++ b/packages/foundation/modeling/ontology/test/SemanticFoundation.test.ts
@@ -1,0 +1,157 @@
+import {
+  DocumentClass,
+  LibrarianInput,
+  runLibrarianLoop,
+  SemanticFoundationSeed,
+  TaxonomyLoader,
+  TaxonomyManifestParseError,
+  TaxonomyManifestReadError,
+  TaxonomySeed,
+  VendorManifestEntry,
+  VendorSliceParseError,
+  VendorSliceReadError,
+  VendorSliceUnvetted,
+} from "@beep/ontology";
+import { IRIReference } from "@beep/rdf";
+import { expect, layer } from "@effect/vitest";
+import { Effect, FileSystem, Match } from "effect";
+import * as A from "effect/Array";
+import * as S from "effect/Schema";
+
+const manifestPath = "test/fixtures/vendor-manifest.jsonl";
+const vendorRoot = "test/fixtures";
+const slicePath = "test/fixtures/fixture-slice.jsonld";
+const encodeEntry = S.encodeUnknownEffect(S.fromJsonString(VendorManifestEntry));
+const encodeSeed = S.encodeUnknownEffect(S.fromJsonString(TaxonomySeed));
+
+const loadWith = Effect.fnUntraced(function* (readFileString: FileSystem.FileSystem["readFileString"]) {
+  const loader = yield* TaxonomyLoader;
+  return yield* loader
+    .load(manifestPath, vendorRoot)
+    .pipe(Effect.provideService(FileSystem.FileSystem, FileSystem.makeNoop({ readFileString })));
+});
+
+layer(TaxonomyLoader.layer)("semantic foundation", (it) => {
+  it.effect("loads the committed seed plus an explicitly VETTED fixture slice", () =>
+    Effect.gen(function* () {
+      const manifest = yield* encodeEntry(
+        VendorManifestEntry.make({
+          format: "jsonld",
+          id: "fixture-legal-intake",
+          loadStatus: "VETTED",
+          path: "fixture-slice.jsonld",
+        })
+      );
+      const slice = yield* encodeSeed(
+        TaxonomySeed.make({
+          concepts: [],
+          filingRoots: [],
+          pathTemplateSegments: ["root", "client", "matter", "taxonomy-concept", "document-class", "file-name"],
+          schemeIri: IRIReference.make("https://ns.beep.sh/ontology/semantic-foundation/taxonomy/fixture"),
+          title: "Fixture vendor slice",
+        })
+      );
+      const loaded = yield* loadWith((path) =>
+        Match.value(path).pipe(
+          Match.when(manifestPath, () => Effect.succeed(manifest)),
+          Match.when(slicePath, () => Effect.succeed(slice)),
+          Match.orElse(() => FileSystem.makeNoop({}).readFileString(path))
+        )
+      );
+      expect(loaded.concepts).toHaveLength(SemanticFoundationSeed.concepts.length);
+    })
+  );
+
+  it.effect("fails closed for a missing manifest", () =>
+    Effect.gen(function* () {
+      const error = yield* loadWith(FileSystem.makeNoop({}).readFileString).pipe(Effect.flip);
+      expect(S.is(TaxonomyManifestReadError)(error)).toBe(true);
+    })
+  );
+
+  it.effect("fails closed for an unparsable manifest", () =>
+    Effect.gen(function* () {
+      const error = yield* loadWith(() => Effect.succeed("not-json")).pipe(Effect.flip);
+      expect(S.is(TaxonomyManifestParseError)(error)).toBe(true);
+    })
+  );
+
+  it.effect("fails closed for an unvetted slice", () =>
+    Effect.gen(function* () {
+      const manifest = yield* encodeEntry(
+        VendorManifestEntry.make({
+          format: "jsonld",
+          id: "fixture-legal-intake",
+          loadStatus: "UNVETTED",
+          path: "fixture-slice.jsonld",
+        })
+      );
+      const error = yield* loadWith(() => Effect.succeed(manifest)).pipe(Effect.flip);
+      expect(S.is(VendorSliceUnvetted)(error)).toBe(true);
+    })
+  );
+
+  it.effect("fails closed for an unreadable vetted slice", () =>
+    Effect.gen(function* () {
+      const manifest = yield* encodeEntry(
+        VendorManifestEntry.make({
+          format: "jsonld",
+          id: "fixture-legal-intake",
+          loadStatus: "VETTED",
+          path: "fixture-slice.jsonld",
+        })
+      );
+      const missing = FileSystem.makeNoop({});
+      const error = yield* loadWith((path) =>
+        Match.value(path).pipe(
+          Match.when(manifestPath, () => Effect.succeed(manifest)),
+          Match.orElse(() => missing.readFileString(path))
+        )
+      ).pipe(Effect.flip);
+      expect(S.is(VendorSliceReadError)(error)).toBe(true);
+    })
+  );
+
+  it.effect("fails closed for an unparsable vetted slice", () =>
+    Effect.gen(function* () {
+      const manifest = yield* encodeEntry(
+        VendorManifestEntry.make({
+          format: "jsonld",
+          id: "fixture-legal-intake",
+          loadStatus: "VETTED",
+          path: "fixture-slice.jsonld",
+        })
+      );
+      const error = yield* loadWith((path) =>
+        Match.value(path).pipe(
+          Match.when(manifestPath, () => Effect.succeed(manifest)),
+          Match.orElse(() => Effect.succeed("not-json"))
+        )
+      ).pipe(Effect.flip);
+      expect(S.is(VendorSliceParseError)(error)).toBe(true);
+    })
+  );
+
+  it.effect("runs the librarian loop purely over registry data", () =>
+    Effect.gen(function* () {
+      const conceptIri = IRIReference.make("https://ns.beep.sh/ontology/semantic-foundation/concept/email-message");
+      const output = yield* runLibrarianLoop(
+        SemanticFoundationSeed,
+        LibrarianInput.make({
+          client: "acme",
+          conceptIri,
+          documentClass: "received",
+          fileName: "intake-email.eml",
+          matter: "aurora",
+        })
+      );
+      expect(output.conceptIri).toBe(conceptIri);
+      expect(output.documentClass).toBe("received");
+      expect(A.map(output.filingPaths, (filingPath) => filingPath.path)).toEqual([
+        "vault/acme/aurora/email-messages/received/intake-email.eml",
+        "box-mirror/acme/aurora/email-messages/received/intake-email.eml",
+      ]);
+      expect(DocumentClass.Options).toEqual(["draft", "redline", "filed", "received", "privileged", "extracted-child"]);
+    })
+  );
+});

--- a/packages/foundation/modeling/ontology/test/SemanticFoundation.test.ts
+++ b/packages/foundation/modeling/ontology/test/SemanticFoundation.test.ts
@@ -1,5 +1,7 @@
 import {
   DocumentClass,
+  FilingSegment,
+  isFilingSegment,
   LibrarianInput,
   runLibrarianLoop,
   SemanticFoundationSeed,
@@ -16,7 +18,9 @@ import { IRIReference } from "@beep/rdf";
 import { expect, layer } from "@effect/vitest";
 import { Effect, FileSystem, Match } from "effect";
 import * as A from "effect/Array";
+import * as O from "effect/Option";
 import * as S from "effect/Schema";
+import { FastCheck as fc } from "effect/testing";
 
 const manifestPath = "test/fixtures/vendor-manifest.jsonl";
 const vendorRoot = "test/fixtures";
@@ -72,6 +76,14 @@ layer(TaxonomyLoader.layer)("semantic foundation", (it) => {
   it.effect("fails closed for an unparsable manifest", () =>
     Effect.gen(function* () {
       const error = yield* loadWith(() => Effect.succeed("not-json")).pipe(Effect.flip);
+      expect(S.is(TaxonomyManifestParseError)(error)).toBe(true);
+    })
+  );
+
+  it.effect("fails closed for a manifest row whose path escapes the vendor root", () =>
+    Effect.gen(function* () {
+      const manifest = `{"format":"jsonld","id":"escape","loadStatus":"VETTED","path":"../secrets.jsonld"}`;
+      const error = yield* loadWith(() => Effect.succeed(manifest)).pipe(Effect.flip);
       expect(S.is(TaxonomyManifestParseError)(error)).toBe(true);
     })
   );
@@ -152,6 +164,33 @@ layer(TaxonomyLoader.layer)("semantic foundation", (it) => {
         "box-mirror/acme/aurora/email-messages/received/intake-email.eml",
       ]);
       expect(DocumentClass.Options).toEqual(["draft", "redline", "filed", "received", "privileged", "extracted-child"]);
+    })
+  );
+
+  it.effect("round-trips generated filing segments and never admits separators", () =>
+    Effect.sync(() =>
+      fc.assert(
+        fc.property(S.toArbitrary(FilingSegment), (segment) => {
+          const decoded = O.flatMap(S.encodeOption(FilingSegment)(segment), S.decodeUnknownOption(FilingSegment));
+          expect(O.exists(decoded, (value) => value === segment)).toBe(true);
+          expect(isFilingSegment(segment)).toBe(true);
+        })
+      )
+    )
+  );
+
+  it.effect("rejects traversal segments in librarian input at decode time", () =>
+    Effect.gen(function* () {
+      const decoded = yield* Effect.sync(() =>
+        S.decodeUnknownResult(LibrarianInput)({
+          client: "acme",
+          conceptIri: "https://ns.beep.sh/ontology/semantic-foundation/concept/email-message",
+          documentClass: "received",
+          fileName: "../../other-matter/document.pdf",
+          matter: "aurora",
+        })
+      );
+      expect(decoded._tag).toBe("Failure");
     })
   );
 });

--- a/packages/foundation/modeling/ontology/test/fixtures/fixture-slice.jsonld
+++ b/packages/foundation/modeling/ontology/test/fixtures/fixture-slice.jsonld
@@ -1,0 +1,14 @@
+{
+  "concepts": [],
+  "filingRoots": [],
+  "pathTemplateSegments": [
+    "root",
+    "client",
+    "matter",
+    "taxonomy-concept",
+    "document-class",
+    "file-name"
+  ],
+  "schemeIri": "https://ns.beep.sh/ontology/semantic-foundation/taxonomy/fixture",
+  "title": "Fixture vendor slice"
+}

--- a/packages/foundation/modeling/ontology/test/fixtures/vendor-manifest.jsonl
+++ b/packages/foundation/modeling/ontology/test/fixtures/vendor-manifest.jsonl
@@ -1,0 +1,1 @@
+{"format":"jsonld","id":"fixture-legal-intake","loadStatus":"VETTED","path":"fixture-slice.jsonld"}

--- a/packages/foundation/modeling/ontology/tsconfig.json
+++ b/packages/foundation/modeling/ontology/tsconfig.json
@@ -9,9 +9,6 @@
   },
   "references": [
     {
-      "path": "../../../tooling/test-kit/test-utils/tsconfig.json"
-    },
-    {
       "path": "../identity/tsconfig.json"
     },
     {
@@ -19,6 +16,9 @@
     },
     {
       "path": "../schema/tsconfig.json"
+    },
+    {
+      "path": "../../../tooling/test-kit/test-utils/tsconfig.json"
     }
   ]
 }

--- a/packages/foundation/modeling/ontology/vitest.config.ts
+++ b/packages/foundation/modeling/ontology/vitest.config.ts
@@ -4,6 +4,7 @@ import shared from "../../../../vitest.shared.ts";
 export default mergeConfig(
   shared,
   defineConfig({
+    root: import.meta.dirname,
     test: {
       // Package-specific overrides
     },

--- a/standards/fallow.boundaries.generated.jsonc
+++ b/standards/fallow.boundaries.generated.jsonc
@@ -1998,11 +1998,17 @@
       {
         "from": "@beep/ontology",
         "allow": [
+          "@beep/identity",
           "@beep/ontology",
+          "@beep/rdf",
+          "@beep/schema",
           "@beep/test-utils"
         ],
         "allowTypeOnly": [
+          "@beep/identity",
           "@beep/ontology",
+          "@beep/rdf",
+          "@beep/schema",
           "@beep/test-utils"
         ]
       },


### PR DESCRIPTION
## feat(ontology): semantic foundation m1 - skos seed, taxonomy registry and fail-closed loader

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- full:pre-push: passed
- publish:head-install-preflight: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/feat_semantic-foundation-m1-3878596ca2ee/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786628708&installation_id=141092090&pr_number=409&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F409&signature=55f8c31a0df4b0ba9499450ce9d78dd30340560fcb6ecfce19e5510693938058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->