### PR TITLE
feat(repo-cli): add image audit and curation commands

### DIFF
--- a/packages/tooling/tool/cli/src/commands/Files/Files.command.ts
+++ b/packages/tooling/tool/cli/src/commands/Files/Files.command.ts
@@ -14,13 +14,17 @@ import {
   CropBordersOptions,
   DetectBordersOptions,
   DetectFacesOptions,
+  ImageAuditOptions,
+  ImageCurationOptions,
   NormalizeFilesOptions,
   ProcessFilesOptions,
 } from "./Files.schemas.ts";
 import {
   archivePoorCandidates,
+  auditImages,
   createCaptionFiles,
   cropBordersFiles,
+  curateImages,
   detectBordersFiles,
   detectFacesFiles,
   FilesCommandServiceLive,
@@ -63,6 +67,28 @@ const cropBordersDirFlag = Flag.directory("dir", { mustExist: true }).pipe(
 );
 const archiveCandidatesDirFlag = Flag.directory("dir", { mustExist: true }).pipe(
   Flag.withDescription("Directory whose direct image files should be assessed for poor-candidate archival")
+);
+const auditImagesDirFlag = Flag.directory("dir", { mustExist: true }).pipe(
+  Flag.withDescription("Directory whose direct image files should be audited without mutation")
+);
+const auditImagesModelFlag = Flag.file("model", { mustExist: true }).pipe(
+  Flag.withDescription("Pinned YuNet-compatible ONNX face detection model")
+);
+const auditImagesManifestFlag = Flag.path("manifest", { pathType: "file" }).pipe(
+  Flag.withDescription("Path to the image audit manifest")
+);
+const curateImagesDirFlag = Flag.directory("dir", { mustExist: true }).pipe(
+  Flag.withDescription("Immutable source directory containing direct image files")
+);
+const curateImagesDecisionsFlag = Flag.file("decisions", { mustExist: true }).pipe(
+  Flag.withDescription("Complete hash-pinned image curation decision ledger")
+);
+const curateImagesOutDirFlag = Flag.directory("out-dir").pipe(
+  Flag.withDescription("Output root for canonical, holdout, reserve, archive, and manifest derivatives")
+);
+const curateImagesManifestFlag = Flag.path("manifest", { pathType: "file" }).pipe(
+  Flag.withDescription("Curation manifest output path; defaults to --out-dir/manifests/image-curation-manifest.json"),
+  Flag.optional
 );
 const archiveDirFlag = Flag.directory("archive-dir").pipe(
   Flag.withDescription("Directory that receives archived poor image candidates")
@@ -133,6 +159,15 @@ const createCaptionsDryRunFlag = Flag.boolean("dry-run").pipe(
 );
 const archiveDryRunFlag = Flag.boolean("dry-run").pipe(
   Flag.withDescription("Print the planned poor-candidate archival without moving files")
+);
+const curateImagesDryRunFlag = Flag.boolean("dry-run").pipe(
+  Flag.withDescription("Validate and print every disposition without writing derivatives")
+);
+const auditImagesOverwriteFlag = Flag.boolean("overwrite").pipe(
+  Flag.withDescription("Overwrite an existing regular-file image audit manifest")
+);
+const curateImagesOverwriteFlag = Flag.boolean("overwrite").pipe(
+  Flag.withDescription("Overwrite existing regular-file curation outputs and manifest")
 );
 const captionTextFlag = Flag.string("caption").pipe(
   Flag.withDefault(""),
@@ -220,6 +255,33 @@ const minFaceAreaPctFlag = Flag.float("min-face-area-pct").pipe(
 const faceEdgeMarginPctFlag = Flag.float("edge-margin-pct").pipe(
   Flag.withDefault(2),
   Flag.withDescription("Flag detected faces whose primary face box is within this percent of an image edge")
+);
+
+const filesAuditImagesCommand = Command.make(
+  "audit-images",
+  {
+    dir: auditImagesDirFlag,
+    manifest: auditImagesManifestFlag,
+    minConfidence: minFaceConfidenceFlag,
+    modelPath: auditImagesModelFlag,
+    overwrite: auditImagesOverwriteFlag,
+  },
+  Effect.fn(function* ({ dir, manifest, minConfidence, modelPath, overwrite }) {
+    yield* runFilesProgram(
+      auditImages(
+        ImageAuditOptions.make({
+          dir,
+          manifest,
+          minConfidence,
+          modelPath,
+          overwrite,
+        })
+      )
+    );
+  })
+).pipe(
+  Command.withDescription("Audit image hashes, geometry, metadata presence, faces, and advisory quality"),
+  Command.provide(FilesCommandServiceLive)
 );
 
 const filesCreateCaptionsCommand = Command.make(
@@ -353,6 +415,35 @@ const filesCropBordersCommand = Command.make(
   })
 ).pipe(
   Command.withDescription("Crop solid or near-solid canvas borders from direct image files"),
+  Command.provide(FilesCommandServiceLive)
+);
+
+const filesCurateImagesCommand = Command.make(
+  "curate-images",
+  {
+    decisionsPath: curateImagesDecisionsFlag,
+    dir: curateImagesDirFlag,
+    dryRun: curateImagesDryRunFlag,
+    manifest: curateImagesManifestFlag,
+    outDir: curateImagesOutDirFlag,
+    overwrite: curateImagesOverwriteFlag,
+  },
+  Effect.fn(function* ({ decisionsPath, dir, dryRun, manifest, outDir, overwrite }) {
+    yield* runFilesProgram(
+      curateImages(
+        ImageCurationOptions.make({
+          decisionsPath,
+          dir,
+          dryRun,
+          manifest,
+          outDir,
+          overwrite,
+        })
+      )
+    );
+  })
+).pipe(
+  Command.withDescription("Materialize hash-pinned image decisions as metadata-free canonical PNG derivatives"),
   Command.provide(FilesCommandServiceLive)
 );
 
@@ -505,9 +596,11 @@ const filesStripMetadataCommand = Command.make(
 export const filesCommand = Command.make("files", {}, () => printFilesIndex).pipe(
   Command.withDescription("Dataset file curation commands"),
   Command.withSubcommands([
+    filesAuditImagesCommand,
     filesArchivePoorCandidatesCommand,
     filesCreateCaptionsCommand,
     filesCropBordersCommand,
+    filesCurateImagesCommand,
     filesDetectBordersCommand,
     filesDetectFacesCommand,
     filesNormalizeCommand,

--- a/packages/tooling/tool/cli/src/commands/Files/Files.schemas.ts
+++ b/packages/tooling/tool/cli/src/commands/Files/Files.schemas.ts
@@ -34,6 +34,20 @@ export * from "./internal/CreateCaptions.schemas.ts";
  */
 export * from "./internal/DetectFaces.schemas.ts";
 /**
+ * Read-only image audit schemas.
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export * from "./internal/ImageAudit.schemas.ts";
+/**
+ * Ledger-driven image curation schemas.
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export * from "./internal/ImageCuration.schemas.ts";
+/**
  * Shared media primitive and probe-boundary schemas.
  *
  * @category schemas

--- a/packages/tooling/tool/cli/src/commands/Files/Files.service.ts
+++ b/packages/tooling/tool/cli/src/commands/Files/Files.service.ts
@@ -98,6 +98,7 @@ import {
   preflightNormalizeOutputs,
   preflightTargetCollisions,
 } from "./internal/Apply.ts";
+import { auditImagesImpl, curateImagesImpl } from "./internal/ImageCuration.ts";
 import { isUnsafeMetadataVideoExtension, probeImageDimensions, probeMediaDimensions } from "./internal/MediaExec.ts";
 import { processFilesImpl } from "./internal/Process.ts";
 import {
@@ -129,6 +130,10 @@ import type {
   DetectFacesEntry,
   DetectFacesOptions,
   DetectFacesSkippedReason,
+  ImageAuditManifest,
+  ImageAuditOptions,
+  ImageCurationOptions,
+  ImageCurationSummary,
   MediaDimensions,
   MediaKind,
   NormalizeImageFormat,
@@ -190,6 +195,12 @@ export interface FilesCommandServiceShape {
   readonly archivePoorCandidates: (
     options: ArchivePoorCandidatesOptions
   ) => Effect.Effect<ArchivePoorCandidatesSummary, FilesCommandError>;
+  /**
+   * Audit direct images without mutating source bytes.
+   *
+   * @since 0.0.0
+   */
+  readonly auditImages: (options: ImageAuditOptions) => Effect.Effect<ImageAuditManifest, FilesCommandError>;
 
   /**
    * Create same-stem caption sidecar files for direct image files.
@@ -206,6 +217,13 @@ export interface FilesCommandServiceShape {
    * @since 0.0.0
    */
   readonly cropBordersFiles: (options: CropBordersOptions) => Effect.Effect<CropBordersSummary, FilesCommandError>;
+
+  /**
+   * Validate a complete decision ledger and materialize canonical PNG derivatives.
+   *
+   * @since 0.0.0
+   */
+  readonly curateImages: (options: ImageCurationOptions) => Effect.Effect<ImageCurationSummary, FilesCommandError>;
 
   /**
    * Detect solid or near-solid borders in direct image files.
@@ -1692,6 +1710,8 @@ const buildStripMetadataPlan = Effect.fn("Files.buildStripMetadataPlan")(functio
  */
 export const printFilesIndex = printLines([
   "Files commands:",
+  "- bun run files audit-images --dir ./raw --model ./face_detection_yunet.onnx --manifest ./audit.json",
+  "- bun run files curate-images --dir ./raw --decisions ./decisions.json --out-dir ./prepared",
   "- bun run files sort-and-rename --prefix image --dir ./tmp",
   "- bun run files sort-and-rename --prefix image --dir ./tmp --with-dimensions",
   "- bun run files strip-metadata --dir ./tmp",
@@ -2416,6 +2436,9 @@ const makeFilesCommandService = Effect.fn("FilesCommandService.make")(function* 
   const runtimeContext = yield* Effect.context<FilesCommandServiceRequirements>();
 
   return FilesCommandService.of({
+    auditImages: Effect.fn("FilesCommandService.auditImages")((options) =>
+      auditImagesImpl(options).pipe(Effect.provide(runtimeContext))
+    ),
     archivePoorCandidates: Effect.fn("FilesCommandService.archivePoorCandidates")((options) =>
       archivePoorCandidatesImpl(options).pipe(Effect.provide(runtimeContext))
     ),
@@ -2424,6 +2447,9 @@ const makeFilesCommandService = Effect.fn("FilesCommandService.make")(function* 
     ),
     cropBordersFiles: Effect.fn("FilesCommandService.cropBordersFiles")((options) =>
       cropBordersFilesImpl(options).pipe(Effect.provide(runtimeContext))
+    ),
+    curateImages: Effect.fn("FilesCommandService.curateImages")((options) =>
+      curateImagesImpl(options).pipe(Effect.provide(runtimeContext))
     ),
     detectBordersFiles: Effect.fn("FilesCommandService.detectBordersFiles")((options) =>
       detectBordersFilesImpl(options).pipe(Effect.provide(runtimeContext))
@@ -2461,6 +2487,27 @@ const makeFilesCommandService = Effect.fn("FilesCommandService.make")(function* 
  */
 export const FilesCommandServiceLive: Layer.Layer<FilesCommandService, never, FilesCommandServiceRequirements> =
   Layer.effect(FilesCommandService, makeFilesCommandService());
+
+/**
+ * Audit direct images and write deterministic review evidence without changing source files.
+ *
+ * @param options - Image audit directory, model, manifest, and overwrite options.
+ * @returns The completed image audit manifest.
+ * @example
+ * ```ts
+ * import { auditImages } from "@beep/repo-cli/commands/Files"
+ *
+ * const example: typeof auditImages = auditImages
+ * ```
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const auditImages = Effect.fn("Files.auditImages")(function* (
+  options: ImageAuditOptions
+): Effect.fn.Return<ImageAuditManifest, FilesCommandError, FilesCommandService> {
+  const files = yield* FilesCommandService;
+  return yield* files.auditImages(options);
+});
 
 /**
  * Archive obvious poor image candidates out of a dataset directory.
@@ -2523,6 +2570,27 @@ export const cropBordersFiles = Effect.fn("Files.cropBordersFiles")(function* (
 ): Effect.fn.Return<CropBordersSummary, FilesCommandError, FilesCommandService> {
   const files = yield* FilesCommandService;
   return yield* files.cropBordersFiles(options);
+});
+
+/**
+ * Validate a complete decision ledger and materialize canonical PNG derivatives.
+ *
+ * @param options - Source, ledger, output, dry-run, and overwrite options.
+ * @returns Summary counts for the curation run.
+ * @example
+ * ```ts
+ * import { curateImages } from "@beep/repo-cli/commands/Files"
+ *
+ * const example: typeof curateImages = curateImages
+ * ```
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const curateImages = Effect.fn("Files.curateImages")(function* (
+  options: ImageCurationOptions
+): Effect.fn.Return<ImageCurationSummary, FilesCommandError, FilesCommandService> {
+  const files = yield* FilesCommandService;
+  return yield* files.curateImages(options);
 });
 
 /**

--- a/packages/tooling/tool/cli/src/commands/Files/internal/ImageAudit.schemas.ts
+++ b/packages/tooling/tool/cli/src/commands/Files/internal/ImageAudit.schemas.ts
@@ -1,0 +1,235 @@
+/**
+ * Image audit schemas for Files commands.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import * as S from "effect/Schema";
+import { FileSha256Hash, PositiveMediaDimension } from "./Media.schemas.ts";
+
+// cspell:ignore Iptc
+
+const $I = $RepoCliId.create("commands/Files/internal/ImageAudit.schemas");
+
+/**
+ * Options used by `files audit-images`.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class ImageAuditOptions extends S.Class<ImageAuditOptions>($I`ImageAuditOptions`)(
+  {
+    dir: S.String,
+    manifest: S.String,
+    minConfidence: S.Finite,
+    modelPath: S.String,
+    overwrite: S.Boolean,
+  },
+  $I.annote("ImageAuditOptions", {
+    description: "Validated inputs for a read-only image identity and quality audit.",
+  })
+) {}
+
+/**
+ * Metadata-presence flags recorded without copying metadata values.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class ImageAuditMetadataPresence extends S.Class<ImageAuditMetadataPresence>($I`ImageAuditMetadataPresence`)(
+  {
+    hasExif: S.Boolean,
+    hasIcc: S.Boolean,
+    hasIptc: S.Boolean,
+    hasXmp: S.Boolean,
+    orientation: S.optionalKey(S.Int),
+    orientationApplied: S.Boolean,
+  },
+  $I.annote("ImageAuditMetadataPresence", {
+    description: "Privacy-preserving metadata presence and orientation facts for a source image.",
+  })
+) {}
+
+/**
+ * Advisory technical-quality measurements for an audited image.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class ImageAuditQualityMetrics extends S.Class<ImageAuditQualityMetrics>($I`ImageAuditQualityMetrics`)(
+  {
+    colorfulness: S.Finite,
+    darkClipPct: S.Finite,
+    edgeEnergy: S.Finite,
+    entropyBits: S.Finite,
+    lightClipPct: S.Finite,
+    meanLuminance: S.Finite,
+  },
+  $I.annote("ImageAuditQualityMetrics", {
+    description: "Advisory luminance, clipping, color, entropy, and edge-energy measurements.",
+  })
+) {}
+
+/**
+ * Face measurements recorded for one audited image.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class ImageAuditFaceMetrics extends S.Class<ImageAuditFaceMetrics>($I`ImageAuditFaceMetrics`)(
+  {
+    faceCount: S.Int,
+    primaryFaceAreaPct: S.optionalKey(S.Finite),
+    primaryFaceConfidence: S.optionalKey(S.Finite),
+    primaryFaceHeight: S.optionalKey(S.Finite),
+    primaryFaceWidth: S.optionalKey(S.Finite),
+  },
+  $I.annote("ImageAuditFaceMetrics", {
+    description: "Detected face count and primary-face scale measurements used only for review.",
+  })
+) {}
+
+/**
+ * One successfully audited source image.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class ImageAuditEntry extends S.Class<ImageAuditEntry>($I`ImageAuditEntry`)(
+  {
+    aspectRatio: S.Finite,
+    colorHash: S.String,
+    decodedPixelSha256: FileSha256Hash,
+    extension: S.String,
+    faces: ImageAuditFaceMetrics,
+    height: PositiveMediaDimension,
+    metadata: ImageAuditMetadataPresence,
+    perceptualHash: S.String,
+    quality: ImageAuditQualityMetrics,
+    sourceName: S.String,
+    sourcePath: S.String,
+    sourceRelativePath: S.String,
+    sourceSha256: FileSha256Hash,
+    sourceSizeBytes: S.String,
+    width: PositiveMediaDimension,
+  },
+  $I.annote("ImageAuditEntry", {
+    description: "Hashes, geometry, metadata presence, face scale, and advisory quality data for one source image.",
+  })
+) {}
+
+/**
+ * A source entry skipped by the image audit.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class ImageAuditSkippedEntry extends S.Class<ImageAuditSkippedEntry>($I`ImageAuditSkippedEntry`)(
+  {
+    message: S.String,
+    sourceName: S.String,
+    sourcePath: S.String,
+  },
+  $I.annote("ImageAuditSkippedEntry", {
+    description: "A non-image, unsafe, or unreadable direct source entry skipped by the audit.",
+  })
+) {}
+
+/**
+ * Advisory perceptual similarity between two audited images.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class ImageAuditSimilarityPair extends S.Class<ImageAuditSimilarityPair>($I`ImageAuditSimilarityPair`)(
+  {
+    colorDistance: S.Finite,
+    perceptualDistance: S.Int,
+    sourceNameA: S.String,
+    sourceNameB: S.String,
+  },
+  $I.annote("ImageAuditSimilarityPair", {
+    description: "A candidate near-duplicate pair and its advisory perceptual and color distances.",
+  })
+) {}
+
+/**
+ * Candidate duplicate or filename-session cluster.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class ImageAuditCluster extends S.Class<ImageAuditCluster>($I`ImageAuditCluster`)(
+  {
+    id: S.String,
+    sourceNames: S.NonEmptyArray(S.String),
+  },
+  $I.annote("ImageAuditCluster", {
+    description: "A deterministic candidate cluster that requires visual confirmation.",
+  })
+) {}
+
+/**
+ * Summary counts for an image audit.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class ImageAuditSummary extends S.Class<ImageAuditSummary>($I`ImageAuditSummary`)(
+  {
+    analyzedCount: S.Int,
+    duplicateClusterCount: S.Int,
+    faceImageCount: S.Int,
+    multiFaceImageCount: S.Int,
+    noFaceImageCount: S.Int,
+    sessionClusterCount: S.Int,
+    similarityPairCount: S.Int,
+    skippedCount: S.Int,
+    totalCount: S.Int,
+  },
+  $I.annote("ImageAuditSummary", {
+    description: "Machine-readable counts for a completed image audit.",
+  })
+) {}
+
+/**
+ * Read-only image audit manifest.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class ImageAuditManifest extends S.Class<ImageAuditManifest>($I`ImageAuditManifest`)(
+  {
+    duplicateClusters: S.Array(ImageAuditCluster),
+    entries: S.Array(ImageAuditEntry),
+    manifestPath: S.String,
+    modelPath: S.String,
+    schemaVersion: S.Literal("beep.files.image-audit.v1"),
+    sessionClusters: S.Array(ImageAuditCluster),
+    similarityPairs: S.Array(ImageAuditSimilarityPair),
+    skipped: S.Array(ImageAuditSkippedEntry),
+    sourceDirectory: S.String,
+    summary: ImageAuditSummary,
+  },
+  $I.annote("ImageAuditManifest", {
+    description: "Deterministic image audit evidence; all scores and clusters are advisory.",
+  })
+) {}
+
+/**
+ * Encode an image audit manifest into its JSON-safe representation.
+ *
+ * @category encoding
+ * @since 0.0.0
+ */
+export const encodeImageAuditManifest = S.encodeUnknownEffect(ImageAuditManifest);
+
+/**
+ * Decode a JSON image audit manifest.
+ *
+ * @category decoding
+ * @since 0.0.0
+ */
+export const decodeImageAuditManifestJson = S.decodeUnknownEffect(S.fromJsonString(ImageAuditManifest));

--- a/packages/tooling/tool/cli/src/commands/Files/internal/ImageCuration.schemas.ts
+++ b/packages/tooling/tool/cli/src/commands/Files/internal/ImageCuration.schemas.ts
@@ -1,0 +1,230 @@
+/**
+ * Ledger-driven image curation schemas for Files commands.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { LiteralKit } from "@beep/schema";
+import { Effect } from "effect";
+import * as O from "effect/Option";
+import * as S from "effect/Schema";
+import { FileSha256Hash, NonNegativePixelOffset, PositiveMediaDimension } from "./Media.schemas.ts";
+
+const $I = $RepoCliId.create("commands/Files/internal/ImageCuration.schemas");
+
+/**
+ * Final materialization disposition for a source image.
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const ImageCurationDisposition = LiteralKit([
+  "active-core",
+  "active-extended",
+  "holdout",
+  "reserve-near-duplicate",
+  "archive-earlier-life",
+  "archive-identity-ambiguous",
+  "archive-other-people",
+  "archive-technical-quality",
+  "archive-synthetic-filtered",
+]).pipe(
+  $I.annoteSchema("ImageCurationDisposition", {
+    description: "Closed set of canonical, holdout, reserve, and archive destinations.",
+  })
+);
+
+/**
+ * Final materialization disposition for a source image.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export type ImageCurationDisposition = typeof ImageCurationDisposition.Type;
+
+/**
+ * Optional lossless crop rectangle in orientation-corrected source coordinates.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class ImageCurationCrop extends S.Class<ImageCurationCrop>($I`ImageCurationCrop`)(
+  {
+    height: PositiveMediaDimension,
+    left: NonNegativePixelOffset,
+    top: NonNegativePixelOffset,
+    width: PositiveMediaDimension,
+  },
+  $I.annote("ImageCurationCrop", {
+    description: "A reviewed natural crop expressed in pixels after EXIF orientation is applied.",
+  })
+) {}
+
+/**
+ * One explicit, hash-pinned source disposition.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class ImageCurationDecision extends S.Class<ImageCurationDecision>($I`ImageCurationDecision`)(
+  {
+    crop: S.optionalKey(ImageCurationCrop),
+    disposition: ImageCurationDisposition,
+    duplicateClusterId: S.optionalKey(S.String),
+    reasons: S.NonEmptyArray(S.String),
+    sessionId: S.optionalKey(S.String),
+    sourceName: S.String,
+    sourceSha256: FileSha256Hash,
+  },
+  $I.annote("ImageCurationDecision", {
+    description: "A human-reviewable source decision pinned to exact source bytes.",
+  })
+) {}
+
+/**
+ * Complete decision ledger consumed by `files curate-images`.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class ImageCurationDecisionDocument extends S.Class<ImageCurationDecisionDocument>(
+  $I`ImageCurationDecisionDocument`
+)(
+  {
+    decisions: S.Array(ImageCurationDecision),
+    schemaVersion: S.Literal("beep.files.image-curation-decisions.v1"),
+    sourceDirectory: S.String,
+  },
+  $I.annote("ImageCurationDecisionDocument", {
+    description: "A complete one-decision-per-source ledger for deterministic image curation.",
+  })
+) {}
+
+/**
+ * Options used by `files curate-images`.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class ImageCurationOptions extends S.Class<ImageCurationOptions>($I`ImageCurationOptions`)(
+  {
+    decisionsPath: S.String,
+    dir: S.String,
+    dryRun: S.Boolean,
+    manifest: S.Option(S.String).pipe(S.withConstructorDefault(Effect.succeed(O.none<string>()))),
+    outDir: S.String,
+    overwrite: S.Boolean,
+  },
+  $I.annote("ImageCurationOptions", {
+    description: "Validated source, ledger, output, dry-run, and overwrite inputs for image curation.",
+  })
+) {}
+
+/**
+ * One source-to-canonical-PNG materialization record.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class ImageCurationManifestEntry extends S.Class<ImageCurationManifestEntry>($I`ImageCurationManifestEntry`)(
+  {
+    crop: S.optionalKey(ImageCurationCrop),
+    disposition: ImageCurationDisposition,
+    duplicateClusterId: S.optionalKey(S.String),
+    outputHeight: PositiveMediaDimension,
+    outputName: S.String,
+    outputPath: S.String,
+    outputRelativePath: S.String,
+    outputSha256: FileSha256Hash,
+    outputSizeBytes: S.String,
+    outputWidth: PositiveMediaDimension,
+    reasons: S.NonEmptyArray(S.String),
+    sessionId: S.optionalKey(S.String),
+    sourceName: S.String,
+    sourcePath: S.String,
+    sourceRelativePath: S.String,
+    sourceSha256: FileSha256Hash,
+  },
+  $I.annote("ImageCurationManifestEntry", {
+    description: "Verified mapping from immutable source bytes to a metadata-free orientation-corrected PNG.",
+  })
+) {}
+
+/**
+ * Summary counts for a curation run.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class ImageCurationSummary extends S.Class<ImageCurationSummary>($I`ImageCurationSummary`)(
+  {
+    archiveCount: S.Int,
+    coreCount: S.Int,
+    dryRun: S.Boolean,
+    extendedCount: S.Int,
+    holdoutCount: S.Int,
+    materializedCount: S.Int,
+    plannedCount: S.Int,
+    reserveCount: S.Int,
+  },
+  $I.annote("ImageCurationSummary", {
+    description: "Counts by final disposition for a ledger validation or materialization run.",
+  })
+) {}
+
+/**
+ * Manifest produced by a successful image curation run.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class ImageCurationManifest extends S.Class<ImageCurationManifest>($I`ImageCurationManifest`)(
+  {
+    decisionDocumentPath: S.String,
+    entries: S.Array(ImageCurationManifestEntry),
+    manifestPath: S.String,
+    outputDirectory: S.String,
+    schemaVersion: S.Literal("beep.files.image-curation.v1"),
+    sourceDirectory: S.String,
+    summary: ImageCurationSummary,
+  },
+  $I.annote("ImageCurationManifest", {
+    description: "Complete provenance map for canonical PNG derivatives and all archived or reserved derivatives.",
+  })
+) {}
+
+/**
+ * Decode a JSON curation decision ledger.
+ *
+ * @category decoding
+ * @since 0.0.0
+ */
+export const decodeImageCurationDecisionDocumentJson = S.decodeUnknownEffect(
+  S.fromJsonString(ImageCurationDecisionDocument)
+);
+
+/**
+ * Encode a curation decision ledger into its JSON-safe representation.
+ *
+ * @category encoding
+ * @since 0.0.0
+ */
+export const encodeImageCurationDecisionDocument = S.encodeUnknownEffect(ImageCurationDecisionDocument);
+
+/**
+ * Encode a curation manifest into its JSON-safe representation.
+ *
+ * @category encoding
+ * @since 0.0.0
+ */
+export const encodeImageCurationManifest = S.encodeUnknownEffect(ImageCurationManifest);
+
+/**
+ * Decode a JSON curation manifest.
+ *
+ * @category decoding
+ * @since 0.0.0
+ */
+export const decodeImageCurationManifestJson = S.decodeUnknownEffect(S.fromJsonString(ImageCurationManifest));

--- a/packages/tooling/tool/cli/src/commands/Files/internal/ImageCuration.ts
+++ b/packages/tooling/tool/cli/src/commands/Files/internal/ImageCuration.ts
@@ -203,6 +203,39 @@ const pathsOverlap = (
   return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
 };
 
+const canonicalizeImageTargetPath = Effect.fn("Files.canonicalizeImageTargetPath")(function* (
+  targetPath: string,
+  description: string
+): Effect.fn.Return<string, FilesCommandError, FileSystem.FileSystem | Path.Path> {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const resolvedTarget = path.resolve(targetPath);
+  let candidate = resolvedTarget;
+
+  while (true) {
+    const exists = yield* fs
+      .exists(candidate)
+      .pipe(Effect.mapError((cause) => formatPlatformError(`Failed to inspect ${description}`, candidate, { cause })));
+    if (exists) {
+      const canonicalCandidate = yield* fs
+        .realPath(candidate)
+        .pipe(
+          Effect.mapError((cause) => formatPlatformError(`Failed to resolve ${description}`, candidate, { cause }))
+        );
+      const relativeSuffix = path.relative(candidate, resolvedTarget);
+      return relativeSuffix === "" ? canonicalCandidate : path.resolve(canonicalCandidate, relativeSuffix);
+    }
+
+    const parent = path.dirname(candidate);
+    if (parent === candidate) {
+      return yield* FilesCommandError.make({
+        message: `Failed to find an existing ancestor for ${description} "${resolvedTarget}".`,
+      });
+    }
+    candidate = parent;
+  }
+});
+
 const collectAuditSources = Effect.fn("Files.collectImageAuditSources")(function* (
   directory: string
 ): Effect.fn.Return<AuditSourceCollection, FilesCommandError, FileSystem.FileSystem | Path.Path> {
@@ -762,8 +795,8 @@ export const auditImagesImpl = Effect.fn("FilesCommandService.auditImages")(func
 
   const path = yield* Path.Path;
   const sources = yield* collectAuditSources(options.dir);
-  const manifestPath = path.resolve(options.manifest);
-  const modelPath = path.resolve(options.modelPath);
+  const manifestPath = yield* canonicalizeImageTargetPath(options.manifest, "image audit manifest path");
+  const modelPath = yield* canonicalizeImageTargetPath(options.modelPath, "image audit face model path");
   if (pathsOverlap(path, sources.canonicalDirectory, manifestPath)) {
     return yield* FilesCommandError.make({
       message: `Image audit manifest must not be written inside source directory "${sources.canonicalDirectory}".`,
@@ -921,16 +954,23 @@ const validateCurationRoots = Effect.fn("Files.validateImageCurationRoots")(func
   sources: AuditSourceCollection,
   decisions: ImageCurationDecisionDocument,
   decisionDocumentPath: string
-): Effect.fn.Return<{ readonly manifestPath: string; readonly outputDirectory: string }, FilesCommandError, Path.Path> {
+): Effect.fn.Return<
+  { readonly manifestPath: string; readonly outputDirectory: string },
+  FilesCommandError,
+  FileSystem.FileSystem | Path.Path
+> {
   const path = yield* Path.Path;
-  const recordedSourceDirectory = path.resolve(decisions.sourceDirectory);
+  const recordedSourceDirectory = yield* canonicalizeImageTargetPath(
+    decisions.sourceDirectory,
+    "decision ledger source directory"
+  );
   if (recordedSourceDirectory !== sources.canonicalDirectory) {
     return yield* FilesCommandError.make({
       message: `Decision ledger sourceDirectory "${recordedSourceDirectory}" does not match "${sources.canonicalDirectory}".`,
     });
   }
 
-  const outputDirectory = path.resolve(options.outDir);
+  const outputDirectory = yield* canonicalizeImageTargetPath(options.outDir, "image curation output directory");
   const outputOverlapsSource =
     pathsOverlap(path, sources.canonicalDirectory, outputDirectory) ||
     pathsOverlap(path, outputDirectory, sources.canonicalDirectory);
@@ -941,11 +981,12 @@ const validateCurationRoots = Effect.fn("Files.validateImageCurationRoots")(func
   }
 
   const defaultManifestPath = path.join(outputDirectory, "manifests", "image-curation-manifest.json");
-  const manifestPath = path.resolve(
+  const manifestPath = yield* canonicalizeImageTargetPath(
     pipe(
       options.manifest,
       O.getOrElse(() => defaultManifestPath)
-    )
+    ),
+    "image curation manifest path"
   );
   if (pathsOverlap(path, sources.canonicalDirectory, manifestPath)) {
     return yield* FilesCommandError.make({
@@ -1087,19 +1128,49 @@ const prepareCurationEntries = (
     };
   });
 
+const canonicalizePreparedCurationEntries = Effect.fn("Files.canonicalizePreparedImageCurationEntries")(function* (
+  entries: ReadonlyArray<PreparedCurationEntry>
+): Effect.fn.Return<ReadonlyArray<PreparedCurationEntry>, FilesCommandError, FileSystem.FileSystem | Path.Path> {
+  let canonicalEntries = A.empty<PreparedCurationEntry>();
+  for (const entry of entries) {
+    const outputPath = yield* canonicalizeImageTargetPath(
+      entry.outputPath,
+      `image curation derivative path for "${entry.source.name}"`
+    );
+    canonicalEntries = A.append(canonicalEntries, { ...entry, outputPath });
+  }
+  return canonicalEntries;
+});
+
 const requireSafeCurationDestinations = Effect.fn("Files.requireSafeImageCurationDestinations")(function* (
   path: Pick<ImagePathOperations, "isAbsolute" | "relative">,
   manifestPath: string,
+  decisionDocumentPath: string,
+  outputDirectory: string,
   entries: ReadonlyArray<PreparedCurationEntry>
 ): Effect.fn.Return<void, FilesCommandError> {
   const outputPaths = MutableHashSet.empty<string>();
   for (const entry of entries) {
+    if (!pathsOverlap(path, outputDirectory, entry.outputPath)) {
+      return yield* FilesCommandError.make({
+        message: `Image curation derivative must remain inside output directory "${outputDirectory}": "${entry.outputPath}".`,
+      });
+    }
     if (MutableHashSet.has(outputPaths, entry.outputPath)) {
       return yield* FilesCommandError.make({
         message: `Duplicate image curation output path: "${entry.outputPath}"`,
       });
     }
     MutableHashSet.add(outputPaths, entry.outputPath);
+
+    const outputOverlapsDecision =
+      pathsOverlap(path, decisionDocumentPath, entry.outputPath) ||
+      pathsOverlap(path, entry.outputPath, decisionDocumentPath);
+    if (outputOverlapsDecision) {
+      return yield* FilesCommandError.make({
+        message: `Image curation derivative must not overlap decision ledger "${decisionDocumentPath}".`,
+      });
+    }
 
     const manifestOverlapsOutput =
       pathsOverlap(path, manifestPath, entry.outputPath) || pathsOverlap(path, entry.outputPath, manifestPath);
@@ -1117,14 +1188,25 @@ const validateDecisionLedger = Effect.fn("Files.validateImageCurationDecisionLed
   const path = yield* Path.Path;
   const sources = yield* collectAuditSources(options.dir);
   yield* requireCleanCurationSources(sources);
-  const decisionDocumentPath = path.resolve(options.decisionsPath);
+  const decisionDocumentPath = yield* canonicalizeImageTargetPath(
+    options.decisionsPath,
+    "image curation decision ledger path"
+  );
   const decisions = yield* readDecisionDocument(decisionDocumentPath);
   const roots = yield* validateCurationRoots(options, sources, decisions, decisionDocumentPath);
   const decisionsByName = yield* indexCurationDecisions(decisions.decisions);
   yield* requireExactDecisionCoverage(sources.files, decisions.decisions, decisionsByName);
   const validatedSources = yield* validateSourceDecisionHashes(sources.files, decisionsByName);
-  const prepared = prepareCurationEntries(path, roots.outputDirectory, allocateCurationOutputNames(validatedSources));
-  yield* requireSafeCurationDestinations(path, roots.manifestPath, prepared);
+  const prepared = yield* canonicalizePreparedCurationEntries(
+    prepareCurationEntries(path, roots.outputDirectory, allocateCurationOutputNames(validatedSources))
+  );
+  yield* requireSafeCurationDestinations(
+    path,
+    roots.manifestPath,
+    decisionDocumentPath,
+    roots.outputDirectory,
+    prepared
+  );
 
   return {
     decisions,

--- a/packages/tooling/tool/cli/src/commands/Files/internal/ImageCuration.ts
+++ b/packages/tooling/tool/cli/src/commands/Files/internal/ImageCuration.ts
@@ -130,6 +130,21 @@ interface MaterializedPng extends OrientedImageDimensions {
   readonly size: number;
 }
 
+interface StagedCurationEntry {
+  readonly entry: PreparedCurationEntry;
+  readonly manifestEntry: ImageCurationManifestEntry;
+  readonly stagedPath: string;
+}
+
+interface CurationCommitRecord {
+  backedUp: boolean;
+  readonly backupPath: string;
+  committed: boolean;
+  readonly description: string;
+  readonly stagedPath: string;
+  readonly targetPath: string;
+}
+
 interface OptionalManifestDecisionFields {
   crop?: ImageCurationCrop;
   duplicateClusterId?: string;
@@ -178,6 +193,15 @@ const isDirectSafeName = (path: Pick<ImagePathOperations, "basename">, value: st
   !value.includes("/") &&
   !value.includes("\\") &&
   !value.includes("\0");
+
+const pathsOverlap = (
+  path: Pick<ImagePathOperations, "isAbsolute" | "relative">,
+  left: string,
+  right: string
+): boolean => {
+  const relative = path.relative(left, right);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+};
 
 const collectAuditSources = Effect.fn("Files.collectImageAuditSources")(function* (
   directory: string
@@ -649,6 +673,18 @@ const candidateSessionClusters = (entries: ReadonlyArray<ImageAuditEntry>): Read
     );
 };
 
+const renderJsonContent = Effect.fn("Files.renderImageCurationJson")(function* (
+  value: unknown,
+  description: string
+): Effect.fn.Return<string, FilesCommandError> {
+  return pipe(
+    yield* encodeUnknownJson(value).pipe(
+      Effect.mapError((cause) => FilesCommandError.new(cause, `Failed to encode ${description}`))
+    ),
+    Str.concat("\n")
+  );
+});
+
 const writeJsonAtomically = Effect.fn("Files.writeImageCurationJsonAtomically")(function* (
   filePath: string,
   value: unknown,
@@ -690,12 +726,7 @@ const writeJsonAtomically = Effect.fn("Files.writeImageCurationJsonAtomically")(
       .pipe(Effect.mapError((cause) => formatPlatformError(`Failed to stage ${description}`, parent, { cause }))),
     Effect.fnUntraced(function* (tempDir) {
       const tempPath = path.join(tempDir, path.basename(resolved));
-      const content = pipe(
-        yield* encodeUnknownJson(value).pipe(
-          Effect.mapError((cause) => FilesCommandError.new(cause, `Failed to encode ${description}`))
-        ),
-        Str.concat("\n")
-      );
+      const content = yield* renderJsonContent(value, description);
       yield* fs
         .writeFileString(tempPath, content)
         .pipe(
@@ -732,11 +763,22 @@ export const auditImagesImpl = Effect.fn("FilesCommandService.auditImages")(func
   const path = yield* Path.Path;
   const sources = yield* collectAuditSources(options.dir);
   const manifestPath = path.resolve(options.manifest);
+  const modelPath = path.resolve(options.modelPath);
+  if (pathsOverlap(path, sources.canonicalDirectory, manifestPath)) {
+    return yield* FilesCommandError.make({
+      message: `Image audit manifest must not be written inside source directory "${sources.canonicalDirectory}".`,
+    });
+  }
+  if (manifestPath === modelPath) {
+    return yield* FilesCommandError.make({
+      message: `Image audit manifest must not overwrite face model "${modelPath}".`,
+    });
+  }
   let entries = A.empty<ImageAuditEntry>();
   let skipped = sources.skipped;
 
   yield* withDetector(
-    FaceDetectionModelConfig.make({ modelPath: path.resolve(options.modelPath) }),
+    FaceDetectionModelConfig.make({ modelPath }),
     Effect.fnUntraced(function* (detector) {
       for (const source of sources.files) {
         const result = yield* Effect.all(
@@ -811,7 +853,7 @@ export const auditImagesImpl = Effect.fn("FilesCommandService.auditImages")(func
     duplicateClusters: duplicates,
     entries,
     manifestPath,
-    modelPath: path.resolve(options.modelPath),
+    modelPath,
     schemaVersion: "beep.files.image-audit.v1",
     sessionClusters: sessions,
     similarityPairs,
@@ -842,15 +884,6 @@ const dispositionDirectories = {
 } as const satisfies Readonly<Record<ImageCurationDisposition, string>>;
 
 const dispositionDirectory = (disposition: ImageCurationDisposition): string => dispositionDirectories[disposition];
-
-const pathsOverlap = (
-  path: Pick<ImagePathOperations, "isAbsolute" | "relative">,
-  left: string,
-  right: string
-): boolean => {
-  const relative = path.relative(left, right);
-  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
-};
 
 const requireCleanCurationSources = Effect.fn("Files.requireCleanCurationSources")(function* (
   sources: AuditSourceCollection
@@ -886,7 +919,8 @@ const readDecisionDocument = Effect.fn("Files.readImageCurationDecisionDocument"
 const validateCurationRoots = Effect.fn("Files.validateImageCurationRoots")(function* (
   options: ImageCurationOptions,
   sources: AuditSourceCollection,
-  decisions: ImageCurationDecisionDocument
+  decisions: ImageCurationDecisionDocument,
+  decisionDocumentPath: string
 ): Effect.fn.Return<{ readonly manifestPath: string; readonly outputDirectory: string }, FilesCommandError, Path.Path> {
   const path = yield* Path.Path;
   const recordedSourceDirectory = path.resolve(decisions.sourceDirectory);
@@ -907,13 +941,30 @@ const validateCurationRoots = Effect.fn("Files.validateImageCurationRoots")(func
   }
 
   const defaultManifestPath = path.join(outputDirectory, "manifests", "image-curation-manifest.json");
+  const manifestPath = path.resolve(
+    pipe(
+      options.manifest,
+      O.getOrElse(() => defaultManifestPath)
+    )
+  );
+  if (pathsOverlap(path, sources.canonicalDirectory, manifestPath)) {
+    return yield* FilesCommandError.make({
+      message: `Image curation manifest must not be written inside source directory "${sources.canonicalDirectory}".`,
+    });
+  }
+  if (manifestPath === decisionDocumentPath) {
+    return yield* FilesCommandError.make({
+      message: `Image curation manifest must not overwrite decision ledger "${decisionDocumentPath}".`,
+    });
+  }
+  if (pathsOverlap(path, manifestPath, outputDirectory)) {
+    return yield* FilesCommandError.make({
+      message: `Image curation manifest path must not contain output directory "${outputDirectory}".`,
+    });
+  }
+
   return {
-    manifestPath: path.resolve(
-      pipe(
-        options.manifest,
-        O.getOrElse(() => defaultManifestPath)
-      )
-    ),
+    manifestPath,
     outputDirectory,
   };
 });
@@ -990,16 +1041,23 @@ const collisionSafeOutputName = (
   const hex = hash.slice("sha256:".length);
   let prefixLength = 20;
   let outputName = `twv1_${hex.slice(0, prefixLength)}.png`;
-  while (
-    pipe(
-      MutableHashMap.get(usedNames, outputName),
-      O.exists((existingHash) => existingHash !== hash)
-    )
-  ) {
-    prefixLength += 1;
-    outputName = `twv1_${hex.slice(0, prefixLength)}.png`;
+  while (true) {
+    const existingHash = MutableHashMap.get(usedNames, outputName);
+    if (O.isNone(existingHash)) return outputName;
+    if (existingHash.value !== hash) {
+      prefixLength += 1;
+      outputName = `twv1_${hex.slice(0, prefixLength)}.png`;
+      continue;
+    }
+
+    let duplicateIndex = 2;
+    let duplicateName = `twv1_${hex.slice(0, prefixLength)}_${duplicateIndex}.png`;
+    while (MutableHashMap.has(usedNames, duplicateName)) {
+      duplicateIndex += 1;
+      duplicateName = `twv1_${hex.slice(0, prefixLength)}_${duplicateIndex}.png`;
+    }
+    return duplicateName;
   }
-  return outputName;
 };
 
 const allocateCurationOutputNames = (
@@ -1029,6 +1087,30 @@ const prepareCurationEntries = (
     };
   });
 
+const requireSafeCurationDestinations = Effect.fn("Files.requireSafeImageCurationDestinations")(function* (
+  path: Pick<ImagePathOperations, "isAbsolute" | "relative">,
+  manifestPath: string,
+  entries: ReadonlyArray<PreparedCurationEntry>
+): Effect.fn.Return<void, FilesCommandError> {
+  const outputPaths = MutableHashSet.empty<string>();
+  for (const entry of entries) {
+    if (MutableHashSet.has(outputPaths, entry.outputPath)) {
+      return yield* FilesCommandError.make({
+        message: `Duplicate image curation output path: "${entry.outputPath}"`,
+      });
+    }
+    MutableHashSet.add(outputPaths, entry.outputPath);
+
+    const manifestOverlapsOutput =
+      pathsOverlap(path, manifestPath, entry.outputPath) || pathsOverlap(path, entry.outputPath, manifestPath);
+    if (manifestOverlapsOutput) {
+      return yield* FilesCommandError.make({
+        message: `Image curation manifest must not overlap generated derivative "${entry.outputPath}".`,
+      });
+    }
+  }
+});
+
 const validateDecisionLedger = Effect.fn("Files.validateImageCurationDecisionLedger")(function* (
   options: ImageCurationOptions
 ): Effect.fn.Return<ValidatedDecisionLedger, FilesCommandError, FileSystem.FileSystem | Path.Path | Crypto.Crypto> {
@@ -1037,11 +1119,12 @@ const validateDecisionLedger = Effect.fn("Files.validateImageCurationDecisionLed
   yield* requireCleanCurationSources(sources);
   const decisionDocumentPath = path.resolve(options.decisionsPath);
   const decisions = yield* readDecisionDocument(decisionDocumentPath);
-  const roots = yield* validateCurationRoots(options, sources, decisions);
+  const roots = yield* validateCurationRoots(options, sources, decisions, decisionDocumentPath);
   const decisionsByName = yield* indexCurationDecisions(decisions.decisions);
   yield* requireExactDecisionCoverage(sources.files, decisions.decisions, decisionsByName);
   const validatedSources = yield* validateSourceDecisionHashes(sources.files, decisionsByName);
   const prepared = prepareCurationEntries(path, roots.outputDirectory, allocateCurationOutputNames(validatedSources));
+  yield* requireSafeCurationDestinations(path, roots.manifestPath, prepared);
 
   return {
     decisions,
@@ -1176,6 +1259,109 @@ const curationSummary = (
     reserveCount: A.length(A.filter(decisions, (decision) => decision.disposition === "reserve-near-duplicate")),
   });
 
+const inspectCurationDestination = Effect.fn("Files.inspectImageCurationDestination")(function* (
+  targetPath: string,
+  overwrite: boolean,
+  description: string
+): Effect.fn.Return<boolean, FilesCommandError, FileSystem.FileSystem> {
+  const fs = yield* FileSystem.FileSystem;
+  const exists = yield* fs
+    .exists(targetPath)
+    .pipe(Effect.mapError((cause) => formatPlatformError(`Failed to inspect ${description}`, targetPath, { cause })));
+  if (!exists) return false;
+  if (!overwrite) {
+    return yield* FilesCommandError.make({
+      message: `Refusing to overwrite existing ${description}: "${targetPath}"`,
+    });
+  }
+
+  const stat = yield* fs
+    .stat(targetPath)
+    .pipe(Effect.mapError((cause) => formatPlatformError(`Failed to stat ${description}`, targetPath, { cause })));
+  if (stat.type !== "File") {
+    return yield* FilesCommandError.make({
+      message: `Refusing to overwrite non-file ${description}: "${targetPath}"`,
+    });
+  }
+  return true;
+});
+
+const preflightCurationDestinations = Effect.fn("Files.preflightImageCurationDestinations")(function* (
+  validated: ValidatedDecisionLedger,
+  overwrite: boolean
+): Effect.fn.Return<void, FilesCommandError, FileSystem.FileSystem> {
+  for (const entry of validated.prepared) {
+    yield* inspectCurationDestination(entry.outputPath, overwrite, "curation output");
+  }
+  yield* inspectCurationDestination(validated.manifestPath, overwrite, "image curation manifest");
+});
+
+const rollbackCurationCommit = Effect.fn("Files.rollbackImageCurationCommit")(function* (
+  records: ReadonlyArray<CurationCommitRecord>
+) {
+  const fs = yield* FileSystem.FileSystem;
+  for (let index = records.length - 1; index >= 0; index -= 1) {
+    const record = records[index];
+    if (record === undefined) continue;
+    if (record.committed) {
+      yield* fs.remove(record.targetPath, { force: true }).pipe(Effect.ignore);
+      record.committed = false;
+    }
+    if (record.backedUp) {
+      yield* fs.rename(record.backupPath, record.targetPath).pipe(Effect.ignore);
+      record.backedUp = false;
+    }
+  }
+});
+
+const commitCurationFiles = Effect.fn("Files.commitImageCurationFiles")(function* (
+  records: ReadonlyArray<CurationCommitRecord>,
+  overwrite: boolean
+): Effect.fn.Return<void, FilesCommandError, FileSystem.FileSystem | Path.Path> {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+
+  yield* Effect.onError(
+    Effect.gen(function* () {
+      for (const record of records) {
+        const parent = path.dirname(record.targetPath);
+        yield* fs
+          .makeDirectory(parent, { recursive: true })
+          .pipe(
+            Effect.mapError((cause) =>
+              formatPlatformError(`Failed to create ${record.description} directory`, parent, { cause })
+            )
+          );
+      }
+
+      for (const record of records) {
+        const exists = yield* inspectCurationDestination(record.targetPath, overwrite, record.description);
+        if (!exists) continue;
+        yield* fs
+          .rename(record.targetPath, record.backupPath)
+          .pipe(
+            Effect.mapError((cause) =>
+              formatPlatformError(`Failed to back up existing ${record.description}`, record.targetPath, { cause })
+            )
+          );
+        record.backedUp = true;
+      }
+
+      for (const record of records) {
+        yield* fs
+          .rename(record.stagedPath, record.targetPath)
+          .pipe(
+            Effect.mapError((cause) =>
+              formatPlatformError(`Failed to commit ${record.description}`, record.targetPath, { cause })
+            )
+          );
+        record.committed = true;
+      }
+    }),
+    () => rollbackCurationCommit(records)
+  );
+});
+
 /**
  * Validate a complete decision ledger and materialize metadata-free PNG derivatives.
  *
@@ -1204,45 +1390,7 @@ export const curateImagesImpl = Effect.fn("FilesCommandService.curateImages")(fu
     return dryRunSummary;
   }
 
-  for (const entry of validated.prepared) {
-    const exists = yield* fs
-      .exists(entry.outputPath)
-      .pipe(
-        Effect.mapError((cause) =>
-          formatPlatformError("Failed to inspect curation output", entry.outputPath, { cause })
-        )
-      );
-    if (exists && !options.overwrite) {
-      return yield* FilesCommandError.make({
-        message: `Refusing to overwrite existing curation output: "${entry.outputPath}"`,
-      });
-    }
-    if (exists) {
-      const stat = yield* fs
-        .stat(entry.outputPath)
-        .pipe(
-          Effect.mapError((cause) => formatPlatformError("Failed to stat curation output", entry.outputPath, { cause }))
-        );
-      if (stat.type !== "File") {
-        return yield* FilesCommandError.make({
-          message: `Refusing to overwrite non-file curation output: "${entry.outputPath}"`,
-        });
-      }
-    }
-  }
-
-  const manifestExists = yield* fs
-    .exists(validated.manifestPath)
-    .pipe(
-      Effect.mapError((cause) =>
-        formatPlatformError("Failed to inspect image curation manifest", validated.manifestPath, { cause })
-      )
-    );
-  if (manifestExists && !options.overwrite) {
-    return yield* FilesCommandError.make({
-      message: `Refusing to overwrite existing image curation manifest: "${validated.manifestPath}"`,
-    });
-  }
+  yield* preflightCurationDestinations(validated, options.overwrite);
 
   yield* fs
     .makeDirectory(validated.outputDirectory, { recursive: true })
@@ -1251,8 +1399,16 @@ export const curateImagesImpl = Effect.fn("FilesCommandService.curateImages")(fu
         formatPlatformError("Failed to create image curation output directory", validated.outputDirectory, { cause })
       )
     );
+  const manifestParent = path.dirname(validated.manifestPath);
+  yield* fs
+    .makeDirectory(manifestParent, { recursive: true })
+    .pipe(
+      Effect.mapError((cause) =>
+        formatPlatformError("Failed to create image curation manifest directory", manifestParent, { cause })
+      )
+    );
 
-  const manifestEntries = yield* Effect.acquireUseRelease(
+  const summary = yield* Effect.acquireUseRelease(
     fs
       .makeTempDirectory({ directory: validated.outputDirectory, prefix: ".beep-files-curate-images-" })
       .pipe(
@@ -1261,50 +1417,88 @@ export const curateImagesImpl = Effect.fn("FilesCommandService.curateImages")(fu
         )
       ),
     Effect.fnUntraced(function* (tempDirectory) {
-      let completed = A.empty<ImageCurationManifestEntry>();
+      let staged = A.empty<StagedCurationEntry>();
       let index = 0;
       for (const entry of validated.prepared) {
-        const tempPath = path.join(tempDirectory, `${`${index}`.padStart(4, "0")}-${entry.outputName}`);
-        const output = yield* materializeCanonicalPng(entry, tempPath);
-        const outputSha256 = yield* fileSha256(tempPath);
-        const destinationDirectory = path.dirname(entry.outputPath);
-        yield* fs
-          .makeDirectory(destinationDirectory, { recursive: true })
-          .pipe(
-            Effect.mapError((cause) =>
-              formatPlatformError("Failed to create curation destination directory", destinationDirectory, { cause })
-            )
-          );
-        if (options.overwrite) yield* fs.remove(entry.outputPath, { force: true }).pipe(Effect.ignore);
-        yield* fs
-          .rename(tempPath, entry.outputPath)
-          .pipe(
-            Effect.mapError((cause) =>
-              formatPlatformError("Failed to commit canonical curation output", entry.outputPath, { cause })
-            )
-          );
-        completed = A.append(completed, makeCurationManifestEntry(entry, output, outputSha256));
+        const stagedPath = path.join(tempDirectory, `${`${index}`.padStart(4, "0")}-${entry.outputName}`);
+        const output = yield* materializeCanonicalPng(entry, stagedPath);
+        const outputSha256 = yield* fileSha256(stagedPath);
+        staged = A.append(staged, {
+          entry,
+          manifestEntry: makeCurationManifestEntry(entry, output, outputSha256),
+          stagedPath,
+        });
         index += 1;
       }
-      return completed;
+
+      const nextSummary = curationSummary(validated.decisions.decisions, false, A.length(staged));
+      const manifest = ImageCurationManifest.make({
+        decisionDocumentPath: path.resolve(options.decisionsPath),
+        entries: staged.map((entry) => entry.manifestEntry),
+        manifestPath: validated.manifestPath,
+        outputDirectory: validated.outputDirectory,
+        schemaVersion: "beep.files.image-curation.v1",
+        sourceDirectory: validated.sourceDirectory,
+        summary: nextSummary,
+      });
+      const encoded = yield* encodeImageCurationManifest(manifest).pipe(
+        Effect.mapError((cause) => FilesCommandError.new(cause, "Failed to encode image curation manifest"))
+      );
+      const manifestContent = yield* renderJsonContent(encoded, "image curation manifest");
+
+      return yield* Effect.acquireUseRelease(
+        fs.makeTempDirectory({ directory: manifestParent, prefix: ".beep-files-curate-images-manifest-" }).pipe(
+          Effect.mapError((cause) =>
+            formatPlatformError("Failed to create image curation manifest staging directory", manifestParent, {
+              cause,
+            })
+          )
+        ),
+        Effect.fnUntraced(function* (manifestTempDirectory) {
+          const stagedManifestPath = path.join(manifestTempDirectory, "image-curation-manifest.json");
+          yield* fs
+            .writeFileString(stagedManifestPath, manifestContent)
+            .pipe(
+              Effect.mapError((cause) =>
+                formatPlatformError("Failed to write staged image curation manifest", stagedManifestPath, { cause })
+              )
+            );
+
+          let records = A.empty<CurationCommitRecord>();
+          for (let recordIndex = 0; recordIndex < staged.length; recordIndex += 1) {
+            const stagedEntry = staged[recordIndex];
+            if (stagedEntry === undefined) continue;
+            records = A.append(records, {
+              backedUp: false,
+              backupPath: path.join(
+                tempDirectory,
+                `backup-${`${recordIndex}`.padStart(4, "0")}-${stagedEntry.entry.outputName}`
+              ),
+              committed: false,
+              description: "curation output",
+              stagedPath: stagedEntry.stagedPath,
+              targetPath: stagedEntry.entry.outputPath,
+            });
+          }
+          records = A.append(records, {
+            backedUp: false,
+            backupPath: path.join(manifestTempDirectory, "previous-image-curation-manifest"),
+            committed: false,
+            description: "image curation manifest",
+            stagedPath: stagedManifestPath,
+            targetPath: validated.manifestPath,
+          });
+
+          yield* commitCurationFiles(records, options.overwrite);
+          return nextSummary;
+        }),
+        (manifestTempDirectory) =>
+          fs.remove(manifestTempDirectory, { recursive: true, force: true }).pipe(Effect.ignore)
+      );
     }),
     (tempDirectory) => fs.remove(tempDirectory, { recursive: true, force: true }).pipe(Effect.ignore)
   );
 
-  const summary = curationSummary(validated.decisions.decisions, false, A.length(manifestEntries));
-  const manifest = ImageCurationManifest.make({
-    decisionDocumentPath: path.resolve(options.decisionsPath),
-    entries: manifestEntries,
-    manifestPath: validated.manifestPath,
-    outputDirectory: validated.outputDirectory,
-    schemaVersion: "beep.files.image-curation.v1",
-    sourceDirectory: validated.sourceDirectory,
-    summary,
-  });
-  const encoded = yield* encodeImageCurationManifest(manifest).pipe(
-    Effect.mapError((cause) => FilesCommandError.new(cause, "Failed to encode image curation manifest"))
-  );
-  yield* writeJsonAtomically(validated.manifestPath, encoded, options.overwrite, "image curation manifest");
   yield* Console.log(
     `files curate-images: materialized ${summary.materializedCount} metadata-free PNG derivative(s) and wrote "${validated.manifestPath}".`
   );

--- a/packages/tooling/tool/cli/src/commands/Files/internal/ImageCuration.ts
+++ b/packages/tooling/tool/cli/src/commands/Files/internal/ImageCuration.ts
@@ -1,0 +1,1312 @@
+/**
+ * Read-only image auditing and ledger-driven canonical PNG materialization.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { createHash } from "node:crypto";
+import {
+  FaceDetectionImageRequest,
+  FaceDetectionModelConfig,
+  FaceDetectionService,
+  makeFaceDetectionService,
+  withDetector,
+} from "@beep/face-detection";
+import { A, Str } from "@beep/utils";
+import { Console, Effect, FileSystem, MutableHashMap, MutableHashSet, Order, Path, pipe } from "effect";
+import * as O from "effect/Option";
+import * as S from "effect/Schema";
+import sharp from "sharp";
+import { hashFileSha256 as hashFileSha256Hex } from "../../../internal/cli/FsGuards.ts";
+import { FilesCommandError, formatPlatformError } from "../Files.errors.ts";
+import { isSupportedMetadataImageExtension, normalizeBareExtension } from "../Files.media.ts";
+import {
+  encodeImageAuditManifest,
+  ImageAuditCluster,
+  ImageAuditEntry,
+  ImageAuditFaceMetrics,
+  ImageAuditManifest,
+  ImageAuditMetadataPresence,
+  ImageAuditQualityMetrics,
+  ImageAuditSimilarityPair,
+  ImageAuditSkippedEntry,
+  ImageAuditSummary,
+} from "./ImageAudit.schemas.ts";
+import {
+  decodeImageCurationDecisionDocumentJson,
+  encodeImageCurationManifest,
+  ImageCurationManifest,
+  ImageCurationManifestEntry,
+  ImageCurationSummary,
+} from "./ImageCuration.schemas.ts";
+import { FileSha256Hash } from "./Media.schemas.ts";
+import type { LoadedFaceDetector } from "@beep/face-detection";
+import type { Terminal } from "effect";
+import type * as Crypto from "effect/Crypto";
+import type { ChildProcessSpawner } from "effect/unstable/process";
+import type { ImageAuditOptions } from "./ImageAudit.schemas.ts";
+import type {
+  ImageCurationCrop,
+  ImageCurationDecision,
+  ImageCurationDecisionDocument,
+  ImageCurationDisposition,
+  ImageCurationOptions,
+} from "./ImageCuration.schemas.ts";
+
+// cspell:ignore Iptc iptc
+
+type SharpInstance = ReturnType<typeof sharp>;
+type SharpMetadata = Awaited<ReturnType<SharpInstance["metadata"]>>;
+
+interface AuditSourceFile {
+  readonly extension: string;
+  readonly name: string;
+  readonly path: string;
+  readonly relativePath: string;
+  readonly size: string;
+}
+
+interface AuditSourceCollection {
+  readonly canonicalDirectory: string;
+  readonly files: ReadonlyArray<AuditSourceFile>;
+  readonly skipped: ReadonlyArray<ImageAuditSkippedEntry>;
+}
+
+interface AuditedPixels {
+  readonly colorHash: string;
+  readonly decodedPixelSha256: FileSha256Hash;
+  readonly height: number;
+  readonly metadata: ImageAuditMetadataPresence;
+  readonly perceptualHash: string;
+  readonly quality: ImageAuditQualityMetrics;
+  readonly width: number;
+}
+
+interface PreparedCurationEntry {
+  readonly decision: ImageCurationDecision;
+  readonly outputName: string;
+  readonly outputPath: string;
+  readonly outputRelativePath: string;
+  readonly source: AuditSourceFile;
+}
+
+interface PixelStatistics {
+  readonly darkCount: number;
+  readonly histogram: Uint32Array;
+  readonly lightCount: number;
+  readonly luminance: Uint8Array;
+  readonly luminanceTotal: number;
+  readonly rgSquaredTotal: number;
+  readonly rgTotal: number;
+  readonly ybSquaredTotal: number;
+  readonly ybTotal: number;
+}
+
+interface ValidatedSourceDecision {
+  readonly decision: ImageCurationDecision;
+  readonly hash: FileSha256Hash;
+  readonly source: AuditSourceFile;
+}
+
+interface NamedSourceDecision extends ValidatedSourceDecision {
+  readonly outputName: string;
+}
+
+interface ValidatedDecisionLedger {
+  readonly decisions: ImageCurationDecisionDocument;
+  readonly manifestPath: string;
+  readonly outputDirectory: string;
+  readonly prepared: ReadonlyArray<PreparedCurationEntry>;
+  readonly sourceDirectory: string;
+}
+
+interface OrientedImageDimensions {
+  readonly height: number;
+  readonly width: number;
+}
+
+interface MaterializedPng extends OrientedImageDimensions {
+  readonly size: number;
+}
+
+interface OptionalManifestDecisionFields {
+  crop?: ImageCurationCrop;
+  duplicateClusterId?: string;
+  sessionId?: string;
+}
+
+interface ImagePathOperations {
+  readonly basename: (value: string) => string;
+  readonly isAbsolute: (value: string) => boolean;
+  readonly join: (...paths: ReadonlyArray<string>) => string;
+  readonly relative: (from: string, to: string) => string;
+}
+
+const decodeFileSha256Hash = S.decodeUnknownEffect(FileSha256Hash);
+const encodeUnknownJson = S.encodeUnknownEffect(S.UnknownFromJsonString);
+const byAuditSourceName = Order.mapInput(Order.String, (source: AuditSourceFile) => source.name);
+const byAuditEntryName = Order.mapInput(Order.String, (entry: ImageAuditEntry) => entry.sourceName);
+const bySkippedEntryName = Order.mapInput(Order.String, (entry: ImageAuditSkippedEntry) => entry.sourceName);
+const roundMetric = (value: number): number => Math.round(value * 1_000_000) / 1_000_000;
+
+const fileSha256 = Effect.fn("Files.imageCurationFileSha256")(function* (
+  filePath: string
+): Effect.fn.Return<FileSha256Hash, FilesCommandError, FileSystem.FileSystem | Crypto.Crypto> {
+  const hex = yield* hashFileSha256Hex(filePath, (cause) =>
+    FilesCommandError.new(cause, `Failed to hash image source "${filePath}"`)
+  );
+  return yield* decodeFileSha256Hash(`sha256:${hex}`).pipe(
+    Effect.mapError((cause) => FilesCommandError.new(cause, `Failed to validate image hash for "${filePath}"`))
+  );
+});
+
+const checkedHash = Effect.fn("Files.imageCurationCheckedHash")(function* (
+  hex: string,
+  context: string
+): Effect.fn.Return<FileSha256Hash, FilesCommandError> {
+  return yield* decodeFileSha256Hash(`sha256:${hex}`).pipe(
+    Effect.mapError((cause) => FilesCommandError.new(cause, `Failed to validate ${context} hash`))
+  );
+});
+
+const isDirectSafeName = (path: Pick<ImagePathOperations, "basename">, value: string): boolean =>
+  Str.isNonEmpty(value) &&
+  value !== "." &&
+  value !== ".." &&
+  path.basename(value) === value &&
+  !value.includes("/") &&
+  !value.includes("\\") &&
+  !value.includes("\0");
+
+const collectAuditSources = Effect.fn("Files.collectImageAuditSources")(function* (
+  directory: string
+): Effect.fn.Return<AuditSourceCollection, FilesCommandError, FileSystem.FileSystem | Path.Path> {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const resolvedDirectory = path.resolve(directory);
+  const canonicalDirectory = yield* fs
+    .realPath(resolvedDirectory)
+    .pipe(
+      Effect.mapError((cause) =>
+        formatPlatformError("Failed to resolve image audit directory", resolvedDirectory, { cause })
+      )
+    );
+  const directoryStat = yield* fs
+    .stat(canonicalDirectory)
+    .pipe(
+      Effect.mapError((cause) =>
+        formatPlatformError("Failed to stat image audit directory", canonicalDirectory, { cause })
+      )
+    );
+
+  if (directoryStat.type !== "Directory") {
+    return yield* FilesCommandError.make({
+      message: `Image audit source must be a directory: "${canonicalDirectory}"`,
+    });
+  }
+
+  const names = yield* fs
+    .readDirectory(canonicalDirectory)
+    .pipe(
+      Effect.mapError((cause) =>
+        formatPlatformError("Failed to read image audit directory", canonicalDirectory, { cause })
+      )
+    );
+  let files = A.empty<AuditSourceFile>();
+  let skipped = A.empty<ImageAuditSkippedEntry>();
+
+  for (const name of A.sort(names, Order.String)) {
+    const sourcePath = path.join(canonicalDirectory, name);
+    const canonicalPath = yield* fs.realPath(sourcePath).pipe(Effect.option);
+
+    if (O.isNone(canonicalPath) || canonicalPath.value !== sourcePath) {
+      skipped = A.append(
+        skipped,
+        ImageAuditSkippedEntry.make({
+          message: "Symlinks and unresolvable entries are not audited.",
+          sourceName: name,
+          sourcePath,
+        })
+      );
+      continue;
+    }
+
+    const stat = yield* fs
+      .stat(sourcePath)
+      .pipe(
+        Effect.mapError((cause) => formatPlatformError("Failed to stat image audit source", sourcePath, { cause }))
+      );
+
+    if (stat.type !== "File") {
+      skipped = A.append(
+        skipped,
+        ImageAuditSkippedEntry.make({
+          message: "Only direct regular image files are audited.",
+          sourceName: name,
+          sourcePath,
+        })
+      );
+      continue;
+    }
+
+    const extension = path.extname(name);
+    if (!isSupportedMetadataImageExtension(normalizeBareExtension(extension))) {
+      skipped = A.append(
+        skipped,
+        ImageAuditSkippedEntry.make({
+          message: "File extension is not supported by the image audit decoder.",
+          sourceName: name,
+          sourcePath,
+        })
+      );
+      continue;
+    }
+
+    files = A.append(files, {
+      extension,
+      name,
+      path: sourcePath,
+      relativePath: path.relative(canonicalDirectory, sourcePath),
+      size: `${stat.size}`,
+    });
+  }
+
+  return {
+    canonicalDirectory,
+    files: A.sort(files, byAuditSourceName),
+    skipped: A.sort(skipped, bySkippedEntryName),
+  };
+});
+
+const bitsToHex = (bits: ReadonlyArray<boolean>): string => {
+  let output = "";
+  for (let index = 0; index < bits.length; index += 4) {
+    let nibble = 0;
+    for (let offset = 0; offset < 4; offset += 1) {
+      nibble = nibble * 2 + (bits[index + offset] === true ? 1 : 0);
+    }
+    output += nibble.toString(16);
+  }
+  return output;
+};
+
+const perceptualHashFromGray = (data: Uint8Array): string => {
+  const bits: Array<boolean> = [];
+  for (let y = 0; y < 12; y += 1) {
+    for (let x = 0; x < 12; x += 1) {
+      bits.push((data[y * 13 + x] ?? 0) > (data[y * 13 + x + 1] ?? 0));
+    }
+  }
+  return bitsToHex(bits);
+};
+
+const colorHashFromRgb = (data: Uint8Array, channels: number): string => {
+  let output = "";
+  for (let pixel = 0; pixel < 16; pixel += 1) {
+    const offset = pixel * channels;
+    output += Math.floor((data[offset] ?? 0) / 16).toString(16);
+    output += Math.floor((data[offset + 1] ?? 0) / 16).toString(16);
+    output += Math.floor((data[offset + 2] ?? 0) / 16).toString(16);
+  }
+  return output;
+};
+
+const numericAt = (data: Uint8Array | Uint32Array, index: number): number => data[index] ?? 0;
+
+const collectPixelStatistics = (data: Uint8Array, pixelCount: number, channels: number): PixelStatistics => {
+  const luminance = new Uint8Array(pixelCount);
+  const histogram = new Uint32Array(256);
+  let darkCount = 0;
+  let lightCount = 0;
+  let luminanceTotal = 0;
+  let rgTotal = 0;
+  let ybTotal = 0;
+  let rgSquaredTotal = 0;
+  let ybSquaredTotal = 0;
+
+  for (let index = 0; index < pixelCount; index += 1) {
+    const offset = index * channels;
+    const red = numericAt(data, offset);
+    const green = numericAt(data, offset + 1);
+    const blue = numericAt(data, offset + 2);
+    const value = Math.round(red * 0.2126 + green * 0.7152 + blue * 0.0722);
+    const rg = red - green;
+    const yb = (red + green) / 2 - blue;
+    luminance[index] = value;
+    histogram[value] = numericAt(histogram, value) + 1;
+    luminanceTotal += value;
+    rgTotal += rg;
+    ybTotal += yb;
+    rgSquaredTotal += rg * rg;
+    ybSquaredTotal += yb * yb;
+    if (value <= 5) darkCount += 1;
+    if (value >= 250) lightCount += 1;
+  }
+
+  return {
+    darkCount,
+    histogram,
+    lightCount,
+    luminance,
+    luminanceTotal,
+    rgSquaredTotal,
+    rgTotal,
+    ybSquaredTotal,
+    ybTotal,
+  };
+};
+
+const edgeEnergyFromLuminance = (luminance: Uint8Array, width: number, height: number): number => {
+  let edgeTotal = 0;
+  let edgeCount = 0;
+  for (let y = 1; y < height; y += 1) {
+    for (let x = 1; x < width; x += 1) {
+      const value = numericAt(luminance, y * width + x);
+      edgeTotal += Math.abs(value - numericAt(luminance, y * width + x - 1));
+      edgeTotal += Math.abs(value - numericAt(luminance, (y - 1) * width + x));
+      edgeCount += 2;
+    }
+  }
+  return edgeCount === 0 ? 0 : edgeTotal / edgeCount;
+};
+
+const entropyFromHistogram = (histogram: Uint32Array, pixelCount: number): number => {
+  let entropyBits = 0;
+  for (const count of histogram) {
+    if (count === 0) continue;
+    const probability = count / pixelCount;
+    entropyBits -= probability * Math.log2(probability);
+  }
+  return entropyBits;
+};
+
+const colorfulnessFromStatistics = (statistics: PixelStatistics, pixelCount: number): number => {
+  const rgMean = statistics.rgTotal / pixelCount;
+  const ybMean = statistics.ybTotal / pixelCount;
+  const rgStd = Math.sqrt(Math.max(0, statistics.rgSquaredTotal / pixelCount - rgMean * rgMean));
+  const ybStd = Math.sqrt(Math.max(0, statistics.ybSquaredTotal / pixelCount - ybMean * ybMean));
+  return Math.sqrt(rgStd * rgStd + ybStd * ybStd) + 0.3 * Math.sqrt(rgMean * rgMean + ybMean * ybMean);
+};
+
+const qualityMetricsFromRgb = (data: Uint8Array, width: number, height: number, channels: number) => {
+  const pixelCount = width * height;
+  const statistics = collectPixelStatistics(data, pixelCount, channels);
+  return ImageAuditQualityMetrics.make({
+    colorfulness: roundMetric(colorfulnessFromStatistics(statistics, pixelCount)),
+    darkClipPct: roundMetric((statistics.darkCount * 100) / pixelCount),
+    edgeEnergy: roundMetric(edgeEnergyFromLuminance(statistics.luminance, width, height)),
+    entropyBits: roundMetric(entropyFromHistogram(statistics.histogram, pixelCount)),
+    lightClipPct: roundMetric((statistics.lightCount * 100) / pixelCount),
+    meanLuminance: roundMetric(statistics.luminanceTotal / pixelCount),
+  });
+};
+
+const hasEmbeddedMetadata = (value: Uint8Array | undefined): boolean => value !== undefined && value.length > 0;
+
+const imageAuditMetadataPresence = (metadata: SharpMetadata): ImageAuditMetadataPresence => {
+  const presence = {
+    hasExif: hasEmbeddedMetadata(metadata.exif),
+    hasIcc: hasEmbeddedMetadata(metadata.icc),
+    hasIptc: hasEmbeddedMetadata(metadata.iptc),
+    hasXmp: hasEmbeddedMetadata(metadata.xmp),
+  };
+  if (metadata.orientation === undefined) {
+    return ImageAuditMetadataPresence.make({
+      ...presence,
+      orientationApplied: false,
+    });
+  }
+  return ImageAuditMetadataPresence.make({
+    ...presence,
+    orientation: metadata.orientation,
+    orientationApplied: metadata.orientation !== 1,
+  });
+};
+
+const analyzePixels = Effect.fn("Files.analyzeImageAuditPixels")(function* (
+  source: AuditSourceFile
+): Effect.fn.Return<AuditedPixels, FilesCommandError> {
+  const metadata = yield* Effect.tryPromise({
+    try: () => sharp(source.path, { failOn: "error" }).metadata(),
+    catch: FilesCommandError.new(`Failed to decode image audit pixels for "${source.path}"`),
+  });
+  const decoded = yield* Effect.tryPromise({
+    try: () =>
+      sharp(source.path, { failOn: "error" })
+        .rotate()
+        .flatten({ background: { b: 255, g: 255, r: 255 } })
+        .toColorspace("srgb")
+        .removeAlpha()
+        .raw()
+        .toBuffer({ resolveWithObject: true }),
+    catch: FilesCommandError.new(`Failed to decode image audit pixels for "${source.path}"`),
+  });
+  const rawOptions = {
+    raw: {
+      channels: decoded.info.channels,
+      height: decoded.info.height,
+      width: decoded.info.width,
+    },
+  } as const;
+  const [perceptual, color, quality] = yield* Effect.all(
+    [
+      Effect.tryPromise({
+        try: () =>
+          sharp(decoded.data, rawOptions)
+            .resize(13, 12, { fit: "fill" })
+            .greyscale()
+            .raw()
+            .toBuffer({ resolveWithObject: true }),
+        catch: FilesCommandError.new(`Failed to compute perceptual hash for "${source.path}"`),
+      }),
+      Effect.tryPromise({
+        try: () =>
+          sharp(decoded.data, rawOptions).resize(4, 4, { fit: "fill" }).raw().toBuffer({ resolveWithObject: true }),
+        catch: FilesCommandError.new(`Failed to compute color hash for "${source.path}"`),
+      }),
+      Effect.tryPromise({
+        try: () =>
+          sharp(decoded.data, rawOptions)
+            .resize(256, 256, { fit: "inside", withoutEnlargement: true })
+            .raw()
+            .toBuffer({ resolveWithObject: true }),
+        catch: FilesCommandError.new(`Failed to compute quality metrics for "${source.path}"`),
+      }),
+    ],
+    { concurrency: 3 }
+  );
+  const decodedHeader = new TextEncoder().encode(
+    `${decoded.info.width}x${decoded.info.height}x${decoded.info.channels}:`
+  );
+  const decodedHash = createHash("sha256").update(decodedHeader).update(decoded.data).digest("hex");
+
+  return {
+    colorHash: colorHashFromRgb(color.data, color.info.channels),
+    decodedPixelSha256: yield* checkedHash(decodedHash, "decoded-pixel"),
+    height: decoded.info.height,
+    metadata: imageAuditMetadataPresence(metadata),
+    perceptualHash: perceptualHashFromGray(perceptual.data),
+    quality: qualityMetricsFromRgb(quality.data, quality.info.width, quality.info.height, quality.info.channels),
+    width: decoded.info.width,
+  };
+});
+
+const analyzeFaceMetrics = Effect.fn("Files.analyzeImageAuditFaces")(function* (
+  detector: LoadedFaceDetector,
+  source: AuditSourceFile,
+  minConfidence: number
+): Effect.fn.Return<ImageAuditFaceMetrics, FilesCommandError> {
+  const detection = yield* detector
+    .detect(
+      FaceDetectionImageRequest.make({
+        imagePath: source.path,
+        minConfidence,
+      })
+    )
+    .pipe(
+      Effect.mapError((cause) =>
+        FilesCommandError.make({
+          cause,
+          message: `Face detection failed for "${source.path}": ${cause.message}`,
+        })
+      )
+    );
+  const primary = A.head(detection.faces);
+
+  if (O.isNone(primary)) {
+    return ImageAuditFaceMetrics.make({ faceCount: 0 });
+  }
+
+  return ImageAuditFaceMetrics.make({
+    faceCount: A.length(detection.faces),
+    primaryFaceAreaPct: roundMetric(
+      (primary.value.box.width * primary.value.box.height * 100) / (detection.width * detection.height)
+    ),
+    primaryFaceConfidence: roundMetric(primary.value.confidence),
+    primaryFaceHeight: roundMetric(primary.value.box.height),
+    primaryFaceWidth: roundMetric(primary.value.box.width),
+  });
+});
+
+const hexHammingDistance = (left: string, right: string): number => {
+  let distance = 0;
+  const length = Math.min(left.length, right.length);
+  for (let index = 0; index < length; index += 1) {
+    const xor = Number.parseInt(left[index] ?? "0", 16) ^ Number.parseInt(right[index] ?? "0", 16);
+    distance += xor.toString(2).replaceAll("0", "").length;
+  }
+  return distance + Math.abs(left.length - right.length) * 4;
+};
+
+const colorHashDistance = (left: string, right: string): number => {
+  let total = 0;
+  const length = Math.min(left.length, right.length);
+  for (let index = 0; index < length; index += 1) {
+    total += Math.abs(Number.parseInt(left[index] ?? "0", 16) - Number.parseInt(right[index] ?? "0", 16));
+  }
+  return roundMetric(length === 0 ? 1 : total / (length * 15));
+};
+
+const candidateSimilarityPairs = (entries: ReadonlyArray<ImageAuditEntry>) => {
+  let pairs = A.empty<ImageAuditSimilarityPair>();
+  for (let leftIndex = 0; leftIndex < entries.length; leftIndex += 1) {
+    const left = entries[leftIndex];
+    if (left === undefined) continue;
+    for (let rightIndex = leftIndex + 1; rightIndex < entries.length; rightIndex += 1) {
+      const right = entries[rightIndex];
+      if (right === undefined) continue;
+      const perceptualDistance = hexHammingDistance(left.perceptualHash, right.perceptualHash);
+      if (perceptualDistance > 24) continue;
+      const colorDistance = colorHashDistance(left.colorHash, right.colorHash);
+      if (colorDistance > 0.42) continue;
+      pairs = A.append(
+        pairs,
+        ImageAuditSimilarityPair.make({
+          colorDistance,
+          perceptualDistance,
+          sourceNameA: left.sourceName,
+          sourceNameB: right.sourceName,
+        })
+      );
+    }
+  }
+  return pairs;
+};
+
+const duplicateClusters = (
+  entries: ReadonlyArray<ImageAuditEntry>,
+  pairs: ReadonlyArray<ImageAuditSimilarityPair>
+): ReadonlyArray<ImageAuditCluster> => {
+  const indexByName = MutableHashMap.empty<string, number>();
+  const parents = entries.map((_entry, index) => index);
+  entries.forEach((entry, index) => MutableHashMap.set(indexByName, entry.sourceName, index));
+
+  const find = (index: number): number => {
+    let current = index;
+    while (parents[current] !== current) current = parents[current] ?? current;
+    let compressed = index;
+    while (parents[compressed] !== current) {
+      const next = parents[compressed] ?? current;
+      parents[compressed] = current;
+      compressed = next;
+    }
+    return current;
+  };
+
+  for (const pair of pairs) {
+    if (pair.perceptualDistance > 12 || pair.colorDistance > 0.3) continue;
+    const left = MutableHashMap.get(indexByName, pair.sourceNameA);
+    const right = MutableHashMap.get(indexByName, pair.sourceNameB);
+    if (O.isNone(left) || O.isNone(right)) continue;
+    const leftRoot = find(left.value);
+    const rightRoot = find(right.value);
+    if (leftRoot !== rightRoot) parents[rightRoot] = leftRoot;
+  }
+
+  const grouped = MutableHashMap.empty<number, ReadonlyArray<string>>();
+  entries.forEach((entry, index) => {
+    const root = find(index);
+    MutableHashMap.set(
+      grouped,
+      root,
+      pipe(MutableHashMap.get(grouped, root), O.getOrElse(A.empty<string>), A.append(entry.sourceName))
+    );
+  });
+
+  return A.fromIterable(MutableHashMap.values(grouped))
+    .filter((names) => names.length > 1)
+    .map((names) => A.sort(names, Order.String))
+    .sort((left, right) => (left[0] ?? "").localeCompare(right[0] ?? ""))
+    .map((names, index) =>
+      ImageAuditCluster.make({
+        id: `duplicate-${`${index + 1}`.padStart(3, "0")}`,
+        sourceNames: names as [string, ...Array<string>],
+      })
+    );
+};
+
+const candidateSessionClusters = (entries: ReadonlyArray<ImageAuditEntry>): ReadonlyArray<ImageAuditCluster> => {
+  const groups = MutableHashMap.empty<string, ReadonlyArray<string>>();
+  for (const entry of entries) {
+    const match = /^([0-9]+)\.[0-9]+\.[^.]+$/u.exec(entry.sourceName);
+    if (match?.[1] === undefined) continue;
+    MutableHashMap.set(
+      groups,
+      match[1],
+      pipe(MutableHashMap.get(groups, match[1]), O.getOrElse(A.empty<string>), A.append(entry.sourceName))
+    );
+  }
+
+  return A.fromIterable(groups)
+    .filter(([, names]) => names.length > 1)
+    .sort(([left], [right]) => Number(left) - Number(right))
+    .map(([prefix, names]) =>
+      ImageAuditCluster.make({
+        id: `filename-session-${prefix}`,
+        sourceNames: A.sort(names, Order.String) as [string, ...Array<string>],
+      })
+    );
+};
+
+const writeJsonAtomically = Effect.fn("Files.writeImageCurationJsonAtomically")(function* (
+  filePath: string,
+  value: unknown,
+  overwrite: boolean,
+  description: string
+): Effect.fn.Return<void, FilesCommandError, FileSystem.FileSystem | Path.Path> {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const resolved = path.resolve(filePath);
+  const exists = yield* fs
+    .exists(resolved)
+    .pipe(Effect.mapError((cause) => formatPlatformError(`Failed to inspect ${description}`, resolved, { cause })));
+
+  if (exists && !overwrite) {
+    return yield* FilesCommandError.make({
+      message: `Refusing to overwrite existing ${description}: "${resolved}"`,
+    });
+  }
+  if (exists) {
+    const stat = yield* fs
+      .stat(resolved)
+      .pipe(Effect.mapError((cause) => formatPlatformError(`Failed to stat ${description}`, resolved, { cause })));
+    if (stat.type !== "File") {
+      return yield* FilesCommandError.make({
+        message: `Refusing to overwrite non-file ${description}: "${resolved}"`,
+      });
+    }
+  }
+
+  const parent = path.dirname(resolved);
+  yield* fs
+    .makeDirectory(parent, { recursive: true })
+    .pipe(
+      Effect.mapError((cause) => formatPlatformError(`Failed to create ${description} directory`, parent, { cause }))
+    );
+  yield* Effect.acquireUseRelease(
+    fs
+      .makeTempDirectory({ directory: parent, prefix: ".beep-files-image-json-" })
+      .pipe(Effect.mapError((cause) => formatPlatformError(`Failed to stage ${description}`, parent, { cause }))),
+    Effect.fnUntraced(function* (tempDir) {
+      const tempPath = path.join(tempDir, path.basename(resolved));
+      const content = pipe(
+        yield* encodeUnknownJson(value).pipe(
+          Effect.mapError((cause) => FilesCommandError.new(cause, `Failed to encode ${description}`))
+        ),
+        Str.concat("\n")
+      );
+      yield* fs
+        .writeFileString(tempPath, content)
+        .pipe(
+          Effect.mapError((cause) => formatPlatformError(`Failed to write staged ${description}`, tempPath, { cause }))
+        );
+      if (exists) yield* fs.remove(resolved, { force: true }).pipe(Effect.ignore);
+      yield* fs
+        .rename(tempPath, resolved)
+        .pipe(Effect.mapError((cause) => formatPlatformError(`Failed to commit ${description}`, resolved, { cause })));
+    }),
+    (tempDir) => fs.remove(tempDir, { force: true, recursive: true }).pipe(Effect.ignore)
+  );
+});
+
+/**
+ * Audit direct images without mutating their source directory.
+ *
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const auditImagesImpl = Effect.fn("FilesCommandService.auditImages")(function* (
+  options: ImageAuditOptions
+): Effect.fn.Return<
+  ImageAuditManifest,
+  FilesCommandError,
+  FileSystem.FileSystem | Path.Path | Terminal.Terminal | ChildProcessSpawner.ChildProcessSpawner | Crypto.Crypto
+> {
+  if (options.minConfidence < 0 || options.minConfidence > 1) {
+    return yield* FilesCommandError.make({
+      message: "Image audit --min-confidence must be between 0 and 1.",
+    });
+  }
+
+  const path = yield* Path.Path;
+  const sources = yield* collectAuditSources(options.dir);
+  const manifestPath = path.resolve(options.manifest);
+  let entries = A.empty<ImageAuditEntry>();
+  let skipped = sources.skipped;
+
+  yield* withDetector(
+    FaceDetectionModelConfig.make({ modelPath: path.resolve(options.modelPath) }),
+    Effect.fnUntraced(function* (detector) {
+      for (const source of sources.files) {
+        const result = yield* Effect.all(
+          [analyzePixels(source), analyzeFaceMetrics(detector, source, options.minConfidence), fileSha256(source.path)],
+          { concurrency: 3 }
+        ).pipe(Effect.result);
+
+        if (result._tag === "Failure") {
+          skipped = A.append(
+            skipped,
+            ImageAuditSkippedEntry.make({
+              message: result.failure.message,
+              sourceName: source.name,
+              sourcePath: source.path,
+            })
+          );
+          continue;
+        }
+
+        const [pixels, faces, sourceSha256] = result.success;
+        entries = A.append(
+          entries,
+          ImageAuditEntry.make({
+            aspectRatio: roundMetric(pixels.width / pixels.height),
+            colorHash: pixels.colorHash,
+            decodedPixelSha256: pixels.decodedPixelSha256,
+            extension: source.extension,
+            faces,
+            height: pixels.height,
+            metadata: pixels.metadata,
+            perceptualHash: pixels.perceptualHash,
+            quality: pixels.quality,
+            sourceName: source.name,
+            sourcePath: source.path,
+            sourceRelativePath: source.relativePath,
+            sourceSha256,
+            sourceSizeBytes: `${source.size}`,
+            width: pixels.width,
+          })
+        );
+      }
+    })
+  ).pipe(
+    Effect.provideService(FaceDetectionService, makeFaceDetectionService()),
+    Effect.mapError((cause) =>
+      FilesCommandError.make({
+        cause,
+        message: `Failed to load or run image audit face model: ${cause.message}`,
+      })
+    )
+  );
+
+  entries = A.sort(entries, byAuditEntryName);
+  skipped = A.sort(skipped, bySkippedEntryName);
+  const similarityPairs = candidateSimilarityPairs(entries);
+  const duplicates = duplicateClusters(entries, similarityPairs);
+  const sessions = candidateSessionClusters(entries);
+  const faceImageCount = A.length(A.filter(entries, (entry) => entry.faces.faceCount > 0));
+  const multiFaceImageCount = A.length(A.filter(entries, (entry) => entry.faces.faceCount > 1));
+  const summary = ImageAuditSummary.make({
+    analyzedCount: A.length(entries),
+    duplicateClusterCount: A.length(duplicates),
+    faceImageCount,
+    multiFaceImageCount,
+    noFaceImageCount: A.length(entries) - faceImageCount,
+    sessionClusterCount: A.length(sessions),
+    similarityPairCount: A.length(similarityPairs),
+    skippedCount: A.length(skipped),
+    totalCount: A.length(entries) + A.length(skipped),
+  });
+  const manifest = ImageAuditManifest.make({
+    duplicateClusters: duplicates,
+    entries,
+    manifestPath,
+    modelPath: path.resolve(options.modelPath),
+    schemaVersion: "beep.files.image-audit.v1",
+    sessionClusters: sessions,
+    similarityPairs,
+    skipped,
+    sourceDirectory: sources.canonicalDirectory,
+    summary,
+  });
+  const encoded = yield* encodeImageAuditManifest(manifest).pipe(
+    Effect.mapError((cause) => FilesCommandError.new(cause, "Failed to encode image audit manifest"))
+  );
+  yield* writeJsonAtomically(manifestPath, encoded, options.overwrite, "image audit manifest");
+  yield* Console.log(
+    `files audit-images: audited ${summary.analyzedCount} image(s), skipped ${summary.skippedCount}, found ${summary.duplicateClusterCount} candidate duplicate cluster(s), and wrote "${manifestPath}".`
+  );
+  return manifest;
+});
+
+const dispositionDirectories = {
+  "active-core": "canonical/active/core",
+  "active-extended": "canonical/active/extended",
+  "archive-earlier-life": "archive/earlier-life",
+  "archive-identity-ambiguous": "archive/identity-ambiguous",
+  "archive-other-people": "archive/other-people",
+  "archive-synthetic-filtered": "archive/synthetic-filtered",
+  "archive-technical-quality": "archive/technical-quality",
+  holdout: "canonical/holdout",
+  "reserve-near-duplicate": "reserve/near-duplicate",
+} as const satisfies Readonly<Record<ImageCurationDisposition, string>>;
+
+const dispositionDirectory = (disposition: ImageCurationDisposition): string => dispositionDirectories[disposition];
+
+const pathsOverlap = (
+  path: Pick<ImagePathOperations, "isAbsolute" | "relative">,
+  left: string,
+  right: string
+): boolean => {
+  const relative = path.relative(left, right);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+};
+
+const requireCleanCurationSources = Effect.fn("Files.requireCleanCurationSources")(function* (
+  sources: AuditSourceCollection
+): Effect.fn.Return<void, FilesCommandError> {
+  if (A.isReadonlyArrayNonEmpty(sources.skipped)) {
+    const count = A.length(sources.skipped);
+    return yield* FilesCommandError.make({
+      message: `Curation requires a clean direct-image source directory; audit skipped ${count} ${
+        count === 1 ? "entry" : "entries"
+      }.`,
+    });
+  }
+});
+
+const readDecisionDocument = Effect.fn("Files.readImageCurationDecisionDocument")(function* (
+  decisionDocumentPath: string
+): Effect.fn.Return<ImageCurationDecisionDocument, FilesCommandError, FileSystem.FileSystem> {
+  const fs = yield* FileSystem.FileSystem;
+  const content = yield* fs
+    .readFileString(decisionDocumentPath)
+    .pipe(
+      Effect.mapError((cause) =>
+        formatPlatformError("Failed to read image curation decision ledger", decisionDocumentPath, { cause })
+      )
+    );
+  return yield* decodeImageCurationDecisionDocumentJson(content).pipe(
+    Effect.mapError((cause) =>
+      FilesCommandError.new(cause, `Failed to decode image curation decision ledger "${decisionDocumentPath}"`)
+    )
+  );
+});
+
+const validateCurationRoots = Effect.fn("Files.validateImageCurationRoots")(function* (
+  options: ImageCurationOptions,
+  sources: AuditSourceCollection,
+  decisions: ImageCurationDecisionDocument
+): Effect.fn.Return<{ readonly manifestPath: string; readonly outputDirectory: string }, FilesCommandError, Path.Path> {
+  const path = yield* Path.Path;
+  const recordedSourceDirectory = path.resolve(decisions.sourceDirectory);
+  if (recordedSourceDirectory !== sources.canonicalDirectory) {
+    return yield* FilesCommandError.make({
+      message: `Decision ledger sourceDirectory "${recordedSourceDirectory}" does not match "${sources.canonicalDirectory}".`,
+    });
+  }
+
+  const outputDirectory = path.resolve(options.outDir);
+  const outputOverlapsSource =
+    pathsOverlap(path, sources.canonicalDirectory, outputDirectory) ||
+    pathsOverlap(path, outputDirectory, sources.canonicalDirectory);
+  if (outputOverlapsSource) {
+    return yield* FilesCommandError.make({
+      message: `Curation output directory must not overlap source directory "${sources.canonicalDirectory}".`,
+    });
+  }
+
+  const defaultManifestPath = path.join(outputDirectory, "manifests", "image-curation-manifest.json");
+  return {
+    manifestPath: path.resolve(
+      pipe(
+        options.manifest,
+        O.getOrElse(() => defaultManifestPath)
+      )
+    ),
+    outputDirectory,
+  };
+});
+
+const indexCurationDecisions = Effect.fn("Files.indexImageCurationDecisions")(function* (
+  decisions: ReadonlyArray<ImageCurationDecision>
+): Effect.fn.Return<MutableHashMap.MutableHashMap<string, ImageCurationDecision>, FilesCommandError, Path.Path> {
+  const path = yield* Path.Path;
+  const decisionsByName = MutableHashMap.empty<string, ImageCurationDecision>();
+  for (const decision of decisions) {
+    if (!isDirectSafeName(path, decision.sourceName)) {
+      return yield* FilesCommandError.make({
+        message: `Unsafe curation decision sourceName: "${decision.sourceName}"`,
+      });
+    }
+    if (MutableHashMap.has(decisionsByName, decision.sourceName)) {
+      return yield* FilesCommandError.make({
+        message: `Duplicate curation decision for sourceName "${decision.sourceName}".`,
+      });
+    }
+    MutableHashMap.set(decisionsByName, decision.sourceName, decision);
+  }
+  return decisionsByName;
+});
+
+const namesOrNone = (names: ReadonlyArray<string>): string => (names.length === 0 ? "none" : names.join(", "));
+
+const requireExactDecisionCoverage = Effect.fn("Files.requireExactImageCurationDecisionCoverage")(function* (
+  sources: ReadonlyArray<AuditSourceFile>,
+  decisions: ReadonlyArray<ImageCurationDecision>,
+  decisionsByName: MutableHashMap.MutableHashMap<string, ImageCurationDecision>
+): Effect.fn.Return<void, FilesCommandError> {
+  const sourceNames = MutableHashSet.fromIterable(sources.map((source) => source.name));
+  const missing = sources
+    .filter((source) => !MutableHashMap.has(decisionsByName, source.name))
+    .map((source) => source.name);
+  const extra = decisions
+    .filter((decision) => !MutableHashSet.has(sourceNames, decision.sourceName))
+    .map((decision) => decision.sourceName);
+  if (missing.length > 0 || extra.length > 0) {
+    return yield* FilesCommandError.make({
+      message: `Curation ledger must contain exactly one decision per source (missing: ${namesOrNone(
+        missing
+      )}; extra: ${namesOrNone(extra)}).`,
+    });
+  }
+});
+
+const validateSourceDecisionHashes = Effect.fn("Files.validateImageCurationSourceHashes")(function* (
+  sources: ReadonlyArray<AuditSourceFile>,
+  decisionsByName: MutableHashMap.MutableHashMap<string, ImageCurationDecision>
+): Effect.fn.Return<ReadonlyArray<ValidatedSourceDecision>, FilesCommandError, FileSystem.FileSystem | Crypto.Crypto> {
+  let validated = A.empty<ValidatedSourceDecision>();
+  for (const source of sources) {
+    const decision = MutableHashMap.get(decisionsByName, source.name);
+    if (O.isNone(decision)) {
+      return yield* FilesCommandError.make({ message: `Missing decision for "${source.name}".` });
+    }
+    const hash = yield* fileSha256(source.path);
+    if (hash !== decision.value.sourceSha256) {
+      return yield* FilesCommandError.make({
+        message: `Source hash mismatch for "${source.name}": decision=${decision.value.sourceSha256}, actual=${hash}.`,
+      });
+    }
+    validated = A.append(validated, { decision: decision.value, hash, source });
+  }
+  return validated;
+});
+
+const collisionSafeOutputName = (
+  hash: FileSha256Hash,
+  usedNames: MutableHashMap.MutableHashMap<string, FileSha256Hash>
+): string => {
+  const hex = hash.slice("sha256:".length);
+  let prefixLength = 20;
+  let outputName = `twv1_${hex.slice(0, prefixLength)}.png`;
+  while (
+    pipe(
+      MutableHashMap.get(usedNames, outputName),
+      O.exists((existingHash) => existingHash !== hash)
+    )
+  ) {
+    prefixLength += 1;
+    outputName = `twv1_${hex.slice(0, prefixLength)}.png`;
+  }
+  return outputName;
+};
+
+const allocateCurationOutputNames = (
+  validated: ReadonlyArray<ValidatedSourceDecision>
+): ReadonlyArray<NamedSourceDecision> => {
+  const usedNames = MutableHashMap.empty<string, FileSha256Hash>();
+  return validated.map((entry) => {
+    const outputName = collisionSafeOutputName(entry.hash, usedNames);
+    MutableHashMap.set(usedNames, outputName, entry.hash);
+    return { ...entry, outputName };
+  });
+};
+
+const prepareCurationEntries = (
+  path: Pick<ImagePathOperations, "join">,
+  outputDirectory: string,
+  entries: ReadonlyArray<NamedSourceDecision>
+): ReadonlyArray<PreparedCurationEntry> =>
+  entries.map(({ decision, outputName, source }) => {
+    const outputRelativePath = path.join(dispositionDirectory(decision.disposition), outputName);
+    return {
+      decision,
+      outputName,
+      outputPath: path.join(outputDirectory, outputRelativePath),
+      outputRelativePath,
+      source,
+    };
+  });
+
+const validateDecisionLedger = Effect.fn("Files.validateImageCurationDecisionLedger")(function* (
+  options: ImageCurationOptions
+): Effect.fn.Return<ValidatedDecisionLedger, FilesCommandError, FileSystem.FileSystem | Path.Path | Crypto.Crypto> {
+  const path = yield* Path.Path;
+  const sources = yield* collectAuditSources(options.dir);
+  yield* requireCleanCurationSources(sources);
+  const decisionDocumentPath = path.resolve(options.decisionsPath);
+  const decisions = yield* readDecisionDocument(decisionDocumentPath);
+  const roots = yield* validateCurationRoots(options, sources, decisions);
+  const decisionsByName = yield* indexCurationDecisions(decisions.decisions);
+  yield* requireExactDecisionCoverage(sources.files, decisions.decisions, decisionsByName);
+  const validatedSources = yield* validateSourceDecisionHashes(sources.files, decisionsByName);
+  const prepared = prepareCurationEntries(path, roots.outputDirectory, allocateCurationOutputNames(validatedSources));
+
+  return {
+    decisions,
+    manifestPath: roots.manifestPath,
+    outputDirectory: roots.outputDirectory,
+    prepared,
+    sourceDirectory: sources.canonicalDirectory,
+  };
+});
+
+const cropWithinBounds = (crop: ImageCurationCrop, width: number, height: number): boolean =>
+  crop.left + crop.width <= width && crop.top + crop.height <= height;
+
+const quarterTurnOrientations = MutableHashSet.make(5, 6, 7, 8);
+
+const inspectOrientedDimensions = Effect.fn("Files.inspectOrientedImageDimensions")(function* (
+  source: AuditSourceFile
+): Effect.fn.Return<OrientedImageDimensions, FilesCommandError> {
+  const metadata = yield* Effect.tryPromise({
+    try: () => sharp(source.path, { failOn: "error" }).metadata(),
+    catch: FilesCommandError.new(`Failed to inspect canonical PNG source "${source.path}"`),
+  });
+  const quarterTurn = MutableHashSet.has(quarterTurnOrientations, metadata.orientation ?? 1);
+  const width = quarterTurn ? metadata.height : metadata.width;
+  const height = quarterTurn ? metadata.width : metadata.height;
+  if (width === undefined || height === undefined) {
+    return yield* FilesCommandError.make({
+      message: `Image decoder did not report usable dimensions for "${source.path}".`,
+    });
+  }
+  return { height, width };
+});
+
+const validateCurationCrop = Effect.fn("Files.validateImageCurationCrop")(function* (
+  entry: PreparedCurationEntry,
+  dimensions: OrientedImageDimensions
+): Effect.fn.Return<ImageCurationCrop | undefined, FilesCommandError> {
+  const crop = entry.decision.crop;
+  if (crop === undefined) return undefined;
+  if (!cropWithinBounds(crop, dimensions.width, dimensions.height)) {
+    return yield* FilesCommandError.make({
+      message: `Crop ${crop.left},${crop.top},${crop.width}x${crop.height} exceeds ${dimensions.width}x${dimensions.height} for "${entry.source.name}".`,
+    });
+  }
+  return crop;
+});
+
+const canonicalPngPipeline = (source: AuditSourceFile, crop: ImageCurationCrop | undefined): SharpInstance => {
+  const pipeline = sharp(source.path, { failOn: "error" })
+    .rotate()
+    .flatten({ background: { b: 255, g: 255, r: 255 } })
+    .toColorspace("srgb")
+    .removeAlpha();
+  if (crop === undefined) return pipeline;
+  return pipeline.extract({
+    height: crop.height,
+    left: crop.left,
+    top: crop.top,
+    width: crop.width,
+  });
+};
+
+const materializeCanonicalPng = Effect.fn("Files.materializeCanonicalPng")(function* (
+  entry: PreparedCurationEntry,
+  tempPath: string
+): Effect.fn.Return<MaterializedPng, FilesCommandError> {
+  const dimensions = yield* inspectOrientedDimensions(entry.source);
+  const crop = yield* validateCurationCrop(entry, dimensions);
+  const pipeline = canonicalPngPipeline(entry.source, crop);
+  const result = yield* Effect.tryPromise({
+    try: () =>
+      pipeline
+        .png({
+          adaptiveFiltering: true,
+          compressionLevel: 9,
+          force: true,
+          palette: false,
+        })
+        .toFile(tempPath),
+    catch: FilesCommandError.new(`Failed to materialize canonical PNG for "${entry.source.path}"`),
+  });
+  return {
+    height: result.height,
+    size: result.size,
+    width: result.width,
+  };
+});
+
+const optionalManifestDecisionFields = (decision: ImageCurationDecision): OptionalManifestDecisionFields => {
+  const fields: OptionalManifestDecisionFields = {};
+  if (decision.crop !== undefined) fields.crop = decision.crop;
+  if (decision.duplicateClusterId !== undefined) fields.duplicateClusterId = decision.duplicateClusterId;
+  if (decision.sessionId !== undefined) fields.sessionId = decision.sessionId;
+  return fields;
+};
+
+const makeCurationManifestEntry = (
+  entry: PreparedCurationEntry,
+  output: MaterializedPng,
+  outputSha256: FileSha256Hash
+): ImageCurationManifestEntry =>
+  ImageCurationManifestEntry.make({
+    ...optionalManifestDecisionFields(entry.decision),
+    disposition: entry.decision.disposition,
+    outputHeight: output.height,
+    outputName: entry.outputName,
+    outputPath: entry.outputPath,
+    outputRelativePath: entry.outputRelativePath,
+    outputSha256,
+    outputSizeBytes: `${output.size}`,
+    outputWidth: output.width,
+    reasons: entry.decision.reasons,
+    sourceName: entry.source.name,
+    sourcePath: entry.source.path,
+    sourceRelativePath: entry.source.relativePath,
+    sourceSha256: entry.decision.sourceSha256,
+  });
+
+const curationSummary = (
+  decisions: ReadonlyArray<ImageCurationDecision>,
+  dryRun: boolean,
+  materializedCount: number
+): ImageCurationSummary =>
+  ImageCurationSummary.make({
+    archiveCount: A.length(A.filter(decisions, (decision) => decision.disposition.startsWith("archive-"))),
+    coreCount: A.length(A.filter(decisions, (decision) => decision.disposition === "active-core")),
+    dryRun,
+    extendedCount: A.length(A.filter(decisions, (decision) => decision.disposition === "active-extended")),
+    holdoutCount: A.length(A.filter(decisions, (decision) => decision.disposition === "holdout")),
+    materializedCount,
+    plannedCount: A.length(decisions),
+    reserveCount: A.length(A.filter(decisions, (decision) => decision.disposition === "reserve-near-duplicate")),
+  });
+
+/**
+ * Validate a complete decision ledger and materialize metadata-free PNG derivatives.
+ *
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const curateImagesImpl = Effect.fn("FilesCommandService.curateImages")(function* (
+  options: ImageCurationOptions
+): Effect.fn.Return<
+  ImageCurationSummary,
+  FilesCommandError,
+  FileSystem.FileSystem | Path.Path | Terminal.Terminal | ChildProcessSpawner.ChildProcessSpawner | Crypto.Crypto
+> {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const validated = yield* validateDecisionLedger(options);
+  const dryRunSummary = curationSummary(validated.decisions.decisions, true, 0);
+
+  if (options.dryRun) {
+    for (const entry of validated.prepared) {
+      yield* Console.log(`${entry.source.name} -> ${entry.outputRelativePath} [${entry.decision.disposition}]`);
+    }
+    yield* Console.log(
+      `files curate-images: dry run validated ${dryRunSummary.plannedCount} hash-pinned decision(s); no files written.`
+    );
+    return dryRunSummary;
+  }
+
+  for (const entry of validated.prepared) {
+    const exists = yield* fs
+      .exists(entry.outputPath)
+      .pipe(
+        Effect.mapError((cause) =>
+          formatPlatformError("Failed to inspect curation output", entry.outputPath, { cause })
+        )
+      );
+    if (exists && !options.overwrite) {
+      return yield* FilesCommandError.make({
+        message: `Refusing to overwrite existing curation output: "${entry.outputPath}"`,
+      });
+    }
+    if (exists) {
+      const stat = yield* fs
+        .stat(entry.outputPath)
+        .pipe(
+          Effect.mapError((cause) => formatPlatformError("Failed to stat curation output", entry.outputPath, { cause }))
+        );
+      if (stat.type !== "File") {
+        return yield* FilesCommandError.make({
+          message: `Refusing to overwrite non-file curation output: "${entry.outputPath}"`,
+        });
+      }
+    }
+  }
+
+  const manifestExists = yield* fs
+    .exists(validated.manifestPath)
+    .pipe(
+      Effect.mapError((cause) =>
+        formatPlatformError("Failed to inspect image curation manifest", validated.manifestPath, { cause })
+      )
+    );
+  if (manifestExists && !options.overwrite) {
+    return yield* FilesCommandError.make({
+      message: `Refusing to overwrite existing image curation manifest: "${validated.manifestPath}"`,
+    });
+  }
+
+  yield* fs
+    .makeDirectory(validated.outputDirectory, { recursive: true })
+    .pipe(
+      Effect.mapError((cause) =>
+        formatPlatformError("Failed to create image curation output directory", validated.outputDirectory, { cause })
+      )
+    );
+
+  const manifestEntries = yield* Effect.acquireUseRelease(
+    fs
+      .makeTempDirectory({ directory: validated.outputDirectory, prefix: ".beep-files-curate-images-" })
+      .pipe(
+        Effect.mapError((cause) =>
+          formatPlatformError("Failed to create image curation staging directory", validated.outputDirectory, { cause })
+        )
+      ),
+    Effect.fnUntraced(function* (tempDirectory) {
+      let completed = A.empty<ImageCurationManifestEntry>();
+      let index = 0;
+      for (const entry of validated.prepared) {
+        const tempPath = path.join(tempDirectory, `${`${index}`.padStart(4, "0")}-${entry.outputName}`);
+        const output = yield* materializeCanonicalPng(entry, tempPath);
+        const outputSha256 = yield* fileSha256(tempPath);
+        const destinationDirectory = path.dirname(entry.outputPath);
+        yield* fs
+          .makeDirectory(destinationDirectory, { recursive: true })
+          .pipe(
+            Effect.mapError((cause) =>
+              formatPlatformError("Failed to create curation destination directory", destinationDirectory, { cause })
+            )
+          );
+        if (options.overwrite) yield* fs.remove(entry.outputPath, { force: true }).pipe(Effect.ignore);
+        yield* fs
+          .rename(tempPath, entry.outputPath)
+          .pipe(
+            Effect.mapError((cause) =>
+              formatPlatformError("Failed to commit canonical curation output", entry.outputPath, { cause })
+            )
+          );
+        completed = A.append(completed, makeCurationManifestEntry(entry, output, outputSha256));
+        index += 1;
+      }
+      return completed;
+    }),
+    (tempDirectory) => fs.remove(tempDirectory, { recursive: true, force: true }).pipe(Effect.ignore)
+  );
+
+  const summary = curationSummary(validated.decisions.decisions, false, A.length(manifestEntries));
+  const manifest = ImageCurationManifest.make({
+    decisionDocumentPath: path.resolve(options.decisionsPath),
+    entries: manifestEntries,
+    manifestPath: validated.manifestPath,
+    outputDirectory: validated.outputDirectory,
+    schemaVersion: "beep.files.image-curation.v1",
+    sourceDirectory: validated.sourceDirectory,
+    summary,
+  });
+  const encoded = yield* encodeImageCurationManifest(manifest).pipe(
+    Effect.mapError((cause) => FilesCommandError.new(cause, "Failed to encode image curation manifest"))
+  );
+  yield* writeJsonAtomically(validated.manifestPath, encoded, options.overwrite, "image curation manifest");
+  yield* Console.log(
+    `files curate-images: materialized ${summary.materializedCount} metadata-free PNG derivative(s) and wrote "${validated.manifestPath}".`
+  );
+  return summary;
+});

--- a/packages/tooling/tool/cli/test/files-command.test.ts
+++ b/packages/tooling/tool/cli/test/files-command.test.ts
@@ -2387,6 +2387,44 @@ describe("files command", { concurrent: false }, () => {
       )
     ));
 
+  it("refuses audit manifests that reach protected files through filesystem aliases", () =>
+    Effect.runPromise(
+      withTempDirectory((tmpDir) =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const datasetDir = yield* makeDatasetDir(tmpDir);
+          const sourcePath = path.join(datasetDir, "source.jpg");
+          const modelDir = path.join(tmpDir, "model");
+          const modelPath = path.join(modelDir, "face-detection.onnx");
+          const sourceAlias = path.join(tmpDir, "source-alias");
+          const modelAlias = path.join(tmpDir, "model-alias");
+
+          yield* writeJpegWithExif(sourcePath, 32, 32);
+          const sourceHash = yield* sha256FileRef(sourcePath);
+          yield* fs.makeDirectory(modelDir, { recursive: true });
+          yield* fs.writeFileString(modelPath, "not a real model");
+          yield* fs.symlink(datasetDir, sourceAlias);
+          yield* fs.symlink(modelDir, modelAlias);
+          const baseArgs = ["audit-images", "--dir", datasetDir, "--model", modelPath, "--overwrite", "--manifest"];
+
+          const sourceAliasError = yield* expectFilesCommandFailure([
+            ...baseArgs,
+            path.join(sourceAlias, "audit.json"),
+          ]);
+          expect(sourceAliasError).toContain("must not be written inside source directory");
+          expect(yield* sha256FileRef(sourcePath)).toBe(sourceHash);
+
+          const modelAliasError = yield* expectFilesCommandFailure([
+            ...baseArgs,
+            path.join(modelAlias, "face-detection.onnx"),
+          ]);
+          expect(modelAliasError).toContain("must not overwrite face model");
+          expect(yield* fs.readFileString(modelPath)).toBe("not a real model");
+        })
+      )
+    ));
+
   it("refuses curation manifests that overlap protected inputs or generated derivatives", () =>
     Effect.runPromise(
       withTempDirectory((tmpDir) =>
@@ -2445,6 +2483,98 @@ describe("files command", { concurrent: false }, () => {
           const derivativeManifestError = yield* expectFilesCommandFailure([...baseArgs, outputPath]);
           expect(derivativeManifestError).toContain("must not overlap generated derivative");
           expect(yield* fs.exists(outDir)).toBe(false);
+        })
+      )
+    ));
+
+  it("refuses filesystem aliases that escape protected curation roots", () =>
+    Effect.runPromise(
+      withTempDirectory((tmpDir) =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const datasetDir = yield* makeDatasetDir(tmpDir);
+          const sourcePath = path.join(datasetDir, "source.jpg");
+          const ledgerDir = path.join(tmpDir, "ledger");
+          const decisionsPath = path.join(ledgerDir, "decisions.json");
+          const sourceAlias = path.join(tmpDir, "source-alias");
+          const ledgerAlias = path.join(tmpDir, "ledger-alias");
+          const outputAlias = path.join(tmpDir, "output-alias");
+          const outDir = path.join(tmpDir, "prepared");
+
+          yield* writeJpegWithExif(sourcePath, 32, 32);
+          const sourceHash = yield* sha256FileRef(sourcePath);
+          const decisionText = yield* encodeImageCurationDecisionDocument(
+            ImageCurationDecisionDocument.make({
+              decisions: [
+                {
+                  disposition: "active-core",
+                  reasons: ["clean-current-identity"],
+                  sourceName: "source.jpg",
+                  sourceSha256: sourceHash,
+                },
+              ],
+              schemaVersion: "beep.files.image-curation-decisions.v1",
+              sourceDirectory: datasetDir,
+            })
+          );
+          yield* fs.makeDirectory(ledgerDir, { recursive: true });
+          yield* fs.writeFileString(decisionsPath, decisionText);
+          yield* fs.symlink(datasetDir, sourceAlias);
+          yield* fs.symlink(ledgerDir, ledgerAlias);
+          yield* fs.symlink(datasetDir, outputAlias);
+
+          const baseArgs = [
+            "curate-images",
+            "--dir",
+            datasetDir,
+            "--decisions",
+            decisionsPath,
+            "--out-dir",
+            outDir,
+            "--overwrite",
+            "--manifest",
+          ];
+          const sourceAliasError = yield* expectFilesCommandFailure([
+            ...baseArgs,
+            path.join(sourceAlias, "manifest.json"),
+          ]);
+          expect(sourceAliasError).toContain("must not be written inside source directory");
+
+          const ledgerAliasError = yield* expectFilesCommandFailure([
+            ...baseArgs,
+            path.join(ledgerAlias, "decisions.json"),
+          ]);
+          expect(ledgerAliasError).toContain("must not overwrite decision ledger");
+          expect(yield* fs.readFileString(decisionsPath)).toBe(decisionText);
+
+          const outputAliasError = yield* expectFilesCommandFailure([
+            "curate-images",
+            "--dir",
+            datasetDir,
+            "--decisions",
+            decisionsPath,
+            "--out-dir",
+            outputAlias,
+            "--dry-run",
+          ]);
+          expect(outputAliasError).toContain("output directory must not overlap source directory");
+
+          const derivativeParent = path.join(outDir, "canonical", "active");
+          yield* fs.makeDirectory(derivativeParent, { recursive: true });
+          yield* fs.symlink(datasetDir, path.join(derivativeParent, "core"));
+          const derivativeAliasError = yield* expectFilesCommandFailure([
+            "curate-images",
+            "--dir",
+            datasetDir,
+            "--decisions",
+            decisionsPath,
+            "--out-dir",
+            outDir,
+            "--dry-run",
+          ]);
+          expect(derivativeAliasError).toContain("derivative must remain inside output directory");
+          expect(yield* sha256FileRef(sourcePath)).toBe(sourceHash);
         })
       )
     ));

--- a/packages/tooling/tool/cli/test/files-command.test.ts
+++ b/packages/tooling/tool/cli/test/files-command.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { Chalk } from "@beep/chalk";
 import { createColors } from "@beep/colors";
 import {
@@ -13,6 +14,9 @@ import {
   DetectBordersReport,
   DetectFacesReport,
   FilesCommandServiceLive,
+  ImageAuditManifest,
+  ImageCurationDecisionDocument,
+  ImageCurationManifest,
   NormalizeManifest,
   ProcessFilesOptions,
   processFiles,
@@ -44,6 +48,8 @@ const runFilesCommand = Command.runWith(filesCommand, { version: "0.0.0" });
 const decodeArchivePoorCandidatesManifest = S.decodeUnknownSync(S.fromJsonString(ArchivePoorCandidatesManifest));
 const decodeDetectBordersReport = S.decodeUnknownSync(S.fromJsonString(DetectBordersReport));
 const decodeDetectFacesReport = S.decodeUnknownEffect(S.fromJsonString(DetectFacesReport));
+const decodeImageAuditManifest = S.decodeUnknownEffect(S.fromJsonString(ImageAuditManifest));
+const decodeImageCurationManifest = S.decodeUnknownEffect(S.fromJsonString(ImageCurationManifest));
 const decodeChildArtifactRecord = S.decodeUnknownEffect(S.fromJsonString(ChildArtifactRecord));
 const decodeFileProcessingCoverageSummary = S.decodeUnknownEffect(S.fromJsonString(FileProcessingCoverageSummary));
 const decodeFileProcessingFailureRecord = S.decodeUnknownEffect(S.fromJsonString(FileProcessingFailureRecord));
@@ -51,6 +57,9 @@ const decodeNormalizeManifest = S.decodeUnknownSync(S.fromJsonString(NormalizeMa
 const decodeProcessRunManifest = S.decodeUnknownEffect(S.fromJsonString(ProcessRunManifest));
 const decodeSourceProcessingRecord = S.decodeUnknownEffect(S.fromJsonString(SourceProcessingRecord));
 const encodeDetectBordersReport = S.encodeUnknownEffect(S.fromJsonString(DetectBordersReport));
+const encodeImageAuditManifest = S.encodeUnknownEffect(S.fromJsonString(ImageAuditManifest));
+const encodeImageCurationDecisionDocument = S.encodeUnknownEffect(S.fromJsonString(ImageCurationDecisionDocument));
+const encodeImageCurationManifest = S.encodeUnknownEffect(S.fromJsonString(ImageCurationManifest));
 const encodeChildArtifactRecord = S.encodeUnknownEffect(S.fromJsonString(ChildArtifactRecord));
 const encodeFileProcessingCoverageSummary = S.encodeUnknownEffect(S.fromJsonString(FileProcessingCoverageSummary));
 const encodeFileProcessingFailureRecord = S.encodeUnknownEffect(S.fromJsonString(FileProcessingFailureRecord));
@@ -62,6 +71,8 @@ const ChildArtifactRecordArbitrary = S.toArbitrary(ChildArtifactRecord);
 const FileProcessingCoverageSummaryArbitrary = S.toArbitrary(FileProcessingCoverageSummary);
 const FileProcessingFailureRecordArbitrary = S.toArbitrary(FileProcessingFailureRecord);
 const NormalizeManifestArbitrary = S.toArbitrary(NormalizeManifest);
+const ImageAuditManifestArbitrary = S.toArbitrary(ImageAuditManifest);
+const ImageCurationManifestArbitrary = S.toArbitrary(ImageCurationManifest);
 const ProcessRunManifestArbitrary = S.toArbitrary(ProcessRunManifest);
 const SourceProcessingRecordArbitrary = S.toArbitrary(SourceProcessingRecord);
 const decodeChildArtifactRecordLine = (line: string) => decodeChildArtifactRecord(line);
@@ -430,11 +441,19 @@ const fileSize = Effect.fn("FilesTest.fileSize")(function* (filePath: string) {
   return stat.size;
 });
 
+const sha256FileRef = Effect.fn("FilesTest.sha256FileRef")(function* (filePath: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const bytes = yield* fs.readFile(filePath);
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+});
+
 describe("files command", { concurrent: false }, () => {
   it("round-trips schema-derived report data through JSON command boundaries", () =>
     fc.assert(
       fc.property(
         DetectBordersReportArbitrary,
+        ImageAuditManifestArbitrary,
+        ImageCurationManifestArbitrary,
         ChildArtifactRecordArbitrary,
         FileProcessingCoverageSummaryArbitrary,
         FileProcessingFailureRecordArbitrary,
@@ -443,6 +462,8 @@ describe("files command", { concurrent: false }, () => {
         SourceProcessingRecordArbitrary,
         (
           detectBordersReport,
+          imageAuditManifest,
+          imageCurationManifest,
           childArtifactRecord,
           coverageSummary,
           failureRecord,
@@ -454,6 +475,18 @@ describe("files command", { concurrent: false }, () => {
           const decodedDetectBordersReport = decodeDetectBordersReport(encodedDetectBordersReport);
           expect(Effect.runSync(encodeDetectBordersReport(decodedDetectBordersReport))).toBe(
             encodedDetectBordersReport
+          );
+
+          const encodedImageAuditManifest = Effect.runSync(encodeImageAuditManifest(imageAuditManifest));
+          const decodedImageAuditManifest = Effect.runSync(decodeImageAuditManifest(encodedImageAuditManifest));
+          expect(Effect.runSync(encodeImageAuditManifest(decodedImageAuditManifest))).toBe(encodedImageAuditManifest);
+
+          const encodedImageCurationManifest = Effect.runSync(encodeImageCurationManifest(imageCurationManifest));
+          const decodedImageCurationManifest = Effect.runSync(
+            decodeImageCurationManifest(encodedImageCurationManifest)
+          );
+          expect(Effect.runSync(encodeImageCurationManifest(decodedImageCurationManifest))).toBe(
+            encodedImageCurationManifest
           );
 
           const encodedChildArtifactRecord = Effect.runSync(encodeChildArtifactRecord(childArtifactRecord));
@@ -2205,6 +2238,167 @@ describe("files command", { concurrent: false }, () => {
 
           expect(yield* fs.readFileString(clipPath)).toBe("vvvv");
           expect(yield* fs.exists(argsPath)).toBe(true);
+        })
+      )
+    ));
+
+  it("materializes a complete hash-pinned image ledger as metadata-free canonical PNGs", () =>
+    Effect.runPromise(
+      withTempDirectory((tmpDir) =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const datasetDir = yield* makeDatasetDir(tmpDir);
+          const firstPath = path.join(datasetDir, "first.jpg");
+          const secondPath = path.join(datasetDir, "second.jpg");
+          const decisionsPath = path.join(tmpDir, "decisions.json");
+          const outDir = path.join(tmpDir, "prepared");
+
+          yield* writeJpegWithExif(firstPath, 64, 48);
+          yield* writeJpegWithExif(secondPath, 48, 64);
+          const firstBefore = yield* sha256FileRef(firstPath);
+          const secondBefore = yield* sha256FileRef(secondPath);
+          const decisionText = yield* encodeImageCurationDecisionDocument(
+            ImageCurationDecisionDocument.make({
+              decisions: [
+                {
+                  disposition: "active-core",
+                  reasons: ["clean-current-identity"],
+                  sourceName: "first.jpg",
+                  sourceSha256: firstBefore,
+                },
+                {
+                  disposition: "archive-technical-quality",
+                  reasons: ["test-technical-archive"],
+                  sourceName: "second.jpg",
+                  sourceSha256: secondBefore,
+                },
+              ],
+              schemaVersion: "beep.files.image-curation-decisions.v1",
+              sourceDirectory: datasetDir,
+            })
+          );
+          yield* fs.writeFileString(decisionsPath, decisionText);
+
+          yield* runFilesCommand([
+            "curate-images",
+            "--dir",
+            datasetDir,
+            "--decisions",
+            decisionsPath,
+            "--out-dir",
+            outDir,
+            "--dry-run",
+          ]);
+          expect(yield* fs.exists(outDir)).toBe(false);
+
+          yield* runFilesCommand([
+            "curate-images",
+            "--dir",
+            datasetDir,
+            "--decisions",
+            decisionsPath,
+            "--out-dir",
+            outDir,
+          ]);
+
+          const manifestPath = path.join(outDir, "manifests", "image-curation-manifest.json");
+          const manifest = yield* decodeImageCurationManifest(yield* fs.readFileString(manifestPath));
+          expect(manifest.schemaVersion).toBe("beep.files.image-curation.v1");
+          expect(manifest.summary.plannedCount).toBe(2);
+          expect(manifest.summary.materializedCount).toBe(2);
+          expect(manifest.summary.coreCount).toBe(1);
+          expect(manifest.summary.archiveCount).toBe(1);
+          expect(manifest.entries.map((entry) => entry.outputRelativePath)).toEqual([
+            `canonical/active/core/twv1_${firstBefore.slice("sha256:".length, "sha256:".length + 20)}.png`,
+            `archive/technical-quality/twv1_${secondBefore.slice("sha256:".length, "sha256:".length + 20)}.png`,
+          ]);
+          for (const entry of manifest.entries) {
+            const metadata = yield* readImageMetadata(entry.outputPath);
+            expect(metadata.format).toBe("png");
+            expect(metadata.exif).toBeUndefined();
+            expect(metadata.iptc).toBeUndefined();
+            expect(metadata.xmp).toBeUndefined();
+          }
+          expect(yield* sha256FileRef(firstPath)).toBe(firstBefore);
+          expect(yield* sha256FileRef(secondPath)).toBe(secondBefore);
+        })
+      )
+    ));
+
+  it("refuses incomplete or source-drifted image curation ledgers", () =>
+    Effect.runPromise(
+      withTempDirectory((tmpDir) =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const datasetDir = yield* makeDatasetDir(tmpDir);
+          const firstPath = path.join(datasetDir, "first.jpg");
+          const secondPath = path.join(datasetDir, "second.jpg");
+          const decisionsPath = path.join(tmpDir, "decisions.json");
+
+          yield* writeJpegWithExif(firstPath, 32, 32);
+          yield* writeJpegWithExif(secondPath, 32, 32);
+          const firstHash = yield* sha256FileRef(firstPath);
+          const incompleteText = yield* encodeImageCurationDecisionDocument(
+            ImageCurationDecisionDocument.make({
+              decisions: [
+                {
+                  disposition: "active-core",
+                  reasons: ["clean-current-identity"],
+                  sourceName: "first.jpg",
+                  sourceSha256: firstHash,
+                },
+              ],
+              schemaVersion: "beep.files.image-curation-decisions.v1",
+              sourceDirectory: datasetDir,
+            })
+          );
+          yield* fs.writeFileString(decisionsPath, incompleteText);
+          const incompleteError = yield* expectFilesCommandFailure([
+            "curate-images",
+            "--dir",
+            datasetDir,
+            "--decisions",
+            decisionsPath,
+            "--out-dir",
+            path.join(tmpDir, "prepared"),
+            "--dry-run",
+          ]);
+          expect(incompleteError).toContain("exactly one decision per source");
+
+          const driftedText = yield* encodeImageCurationDecisionDocument(
+            ImageCurationDecisionDocument.make({
+              decisions: [
+                {
+                  disposition: "active-core",
+                  reasons: ["clean-current-identity"],
+                  sourceName: "first.jpg",
+                  sourceSha256: `sha256:${"0".repeat(64)}`,
+                },
+                {
+                  disposition: "active-extended",
+                  reasons: ["useful-identity-signal"],
+                  sourceName: "second.jpg",
+                  sourceSha256: yield* sha256FileRef(secondPath),
+                },
+              ],
+              schemaVersion: "beep.files.image-curation-decisions.v1",
+              sourceDirectory: datasetDir,
+            })
+          );
+          yield* fs.writeFileString(decisionsPath, driftedText);
+          const driftError = yield* expectFilesCommandFailure([
+            "curate-images",
+            "--dir",
+            datasetDir,
+            "--decisions",
+            decisionsPath,
+            "--out-dir",
+            path.join(tmpDir, "prepared"),
+            "--dry-run",
+          ]);
+          expect(driftError).toContain('Source hash mismatch for "first.jpg"');
         })
       )
     ));

--- a/packages/tooling/tool/cli/test/files-command.test.ts
+++ b/packages/tooling/tool/cli/test/files-command.test.ts
@@ -2326,6 +2326,197 @@ describe("files command", { concurrent: false }, () => {
       )
     ));
 
+  it("allocates distinct derivative paths for byte-identical image sources", () =>
+    Effect.runPromise(
+      withTempDirectory((tmpDir) =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const datasetDir = yield* makeDatasetDir(tmpDir);
+          const firstPath = path.join(datasetDir, "first.jpg");
+          const secondPath = path.join(datasetDir, "second.jpg");
+          const decisionsPath = path.join(tmpDir, "decisions.json");
+          const outDir = path.join(tmpDir, "prepared");
+
+          yield* writeJpegWithExif(firstPath, 32, 32);
+          yield* fs.writeFile(secondPath, yield* fs.readFile(firstPath));
+          const sourceHash = yield* sha256FileRef(firstPath);
+          const decisionText = yield* encodeImageCurationDecisionDocument(
+            ImageCurationDecisionDocument.make({
+              decisions: [
+                {
+                  disposition: "active-core",
+                  reasons: ["preferred-duplicate"],
+                  sourceName: "first.jpg",
+                  sourceSha256: sourceHash,
+                },
+                {
+                  disposition: "active-core",
+                  reasons: ["preserved-duplicate"],
+                  sourceName: "second.jpg",
+                  sourceSha256: sourceHash,
+                },
+              ],
+              schemaVersion: "beep.files.image-curation-decisions.v1",
+              sourceDirectory: datasetDir,
+            })
+          );
+          yield* fs.writeFileString(decisionsPath, decisionText);
+
+          yield* runFilesCommand([
+            "curate-images",
+            "--dir",
+            datasetDir,
+            "--decisions",
+            decisionsPath,
+            "--out-dir",
+            outDir,
+          ]);
+
+          const manifestPath = path.join(outDir, "manifests", "image-curation-manifest.json");
+          const manifest = yield* decodeImageCurationManifest(yield* fs.readFileString(manifestPath));
+          const hashPrefix = sourceHash.slice("sha256:".length, "sha256:".length + 20);
+          expect(manifest.entries.map((entry) => entry.outputName)).toEqual([
+            `twv1_${hashPrefix}.png`,
+            `twv1_${hashPrefix}_2.png`,
+          ]);
+          expect(manifest.entries[0]?.outputPath).not.toBe(manifest.entries[1]?.outputPath);
+          expect(yield* fs.exists(manifest.entries[0]?.outputPath ?? "")).toBe(true);
+          expect(yield* fs.exists(manifest.entries[1]?.outputPath ?? "")).toBe(true);
+        })
+      )
+    ));
+
+  it("refuses curation manifests that overlap protected inputs or generated derivatives", () =>
+    Effect.runPromise(
+      withTempDirectory((tmpDir) =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const datasetDir = yield* makeDatasetDir(tmpDir);
+          const sourcePath = path.join(datasetDir, "source.jpg");
+          const decisionsPath = path.join(tmpDir, "decisions.json");
+          const outDir = path.join(tmpDir, "prepared");
+
+          yield* writeJpegWithExif(sourcePath, 32, 32);
+          const sourceHash = yield* sha256FileRef(sourcePath);
+          const decisionText = yield* encodeImageCurationDecisionDocument(
+            ImageCurationDecisionDocument.make({
+              decisions: [
+                {
+                  disposition: "active-core",
+                  reasons: ["clean-current-identity"],
+                  sourceName: "source.jpg",
+                  sourceSha256: sourceHash,
+                },
+              ],
+              schemaVersion: "beep.files.image-curation-decisions.v1",
+              sourceDirectory: datasetDir,
+            })
+          );
+          yield* fs.writeFileString(decisionsPath, decisionText);
+          const baseArgs = [
+            "curate-images",
+            "--dir",
+            datasetDir,
+            "--decisions",
+            decisionsPath,
+            "--out-dir",
+            outDir,
+            "--overwrite",
+            "--manifest",
+          ];
+
+          const sourceManifestError = yield* expectFilesCommandFailure([...baseArgs, sourcePath]);
+          expect(sourceManifestError).toContain("must not be written inside source directory");
+          expect(yield* sha256FileRef(sourcePath)).toBe(sourceHash);
+
+          const decisionManifestError = yield* expectFilesCommandFailure([...baseArgs, decisionsPath]);
+          expect(decisionManifestError).toContain("must not overwrite decision ledger");
+          expect(yield* fs.readFileString(decisionsPath)).toBe(decisionText);
+
+          const outputPath = path.join(
+            outDir,
+            "canonical",
+            "active",
+            "core",
+            `twv1_${sourceHash.slice("sha256:".length, "sha256:".length + 20)}.png`
+          );
+          const derivativeManifestError = yield* expectFilesCommandFailure([...baseArgs, outputPath]);
+          expect(derivativeManifestError).toContain("must not overlap generated derivative");
+          expect(yield* fs.exists(outDir)).toBe(false);
+        })
+      )
+    ));
+
+  it("keeps prior outputs intact when a later curation source cannot be materialized", () =>
+    Effect.runPromise(
+      withTempDirectory((tmpDir) =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const datasetDir = yield* makeDatasetDir(tmpDir);
+          const validPath = path.join(datasetDir, "a-valid.jpg");
+          const brokenPath = path.join(datasetDir, "z-broken.jpg");
+          const decisionsPath = path.join(tmpDir, "decisions.json");
+          const outDir = path.join(tmpDir, "prepared");
+          const manifestPath = path.join(outDir, "manifests", "image-curation-manifest.json");
+
+          yield* writeJpegWithExif(validPath, 32, 32);
+          yield* fs.writeFileString(brokenPath, "not-an-image");
+          const validHash = yield* sha256FileRef(validPath);
+          const decisionText = yield* encodeImageCurationDecisionDocument(
+            ImageCurationDecisionDocument.make({
+              decisions: [
+                {
+                  disposition: "active-core",
+                  reasons: ["clean-current-identity"],
+                  sourceName: "a-valid.jpg",
+                  sourceSha256: validHash,
+                },
+                {
+                  disposition: "archive-technical-quality",
+                  reasons: ["broken-decoder-input"],
+                  sourceName: "z-broken.jpg",
+                  sourceSha256: yield* sha256FileRef(brokenPath),
+                },
+              ],
+              schemaVersion: "beep.files.image-curation-decisions.v1",
+              sourceDirectory: datasetDir,
+            })
+          );
+          yield* fs.writeFileString(decisionsPath, decisionText);
+
+          const existingOutputPath = path.join(
+            outDir,
+            "canonical",
+            "active",
+            "core",
+            `twv1_${validHash.slice("sha256:".length, "sha256:".length + 20)}.png`
+          );
+          yield* fs.makeDirectory(path.dirname(existingOutputPath), { recursive: true });
+          yield* fs.makeDirectory(path.dirname(manifestPath), { recursive: true });
+          yield* fs.writeFileString(existingOutputPath, "previous-output");
+          yield* fs.writeFileString(manifestPath, "previous-manifest");
+
+          const output = yield* expectFilesCommandFailure([
+            "curate-images",
+            "--dir",
+            datasetDir,
+            "--decisions",
+            decisionsPath,
+            "--out-dir",
+            outDir,
+            "--overwrite",
+          ]);
+
+          expect(output).toContain("Failed to inspect canonical PNG source");
+          expect(yield* fs.readFileString(existingOutputPath)).toBe("previous-output");
+          expect(yield* fs.readFileString(manifestPath)).toBe("previous-manifest");
+        })
+      )
+    ));
+
   it("refuses incomplete or source-drifted image curation ledgers", () =>
     Effect.runPromise(
       withTempDirectory((tmpDir) =>


### PR DESCRIPTION
## Summary

- add `files audit-images` to inventory image properties, metadata presence, quality and face signals, perceptual-similarity candidates, duplicate clusters, and capture-session clusters in a typed JSON manifest
- add `files curate-images` to validate a complete hash-pinned human decision ledger, support dry runs and bounded crops, and materialize deterministic metadata-free PNG derivatives into disposition folders
- make curation collision-safe and transactional: byte-identical sources receive distinct deterministic paths, protected manifest destinations are rejected, and failed runs restore prior outputs and manifests
- canonicalize filesystem targets through their deepest existing ancestors so symlinked source, ledger, model, output, manifest, and derivative paths cannot bypass the safety boundary
- expose the new Effect Schema models and Files service methods, with regression coverage for schema round trips, audit behavior, exact decision coverage, hash drift, collisions, protected destinations, filesystem aliases, and rollback

## Data and privacy boundary

This PR contains source code and tests only. It does **not** include source photos, prepared images, generated audit or curation manifests, reports, datasets, model weights, API credentials, or 1Password secret values. Test images are generated ephemerally in temporary directories.

## Validation

- authoritative staged-only Yeet publish completed local build, check, lint, docgen, unit, type, integration, fallow, repository-sanity, security, SAST, Nix, and detached-install gates for `9f8b461f1d`
- `@beep/repo-cli`: 53 test files and 739 tests passed; changed Files command suite: 64/64 passed
- gitleaks: 3 commits scanned, no leaks
- Semgrep: 128 rules across all 7 changed files, 0 findings
- OSV scan: no unfiltered issues; Nix flake and dev shell passed; frozen-lockfile detached-HEAD install passed