### PR TITLE
feat(libpff): encode over-long EML body parts as base64

### DIFF
--- a/.changeset/libpff-body-cte-base64.md
+++ b/.changeset/libpff-body-cte-base64.md
@@ -1,0 +1,5 @@
+---
+"@beep/libpff": patch
+---
+
+Emit assembled EML body parts as base64 when any physical body line exceeds RFC 5322's 998-octet limit, instead of always `8bit` verbatim. The trigger measures octets per line split on `/\r?\n/` (a lone CR counts as content), the switch covers the whole part losslessly — decoding restores the exact body string — and compliant bodies keep their byte-identical `8bit` output. Attachment parts are unchanged.

--- a/goals/file-processing-capability/research/p3-libpff-design.md
+++ b/goals/file-processing-capability/research/p3-libpff-design.md
@@ -92,8 +92,11 @@ without an EML), and is written inside the item directory:
   sanitizer).
 - No attachments: single-part message, `Content-Type` from the body variant
   (`text/plain; charset=utf-8` / `text/html; charset=utf-8` /
-  `application/rtf`), `Content-Transfer-Encoding: 8bit`, body verbatim. A
-  headers-only item (InternetHeaders.txt, no body) yields an empty
+  `application/rtf`), `Content-Transfer-Encoding: 8bit`, body verbatim —
+  unless any physical body line exceeds RFC 5322's 998-octet limit, in which
+  case the whole part is emitted as base64, losslessly (see the v5 addendum).
+  The same conditional rule governs the body part of the multipart branch
+  below. A headers-only item (InternetHeaders.txt, no body) yields an empty
   `text/plain` body part.
 - Attachments present: `multipart/mixed`; part 1 is the body (as above), one
   part per attachment ordered by relative path, base64,
@@ -270,6 +273,32 @@ ran against the implementation diff. Resolutions:
   acquisition discriminates `AlreadyExists` from other platform failures, so a
   permission or filesystem error reports "export claim could not be created"
   instead of falsely blaming a concurrent export.
+
+## Addendum (v5 — body content-transfer-encoding decision, 2026-07-27)
+
+Decided via a three-lens adversarial panel with a cross-examining judge on
+2026-07-27.
+
+- Decision: conditional base64. A body part stays `8bit` verbatim unless any
+  physical line (split on `/\r?\n/`; a lone CR is content and counts toward
+  its line's octets) exceeds RFC 5322's 998-octet limit, in which case the
+  whole part is emitted as base64 — 76-column wrapped, same helper as the
+  attachment path — losslessly: decoding restores the exact body string.
+- Quoted-printable rejected: text-mode QP normalizes bare LF to CRLF on
+  decode — a byte mutation; binary-mode QP forfeits the readability that
+  would justify QP while demanding a novel hand-rolled encoder; no QP encoder
+  exists in the repo.
+- Unconditional base64 and do-nothing rejected: unconditional encoding is
+  fixture churn for nothing (the overwhelmingly common short-line bodies are
+  already compliant), and the header-waiver precedent does not transfer to
+  bodies because a content-transfer-encoding is losslessly reversible while
+  folding is not.
+- Residual waivers: remaining `8bit` parts may carry bare-LF line endings —
+  pre-existing, deliberately not normalized. "Byte-lossless" is relative to
+  the UTF-8-decoded body string (post U+FFFD replacement); the raw body file
+  remains the authoritative byte copy beside the EML. The ~33% growth of
+  encoded parts reaches `maxMaterializedBytes` sooner, but the raw-bytes
+  lower-bound pre-skip stays valid since base64 only expands.
 
 ## Out of scope (unchanged)
 

--- a/packages/drivers/libpff/src/Libpff.eml.ts
+++ b/packages/drivers/libpff/src/Libpff.eml.ts
@@ -37,6 +37,8 @@ const outlookSenderNameKey = "Sender name";
 const outlookSenderEmailKey = "Sender email address";
 const outlookClientSubmitTimeKey = "Client submit time";
 
+// RFC 5322's 998-octet physical-line limit. It governs headers and bodies
+// alike: header lines fold against it, body parts switch encoding against it.
 const headerLineOctetLimit = 998;
 const outlookTimestampPattern = /^([A-Za-z]{3}) (\d{1,2}), (\d{4}) (\d{2}):(\d{2}):(\d{2})(?:\.\d+)? UTC$/;
 const monthAbbreviations = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
@@ -360,6 +362,23 @@ interface EmlAssemblyInput {
 
 const emptyBody: EmlBodyPart = { content: "", contentType: "text/plain; charset=utf-8" };
 
+// A body part obeys the same 998-octet physical-line limit as headers, but
+// folding would corrupt content, so a part with any over-long line switches
+// to base64 (losslessly — decoding restores the exact body string) while
+// every other part stays verbatim 8bit. Splitting on the line-break pattern
+// leaves a lone CR inside its line, where it counts toward the octet length:
+// a deliberate safe over-trigger for the one break style RFC 5322 does not
+// recognize.
+const bodySectionLines = (body: EmlBodyPart): ReadonlyArray<string> =>
+  A.some(body.content.split(lineBreakPattern), (line) => octetLength(line) > headerLineOctetLimit)
+    ? [
+        `Content-Type: ${body.contentType}`,
+        "Content-Transfer-Encoding: base64",
+        "",
+        foldBase64Lines(Encoding.encodeBase64(body.content)),
+      ]
+    : [`Content-Type: ${body.contentType}`, "Content-Transfer-Encoding: 8bit", "", body.content];
+
 /**
  * Assemble a deterministic EML document from pre-read message parts.
  *
@@ -367,6 +386,17 @@ const emptyBody: EmlBodyPart = { content: "", contentType: "text/plain; charset=
  * type; with attachments it becomes `multipart/mixed` with the body as the
  * first part and one base64 part per attachment. A missing body yields an
  * empty `text/plain` part. Output is byte-stable given identical inputs.
+ *
+ * @remarks
+ * Body parts follow RFC 5322's 998-octet physical-line limit: a part whose
+ * lines all fit is emitted verbatim as 8bit, while a part with any longer
+ * line is emitted as base64. That switch is a cliff — a one-octet difference
+ * flips the whole part between encodings, so output stays deterministic per
+ * input but near-identical messages can diff dissimilarly. Base64 here is
+ * lossless relative to the decoded body string (the raw file's bytes after
+ * UTF-8 decoding with U+FFFD replacement): decoding the part restores that
+ * string exactly, while the raw body file beside the EML remains the
+ * authoritative byte-for-byte artifact.
  *
  * @example
  * ```ts
@@ -390,17 +420,7 @@ export const assembleEml = (input: EmlAssemblyInput): string => {
   const headerLines = Str.isNonEmpty(input.headerBlock) ? [input.headerBlock] : [];
 
   if (A.isReadonlyArrayEmpty(input.attachments)) {
-    return A.join(
-      [
-        ...headerLines,
-        "MIME-Version: 1.0",
-        `Content-Type: ${body.contentType}`,
-        "Content-Transfer-Encoding: 8bit",
-        "",
-        body.content,
-      ],
-      CRLF
-    );
+    return A.join([...headerLines, "MIME-Version: 1.0", ...bodySectionLines(body)], CRLF);
   }
 
   const sections: Array<string> = [
@@ -409,10 +429,7 @@ export const assembleEml = (input: EmlAssemblyInput): string => {
     `Content-Type: multipart/mixed; boundary="${input.boundary}"`,
     "",
     `--${input.boundary}`,
-    `Content-Type: ${body.contentType}`,
-    "Content-Transfer-Encoding: 8bit",
-    "",
-    body.content,
+    ...bodySectionLines(body),
   ];
 
   for (const attachment of input.attachments) {

--- a/packages/drivers/libpff/test/Libpff.eml.test.ts
+++ b/packages/drivers/libpff/test/Libpff.eml.test.ts
@@ -1,4 +1,5 @@
 import {
+  assembleEml,
   foldHeaderLine,
   rfc5322DateFromOutlookTimestamp,
   stripMimeStructuralHeaders,
@@ -6,6 +7,7 @@ import {
 } from "@beep/libpff";
 import { O } from "@beep/utils";
 import { describe, expect, it } from "@effect/vitest";
+import { Encoding, Result } from "effect";
 
 const octets = (value: string): number => new TextEncoder().encode(value).length;
 
@@ -139,6 +141,120 @@ describe("stripMimeStructuralHeaders", () => {
     const block = "Subject: hi\r\nContent-Type: multipart/mixed;\r\n boundary=x\r\nFrom: a@b.c\r\n";
 
     expect(stripMimeStructuralHeaders(block)).toBe("Subject: hi\r\nFrom: a@b.c");
+  });
+});
+
+describe("assembleEml", () => {
+  const boundary = "=_beep-test-boundary";
+
+  const singlePart = (content: string, contentType = "text/plain; charset=utf-8"): string =>
+    assembleEml({
+      attachments: [],
+      body: O.some({ content, contentType }),
+      boundary,
+      headerBlock: "Subject: hi",
+    });
+
+  // Strips the RFC 2045 76-column wrapping and decodes the payload back to
+  // the body string the part was assembled from.
+  const decodeBase64Payload = (payload: string): string =>
+    Result.getOrElse(Encoding.decodeBase64String(payload.split("\r\n").join("")), () => "");
+
+  const singlePartPayload = (eml: string): string => eml.slice(eml.indexOf("\r\n\r\n") + 4);
+
+  it("keeps a short body 8bit and byte-identical", () => {
+    expect(singlePart("hello")).toBe(
+      [
+        "Subject: hi",
+        "MIME-Version: 1.0",
+        "Content-Type: text/plain; charset=utf-8",
+        "Content-Transfer-Encoding: 8bit",
+        "",
+        "hello",
+      ].join("\r\n")
+    );
+  });
+
+  it("flips a single 999-octet line to wrapped base64 that round-trips", () => {
+    const content = "a".repeat(999);
+    const eml = singlePart(content);
+
+    expect(eml).toContain("Content-Transfer-Encoding: base64");
+    const payload = singlePartPayload(eml);
+    expect(payload.split("\r\n").every((line) => line.length <= 76)).toBe(true);
+    expect(decodeBase64Payload(payload)).toBe(content);
+  });
+
+  it("keeps a body line of exactly 998 octets 8bit", () => {
+    const content = "a".repeat(998);
+    const eml = singlePart(content);
+
+    expect(eml).toContain("Content-Transfer-Encoding: 8bit");
+    expect(eml).not.toContain("Content-Transfer-Encoding: base64");
+    expect(singlePartPayload(eml)).toBe(content);
+  });
+
+  it("measures octets rather than characters", () => {
+    // Each euro sign is three octets, so 333 of them cross the limit while
+    // the character count stays far below it.
+    const content = "€".repeat(333);
+    const eml = singlePart(content);
+
+    expect(content.length).toBe(333);
+    expect(octets(content)).toBe(999);
+    expect(eml).toContain("Content-Transfer-Encoding: base64");
+    expect(decodeBase64Payload(singlePartPayload(eml))).toBe(content);
+  });
+
+  it("preserves mixed line endings byte for byte through base64", () => {
+    const content = `a\r\nb\n${"x".repeat(999)}`;
+    const eml = singlePart(content);
+
+    expect(eml).toContain("Content-Transfer-Encoding: base64");
+    expect(decodeBase64Payload(singlePartPayload(eml))).toBe(content);
+  });
+
+  it("counts a lone CR toward its physical line", () => {
+    // No recognized line break splits this, so it is one 1001-octet physical
+    // line: the bare CR is content, not a terminator.
+    const content = `${"c".repeat(500)}\r${"d".repeat(500)}`;
+    const eml = singlePart(content);
+
+    expect(eml).toContain("Content-Transfer-Encoding: base64");
+    expect(decodeBase64Payload(singlePartPayload(eml))).toBe(content);
+  });
+
+  it("encodes a long multipart body while leaving the attachment part and boundaries unchanged", () => {
+    const content = `<p>${"x".repeat(1200)}</p>`;
+    const eml = assembleEml({
+      attachments: [{ bytes: new TextEncoder().encode("pdfbytes"), fileName: "report.pdf" }],
+      body: O.some({ content, contentType: "text/html; charset=utf-8" }),
+      boundary,
+      headerBlock: "Subject: hi",
+    });
+
+    expect(eml).toContain(`Content-Type: multipart/mixed; boundary="${boundary}"`);
+    expect(eml).toContain("Content-Type: text/html; charset=utf-8\r\nContent-Transfer-Encoding: base64");
+    expect(eml).toContain('Content-Type: application/octet-stream; name="report.pdf"');
+    expect(eml).toContain('Content-Disposition: attachment; filename="report.pdf"');
+    expect(eml).toContain("cGRmYnl0ZXM=");
+    expect(eml.endsWith(`--${boundary}--`)).toBe(true);
+
+    const bodySection = eml.split(`\r\n--${boundary}\r\n`)[1] ?? "";
+    expect(decodeBase64Payload(bodySection.slice(bodySection.indexOf("\r\n\r\n") + 4))).toBe(content);
+  });
+
+  it("keeps a missing body 8bit with an empty part", () => {
+    expect(assembleEml({ attachments: [], body: O.none(), boundary, headerBlock: "Subject: hi" })).toBe(
+      [
+        "Subject: hi",
+        "MIME-Version: 1.0",
+        "Content-Type: text/plain; charset=utf-8",
+        "Content-Transfer-Encoding: 8bit",
+        "",
+        "",
+      ].join("\r\n")
+    );
   });
 });
 

--- a/packages/drivers/libpff/test/Libpff.pffexport.test.ts
+++ b/packages/drivers/libpff/test/Libpff.pffexport.test.ts
@@ -13,7 +13,7 @@ import { PosixPath } from "@beep/schema/PosixPath";
 import { fcRuns, provideScopedLayer } from "@beep/test-utils";
 import { NodeChildProcessSpawner, NodeServices } from "@effect/platform-node";
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, FileSystem, Layer, Path } from "effect";
+import { Effect, Encoding, FileSystem, Layer, Path, Result } from "effect";
 import * as S from "effect/Schema";
 import { FastCheck as fc } from "effect/testing";
 
@@ -55,6 +55,24 @@ for base in $bases; do
   printf 'Subject:\\tRe: hello\\nSender name:\\tGrace Hopper\\nSender email address:\\tgrace@example.com\\n' > "$sent/OutlookHeaders.txt"
   printf 'sent body' > "$sent/Message.txt"
 done
+exit 0
+`;
+
+// One item whose only body is a single physical HTML line over the RFC 5322
+// 998-octet limit; the assembled EML must re-encode that part as base64.
+const overlongBodyStub = `#!/usr/bin/env bash
+${stubVersionBanner}
+target=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "-t" ]; then target="$arg"; fi
+  prev="$arg"
+done
+item="$target.export/Top of Personal Folders/Inbox/Message00001"
+mkdir -p "$item"
+printf 'Subject:\\toverlong body\\n' > "$item/OutlookHeaders.txt"
+long=$(printf 'x%.0s' $(seq 1 1200))
+printf '<p>%s</p>' "$long" > "$item/Message.html"
 exit 0
 `;
 
@@ -258,6 +276,37 @@ describe("makePffexportFileProcessingEngine", () => {
         expect(result.children.some((child) => child.relativePath.includes(".export/"))).toBe(true);
         expect(result.children.some((child) => child.relativePath.includes(".orphans/"))).toBe(true);
         expect(result.children.some((child) => child.relativePath.includes(".recovered/"))).toBe(true);
+      },
+      Effect.scoped,
+      provideTestLayer
+    )
+  );
+
+  it.effect(
+    "re-encodes an over-long body line as base64 in the assembled EML",
+    Effect.fnUntraced(
+      function* () {
+        const { exportRoot, operation, stubPath } = yield* fixture(overlongBodyStub);
+        const engine = yield* makePffexportFileProcessingEngine(
+          PffexportEngineConfig.make({ exportRoot, pffexportPath: stubPath })
+        );
+
+        const result = yield* engine.exportArchive(operation);
+
+        expect(result.children.some((child) => child.relativePath.endsWith("/Message.eml"))).toBe(true);
+
+        const eml = yield* readExported(
+          exportRoot,
+          `${operation.source.id}.export/Top of Personal Folders/Inbox/Message00001/Message.eml`
+        );
+        expect(eml).toContain("Content-Type: text/html; charset=utf-8");
+        expect(eml).toContain("Content-Transfer-Encoding: base64");
+
+        const payload = eml.slice(eml.indexOf("\r\n\r\n") + 4);
+        expect(payload.split("\r\n").every((line) => line.length <= 76)).toBe(true);
+        expect(Result.getOrElse(Encoding.decodeBase64String(payload.split("\r\n").join("")), () => "")).toBe(
+          `<p>${"x".repeat(1200)}</p>`
+        );
       },
       Effect.scoped,
       provideTestLayer

--- a/packages/drivers/libpff/test/integration/Libpff.pffexport.live.test.ts
+++ b/packages/drivers/libpff/test/integration/Libpff.pffexport.live.test.ts
@@ -111,26 +111,26 @@ describe("@beep/libpff live pffexport", () => {
           const record = yield* decodeMessageRecord(jsonl.trimEnd().split("\n")[0]);
           expect(record.messagePath.length).toBeGreaterThan(0);
 
-          // Every assembled header block must be RFC 5322-shaped: no foldable
-          // line over the 998-octet limit, and a real Date header wherever
+          // Every assembled EML must be RFC 5322-shaped: no foldable line
+          // over the 998-octet limit anywhere in the message — headers fold,
+          // and a body part with a longer physical line is re-encoded as
+          // base64 rather than folded — plus a real Date header wherever
           // pffexport gave us a parseable client-submit time.
           //
-          // Two deliberate exemptions keep this from becoming a false alarm on
-          // a future fixture. A header line with no space has no fold point to
-          // promote to a continuation indent, so the driver emits it intact
-          // rather than mutating the value — those lines are skipped here.
-          // Body lines are not checked at all: an over-long body line needs a
-          // different content-transfer-encoding, not folding, which would
-          // corrupt the content.
+          // One deliberate exemption keeps this from becoming a false alarm
+          // on a future fixture. A header line with no space has no fold
+          // point to promote to a continuation indent, so the driver emits it
+          // intact rather than mutating the value — those lines are skipped
+          // here. Lines split on /\r?\n/, not "\r\n": remaining 8bit bodies
+          // may legally carry bare-LF endings, and splitting only on CRLF
+          // would glue their lines into false over-long positives.
           const encoder = new TextEncoder();
           const foldable = (line: string): boolean => line.includes(" ");
           let datedEmlCount = 0;
           for (const child of emlChildren) {
             const eml = yield* fs.readFileString(path.join(exportRoot, child.relativePath));
             const headerBlock = eml.slice(0, eml.indexOf("\r\n\r\n"));
-            const overLong = headerBlock
-              .split("\r\n")
-              .filter((line) => foldable(line) && encoder.encode(line).length > 998);
+            const overLong = eml.split(/\r?\n/).filter((line) => foldable(line) && encoder.encode(line).length > 998);
             expect(overLong).toStrictEqual([]);
             expect(headerBlock).not.toContain("X-Beep-Libpff-Client-Submit-Time");
             if (headerBlock.includes("\r\nDate: ") || headerBlock.startsWith("Date: ")) {


### PR DESCRIPTION
## feat(libpff): encode over-long EML body parts as base64

A body part whose every physical line fits RFC 5322's 998-octet limit
stays 8bit verbatim, byte-identical to before. Any part with a longer
line (octets, split on /\r?\n/, lone CR counted as content) is emitted
as 76-column-wrapped base64 instead — lossless: decoding restores the
exact body string, with the raw body file remaining the authoritative
byte copy. The shared body-section helper now feeds both the
single-part and multipart branches; attachments are untouched.

The live lane's body-line exemption becomes a real assertion: every
foldable line of the full EML must fit the 998-octet limit. Decision
recorded as the v5 addendum in the P3 libpff design doc (three-lens
adversarial panel with cross-examination, 2026-07-27).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Q33hjM3bwvLHfXqF9jsXkc

## Local proof

- publish:head-install-preflight: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/feat_libpff-body-cte-base64-c3ffaeb7f23f/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787758219&installation_model_id=424656&pr_number=478&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F478&signature=0651129bcb71881e0228a57c0667298d152a33149191829ed5841390d9eb6b62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->