### PR TITLE
chore(security): allowlist spike-evidence inventory digests in gitleaks

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -39,3 +39,14 @@ paths = [
   '''^(?:/repo/)?explorations/[^/]+/research/SOURCES\.md$''',
   '''^(?:/repo/)?goals/[^/]+/research/SOURCES\.md$''',
 ]
+
+[[allowlists]]
+description = "Archived P0/phase spike evidence under goals/*/history/ records content-addressed inventory digests (bare sha256 hex) as the proof that an immutable root did not change. Where a case name contains a keyword such as \"token\" (e.g. `writer case: token-swap root_before=<sha256>`), the adjacent digest trips the generic-api-key entropy heuristic. Scoped with condition=AND so ONLY bare 64-char lowercase hex under an evidence path is exempt: any real key shape (sk-, ghp_, base64, JWT) in the same files still fails. Spike harnesses additionally run their own exact-value and token-shape scans before archiving. Anchored at the repo root (with an optional /repo/ CI-mount prefix) so a nested attacker-controlled path cannot inherit the allowlist. Path/rule allowlist (survives squash-merge) rather than a commit fingerprint."
+condition = "AND"
+targetRules = ["generic-api-key"]
+paths = [
+  '''^(?:/repo/)?goals/[^/]+/history/.*$''',
+]
+regexes = [
+  '''^[a-f0-9]{64}$''',
+]


### PR DESCRIPTION
## Why

Archived gauntlet evidence under `goals/*/history/` records **content-addressed
inventory digests** — the sha256 of a directory inventory taken before and
after each spike case, which is the proof that an immutable config root did
not change. When a case name happens to contain a keyword like `token`, the
adjacent digest trips the `generic-api-key` entropy heuristic:

```
== writer case: token-swap root_before=<sha256> ==
```

This blocks #472 (the P0 gauntlet completion evidence) and would recur for
every future phase that archives run evidence.

## What

One `[[allowlists]]` entry, scoped with `condition = "AND"` so **both** must
hold: the file is under an evidence path, **and** the flagged value is a bare
64-character lowercase hex string.

Uses a path/rule allowlist rather than a `.gitleaksignore` commit fingerprint
so it survives squash-merge — the same reasoning the SOURCES.md entry already
records.

## Verification

Tested against planted fixtures:

| Case | Expected | Result |
| --- | --- | --- |
| Bare sha256 digest in `goals/*/history/` | allowed | not reported |
| `sk-live-…` key in the **same** evidence file | still caught | reported |
| 64-hex value outside evidence paths (`packages/foo/src/leak.ts`) | still caught | reported |

Also confirmed the real #472 branch scans clean under this config using the
exact CI invocation (base-pinned config + ignore, `origin/main..HEAD`).

Note the gate deliberately pins config and ignore file to the base branch so a
PR cannot suppress findings in its own change — which is why this lands
separately for review rather than inside #472.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787736916&installation_model_id=424656&pr_number=473&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F473&signature=102f4779fc88ef0630db8c9366c130951748db8b86c5e1a1bd0ab7780395066b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->