### PR TITLE
chore(claude): drop redundant Write() permission deny rules

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -93,11 +93,8 @@
       "Bash(gh api -X PUT:*)",
       "Bash(gh api --method PUT:*)",
       "Edit(**/.github/workflows/**)",
-      "Write(**/.github/workflows/**)",
       "Edit(**/docs/_internal/**)",
-      "Write(**/docs/_internal/**)",
-      "Edit(**/.claude/settings.json)",
-      "Write(**/.claude/settings.json)"
+      "Edit(**/.claude/settings.json)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
## chore(claude): drop redundant Write() permission deny rules

Edit(path) deny rules already cover all file-editing tools including
Write, so the duplicate Write() variants only triggered a startup
warning in Claude Code without adding protection.

## Local proof

- fallow-advisory-feedback: passed
- publish:head-install-preflight: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/chore_remove-redundant-write-deny-rules-5ac77f4ac9ff/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/442"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787556339&installation_model_id=424656&pr_number=442&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F442&signature=ca29fda3c19de990556e85fd0e0dd7f17318a63d6e3e02ec899a365819eb354e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->