### PR TITLE
fix(professional-desktop): route packaged-webview rpc to the loopback sidecar on windows

### DIFF
--- a/.changeset/oip-web-start-unwrapped.md
+++ b/.changeset/oip-web-start-unwrapped.md
@@ -1,0 +1,8 @@
+---
+"@beep/oip-web": patch
+---
+
+Greptile review fixes that missed the portless PR's merge window: `start`
+returns to plain `next start` (production startup must not depend on the
+portless dev CLI), and the dead `https://*.localhost:*` dev CSP wildcard
+from the abandoned HTTPS proxy mode is removed.

--- a/.changeset/portless-default-react-grab-storybook.md
+++ b/.changeset/portless-default-react-grab-storybook.md
@@ -13,8 +13,9 @@ Make portless the only dev-server path and enable react-grab in Storybook.
   skips the install inside iframes); guarded out of `storybook build` and
   addon-vitest browser-mode runs, with a leak-guard assertion in the vitest
   setup file.
-- oip-web: portless route renamed to `oip-web.beep`, `dev:raw` removed,
-  `next start` wrapped; dev now rides the shared HTTP proxy
+- oip-web: portless route renamed to `oip-web.beep`, `dev:raw` removed
+  (`start` stays plain `next start` — production startup must not depend
+  on the portless dev CLI); dev now rides the shared HTTP proxy
   (`PORTLESS_HTTPS` dropped — the HTTPS/h2 proxy mode breaks vite HMR
   websockets and hard-conflicts with the proxy the other apps need);
   react-grab unpkg pin bumped to catalog 0.1.48.

--- a/.changeset/tauri-packaged-rpc-origin.md
+++ b/.changeset/tauri-packaged-rpc-origin.md
@@ -1,0 +1,7 @@
+---
+"@beep/agents-client": patch
+"@beep/professional-desktop": patch
+---
+
+Route Windows packaged Tauri HTTP origins to the loopback RPC sidecar and add
+pipeable desktop helper overloads.

--- a/apps/oip-web/package.json
+++ b/apps/oip-web/package.json
@@ -18,7 +18,7 @@
     "beep:audit": "bun run beep:build && bun run beep:check && bun run beep:test && bun run beep:lint",
     "beep:build": "NEXT_DISABLE_PWA=1 next build --turbopack",
     "build:pwa": "NEXT_DISABLE_PWA=0 next build --webpack",
-    "start": "portless oip-web.beep next start",
+    "start": "next start",
     "beep:check": "tsgo -b tsconfig.json",
     "beep:lint": "biome check .",
     "beep:lint:fix": "biome check . --write",

--- a/apps/oip-web/src/proxy.ts
+++ b/apps/oip-web/src/proxy.ts
@@ -22,9 +22,7 @@ const isDevelopment = !configStringEqualsSync("NODE_ENV", "production");
 const developmentScriptSources = isDevelopment ? " 'unsafe-eval' https://unpkg.com" : "";
 const developmentStyleSources = isDevelopment ? " https://fonts.googleapis.com" : "";
 const developmentFontSources = isDevelopment ? " https://fonts.gstatic.com" : "";
-const developmentConnectSources = isDevelopment
-  ? " https://*.localhost:* ws: wss: https://react-grab.com https://www.react-grab.com"
-  : "";
+const developmentConnectSources = isDevelopment ? " ws: wss: https://react-grab.com https://www.react-grab.com" : "";
 const vercelLiveSource = " https://vercel.live";
 
 const buildCspHeader = (nonce: string): string =>

--- a/apps/professional-desktop/src/transport/DesktopHttpProtocol.ts
+++ b/apps/professional-desktop/src/transport/DesktopHttpProtocol.ts
@@ -11,15 +11,41 @@ import * as Str from "effect/String";
 import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http";
 import { RpcClient, RpcSerialization } from "effect/unstable/rpc";
 
-const SERVER_URL = ((): string => {
-  if (typeof window !== "undefined") {
-    const origin = window.location.origin;
-    if (Str.startsWith("http://")(origin) || Str.startsWith("https://")(origin)) {
-      return new URL("/rpc", origin).toString();
-    }
+const SIDECAR_RPC_URL = "http://127.0.0.1:3939/rpc" as const;
+const WINDOWS_TAURI_HTTP_ORIGIN = "http://tauri.localhost" as const;
+const WINDOWS_TAURI_HTTPS_ORIGIN = "https://tauri.localhost" as const;
+
+/**
+ * Resolve the desktop RPC endpoint for a browser origin.
+ *
+ * Packaged Tauri origins use the loopback sidecar, including Windows' HTTP(S)
+ * `tauri.localhost` origins. Other HTTP(S) origins are development servers and
+ * keep their origin-relative `/rpc` route.
+ *
+ * @example
+ * ```ts
+ * import { resolveDesktopRpcServerUrl } from "@/transport/DesktopHttpProtocol"
+ *
+ * console.log(resolveDesktopRpcServerUrl("http://tauri.localhost"))
+ * // "http://127.0.0.1:3939/rpc"
+ * ```
+ *
+ * @category transport
+ * @since 0.0.0
+ */
+export const resolveDesktopRpcServerUrl = (origin: string | undefined): string => {
+  if (
+    origin !== undefined &&
+    origin !== WINDOWS_TAURI_HTTP_ORIGIN &&
+    origin !== WINDOWS_TAURI_HTTPS_ORIGIN &&
+    (Str.startsWith("http://")(origin) || Str.startsWith("https://")(origin))
+  ) {
+    return new URL("/rpc", origin).toString();
   }
-  return "http://127.0.0.1:3939/rpc";
-})();
+  return SIDECAR_RPC_URL;
+};
+
+const SERVER_URL = resolveDesktopRpcServerUrl(typeof window === "undefined" ? undefined : window.location.origin);
 
 /**
  * Build the desktop HTTP RPC protocol, optionally carrying the shell-issued

--- a/apps/professional-desktop/test/packaged-rpc-origin.test.ts
+++ b/apps/professional-desktop/test/packaged-rpc-origin.test.ts
@@ -1,0 +1,24 @@
+import { resolveChatRpcServerUrl } from "@beep/agents-client/Chat.atoms";
+import { describe, expect, it } from "vitest";
+import { resolveDesktopRpcServerUrl } from "@/transport/DesktopHttpProtocol";
+
+const SIDECAR_RPC_URL = "http://127.0.0.1:3939/rpc";
+const resolvers = [resolveDesktopRpcServerUrl, resolveChatRpcServerUrl];
+
+describe("packaged Tauri RPC origin routing", () => {
+  it.each(["http", "https"])("routes the Windows %s packaged origin to the loopback sidecar", (scheme) => {
+    const origin = `${scheme}://tauri.localhost`;
+
+    for (const resolveRpcServerUrl of resolvers) {
+      expect(resolveRpcServerUrl(origin)).toBe(SIDECAR_RPC_URL);
+    }
+  });
+
+  it("keeps ordinary HTTP development origins relative to the dev server", () => {
+    for (const resolveRpcServerUrl of resolvers) {
+      expect(resolveRpcServerUrl("http://professional-desktop.beep.localhost:1355")).toBe(
+        "http://professional-desktop.beep.localhost:1355/rpc"
+      );
+    }
+  });
+});

--- a/packages/agents/client/src/Chat.atoms.ts
+++ b/packages/agents/client/src/Chat.atoms.ts
@@ -44,18 +44,45 @@ type StreamingTurnReconciliation = typeof StreamingTurnReconciliation.Type;
 // Dev (browser or `tauri dev`): the page is served from a real http(s) origin
 // (the dev server), so the rpc URL rides that origin relative to `/rpc` — which
 // keeps the app reachable from any device that can reach the dev server.
-// Packaged Tauri serves from a `tauri://`-style origin, so there is no http
-// server to ride: talk to the sidecar directly. We avoid `import.meta.env`
-// (vite-only, untyped under NodeNext) and key off the live origin instead.
-const SERVER_URL = ((): string => {
-  if (typeof window !== "undefined") {
-    const origin = window.location.origin;
-    if (Str.startsWith(origin, "http://") || Str.startsWith(origin, "https://")) {
-      return new URL("/rpc", origin).toString();
-    }
+// Packaged Tauri serves from a `tauri://`-style origin on Linux/macOS and an
+// http(s) `tauri.localhost` origin on Windows, so there is no dev server to
+// ride: talk to the sidecar directly. We avoid `import.meta.env` (vite-only,
+// untyped under NodeNext) and key off the live origin instead.
+const SIDECAR_RPC_URL = "http://127.0.0.1:3939/rpc" as const;
+const WINDOWS_TAURI_HTTP_ORIGIN = "http://tauri.localhost" as const;
+const WINDOWS_TAURI_HTTPS_ORIGIN = "https://tauri.localhost" as const;
+
+/**
+ * Resolve the chat RPC endpoint for a browser origin.
+ *
+ * Packaged Tauri origins use the loopback sidecar, including Windows' HTTP(S)
+ * `tauri.localhost` origins. Other HTTP(S) origins are development servers and
+ * keep their origin-relative `/rpc` route.
+ *
+ * @example
+ * ```ts
+ * import { resolveChatRpcServerUrl } from "@beep/agents-client/Chat.atoms"
+ *
+ * console.log(resolveChatRpcServerUrl("http://tauri.localhost"))
+ * // "http://127.0.0.1:3939/rpc"
+ * ```
+ *
+ * @category clients
+ * @since 0.0.0
+ */
+export const resolveChatRpcServerUrl = (origin: string | undefined): string => {
+  if (
+    origin !== undefined &&
+    origin !== WINDOWS_TAURI_HTTP_ORIGIN &&
+    origin !== WINDOWS_TAURI_HTTPS_ORIGIN &&
+    (Str.startsWith(origin, "http://") || Str.startsWith(origin, "https://"))
+  ) {
+    return new URL("/rpc", origin).toString();
   }
-  return "http://127.0.0.1:3939/rpc";
-})();
+  return SIDECAR_RPC_URL;
+};
+
+const SERVER_URL = resolveChatRpcServerUrl(typeof window === "undefined" ? undefined : window.location.origin);
 
 // Ambient telemetry (logger/tracer/metrics are fiber-runtime concerns, not
 // typed services) rides every atom runtime via the global layer; this is what


### PR DESCRIPTION
## fix(oip-web): keep production start unwrapped and drop dead dev CSP wildcard

Greptile review fixes on PR #428: the `start` script must not depend on
the portless dev CLI at production runtime (the Dev Servers law covers
dev servers only), and the dev CSP's https://*.localhost:* wildcard is
dead now that dev rides the plain-HTTP proxy.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

## fix(professional-desktop): route packaged-webview rpc to the loopback sidecar on windows

Windows packaged Tauri serves the frontend from http://tauri.localhost (not
tauri://localhost), so the desktop and chat RPC resolvers treated it as a dev
origin and hit http://tauri.localhost/rpc with no handler. Both resolvers now
map http(s)://tauri.localhost to the loopback sidecar http://127.0.0.1:3939/rpc,
with a unit test covering the Windows packaged origin.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

## Local proof

- publish:head-install-preflight: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/fix_oip-web-start-and-dead-csp-4178d24ea501/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786908023&installation_id=141092090&pr_number=430&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F430&signature=42114d989ef3308d4b89c6148e0924932f1c5f72b7c8e3dc23c3331a59e3b646"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->