### PR TITLE
fix(law-practice): join extracted text into the bundle document_text table

### DIFF
--- a/.changeset/practice-kg-document-text-regex.md
+++ b/.changeset/practice-kg-document-text-regex.md
@@ -1,0 +1,5 @@
+---
+{}
+---
+
+No release: fix the practice KG document-text ingest regex so extracted text reaches the bundle.

--- a/packages/law-practice/server/src/PracticeKg.fts.ts
+++ b/packages/law-practice/server/src/PracticeKg.fts.ts
@@ -167,7 +167,7 @@ SELECT
   t.content
 FROM read_json(${sqlStringLiteral(sourcesPath)}, format='newline_delimited') s
 JOIN read_text(${sqlStringLiteral(textGlob)}) t
-  ON regexp_extract(t.filename, 'operation:([^/\\\\]+)\\\\.txt$', 1) = s.operationId`
+  ON regexp_extract(t.filename, 'operation:([^/\\\\]+)\\.txt$', 1) = s.operationId`
     ),
     "\nUNION ALL\n"
   );

--- a/packages/law-practice/server/test/PracticeKg.projections.test.ts
+++ b/packages/law-practice/server/test/PracticeKg.projections.test.ts
@@ -405,6 +405,33 @@ describe("practice KG projections", () => {
       expect(first.counts.edges).toBe(9);
 
       yield* Effect.gen(function* () {
+        const db = yield* DuckDb;
+        const textLines = yield* db
+          .query(
+            "SELECT to_json(t)::VARCHAR AS line FROM (SELECT operation_id, text FROM document_text ORDER BY digest) t"
+          )
+          .pipe(Effect.flatMap(decodeDumpLines));
+        expect(A.map(textLines, (row) => row.line)).toStrictEqual([
+          '{"operation_id":"op-a","text":"alpha docket 20001US01 response"}',
+          '{"operation_id":"op-b","text":"family 20001 patent application"}',
+        ]);
+        const ftsDocLines = yield* db
+          .query(
+            "SELECT to_json(x)::VARCHAR AS line FROM (SELECT COUNT(*) AS indexed_documents FROM fts_docstats WHERE doc_id LIKE 'document:%') x"
+          )
+          .pipe(Effect.flatMap(decodeDumpLines));
+        expect(A.map(ftsDocLines, (row) => row.line)).toStrictEqual(['{"indexed_documents":2}']);
+      }).pipe(withDuckDb(path.join(firstOut, "practice.duckdb")));
+
+      yield* Effect.gen(function* () {
+        const db = yield* DuckDb;
+        const refreshTextLines = yield* db
+          .query("SELECT to_json(x)::VARCHAR AS line FROM (SELECT COUNT(*) AS text_rows FROM document_text) x")
+          .pipe(Effect.flatMap(decodeDumpLines));
+        expect(A.map(refreshTextLines, (row) => row.line)).toStrictEqual(['{"text_rows":3}']);
+      }).pipe(withDuckDb(path.join(refreshOut, "practice.duckdb")));
+
+      yield* Effect.gen(function* () {
         const sql = (yield* SqlClient.SqlClient).withoutTransforms();
         const provenanceRows = yield* sql
           .unsafe(
@@ -468,6 +495,10 @@ describe("practice KG projections", () => {
           expect(result.epistemic_status).toBe("derived-from-official-records");
         });
         expect(O.getOrUndefined(A.get(results, 6))?.note).toContain("archive-level confidence");
+        const search = O.getOrThrow(A.get(results, 4));
+        const searchRow = R.fromEntries(A.zip(search.data.columns, O.getOrThrow(A.head(search.data.rows))));
+        expect(searchRow.digest).toBe(fixtureDigests.docket);
+        expect(searchRow.snippet).toContain("alpha docket 20001US01");
         const digestProvenance = yield* callToolText("kg_provenance", { digest: fixtureDigests.docket }).pipe(
           Effect.flatMap(decodeToolResultJson)
         );

--- a/standards/dual-arity.inventory.jsonc
+++ b/standards/dual-arity.inventory.jsonc
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedOn": "2026-07-28",
+  "generatedOn": "2026-07-29",
   "scope": ["apps/**/*.{ts,tsx}", "packages/**/*.{ts,tsx}", "infra/**/*.ts"],
   "enforcedRoots": [
     "packages/tooling/tool/cli/src/commands/Laws/DualArity.ts",


### PR DESCRIPTION
## Summary

Fixes a shipped bug found while building the first real-corpus practice KG
bundle: `document_text` was empty on every corpus, so full-text search covered
only email subjects.

- Root cause: the `read_text` join regex in `buildDocumentTextSql`
  (`PracticeKg.fts.ts`) over-escaped the dot — the SQL literal carried
  `\\.txt$`, which RE2 reads as a literal backslash followed by any character,
  so the pattern matched no real filename and the operationId join produced
  zero rows.
- Why tests stayed green: the determinism test compares run-1 dumps to run-2
  dumps (two identically empty tables are byte-identical), and the tool test
  asserted only envelope fields. The exact intake-P1 lesson.
- Fix: single-escape the dot (`\.txt$` in the SQL) so the operation id
  extracts again; verified against both Linux and Windows path shapes.

## Regression coverage (proven red on the old code)

- Fixture `document_text` contents asserted row-for-row (base build).
- FTS document coverage asserted (`doc_id LIKE 'document:%'` count).
- Refresh-lane text row count asserted (multi-source union path).
- `corpus_search_text` must now resolve the fixture docket digest with its
  snippet, end to end through the MCP toolkit.

All four assertions fail on the pre-fix code and pass on the fix.

## Verification

- `bun run beep yeet verify` green end-to-end (`full:pre-push` passed).
- Projections suite green: 5 passed, 1 env-gated skip.
- Exact-pattern DuckDB probe extracts the operation id on Linux and
  Windows-style filenames and rejects near-miss names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvSS2JJh83esvisoZAR3Ma

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787884211&installation_model_id=424656&pr_number=496&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F496&signature=6ce41495b5fbfdcf3ccc9b0742bab8bd4a16f67abc3466032e7408fd5154986a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->