### PR TITLE
fix(law-practice): survive real-world inputs in the claims batch

### DIFF
--- a/.changeset/practice-kg-claims-docket.md
+++ b/.changeset/practice-kg-claims-docket.md
@@ -1,0 +1,5 @@
+---
+{}
+---
+
+No release: extract dockets anywhere in claims-batch filenames and skip docketless inputs.

--- a/packages/law-practice/server/src/PracticeKg.claims.ts
+++ b/packages/law-practice/server/src/PracticeKg.claims.ts
@@ -17,6 +17,8 @@ import {
   SourceArtifact,
 } from "@beep/file-processing/Artifact";
 import { $LawPracticeServerId } from "@beep/identity/packages";
+import { LangExtractError } from "@beep/langextract/Extraction";
+import { IrToLawExtractionError } from "@beep/law-practice-use-cases/IrToLaw";
 import { OfficeActionReview, OfficeActionReviewInput } from "@beep/law-practice-use-cases/OfficeActionReview";
 import { NonNegativeInt, PosInt, Sha256HexFromBytes, TaggedErrorClass } from "@beep/schema";
 import { PosixPath } from "@beep/schema/PosixPath";
@@ -29,7 +31,8 @@ import { SqlClient as SqlClientService } from "effect/unstable/sql/SqlClient";
 import type * as SqlClient from "effect/unstable/sql/SqlClient";
 
 const $I = $LawPracticeServerId.create("PracticeKg.claims");
-const docketPattern = /^(\d{5}(?:[A-Z]{2}\d{2})?)/iu;
+const docketPattern = /(?<!\d)(\d{5}[A-Z]{2}\d{2})(?!\d)/iu;
+const leadingDocketPattern = /^(\d{5})(?!\d)/u;
 const textEncoder = new TextEncoder();
 class ClaimsCountRow extends S.Class<ClaimsCountRow>($I`ClaimsCountRow`)({
   count: S.Finite,
@@ -129,6 +132,7 @@ export class PracticeKgClaimsOptions extends S.Class<PracticeKgClaimsOptions>($I
  *
  * const summary = PracticeKgClaimsSummary.make({
  *   claims: NonNegativeInt.make(1),
+ *   failedFiles: NonNegativeInt.make(0),
  *   files: NonNegativeInt.make(1)
  * })
  * console.log(summary.claims)
@@ -140,10 +144,11 @@ export class PracticeKgClaimsOptions extends S.Class<PracticeKgClaimsOptions>($I
 export class PracticeKgClaimsSummary extends S.Class<PracticeKgClaimsSummary>($I`PracticeKgClaimsSummary`)(
   {
     claims: NonNegativeInt,
+    failedFiles: NonNegativeInt,
     files: NonNegativeInt,
   },
   $I.annote("PracticeKgClaimsSummary", {
-    description: "Number of source files and grounded claims persisted by a batch.",
+    description: "Extracted, extraction-failed, and persisted-claim counts for a batch.",
   })
 ) {}
 
@@ -172,7 +177,11 @@ export class PracticeKgClaimsError extends TaggedErrorClass<PracticeKgClaimsErro
 ) {}
 
 const docketFromFilename = (filename: string): O.Option<string> =>
-  Str.match(docketPattern)(filename).pipe(O.flatMap(A.get(1)));
+  Str.match(docketPattern)(filename).pipe(
+    O.orElse(() => Str.match(leadingDocketPattern)(filename)),
+    O.flatMap(A.get(1)),
+    O.map(Str.toUpperCase)
+  );
 
 const persistCandidate = Effect.fn("PracticeKgClaims.persistCandidate")(function* (
   sql: SqlClient.SqlClient,
@@ -250,74 +259,110 @@ export const runPracticeKgClaimsBatch = Effect.fn("PracticeKgClaims.run")(
       { discard: true }
     );
     const entries = A.sort(yield* fs.readDirectory(options.inputs), Order.String);
-    const files = yield* Effect.forEach(
-      entries,
-      Effect.fnUntraced(function* (filename) {
-        const docket = yield* docketFromFilename(filename).pipe(
-          O.match({
-            onNone: () => Effect.fail(PracticeKgClaimsError.make({ message: `No docket number in "${filename}".` })),
-            onSome: Effect.succeed,
-          })
-        );
-        const sourcePath = path.join(options.inputs, filename);
-        const text = yield* fs.readFileString(sourcePath);
-        const digestHex = yield* hashBytes(textEncoder.encode(text));
-        const artifactId = yield* decodeArtifactId(`artifact:${digestHex}`);
-        const digest = yield* decodeContentDigest(`sha256:${digestHex}`);
-        const operationId = yield* decodeOperationId(`operation:${digestHex}`);
-        const relativePath = yield* decodePosixPath(filename);
-        // Identity derives from content, not loop position, so re-runs are stable (B2).
-        // Bounded so the shim's `seed * 10 + 1` stays inside the int32 serial range.
-        const entitySeed = PosInt.make((Number.parseInt(Str.slice(0, 8)(digestHex), 16) % 214_748_363) + 1);
-        const extracted = yield* review.extractCandidate(
-          OfficeActionReviewInput.make({
-            entitySeed,
-            matterFixtureKey: `matter:${docket}`,
-            officeActionFixtureKey: `office-action:${digest}`,
-            operationId,
-            sourceArtifact: SourceArtifact.make({
-              digest,
-              extension: Str.slice(1)(path.extname(filename)),
-              id: artifactId,
-              locator: ArtifactLocator.make({ kind: "synthetic", value: relativePath }),
-              name: filename,
-              relativePath,
-              sizeBytes: NonNegativeInt.make(text.length),
-              text,
-            }),
-          })
-        );
-        const evidenceFixtureKey = `evidence:${digest}`;
-        const evidence = Evidence.make({
-          ...extracted.evidence,
-          artifactFixtureKey: digest,
-          spanFixtureKey: evidenceFixtureKey,
-        });
-        const candidate = CandidateClaim.make({
-          ...extracted.candidate,
-          fixtureKey: `claim:${digest}`,
-          snapshot: {
-            ...extracted.candidate.snapshot,
-            activityKind: "extract-operation",
-            activityOperation: operationId,
+    const skippedFiles = A.filter(entries, (filename) => O.isNone(docketFromFilename(filename)));
+    const docketedFiles = A.getSomes(
+      A.map(entries, (filename) => O.map(docketFromFilename(filename), (docket) => ({ docket, filename })))
+    );
+    if (A.isReadonlyArrayNonEmpty(skippedFiles)) {
+      yield* Effect.logInfo("PracticeKgClaims.skippedInputs", {
+        count: A.length(skippedFiles),
+        files: skippedFiles,
+      });
+    }
+    const extractOne = Effect.fnUntraced(function* ({
+      docket,
+      filename,
+    }: {
+      readonly docket: string;
+      readonly filename: string;
+    }) {
+      const sourcePath = path.join(options.inputs, filename);
+      const text = yield* fs.readFileString(sourcePath);
+      const digestHex = yield* hashBytes(textEncoder.encode(text));
+      const artifactId = yield* decodeArtifactId(`artifact:${digestHex}`);
+      const digest = yield* decodeContentDigest(`sha256:${digestHex}`);
+      const operationId = yield* decodeOperationId(`operation:${digestHex}`);
+      const relativePath = yield* decodePosixPath(filename);
+      // Identity derives from content, not loop position, so re-runs are stable (B2).
+      // Bounded so the shim's `seed * 10 + 1` stays inside the int32 serial range.
+      const entitySeed = PosInt.make((Number.parseInt(Str.slice(0, 8)(digestHex), 16) % 214_748_363) + 1);
+      const extracted = yield* review.extractCandidate(
+        OfficeActionReviewInput.make({
+          entitySeed,
+          matterFixtureKey: `matter:${docket}`,
+          officeActionFixtureKey: `office-action:${digest}`,
+          operationId,
+          sourceArtifact: SourceArtifact.make({
             digest,
-            docket,
-            evidenceFixtureKey,
-            family: Str.slice(0, 5)(docket),
-            sourceFile: filename,
-          },
-        });
-        yield* persistCandidate(sql, candidate, evidence);
-        return filename;
-      }),
+            extension: Str.slice(1)(path.extname(filename)),
+            id: artifactId,
+            locator: ArtifactLocator.make({ kind: "synthetic", value: relativePath }),
+            name: filename,
+            relativePath,
+            sizeBytes: NonNegativeInt.make(text.length),
+            text,
+          }),
+        })
+      );
+      const evidenceFixtureKey = `evidence:${digest}`;
+      const evidence = Evidence.make({
+        ...extracted.evidence,
+        artifactFixtureKey: digest,
+        spanFixtureKey: evidenceFixtureKey,
+      });
+      const candidate = CandidateClaim.make({
+        ...extracted.candidate,
+        fixtureKey: `claim:${digest}`,
+        snapshot: {
+          ...extracted.candidate.snapshot,
+          activityKind: "extract-operation",
+          activityOperation: operationId,
+          digest,
+          docket,
+          evidenceFixtureKey,
+          family: Str.slice(0, 5)(docket),
+          sourceFile: filename,
+        },
+      });
+      yield* persistCandidate(sql, candidate, evidence);
+      return filename;
+    });
+    const isExtractionQualityError = (error: unknown): boolean =>
+      S.is(IrToLawExtractionError)(error) || S.is(LangExtractError)(error);
+    const outcomes = yield* Effect.forEach(
+      docketedFiles,
+      (entry) =>
+        extractOne(entry).pipe(
+          Effect.map((filename) => ({ extracted: true as const, filename })),
+          Effect.catchIf(isExtractionQualityError, (error) =>
+            Effect.logWarning("PracticeKgClaims.extractionFailed", {
+              error: String(error),
+              file: entry.filename,
+            }).pipe(Effect.as({ extracted: false as const, filename: entry.filename }))
+          )
+        ),
       { concurrency: 1 }
     );
+    const extractedFiles = A.filter(outcomes, (outcome) => outcome.extracted);
+    const failedExtractions = A.filter(outcomes, (outcome) => !outcome.extracted);
+    if (A.isReadonlyArrayNonEmpty(failedExtractions)) {
+      yield* Effect.logWarning("PracticeKgClaims.failedExtractions", {
+        count: A.length(failedExtractions),
+        files: A.map(failedExtractions, (outcome) => outcome.filename),
+      });
+    }
     const claimCountRows = yield* sql
       .unsafe("SELECT COUNT(*)::FLOAT8 AS count FROM epistemic_candidate_claim")
       .pipe(Effect.flatMap(decodeClaimsCountRows));
+    if (A.isReadonlyArrayNonEmpty(docketedFiles) && A.headNonEmpty(claimCountRows).count === 0) {
+      return yield* PracticeKgClaimsError.make({
+        message: "Claims batch persisted zero claims across all extractable inputs.",
+      });
+    }
     return PracticeKgClaimsSummary.make({
       claims: NonNegativeInt.make(A.headNonEmpty(claimCountRows).count),
-      files: NonNegativeInt.make(A.length(files)),
+      failedFiles: NonNegativeInt.make(A.length(failedExtractions)),
+      files: NonNegativeInt.make(A.length(extractedFiles)),
     });
   },
   Effect.mapError((cause) =>

--- a/packages/law-practice/server/test/PracticeKg.projections.test.ts
+++ b/packages/law-practice/server/test/PracticeKg.projections.test.ts
@@ -91,6 +91,7 @@ const declaredColumnNames = (columns: Readonly<Record<string, { readonly name: s
   );
 
 const fixtureModelOutput = `{"extractions":[{"label":"office_action","text":"Office Action"},{"label":"claim","text":"A widget comprising a lid and a base."},{"label":"rejection_reference","text":"Smith"},{"label":"distinction","text":"a hinge coupling the lid to the base"}]}`;
+const fixtureRejectionlessOutput = `{"extractions":[{"label":"office_action","text":"Office Action"},{"label":"claim","text":"A widget comprising a lid and a base."}]}`;
 const fixtureUsage = Response.Usage.make({
   inputTokens: { cacheRead: undefined, cacheWrite: undefined, total: 0, uncached: 0 },
   outputTokens: { reasoning: undefined, text: 0, total: 0 },
@@ -98,9 +99,13 @@ const fixtureUsage = Response.Usage.make({
 const fixtureLanguageModel = Layer.effect(
   LanguageModel.LanguageModel,
   LanguageModel.make({
-    generateText: () =>
+    generateText: (options) =>
       Effect.succeed([
-        Response.makePart("text", { text: fixtureModelOutput }),
+        Response.makePart("text", {
+          text: Str.includes("without office action rejections")(JSON.stringify(options.prompt))
+            ? fixtureRejectionlessOutput
+            : fixtureModelOutput,
+        }),
         Response.makePart("finish", { reason: "stop", response: undefined, usage: fixtureUsage }),
       ]),
     streamText: () => Stream.empty,
@@ -569,7 +574,23 @@ describe("practice KG projections", () => {
       const inputs = path.join(corpusRoot, "claims-inputs");
       yield* runBuild(graphOptions(corpusRoot, bundleOut), bundleOut);
       yield* fs.makeDirectory(inputs, { recursive: true });
-      yield* fs.writeFileString(path.join(inputs, "20001US01-office-action.txt"), OFFICE_ACTION_FIXTURE);
+      yield* fs.writeFileString(
+        path.join(inputs, "0_Assignment - 20001US03.txt"),
+        "assignment fixture without office action rejections"
+      );
+      yield* fs.writeFileString(path.join(inputs, "1_Response OA - 20001US01.txt"), OFFICE_ACTION_FIXTURE);
+      yield* fs.writeFileString(
+        path.join(inputs, "10013 OA memo.txt"),
+        `${OFFICE_ACTION_FIXTURE}\nleading bare docket fallback exercise`
+      );
+      yield* fs.writeFileString(
+        path.join(inputs, "2_Letter - 20001US04.txt"),
+        "letter fixture with unalignable content"
+      );
+      yield* fs.writeFileString(
+        path.join(inputs, "US7699009-fulltext.txt"),
+        "patent fulltext reference without a docket"
+      );
 
       const claimsLayer = Layer.mergeAll(
         LawPracticeServerLive,
@@ -581,11 +602,34 @@ describe("practice KG projections", () => {
       const summary = yield* runPracticeKgClaimsBatch(PracticeKgClaimsOptions.make({ bundleOut, inputs })).pipe(
         provideScopedLayer(claimsLayer)
       );
-      expect(summary.claims).toBe(1);
+      expect(summary.claims).toBe(2);
+      expect(summary.files).toBe(2);
+      expect(summary.failedFiles).toBe(2);
       const rerunSummary = yield* runPracticeKgClaimsBatch(PracticeKgClaimsOptions.make({ bundleOut, inputs })).pipe(
         provideScopedLayer(claimsLayer)
       );
-      expect(rerunSummary.claims).toBe(1);
+      expect(rerunSummary.claims).toBe(2);
+
+      const emptyBundleOut = path.join(corpusRoot, "bundle-claims-empty");
+      const emptyInputs = path.join(corpusRoot, "claims-empty-inputs");
+      yield* runBuild(graphOptions(corpusRoot, emptyBundleOut), emptyBundleOut);
+      yield* fs.makeDirectory(emptyInputs, { recursive: true });
+      yield* fs.writeFileString(
+        path.join(emptyInputs, "0_Assignment - 20001US03.txt"),
+        "assignment fixture without office action rejections"
+      );
+      const emptyClaimsLayer = Layer.mergeAll(
+        LawPracticeServerLive,
+        Pglite.makeLayer({ dataDir: path.join(emptyBundleOut, "kg.pglite") })
+      ).pipe(
+        Layer.provide(fixtureLanguageModel),
+        Layer.provide(ConfigProvider.layer(ConfigProvider.fromUnknown({ BEEP_LANGEXTRACT_ALLOW_REMOTE: "true" })))
+      );
+      const zeroClaimsFailure = yield* runPracticeKgClaimsBatch(
+        PracticeKgClaimsOptions.make({ bundleOut: emptyBundleOut, inputs: emptyInputs })
+      ).pipe(Effect.flip, provideScopedLayer(emptyClaimsLayer));
+      expect(zeroClaimsFailure.message).toContain("zero claims");
+
       const persistedRows = yield* Effect.gen(function* () {
         const sql = (yield* SqlClient.SqlClient).withoutTransforms();
         yield* Effect.forEach(
@@ -628,7 +672,7 @@ describe("practice KG projections", () => {
       expect(row.label).toBe("candidate — unreviewed");
       expect(row.claimText).toBe("A widget comprising a lid and a base.");
       expect(row.evidenceQuote).toBe("A Hinge Coupling The Lid To The Base");
-      expect(row.sourceFile).toBe("20001US01-office-action.txt");
+      expect(row.sourceFile).toBe("1_Response OA - 20001US01.txt");
       expect(OFFICE_ACTION_FIXTURE.slice(Number(row.startChar), Number(row.endChar))).toBe(row.evidenceQuote);
       expect(row.activityOperation).toContain("operation:");
     }, provideTestLayer),


### PR DESCRIPTION
## Summary

Makes the claims batch survive the real demo-input directory. The first
real-model run failed three ways; each is fixed with fixture shapes that now
mirror the real files:

- **Docket extraction anchored to the filename start.** Real inputs are
  email-attachment exports whose docket sits mid-name
  (`1_Amended Claims (Tracked) - 10008JP02.txt`). The full docket form is now
  searched anywhere in the name with digit guards, the original leading bare
  form remains as fallback, and the capture is uppercased so matter keys align
  with the spine.
- **Docketless reference files aborted the run.** Patent fulltexts
  (`US7699009-fulltext.txt`) are now skipped with a logged summary.
- **One non-office-action document killed the whole batch.** Assignments and
  amended claims fail OA extraction by design (missing required labels).
  Extraction-quality failures (`IrToLawExtractionError`, `LangExtractError`)
  are now tolerated per file with a logged summary; the batch still fails if
  nothing extracts at all, and `PracticeKgClaimsSummary` reports extracted and
  failed counts separately (`files` / `failedFiles`).

## Verification

- Suite fails against the old behavior on all three shapes (mid-name docket,
  docketless skip, rejectionless extraction) and passes against this one; the
  failing fixture sorts first to prove the batch continues past a failure.
- Dry-run of the new pattern over the 102 real demo filenames: 97 extract the
  full docket form, 0 need the fallback, 5 correctly have no docket.
- `bun run beep yeet verify` green end-to-end on the branch rebased onto the
  merged #496/#497 fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvSS2JJh83esvisoZAR3Ma

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/498"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787888991&installation_model_id=424656&pr_number=498&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F498&signature=e7a82e8bd6d9e7e9a43d5919bf01d550d8f121ac7fee1b21b1a4d420262a392e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->