### PR TITLE
fix(ui): await overlay visibility in Storybook interaction tests

### DIFF
--- a/.changeset/storybook-popover-visibility-races.md
+++ b/.changeset/storybook-popover-visibility-races.md
@@ -1,0 +1,10 @@
+---
+"@beep/ui": patch
+"@beep/form": patch
+---
+
+Await overlay visibility in Storybook interaction tests instead of asserting it in the microtask after a click.
+
+The DatePicker `Default` story raced the Radix popover enter animation and failed on CI runners with the calendar grid present in the DOM but not yet visible. The same unguarded pattern is corrected in the Drawer stories and the Emoji form field. The `NonDismissible` drawer assertion stays synchronous on purpose, with a comment explaining that a retrying `waitFor` would mask a drawer that closes and reopens.
+
+Story files only — no component behavior changes.

--- a/packages/foundation/ui-system/form/stories/fields/Emoji.stories.tsx
+++ b/packages/foundation/ui-system/form/stories/fields/Emoji.stories.tsx
@@ -1,6 +1,6 @@
 import { Form, makeFormOptions, useAppForm } from "@beep/form";
 import * as S from "effect/Schema";
-import { expect, screen, userEvent, within } from "storybook/test";
+import { expect, screen, userEvent, waitFor, within } from "storybook/test";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 const Schema = S.Struct({ emoji: S.String });
@@ -32,8 +32,8 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   play: ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    return userEvent.click(canvas.getByRole("button", { name: /select emoji/i })).then(() => {
-      expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument();
-    });
+    return userEvent
+      .click(canvas.getByRole("button", { name: /select emoji/i }))
+      .then(() => waitFor(() => expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument()));
   },
 };

--- a/packages/foundation/ui-system/ui/stories/components/date-picker.stories.tsx
+++ b/packages/foundation/ui-system/ui/stories/components/date-picker.stories.tsx
@@ -60,10 +60,10 @@ export const Default: Story = {
     const canvas = within(canvasElement);
     const trigger = canvas.getByRole("button", { name: "Pick a date" });
     expect(trigger).toBeVisible();
-    return userEvent.click(trigger).then(() => {
-      const popover = within(document.body);
-      expect(popover.getByRole("grid")).toBeVisible();
-    });
+    return userEvent
+      .click(trigger)
+      .then(() => screen.findByRole("grid"))
+      .then((grid) => waitFor(() => expect(grid).toBeVisible()));
   },
 };
 

--- a/packages/foundation/ui-system/ui/stories/components/drawer.stories.tsx
+++ b/packages/foundation/ui-system/ui/stories/components/drawer.stories.tsx
@@ -96,10 +96,12 @@ export const Default: Story = {
     const canvas = within(canvasElement);
     const trigger = canvas.getByRole("button", { name: "Open drawer" });
     expect(trigger).toBeVisible();
-    return userEvent.click(trigger).then(() => {
-      expect(screen.getByText("Edit profile")).toBeVisible();
-      expect(args.onOpenChange).toHaveBeenCalled();
-    });
+    return userEvent.click(trigger).then(() =>
+      waitFor(() => {
+        expect(screen.getByText("Edit profile")).toBeVisible();
+        expect(args.onOpenChange).toHaveBeenCalled();
+      })
+    );
   },
 };
 
@@ -129,10 +131,7 @@ export const DefaultOpen: Story = {
       </DrawerContent>
     </Drawer>
   ),
-  play: () => {
-    expect(screen.getByText("Welcome aboard")).toBeVisible();
-    return Promise.resolve();
-  },
+  play: () => waitFor(() => expect(screen.getByText("Welcome aboard")).toBeVisible()),
 };
 
 /**
@@ -162,9 +161,9 @@ export const RightSide: Story = {
   ),
   play: ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    return userEvent.click(canvas.getByRole("button", { name: "Open panel" })).then(() => {
-      expect(screen.getByText("Filters")).toBeVisible();
-    });
+    return userEvent
+      .click(canvas.getByRole("button", { name: "Open panel" }))
+      .then(() => waitFor(() => expect(screen.getByText("Filters")).toBeVisible()));
   },
 };
 
@@ -249,10 +248,8 @@ export const Closing: Story = {
     const canvas = within(canvasElement);
     return userEvent
       .click(canvas.getByRole("button", { name: "Open drawer" }))
-      .then(() => {
-        expect(screen.getByText("Session expiring")).toBeVisible();
-        return userEvent.click(screen.getByRole("button", { name: "Cancel" }));
-      })
+      .then(() => waitFor(() => expect(screen.getByText("Session expiring")).toBeVisible()))
+      .then(() => userEvent.click(screen.getByRole("button", { name: "Cancel" })))
       .then(() =>
         waitFor(() => {
           expect(screen.queryByText("Session expiring")).toBeNull();
@@ -293,9 +290,9 @@ export const Destructive: Story = {
   ),
   play: ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    return userEvent.click(canvas.getByRole("button", { name: "Delete account" })).then(() => {
-      expect(screen.getByRole("button", { name: "Delete" })).toBeVisible();
-    });
+    return userEvent
+      .click(canvas.getByRole("button", { name: "Delete account" }))
+      .then(() => waitFor(() => expect(screen.getByRole("button", { name: "Delete" })).toBeVisible()));
   },
 };
 
@@ -329,11 +326,11 @@ export const NonDismissible: Story = {
     const canvas = within(canvasElement);
     return userEvent
       .click(canvas.getByRole("button", { name: "Open drawer" }))
+      .then(() => waitFor(() => expect(screen.getByText("Action required")).toBeVisible()))
+      .then(() => userEvent.keyboard("{Escape}"))
       .then(() => {
-        expect(screen.getByText("Action required")).toBeVisible();
-        return userEvent.keyboard("{Escape}");
-      })
-      .then(() => {
+        // Asserted synchronously on purpose: the drawer must NOT close, so a
+        // retrying waitFor would mask a drawer that closes and reopens.
         expect(screen.getByText("Action required")).toBeVisible();
       });
   },


### PR DESCRIPTION
## fix(ui): await overlay visibility in Storybook interaction tests

The DatePicker Default story asserted the calendar grid was visible in the
microtask right after the click resolved, so it raced the Radix popover enter
animation. It passes on fast hardware and loses on CI runners, where it failed
with the grid present in the DOM but not yet visible.

This was masked on main: Turbo replayed a cached @beep/storybook#test:storybook
result on every run, so the browser tests never actually executed. Any branch
whose input hash missed that entry ran them for real and failed. Because the
chunk runner exits on the first failing chunk, chunks 2-4 had not run at all.

Wrap the unguarded portal reads that follow an interaction on an animated
overlay in waitFor, covering DatePicker, Drawer, and the Emoji form field. The
NonDismissible drawer assertion stays synchronous on purpose and now says why:
it asserts the drawer does not close, which a retrying waitFor would mask.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit:amend: passed
- full:pre-push: passed
- publish:head-install-preflight: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/fix_storybook-popover-visibility-races-d01ba55d2884/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787653773&installation_model_id=424656&pr_number=460&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F460&signature=2984a3489cbc6cbe3d3a4366aa3233fb543d2bdb454637e7d8dac9468f0d0e2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->