### PR TITLE
fix(dock-react): resolve tab renderers by own key only

### DIFF
--- a/.changeset/dock-react-tab-renderer-own-key.md
+++ b/.changeset/dock-react-tab-renderer-own-key.md
@@ -1,0 +1,7 @@
+---
+"@beep/dock-react": patch
+---
+
+Resolve tab renderers by own key only, so a persisted `tabComponent` naming a
+prototype property (`toString`, `constructor`, `__proto__`) falls back to the panel
+title instead of mounting an inherited value as a React component.

--- a/packages/foundation/ui-system/dock-react/src/internal/GroupPane.tsx
+++ b/packages/foundation/ui-system/dock-react/src/internal/GroupPane.tsx
@@ -18,6 +18,7 @@ import * as Bool from "effect/Boolean";
 import * as Eq from "effect/Equal";
 import * as O from "effect/Option";
 import * as P from "effect/Predicate";
+import * as R from "effect/Record";
 import { useCallback, useEffect, useRef } from "react";
 import { makeOperation } from "./AdapterState.ts";
 import { boxStyle, compileDrop, preFloatContextFor, pressStartsOnButton, relativePositionOf } from "./DropCompiler.ts";
@@ -108,7 +109,7 @@ const Tab = (props: {
   };
   const Renderer = O.getOrElse(
     O.flatMap(props.panel.tabComponent, (key) =>
-      O.flatMap(O.fromUndefinedOr(props.tabComponents), (components) => O.fromUndefinedOr(components[key]))
+      O.flatMap(O.fromUndefinedOr(props.tabComponents), (components) => R.get(components, key))
     ),
     () => props.defaultTabComponent
   );

--- a/packages/foundation/ui-system/dock-react/test/DockviewReact.test.tsx
+++ b/packages/foundation/ui-system/dock-react/test/DockviewReact.test.tsx
@@ -224,6 +224,22 @@ describe("DockviewReact", { concurrent: false }, () => {
     })
   );
 
+  it.effect("treats prototype tab renderer keys as missing", () =>
+    Effect.gen(function* () {
+      const inherited = Panel.make({
+        id: panel1Id,
+        title: "Inherited Tab",
+        view: TextPanelView.make({ text: "first" }),
+        tabComponent: O.some(RendererKey.make("toString")),
+      });
+      const graph = yield* makeGraph(makeWorkspace([inherited]));
+      render(<DockviewReact graph={graph} components={{}} tabComponents={{}} />);
+      sizeRoot();
+      expect((yield* Effect.promise(() => screen.findByRole("tab"))).textContent).toContain("Inherited Tab");
+      graph.dispose();
+    })
+  );
+
   it.effect("survives StrictMode remount cleanup without taking ownership of the graph", () =>
     Effect.gen(function* () {
       const graph = yield* makeGraph();


### PR DESCRIPTION
Follow-up to #445. Panel renderer lookup was hardened there, but the tab renderer
path still indexed the components record directly, so a persisted `tabComponent`
naming a prototype property (`toString`, `constructor`, `__proto__`) resolved an
inherited value and mounted it as a React component.

Verified the regression test discriminates: against the unfixed lookup the tab
renders `[object Undefined]` (Object.prototype.toString invoked as a component);
with own-key lookup it falls back to the panel title.

- `R.get` own-key lookup in the tab renderer resolution
- regression test for a prototype `tabComponent` key
- patch changeset

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/448"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787590110&installation_model_id=424656&pr_number=448&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F448&signature=7b62444f047db1bf4845f87471dc59a03f29a0ca5069808ba41187caca9d8100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->