### PR TITLE
fix(law-practice): match prefixed operation ids when joining document text

### DIFF
--- a/.changeset/practice-kg-operation-id-join.md
+++ b/.changeset/practice-kg-operation-id-join.md
@@ -1,0 +1,5 @@
+---
+{}
+---
+
+No release: match the prefixed extraction operation id when joining bundle document text.

--- a/apps/practice-kg-mcp/src/smoke.ts
+++ b/apps/practice-kg-mcp/src/smoke.ts
@@ -112,7 +112,7 @@ const makeFixtureBundle = Effect.fn("PracticeKgSmoke.makeFixtureBundle")(functio
   yield* makeCatalog(path.join(catalogRoot, "corpus.duckdb"));
   yield* fs.writeFileString(
     path.join(extractRoot, "sources.jsonl"),
-    `{"artifactId":"artifact-smoke","digest":"${FixtureDigest}","engine":"tika","format":"text","operationId":"smoke","relativePath":"text/operation:smoke.txt","sizeBytes":13,"status":"succeeded"}\n`
+    `{"artifactId":"artifact-smoke","digest":"${FixtureDigest}","engine":"tika","format":"text","operationId":"operation:smoke","relativePath":"text/operation:smoke.txt","sizeBytes":13,"status":"succeeded"}\n`
   );
   yield* fs.writeFileString(path.join(textRoot, "operation:smoke.txt"), "smoke fixture");
   yield* Effect.scoped(

--- a/packages/law-practice/server/src/PracticeKg.fts.ts
+++ b/packages/law-practice/server/src/PracticeKg.fts.ts
@@ -167,7 +167,7 @@ SELECT
   t.content
 FROM read_json(${sqlStringLiteral(sourcesPath)}, format='newline_delimited') s
 JOIN read_text(${sqlStringLiteral(textGlob)}) t
-  ON regexp_extract(t.filename, 'operation:([^/\\\\]+)\\.txt$', 1) = s.operationId`
+  ON regexp_extract(t.filename, '(operation:[^/\\\\]+)\\.txt$', 1) = s.operationId`
     ),
     "\nUNION ALL\n"
   );

--- a/packages/law-practice/server/test/PracticeKg.projections.test.ts
+++ b/packages/law-practice/server/test/PracticeKg.projections.test.ts
@@ -202,7 +202,7 @@ const makeFixtureExtract = Effect.fn("PracticeKgTest.makeFixtureExtract")(functi
       digest: fixtureDigests.docket,
       engine: "tika",
       format: "text",
-      operationId: "op-a",
+      operationId: "operation:op-a",
       relativePath: "text/operation:op-a.txt",
       sizeBytes: 20,
       status: "succeeded",
@@ -212,7 +212,7 @@ const makeFixtureExtract = Effect.fn("PracticeKgTest.makeFixtureExtract")(functi
       digest: fixtureDigests.family,
       engine: "tika",
       format: "text",
-      operationId: "op-b",
+      operationId: "operation:op-b",
       relativePath: "text/operation:op-b.txt",
       sizeBytes: 20,
       status: "succeeded",
@@ -228,7 +228,7 @@ const makeFixtureExtract = Effect.fn("PracticeKgTest.makeFixtureExtract")(functi
       digest: fixtureDigests.refresh,
       engine: "tika",
       format: "text",
-      operationId: "op-refresh",
+      operationId: "operation:op-refresh",
       relativePath: "text/operation:op-refresh.txt",
       sizeBytes: 24,
       status: "succeeded",
@@ -412,8 +412,8 @@ describe("practice KG projections", () => {
           )
           .pipe(Effect.flatMap(decodeDumpLines));
         expect(A.map(textLines, (row) => row.line)).toStrictEqual([
-          '{"operation_id":"op-a","text":"alpha docket 20001US01 response"}',
-          '{"operation_id":"op-b","text":"family 20001 patent application"}',
+          '{"operation_id":"operation:op-a","text":"alpha docket 20001US01 response"}',
+          '{"operation_id":"operation:op-b","text":"family 20001 patent application"}',
         ]);
         const ftsDocLines = yield* db
           .query(


### PR DESCRIPTION
## Summary

Companion fix to #496: on a real corpus `document_text` was still empty,
because the join key itself was wrong, not just the regex escaping.

- The extraction pipeline writes `operationId` values with their prefix
  (`operation:<hex>`), and text files are named `${operationId}.txt`. The
  join extracted only the hex tail from the filename, so it compared
  `<hex>` against `operation:<hex>` and matched nothing.
- Fix: capture the full prefixed token in the `read_text` join.
- Fixture realism: both the projections-test fixture and the compiled-smoke
  fixture used bare `op-a`-style operation ids — the code's wrong assumption
  encoded into the fixtures. Both now mirror the real prefixed shape, so the
  #496 regression assertions exercise the true data contract.

## Verification

- Red proof in the right order: fixtures made realistic first → the #496
  document-text assertions fail against the old join; join fixed → green
  (5 passed, 1 env-gated skip).
- The exact production join SQL was run against the real corpus
  `sources.jsonl` and real extracted text files: rows join with correct
  digests and content.
- Full real-corpus bundle rebuild with this fix: `document_text` populates
  6,702 rows (one per extracted text file, 75 MB inline text, 0 truncated);
  FTS covers 6,696 documents alongside 118,738 emails; BM25 search returns
  real Office Action content; `corpus_search_text` answers over stdio against
  the real bundle with `derived-from-official-records` labeling.
- `bun run beep yeet verify` green end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvSS2JJh83esvisoZAR3Ma

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787886966&installation_model_id=424656&pr_number=497&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F497&signature=ff03b692e977259c763c137d7c082878531cd4578fee017f43de1bb30c7e9be8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->