### PR TITLE
refactor(law-practice): crispen the practice-kg surface

### DIFF
--- a/.changeset/practice-kg-crispen.md
+++ b/.changeset/practice-kg-crispen.md
@@ -1,0 +1,5 @@
+---
+{}
+---
+
+No release: crispen the practice KG surface — literal domains on tool rows, schema defaults, helper-wall deletion.

--- a/apps/practice-kg-mcp/src/bin.ts
+++ b/apps/practice-kg-mcp/src/bin.ts
@@ -22,8 +22,6 @@ import "../../../node_modules/@electric-sql/pglite/dist/pglite.wasm" with { type
 const bundleDir = Flag.directory("bundle-dir", { mustExist: true }).pipe(Flag.optional);
 const corpusRoot = Flag.directory("corpus-root", { mustExist: true }).pipe(Flag.optional);
 
-const firstSome = <A>(...values: ReadonlyArray<O.Option<A>>): O.Option<A> => O.firstSomeOf(values);
-
 const serverCommand = Command.make(
   "practice-kg-mcp",
   { bundleDir, corpusRoot },
@@ -31,7 +29,7 @@ const serverCommand = Command.make(
     const configuredBundleDir = yield* Config.option(Config.string("PRACTICE_KG_BUNDLE_DIR"));
     const shortBundleDir = yield* Config.option(Config.string("BUNDLE_DIR"));
     const configuredCorpusRoot = yield* Config.option(Config.string("PRACTICE_KG_CORPUS_ROOT"));
-    const resolvedBundleDir = yield* firstSome(flags.bundleDir, configuredBundleDir, shortBundleDir).pipe(
+    const resolvedBundleDir = yield* O.firstSomeOf([flags.bundleDir, configuredBundleDir, shortBundleDir]).pipe(
       O.match({
         onNone: () =>
           PracticeKgHostError.make({
@@ -40,7 +38,7 @@ const serverCommand = Command.make(
         onSome: Effect.succeed,
       })
     );
-    const resolvedCorpusRoot = O.getOrUndefined(firstSome(flags.corpusRoot, configuredCorpusRoot));
+    const resolvedCorpusRoot = O.getOrUndefined(O.firstSomeOf([flags.corpusRoot, configuredCorpusRoot]));
     const context = yield* loadPracticeKgBundleContext(resolvedBundleDir, resolvedCorpusRoot);
     return yield* Layer.launch(makePracticeKgHostLayer(context));
   })

--- a/apps/practice-kg-mcp/src/build.ts
+++ b/apps/practice-kg-mcp/src/build.ts
@@ -7,7 +7,8 @@
  */
 
 import { buildPracticeKgBundle, PracticeKgOptions } from "@beep/law-practice-server";
-import { NonNegativeInt } from "@beep/schema";
+import { PosInt } from "@beep/schema";
+import * as OptionUtils from "@beep/utils/Option";
 import { BunRuntime } from "@effect/platform-bun";
 import * as BunServices from "@effect/platform-bun/BunServices";
 import { Effect, FileSystem, Layer, Path } from "effect";
@@ -19,7 +20,7 @@ const corpusRoot = Flag.directory("corpus-root", { mustExist: true });
 const bundleOut = Flag.directory("bundle-out").pipe(Flag.optional);
 const includeRefresh = Flag.boolean("include-refresh");
 const skipEmails = Flag.boolean("skip-emails");
-const maxTextBytes = Flag.integer("max-text-bytes").pipe(Flag.withDefault(2_097_152));
+const maxTextBytes = Flag.integer("max-text-bytes").pipe(Flag.optional);
 const overwrite = Flag.boolean("overwrite");
 
 const buildCommand = Command.make(
@@ -28,8 +29,9 @@ const buildCommand = Command.make(
   Effect.fnUntraced(function* (flags) {
     const path = yield* Path.Path;
     const fs = yield* FileSystem.FileSystem;
-    const resolvedBundleOut = O.getOrElse(flags.bundleOut, () =>
-      path.join(flags.corpusRoot, "staging", "practice-kg-bundle")
+    const resolvedBundleOut = PracticeKgOptions.resolveBundleOut(
+      { corpusRoot: flags.corpusRoot, ...OptionUtils.getSomesStruct({ bundleOut: flags.bundleOut }) },
+      path
     );
     const bundleExists = yield* fs.exists(resolvedBundleOut).pipe(Effect.orElseSucceed(() => false));
     if (bundleExists && flags.overwrite) {
@@ -38,9 +40,12 @@ const buildCommand = Command.make(
     yield* fs.makeDirectory(resolvedBundleOut, { recursive: true });
     const build = buildPracticeKgBundle(
       PracticeKgOptions.make({
-        ...flags,
         bundleOut: resolvedBundleOut,
-        maxTextBytes: NonNegativeInt.make(flags.maxTextBytes),
+        corpusRoot: flags.corpusRoot,
+        includeRefresh: flags.includeRefresh,
+        overwrite: flags.overwrite,
+        skipEmails: flags.skipEmails,
+        ...OptionUtils.getSomesStruct({ maxTextBytes: O.map(flags.maxTextBytes, PosInt.make) }),
       })
     );
     yield* Effect.scoped(

--- a/apps/practice-kg-mcp/src/package.ts
+++ b/apps/practice-kg-mcp/src/package.ts
@@ -64,6 +64,21 @@ const ForbiddenArchiveFragments = [
 const PackageTarget = S.Literals(["all", "linux-x64", "windows-x64"]);
 type PackageTarget = typeof PackageTarget.Type;
 
+const TargetSpecs = {
+  "linux-x64": {
+    bunTarget: "bun-linux-x64",
+    executable: "practice-kg-mcp",
+    nativePackage: "node-bindings-linux-x64",
+    platform: "linux",
+  },
+  "windows-x64": {
+    bunTarget: "bun-windows-x64",
+    executable: "practice-kg-mcp.exe",
+    nativePackage: "node-bindings-win32-x64",
+    platform: "win32",
+  },
+} as const satisfies Record<Exclude<PackageTarget, "all">, Record<string, string>>;
+
 class PackageFailure extends TaggedErrorClass<PackageFailure>($I`PackageFailure`)(
   "PackageFailure",
   {
@@ -75,9 +90,7 @@ class PackageFailure extends TaggedErrorClass<PackageFailure>($I`PackageFailure`
   })
 ) {}
 
-const target = Flag.choice("target", ["all", "linux-x64", "windows-x64"]).pipe(
-  Flag.withDefault("all" satisfies PackageTarget)
-);
+const target = Flag.choice("target", PackageTarget.literals).pipe(Flag.withDefault("all" satisfies PackageTarget));
 const output = Flag.directory("output").pipe(Flag.withDefault("apps/practice-kg-mcp/dist/mcpb"));
 
 const run = Effect.fn("PracticeKgPackage.run")(function* (
@@ -168,10 +181,10 @@ const ensureWindowsBindings = Effect.fn("PracticeKgPackage.ensureWindowsBindings
 /*
  * Tool names DERIVE from the canonical PracticeKgToolkit so the shipped
  * manifest cannot drift from the served surface; only the human-facing
- * descriptions live here, and a toolkit tool without a description entry
- * fails packaging.
+ * descriptions live here, and the keyed record type makes a toolkit tool
+ * without a description entry a compile error.
  */
-const ManifestToolDescriptions: Readonly<Record<string, string>> = {
+const ManifestToolDescriptions: Readonly<Record<keyof typeof PracticeKgToolkit.tools, string>> = {
   corpus_get_document: "Read a digest-addressed document.",
   corpus_search_text: "Search extracted corpus text.",
   email_search: "Search indexed correspondence headers.",
@@ -183,64 +196,50 @@ const ManifestToolDescriptions: Readonly<Record<string, string>> = {
   kg_provenance: "Resolve row provenance or report bundle status.",
 };
 
-const toolkitToolNames: ReadonlyArray<string> = R.keys(PracticeKgToolkit.tools);
+const toolkitToolNames = R.keys(PracticeKgToolkit.tools);
 
-const manifestToolsJson = A.join(
-  A.map(
-    toolkitToolNames,
-    (name) => `    { "name": "${name}", "description": "${ManifestToolDescriptions[name] ?? ""}" }`
-  ),
-  ",\n"
-);
-
-const assertManifestToolCoverage = Effect.fn("PracticeKgPackage.assertManifestToolCoverage")(function* () {
-  const undocumented = A.findFirst(toolkitToolNames, (name) => !(name in ManifestToolDescriptions));
-  if (O.isSome(undocumented)) {
-    return yield* PackageFailure.make({
-      message: `Toolkit tool "${undocumented.value}" has no manifest description; update ManifestToolDescriptions.`,
-    });
-  }
-});
-
-const manifestFor = (platform: "linux" | "win32", executable: string) => `{
-  "manifest_version": "0.3",
-  "name": "beep-practice-kg",
-  "display_name": "Beep Practice Knowledge Graph",
-  "version": "0.0.0",
-  "description": "Read-only local practice knowledge-graph queries over a separately supplied data bundle.",
-  "author": { "name": "Beep Effect contributors" },
-  "repository": { "type": "git", "url": "https://github.com/kriegcloud/beep-effect.git" },
-  "license": "MIT",
-  "compatibility": { "platforms": ["${platform}"] },
-  "server": {
-    "type": "binary",
-    "entry_point": "${executable}",
-    "mcp_config": {
-      "command": "\${__dirname}/${executable}",
-      "env": {
-        "BUNDLE_DIR": "\${user_config.bundle_dir}",
-        "PRACTICE_KG_CORPUS_ROOT": "\${user_config.corpus_root}"
-      }
-    }
-  },
-  "user_config": {
-    "bundle_dir": {
-      "type": "directory",
-      "title": "Practice KG data bundle",
-      "description": "Directory containing bundle.manifest.json, kg.pglite, and practice.duckdb.",
-      "required": true
+const manifestFor = (platform: "linux" | "win32", executable: string): string =>
+  JSON.stringify(
+    {
+      manifest_version: "0.3",
+      name: "beep-practice-kg",
+      display_name: "Beep Practice Knowledge Graph",
+      version: "0.0.0",
+      description: "Read-only local practice knowledge-graph queries over a separately supplied data bundle.",
+      author: { name: "Beep Effect contributors" },
+      repository: { type: "git", url: "https://github.com/kriegcloud/beep-effect.git" },
+      license: "MIT",
+      compatibility: { platforms: [platform] },
+      server: {
+        type: "binary",
+        entry_point: executable,
+        mcp_config: {
+          command: `\${__dirname}/${executable}`,
+          env: {
+            BUNDLE_DIR: "${user_config.bundle_dir}",
+            PRACTICE_KG_CORPUS_ROOT: "${user_config.corpus_root}",
+          },
+        },
+      },
+      user_config: {
+        bundle_dir: {
+          type: "directory",
+          title: "Practice KG data bundle",
+          description: "Directory containing bundle.manifest.json, kg.pglite, and practice.duckdb.",
+          required: true,
+        },
+        corpus_root: {
+          type: "directory",
+          title: "Practice corpus root",
+          description: "Optional corpus root used for click-through to source files and email bodies.",
+          required: false,
+        },
+      },
+      tools: A.map(toolkitToolNames, (name) => ({ name, description: ManifestToolDescriptions[name] })),
     },
-    "corpus_root": {
-      "type": "directory",
-      "title": "Practice corpus root",
-      "description": "Optional corpus root used for click-through to source files and email bodies.",
-      "required": false
-    }
-  },
-  "tools": [
-${manifestToolsJson}
-  ]
-}`;
+    null,
+    2
+  );
 
 // fallow-ignore-next-line complexity -- archive gate is deliberately explicit; exercised by package:mcpb on every build
 const assertArchive = Effect.fn("PracticeKgPackage.assertArchive")(function* (
@@ -299,19 +298,15 @@ const packageTarget = Effect.fn("PracticeKgPackage.packageTarget")(function* (
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const repoRoot = path.resolve(import.meta.dir, "..", "..", "..");
-  const windows = targetName === "windows-x64";
-  const platform = windows ? "win32" : "linux";
-  const bunTarget = windows ? "bun-windows-x64" : "bun-linux-x64";
-  const executable = windows ? "practice-kg-mcp.exe" : "practice-kg-mcp";
-  const nativePackage = windows ? "node-bindings-win32-x64" : "node-bindings-linux-x64";
+  const { bunTarget, executable, nativePackage, platform } = TargetSpecs[targetName];
   const resolvedOutputRoot = path.resolve(repoRoot, outputRoot);
   const bundleDir = path.resolve(resolvedOutputRoot, targetName);
   const archivePath = path.resolve(resolvedOutputRoot, `practice-kg-mcp-${targetName}.mcpb`);
   const cacheDir = path.resolve(resolvedOutputRoot, ".cache");
-  const nativeSource = windows
-    ? yield* ensureWindowsBindings(cacheDir, repoRoot)
-    : path.resolve(repoRoot, "node_modules", "@duckdb", nativePackage);
-  yield* assertManifestToolCoverage();
+  const nativeSource =
+    targetName === "windows-x64"
+      ? yield* ensureWindowsBindings(cacheDir, repoRoot)
+      : path.resolve(repoRoot, "node_modules", "@duckdb", nativePackage);
   yield* fs.remove(bundleDir, { recursive: true, force: true });
   yield* fs.makeDirectory(bundleDir, { recursive: true });
   const manifest = manifestFor(platform, executable);

--- a/apps/practice-kg-mcp/src/runtime/Layer.ts
+++ b/apps/practice-kg-mcp/src/runtime/Layer.ts
@@ -20,7 +20,6 @@ import { makePracticeKgPgliteLayer } from "./Pglite.ts";
  * @example
  * ```ts
  * import { buildPracticeKgBundle, PracticeKgOptions } from "@beep/law-practice-server"
- * import { NonNegativeInt } from "@beep/schema"
  * import * as BunServices from "@effect/platform-bun/BunServices"
  * import { Effect, Layer } from "effect"
  * import { makePracticeKgBuildLayer } from "../../src/runtime/Layer.ts"
@@ -32,7 +31,6 @@ import { makePracticeKgPgliteLayer } from "./Pglite.ts";
  *     bundleOut,
  *     corpusRoot: "/corpus",
  *     includeRefresh: true,
- *     maxTextBytes: NonNegativeInt.make(2_097_152),
  *     overwrite: true,
  *     skipEmails: false
  *   })

--- a/apps/practice-kg-mcp/src/smoke.ts
+++ b/apps/practice-kg-mcp/src/smoke.ts
@@ -11,7 +11,7 @@
 import { DuckDb, DuckDbConnectionOptions } from "@beep/duckdb";
 import { $PracticeKgMcpId } from "@beep/identity/packages";
 import { buildPracticeKgBundle, PracticeKgOptions, PracticeKgToolkit } from "@beep/law-practice-server";
-import { NonNegativeInt, TaggedErrorClass } from "@beep/schema";
+import { TaggedErrorClass } from "@beep/schema";
 import { BunRuntime } from "@effect/platform-bun";
 import * as BunServices from "@effect/platform-bun/BunServices";
 import { Effect, FileSystem, Layer, Path } from "effect";
@@ -42,7 +42,7 @@ class SmokeToolsResponse extends S.Class<SmokeToolsResponse>($I`SmokeToolsRespon
 ) {}
 
 class SmokeServerInfo extends S.Class<SmokeServerInfo>($I`SmokeServerInfo`)(
-  { name: S.String },
+  { name: S.Literal("beep-practice-kg") },
   $I.annote("SmokeServerInfo", { description: "Server identity returned by MCP initialization." })
 ) {}
 
@@ -123,7 +123,6 @@ const makeFixtureBundle = Effect.fn("PracticeKgSmoke.makeFixtureBundle")(functio
             bundleOut,
             corpusRoot,
             includeRefresh: false,
-            maxTextBytes: NonNegativeInt.make(2_097_152),
             overwrite: false,
             skipEmails: true,
           })
@@ -162,18 +161,16 @@ const runCompiledHost = Effect.fn("PracticeKgSmoke.runCompiledHost")(function* (
     return yield* SmokeFailure.make({ message: `Compiled host exited with code ${exitCode}.` });
   }
   const lines = A.filter(Str.split("\n")(Str.trim(responseText)), Str.isNonEmpty);
-  const initializeLine = yield* A.get(lines, 0).pipe(
-    O.match({
-      onNone: () => SmokeFailure.make({ message: "Compiled host returned no initialize response." }),
-      onSome: Effect.succeed,
-    })
-  );
-  const toolsLine = yield* A.get(lines, 1).pipe(
-    O.match({
-      onNone: () => SmokeFailure.make({ message: "Compiled host returned no tools/list response." }),
-      onSome: Effect.succeed,
-    })
-  );
+  const responseLine = (index: number, what: string) =>
+    A.get(lines, index).pipe(
+      O.match({
+        onNone: () => SmokeFailure.make({ message: `Compiled host returned no ${what} response.` }),
+        onSome: Effect.succeed,
+      })
+    );
+  const initializeLine = yield* responseLine(0, "initialize");
+  const toolsLine = yield* responseLine(1, "tools/list");
+  // Server-name mismatch fails here too: SmokeServerInfo.name is a literal.
   const initialize = yield* decodeInitialize(initializeLine).pipe(
     Effect.mapError((cause) => SmokeFailure.make({ cause, message: "Initialize response was invalid." }))
   );
@@ -181,9 +178,6 @@ const runCompiledHost = Effect.fn("PracticeKgSmoke.runCompiledHost")(function* (
     Effect.mapError((cause) => SmokeFailure.make({ cause, message: "Tools/list response was invalid." }))
   );
   const names = A.map(tools.result.tools, (tool) => tool.name);
-  if (initialize.result.serverInfo.name !== "beep-practice-kg") {
-    return yield* SmokeFailure.make({ message: "Compiled host returned the wrong server name." });
-  }
   if (names.length !== A.length(ExpectedTools) || !A.every(ExpectedTools, (name) => A.contains(names, name))) {
     return yield* SmokeFailure.make({
       message: `Compiled host did not list the expected toolkit tools: ${A.join(names, ", ")}`,

--- a/goals/practice-kg-mcp/history/p4/2026-07-29-quality-review.md
+++ b/goals/practice-kg-mcp/history/p4/2026-07-29-quality-review.md
@@ -1,0 +1,63 @@
+# P4 evidence — crispen pass + quality-review loop over the packet surface
+
+Date: 2026-07-29 · Phase: P4 Distribution (pre-handoff hardening) · Scope:
+`/crispen full` refactor of the packet code surface followed by a
+quality-review-fix loop (10-role read-only reviewer panel), before re-staging
+the Tom handoff `.mcpb`.
+
+## Crispen pass (baseline commit 0c516ff879)
+
+- `PracticeKgEpistemicStatus` / `PracticeKgProvenanceKind` moved to
+  `law-practice/domain` values; tool rows now carry real literal domains
+  (`epistemic_status`, `kind`, `provenanceKind` were `S.String` /
+  `S.NonEmptyString`), with the two synthetic bundle-status members admitted
+  through a named union rather than widening the domain kits.
+- Schema defaults absorbed: `maxTextBytes` (PosInt, 2 MiB key default —
+  replaces a deleted runtime `<= 0` guard), `corpus_get_document` range,
+  node/edge `epistemicStatus` constructor default (spine-writers-only
+  invariant recorded inline), dual `resolveBundleOut` static as the single
+  home of the bundle path default.
+- Helper walls deleted: `nullable()`, five byte-identical record mappers →
+  `toToolRecord`, imperative tier loop → `A.findFirst` fold, claims
+  split-on-";" DDL → statement array, two double-scans → `A.partition`,
+  structural `GraphTextSourceSpec` bypass (now exported, `$I` identifiers),
+  `.mcpb` manifest via `JSON.stringify` with compile-time tool-description
+  coverage.
+- Freeze proofs: regression suite green with fixtures untouched; live stdio
+  probe against the staged real bundle returned identical shapes, labels,
+  tiers, and the email linkage note across 6 tools; `bundle_version` and
+  schema versions unchanged (staged 397 MB bundle needs no rebuild).
+
+## Reviewer panel (round 1, 10 roles, read-only)
+
+Result: **26 findings, 0 blocking** — zero-gate passed first round.
+Breakdown: 12 non-blocking, 11 notes, 3 questions; all P3-low.
+
+Fixed same-branch (post-baseline commit):
+
+- stale `bundleOut is the only optional key` remark; missing default-behavior
+  remarks on node/edge rows (documentation-api-001/-002)
+- `kg_find` LIKE pattern now routed through `likePattern` (reuse-duplication)
+- raw `candidate-unreviewed` literals → `PracticeKgEpistemicStatus.Enum`
+  accessors in tool-handlers (effect-law-002)
+- duplicated `withConstantDefault` pipe → shared `spineEpistemicStatus`
+  (reuse-duplication)
+- schema-absorbed defaults pinned by test (maxTextBytes make+decode 2_097_152;
+  tool-result literal-domain rejection) (testing)
+
+Answered questions: the packet-close state flips + reflection are NOT this
+PR — they land in the P5 closeout PR per plan, gated on AC-4/AC-5/AC-6
+observations (quality-gate-001, evolution-deprecation-002).
+
+## Backlog (P3-low, accepted for now)
+
+- `--max-text-bytes 0` on the workstation build CLI dies as a PosInt brand
+  defect instead of a typed CLI error (workstation-only tooling; Tom's machine
+  never runs builds).
+- `.mcpb` `manifestFor` uses `JSON.stringify` rather than a schema JSON codec
+  (EF-3 advisory; replaced a worse hand-built template string).
+- Server re-export of the moved literal kits is a transitional-compatibility
+  shim with no in-repo consumers — delete after handoff freeze lifts (record
+  carried to closeout).
+- 2 MiB constant exists in two semantically distinct homes (build text cap vs
+  read-range length); left unlinked deliberately.

--- a/packages/law-practice/domain/src/values/PracticeKgEpistemicStatus/PracticeKgEpistemicStatus.model.ts
+++ b/packages/law-practice/domain/src/values/PracticeKgEpistemicStatus/PracticeKgEpistemicStatus.model.ts
@@ -1,0 +1,60 @@
+/**
+ * Closed epistemic-status domain for practice knowledge-graph rows.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $LawPracticeDomainId } from "@beep/identity/packages";
+import { LiteralKit } from "@beep/schema";
+
+const $I = $LawPracticeDomainId.create("values/PracticeKgEpistemicStatus");
+
+/**
+ * Epistemic labels stored on practice knowledge-graph projections.
+ *
+ * @remarks
+ * The distinction is load-bearing rather than descriptive: rows labelled
+ * `derived-from-official-records` are reconcilable against the corpus catalog,
+ * while `candidate-unreviewed` rows come from enrichment or extraction and must
+ * not be presented as settled fact.
+ *
+ * @example
+ * ```ts
+ * import { PracticeKgEpistemicStatus } from "@beep/law-practice-domain/values"
+ * import * as S from "effect/Schema"
+ *
+ * const status = S.decodeUnknownSync(PracticeKgEpistemicStatus)("candidate-unreviewed")
+ * console.log(status) // "candidate-unreviewed"
+ * console.log(PracticeKgEpistemicStatus.Enum["derived-from-official-records"])
+ * // "derived-from-official-records"
+ * ```
+ *
+ * @see {@link PracticeKgProvenanceKind} for the source-reference kinds carried beside this label.
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const PracticeKgEpistemicStatus = LiteralKit(["derived-from-official-records", "candidate-unreviewed"]).pipe(
+  $I.annoteSchema("PracticeKgEpistemicStatus", {
+    description: "Authority label distinguishing deterministic spine rows from candidate claims.",
+  })
+);
+
+/**
+ * Runtime type for {@link PracticeKgEpistemicStatus}.
+ *
+ * @example
+ * ```ts
+ * import type { PracticeKgEpistemicStatus } from "@beep/law-practice-domain/values"
+ *
+ * const isSettled = (status: PracticeKgEpistemicStatus): boolean =>
+ *   status === "derived-from-official-records"
+ *
+ * console.log(isSettled("candidate-unreviewed")) // false
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export type PracticeKgEpistemicStatus = typeof PracticeKgEpistemicStatus.Type;

--- a/packages/law-practice/domain/src/values/PracticeKgEpistemicStatus/index.ts
+++ b/packages/law-practice/domain/src/values/PracticeKgEpistemicStatus/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Practice knowledge-graph epistemic-status export surface.
+ *
+ * @packageDocumentation
+ * @category value-objects
+ * @since 0.0.0
+ */
+
+export * from "./PracticeKgEpistemicStatus.model.ts";

--- a/packages/law-practice/domain/src/values/PracticeKgProvenanceKind/PracticeKgProvenanceKind.model.ts
+++ b/packages/law-practice/domain/src/values/PracticeKgProvenanceKind/PracticeKgProvenanceKind.model.ts
@@ -1,0 +1,64 @@
+/**
+ * Closed provenance-reference kind domain for practice knowledge-graph rows.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $LawPracticeDomainId } from "@beep/identity/packages";
+import { LiteralKit } from "@beep/schema";
+
+const $I = $LawPracticeDomainId.create("values/PracticeKgProvenanceKind");
+
+/**
+ * Closed provenance-reference kinds stored on graph projections.
+ *
+ * @remarks
+ * The kind tells a reader how to interpret the accompanying `provenanceRef`: a
+ * `catalog-digest` ref is a content digest, a `uspto-anchor` ref is an
+ * application number, and so on. Widening this set means teaching every consumer
+ * a new ref format.
+ *
+ * @example
+ * ```ts
+ * import { PracticeKgProvenanceKind } from "@beep/law-practice-domain/values"
+ * import * as S from "effect/Schema"
+ *
+ * const kind = S.decodeUnknownSync(PracticeKgProvenanceKind)("uspto-anchor")
+ * console.log(kind) // "uspto-anchor"
+ * console.log(PracticeKgProvenanceKind.Enum["extract-operation"]) // "extract-operation"
+ * ```
+ *
+ * @see {@link PracticeKgEpistemicStatus} for the authority label carried beside this kind.
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const PracticeKgProvenanceKind = LiteralKit([
+  "catalog-digest",
+  "uspto-anchor",
+  "organize-row",
+  "extract-operation",
+]).pipe(
+  $I.annoteSchema("PracticeKgProvenanceKind", {
+    description: "Stable source-reference kinds accepted by the practice knowledge graph.",
+  })
+);
+
+/**
+ * Runtime type for {@link PracticeKgProvenanceKind}.
+ *
+ * @example
+ * ```ts
+ * import type { PracticeKgProvenanceKind } from "@beep/law-practice-domain/values"
+ *
+ * const refLabel = (kind: PracticeKgProvenanceKind): string =>
+ *   kind === "uspto-anchor" ? "application number" : "corpus reference"
+ *
+ * console.log(refLabel("uspto-anchor")) // "application number"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export type PracticeKgProvenanceKind = typeof PracticeKgProvenanceKind.Type;

--- a/packages/law-practice/domain/src/values/PracticeKgProvenanceKind/index.ts
+++ b/packages/law-practice/domain/src/values/PracticeKgProvenanceKind/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Practice knowledge-graph provenance-kind export surface.
+ *
+ * @packageDocumentation
+ * @category value-objects
+ * @since 0.0.0
+ */
+
+export * from "./PracticeKgProvenanceKind.model.ts";

--- a/packages/law-practice/domain/src/values/index.ts
+++ b/packages/law-practice/domain/src/values/index.ts
@@ -436,6 +436,20 @@ export * from "./PatentOffice/index.ts";
  */
 export * from "./PinciteInfo/index.ts";
 /**
+ * Practice knowledge-graph epistemic-status exports.
+ *
+ * @category value-objects
+ * @since 0.0.0
+ */
+export * from "./PracticeKgEpistemicStatus/index.ts";
+/**
+ * Practice knowledge-graph provenance-kind exports.
+ *
+ * @category value-objects
+ * @since 0.0.0
+ */
+export * from "./PracticeKgProvenanceKind/index.ts";
+/**
  * Public-law-citation value-object exports.
  *
  * @example

--- a/packages/law-practice/server/src/PracticeKg.claims.ts
+++ b/packages/law-practice/server/src/PracticeKg.claims.ts
@@ -22,7 +22,7 @@ import { IrToLawExtractionError } from "@beep/law-practice-use-cases/IrToLaw";
 import { OfficeActionReview, OfficeActionReviewInput } from "@beep/law-practice-use-cases/OfficeActionReview";
 import { NonNegativeInt, PosInt, Sha256HexFromBytes, TaggedErrorClass } from "@beep/schema";
 import { PosixPath } from "@beep/schema/PosixPath";
-import { Effect, FileSystem, Order, Path } from "effect";
+import { Effect, FileSystem, Order, Path, Result } from "effect";
 import * as A from "effect/Array";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
@@ -46,8 +46,8 @@ const decodePosixPath = S.decodeUnknownEffect(PosixPath);
 const hashBytes = S.decodeUnknownEffect(Sha256HexFromBytes);
 const encodeUnknownJson = S.encodeUnknownEffect(S.UnknownFromJsonString);
 
-const createClaimsTables = `
-CREATE TABLE IF NOT EXISTS epistemic_candidate_claim (
+const createClaimsTables = [
+  `CREATE TABLE IF NOT EXISTS epistemic_candidate_claim (
   created_at BIGINT NOT NULL,
   created_by_principal JSONB NOT NULL,
   org_id INTEGER NOT NULL,
@@ -62,10 +62,10 @@ CREATE TABLE IF NOT EXISTS epistemic_candidate_claim (
   snapshot JSONB NOT NULL,
   entity_type TEXT NOT NULL,
   id SERIAL PRIMARY KEY
-);
-CREATE UNIQUE INDEX IF NOT EXISTS epistemic_candidate_claim_public_id_unique_idx
-  ON epistemic_candidate_claim (public_id);
-CREATE TABLE IF NOT EXISTS epistemic_evidence (
+)`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS epistemic_candidate_claim_public_id_unique_idx
+  ON epistemic_candidate_claim (public_id)`,
+  `CREATE TABLE IF NOT EXISTS epistemic_evidence (
   created_at BIGINT NOT NULL,
   created_by_principal JSONB NOT NULL,
   org_id INTEGER NOT NULL,
@@ -80,9 +80,10 @@ CREATE TABLE IF NOT EXISTS epistemic_evidence (
   span_fixture_key TEXT NOT NULL,
   entity_type TEXT NOT NULL,
   id SERIAL PRIMARY KEY
-);
-CREATE UNIQUE INDEX IF NOT EXISTS epistemic_evidence_public_id_unique_idx
-  ON epistemic_evidence (public_id)`;
+)`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS epistemic_evidence_public_id_unique_idx
+  ON epistemic_evidence (public_id)`,
+];
 
 const insertCandidate = `
 INSERT INTO epistemic_candidate_claim (
@@ -253,15 +254,13 @@ export const runPracticeKgClaimsBatch = Effect.fn("PracticeKgClaims.run")(
     const path = yield* Path.Path;
     const review = yield* OfficeActionReview;
     const sql = (yield* SqlClientService).withoutTransforms();
-    yield* Effect.forEach(
-      A.filter(A.map(Str.split(";")(createClaimsTables), Str.trim), Str.isNonEmpty),
-      (statement) => sql.unsafe(statement),
-      { discard: true }
-    );
+    yield* Effect.forEach(createClaimsTables, (statement) => sql.unsafe(statement), { discard: true });
     const entries = A.sort(yield* fs.readDirectory(options.inputs), Order.String);
-    const skippedFiles = A.filter(entries, (filename) => O.isNone(docketFromFilename(filename)));
-    const docketedFiles = A.getSomes(
-      A.map(entries, (filename) => O.map(docketFromFilename(filename), (docket) => ({ docket, filename })))
+    const [skippedFiles, docketedFiles] = A.partition(entries, (filename) =>
+      O.match(docketFromFilename(filename), {
+        onNone: () => Result.fail(filename),
+        onSome: (docket) => Result.succeed({ docket, filename }),
+      })
     );
     if (A.isReadonlyArrayNonEmpty(skippedFiles)) {
       yield* Effect.logInfo("PracticeKgClaims.skippedInputs", {
@@ -327,8 +326,7 @@ export const runPracticeKgClaimsBatch = Effect.fn("PracticeKgClaims.run")(
       yield* persistCandidate(sql, candidate, evidence);
       return filename;
     });
-    const isExtractionQualityError = (error: unknown): boolean =>
-      S.is(IrToLawExtractionError)(error) || S.is(LangExtractError)(error);
+    const isExtractionQualityError = S.is(S.Union([IrToLawExtractionError, LangExtractError]));
     const outcomes = yield* Effect.forEach(
       docketedFiles,
       (entry) =>
@@ -343,8 +341,9 @@ export const runPracticeKgClaimsBatch = Effect.fn("PracticeKgClaims.run")(
         ),
       { concurrency: 1 }
     );
-    const extractedFiles = A.filter(outcomes, (outcome) => outcome.extracted);
-    const failedExtractions = A.filter(outcomes, (outcome) => !outcome.extracted);
+    const [failedExtractions, extractedFiles] = A.partition(outcomes, (outcome) =>
+      outcome.extracted ? Result.succeed(outcome) : Result.fail(outcome)
+    );
     if (A.isReadonlyArrayNonEmpty(failedExtractions)) {
       yield* Effect.logWarning("PracticeKgClaims.failedExtractions", {
         count: A.length(failedExtractions),

--- a/packages/law-practice/server/src/PracticeKg.fts.ts
+++ b/packages/law-practice/server/src/PracticeKg.fts.ts
@@ -6,6 +6,7 @@
  */
 
 import { DuckDb, DuckDbConnectionOptions } from "@beep/duckdb";
+import { $LawPracticeServerId } from "@beep/identity/packages";
 import { Effect, pipe } from "effect";
 import * as A from "effect/Array";
 import * as S from "effect/Schema";
@@ -16,12 +17,38 @@ import type { DuckDbShape } from "@beep/duckdb";
 import type { PracticeKgCatalogRow, PracticeKgEnrichmentRow } from "./PracticeKg.rows.ts";
 import type { PracticeKgEmailHeaderRow } from "./PracticeKg.schemas.ts";
 
-class GraphTextSourceSpec extends S.Class<GraphTextSourceSpec>("PracticeKgTextSourceSpec")({
-  sourcesPath: S.String,
-  textGlob: S.String,
-}) {}
+const $I = $LawPracticeServerId.create("PracticeKg.fts");
 
-class GraphDuckCountsRow extends S.Class<GraphDuckCountsRow>("GraphDuckCountsRow")({
+/**
+ * One extraction source feeding the bundle's `document_text` table: a
+ * `sources.jsonl` manifest plus the glob of its extracted text files.
+ *
+ * @example
+ * ```ts
+ * import { GraphTextSourceSpec } from "../../src/PracticeKg.fts.ts"
+ *
+ * const spec = GraphTextSourceSpec.make({
+ *   sourcesPath: "/corpus/staging/extract/sources.jsonl",
+ *   textGlob: "/corpus/staging/extract/text/operation:*.txt"
+ * })
+ *
+ * console.log(spec.textGlob.endsWith(".txt")) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class GraphTextSourceSpec extends S.Class<GraphTextSourceSpec>($I`GraphTextSourceSpec`)(
+  {
+    sourcesPath: S.String,
+    textGlob: S.String,
+  },
+  $I.annote("GraphTextSourceSpec", {
+    description: "Extraction manifest path and text glob pair joined into document_text.",
+  })
+) {}
+
+class GraphDuckCountsRow extends S.Class<GraphDuckCountsRow>($I`GraphDuckCountsRow`)({
   documents: S.Finite,
   emails: S.Finite,
 }) {}

--- a/packages/law-practice/server/src/PracticeKg.projections.ts
+++ b/packages/law-practice/server/src/PracticeKg.projections.ts
@@ -19,7 +19,7 @@ import * as Str from "effect/String";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 import { readEmailRows } from "./PracticeKg.emails.ts";
 import { PracticeKgProjectionError } from "./PracticeKg.errors.ts";
-import { buildDuckDb } from "./PracticeKg.fts.ts";
+import { buildDuckDb, GraphTextSourceSpec } from "./PracticeKg.fts.ts";
 import { PracticeKgCatalogRow, PracticeKgEnrichmentRow, stripPrefix, withDuckDb } from "./PracticeKg.rows.ts";
 import {
   encodePracticeKgBundleManifestJson,
@@ -30,12 +30,13 @@ import {
   PracticeKgCounts,
   PracticeKgEdgeRow,
   PracticeKgNodeRow,
+  PracticeKgOptions,
   PracticeKgSchemaVersions,
   PracticeKgSourceRuns,
   PracticeKgSummary,
 } from "./PracticeKg.schemas.ts";
 import type { KgEdgePredicate, KgNodeKind } from "@beep/law-practice-domain/values";
-import type { PracticeKgEmailHeaderRow, PracticeKgOptions, PracticeKgProvenanceKind } from "./PracticeKg.schemas.ts";
+import type { PracticeKgEmailHeaderRow, PracticeKgProvenanceKind } from "./PracticeKg.schemas.ts";
 
 const $I = $LawPracticeServerId.create("PracticeKg.projections");
 const graphIdentity = $BeepId.create("practice-kg");
@@ -196,7 +197,7 @@ VALUES ($1, $2, $3, $4, $5, $6)`;
 
 const graphIri = (kind: KgNodeKind, naturalKey: string): string => graphIdentity.create(kind).create(naturalKey).iri;
 
-const nullable = <A>(value: A | null): A | undefined => value ?? undefined;
+const edgeKey = (edge: PracticeKgEdgeRow): string => `${edge.subjectIri}\u0000${edge.predicate}\u0000${edge.objectIri}`;
 
 const splitList = (value: string): ReadonlyArray<string> =>
   A.filter(A.map(Str.split(" | ")(value), Str.trim), Str.isNonEmpty);
@@ -245,13 +246,12 @@ const createNode = (
   provenanceKind: PracticeKgProvenanceKind,
   provenanceRef: string,
   options: {
-    readonly client?: string | undefined;
-    readonly docketFamily?: string | undefined;
+    readonly client?: string | null | undefined;
+    readonly docketFamily?: string | null | undefined;
     readonly payload?: Readonly<Record<string, unknown>> | undefined;
   } = {}
 ): PracticeKgNodeRow =>
   PracticeKgNodeRow.make({
-    epistemicStatus: "derived-from-official-records",
     iri: graphIri(kind, naturalKey),
     kind,
     label,
@@ -260,8 +260,8 @@ const createNode = (
     provenanceKind,
     provenanceRef,
     ...O.getSomesStruct({
-      client: O.fromUndefinedOr(options.client),
-      docketFamily: O.fromUndefinedOr(options.docketFamily),
+      client: O.fromNullishOr(options.client),
+      docketFamily: O.fromNullishOr(options.docketFamily),
     }),
   });
 
@@ -275,7 +275,6 @@ const createEdge = (
   provenanceRef: string
 ): PracticeKgEdgeRow =>
   PracticeKgEdgeRow.make({
-    epistemicStatus: "derived-from-official-records",
     objectIri: graphIri(objectKind, objectKey),
     predicate,
     provenanceKind,
@@ -297,13 +296,11 @@ const buildGraphRows = (
     MutableHashMap.set(nodes, node.iri, node);
   };
   const addEdge = (edge: PracticeKgEdgeRow): void => {
-    MutableHashMap.set(edges, `${edge.subjectIri}\u0000${edge.predicate}\u0000${edge.objectIri}`, edge);
+    MutableHashMap.set(edges, edgeKey(edge), edge);
   };
 
   A.forEach(catalogRows, (row) => {
-    const docketFamily = nullable(row.docketFamily);
-    const docket = nullable(row.docket);
-    const client = nullable(row.client);
+    const { client, docket, docketFamily } = row;
     addNode(
       createNode("document", row.digest, row.effectiveName, "catalog-digest", row.digest, {
         client,
@@ -324,9 +321,9 @@ const buildGraphRows = (
         })
       );
     }
-    if (docketFamily !== undefined) {
+    if (docketFamily !== null) {
       addNode(createNode("docket_family", docketFamily, docketFamily, "organize-row", docketFamily, { client }));
-      if (docket === undefined) {
+      if (docket === null) {
         addEdge(
           createEdge(
             "docket_family",
@@ -340,14 +337,14 @@ const buildGraphRows = (
         );
       }
     }
-    if (docket !== undefined && docketFamily !== undefined) {
+    if (docket !== null && docketFamily !== null) {
       addNode(createNode("docket", docket, docket, "organize-row", row.sourceRelativePath, { client, docketFamily }));
       addEdge(createEdge("docket_family", docketFamily, "has_docket", "docket", docket, "organize-row", docket));
       addEdge(createEdge("docket", docket, "has_document", "document", row.digest, "catalog-digest", row.digest));
       const familyDockets = pipe(MutableHashMap.get(docketsByFamily, docketFamily), O.getOrElse(A.empty<string>));
       MutableHashMap.set(docketsByFamily, docketFamily, A.dedupe(A.append(familyDockets, docket)));
     }
-    if (client !== undefined && docketFamily !== undefined) {
+    if (client !== null && docketFamily !== null) {
       addNode(createNode("client", client, client, "organize-row", row.sourceLabel));
       addEdge(
         createEdge(
@@ -367,26 +364,18 @@ const buildGraphRows = (
     if (row.status !== "resolved") {
       return;
     }
-    const application = nullable(row.applicationNumber);
-    const patent = nullable(row.patentNumber);
+    const { applicationNumber: application, patentNumber: patent } = row;
     const families = splitList(row.docketFamilies);
     const parents = splitList(row.parentApplicationNumbers);
-    if (application !== undefined) {
+    if (application !== null) {
       addNode(
-        createNode(
-          "application",
-          application,
-          nullable(row.inventionTitle) ?? application,
-          "uspto-anchor",
-          application,
-          {
-            payload: {
-              firstApplicantName: row.firstApplicantName,
-              firstInventorName: row.firstInventorName,
-              inventionTitle: row.inventionTitle,
-            },
-          }
-        )
+        createNode("application", application, row.inventionTitle ?? application, "uspto-anchor", application, {
+          payload: {
+            firstApplicantName: row.firstApplicantName,
+            firstInventorName: row.firstInventorName,
+            inventionTitle: row.inventionTitle,
+          },
+        })
       );
       A.forEach(families, (family) => {
         addNode(createNode("docket_family", family, family, "uspto-anchor", application));
@@ -412,13 +401,13 @@ const buildGraphRows = (
         );
       });
     }
-    if (patent !== undefined) {
+    if (patent !== null) {
       addNode(
-        createNode("patent", patent, nullable(row.inventionTitle) ?? patent, "uspto-anchor", patent, {
+        createNode("patent", patent, row.inventionTitle ?? patent, "uspto-anchor", patent, {
           payload: { inventionTitle: row.inventionTitle },
         })
       );
-      if (application !== undefined) {
+      if (application !== null) {
         addEdge(createEdge("application", application, "granted_as", "patent", patent, "uspto-anchor", patent));
       }
     }
@@ -452,13 +441,7 @@ const buildGraphRows = (
   });
 
   return {
-    edges: A.sort(
-      A.fromIterable(MutableHashMap.values(edges)),
-      Order.mapInput(
-        Order.String,
-        (edge: PracticeKgEdgeRow) => `${edge.subjectIri}\u0000${edge.predicate}\u0000${edge.objectIri}`
-      )
-    ),
+    edges: A.sort(A.fromIterable(MutableHashMap.values(edges)), Order.mapInput(Order.String, edgeKey)),
     nodes: A.sort(
       A.fromIterable(MutableHashMap.values(nodes)),
       Order.mapInput(Order.String, (node: PracticeKgNodeRow) => node.iri)
@@ -527,11 +510,7 @@ const writePgliteProjection = Effect.fn("PracticeKg.writePgliteProjection")(func
 const existingSourceSpecs = Effect.fn("PracticeKg.existingSourceSpecs")(function* (
   corpusRoot: string,
   includeRefresh: boolean
-): Effect.fn.Return<
-  ReadonlyArray<{ readonly sourcesPath: string; readonly textGlob: string }>,
-  never,
-  FileSystem.FileSystem | Path.Path
-> {
+): Effect.fn.Return<ReadonlyArray<GraphTextSourceSpec>, never, FileSystem.FileSystem | Path.Path> {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const roots = includeRefresh ? ["staging/extract", "staging/extract-2026-07-refresh"] : ["staging/extract"];
@@ -541,7 +520,9 @@ const existingSourceSpecs = Effect.fn("PracticeKg.existingSourceSpecs")(function
     return Effect.all([fs.exists(sourcesPath), fs.exists(textDir)]).pipe(
       Effect.orElseSucceed(() => [false, false]),
       Effect.map(([sourcesExist, textExists]) =>
-        sourcesExist && textExists ? O.some({ sourcesPath, textGlob: path.join(textDir, "operation:*.txt") }) : O.none()
+        sourcesExist && textExists
+          ? O.some(GraphTextSourceSpec.make({ sourcesPath, textGlob: path.join(textDir, "operation:*.txt") }))
+          : O.none()
       )
     );
   });
@@ -564,7 +545,6 @@ const existingSourceSpecs = Effect.fn("PracticeKg.existingSourceSpecs")(function
  * @example
  * ```ts
  * import { PracticeKgOptions } from "@beep/law-practice-server"
- * import { NonNegativeInt } from "@beep/schema"
  * import { Effect } from "effect"
  * import { buildPracticeKgBundleImpl } from "../../src/PracticeKg.projections.ts"
  *
@@ -573,7 +553,6 @@ const existingSourceSpecs = Effect.fn("PracticeKg.existingSourceSpecs")(function
  *     bundleOut: "/corpus/staging/practice-kg-bundle",
  *     corpusRoot: "/corpus",
  *     includeRefresh: true,
- *     maxTextBytes: NonNegativeInt.make(2_097_152),
  *     overwrite: true,
  *     skipEmails: false
  *   })
@@ -597,10 +576,7 @@ export const buildPracticeKgBundleImpl = Effect.fn("PracticeKg.build")(function*
 > {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
-  if (options.maxTextBytes <= 0) {
-    return yield* PracticeKgProjectionError.make({ message: "--max-text-bytes must be greater than zero." });
-  }
-  const bundleOut = options.bundleOut ?? path.join(options.corpusRoot, "staging", "practice-kg-bundle");
+  const bundleOut = PracticeKgOptions.resolveBundleOut(options, path);
   const catalogPath = path.join(options.corpusRoot, "catalog", "corpus.duckdb");
   const reportsDir = path.join(options.corpusRoot, "catalog", "reports");
   const summaryPath = path.join(reportsDir, "graph-summary.json");
@@ -695,7 +671,6 @@ export const buildPracticeKgBundleImpl = Effect.fn("PracticeKg.build")(function*
  * @example
  * ```ts
  * import { PracticeKgOptions, PracticeKgProjections } from "@beep/law-practice-server"
- * import { NonNegativeInt } from "@beep/schema"
  * import { Effect } from "effect"
  *
  * const edgeCount = Effect.gen(function* () {
@@ -704,7 +679,6 @@ export const buildPracticeKgBundleImpl = Effect.fn("PracticeKg.build")(function*
  *     PracticeKgOptions.make({
  *       corpusRoot: "/corpus",
  *       includeRefresh: true,
- *       maxTextBytes: NonNegativeInt.make(2_097_152),
  *       overwrite: true,
  *       skipEmails: false
  *     })
@@ -779,7 +753,6 @@ export const PracticeKgProjectionsLive = Layer.effect(
  * ```ts
  * import { buildPracticeKgBundle, PracticeKgOptions, PracticeKgProjectionsLive } from "@beep/law-practice-server"
  * import * as Pglite from "@beep/pglite"
- * import { NonNegativeInt } from "@beep/schema"
  * import * as BunServices from "@effect/platform-bun/BunServices"
  * import { Effect } from "effect"
  *
@@ -788,7 +761,6 @@ export const PracticeKgProjectionsLive = Layer.effect(
  *     bundleOut: "/corpus/staging/practice-kg-bundle",
  *     corpusRoot: "/corpus",
  *     includeRefresh: true,
- *     maxTextBytes: NonNegativeInt.make(2_097_152),
  *     overwrite: true,
  *     skipEmails: false
  *   })

--- a/packages/law-practice/server/src/PracticeKg.rows.ts
+++ b/packages/law-practice/server/src/PracticeKg.rows.ts
@@ -272,74 +272,19 @@ export const decodePracticeKgEmailRows = S.decodeUnknownEffect(S.Array(PracticeK
 export const decodePracticeKgCandidateClaimRows = S.decodeUnknownEffect(S.Array(PracticeKgCandidateClaimToolRow));
 
 /**
- * Convert a graph row to the generic record accepted by the field-tier projector.
+ * Convert any decoded tool row to the generic record accepted by the
+ * field-tier projector.
  *
  * @example
  * ```ts
- * import { graphToolRecord } from "@beep/law-practice-server"
+ * import { toToolRecord } from "@beep/law-practice-server"
  *
- * console.log(typeof graphToolRecord) // "function"
+ * console.log(toToolRecord({ digest: "sha256:9f2c" })) // { digest: "sha256:9f2c" }
  * ```
  * @category mappers
  * @since 0.0.0
  */
-export const graphToolRecord = (row: PracticeKgGraphToolRow): Record<string, unknown> => ({ ...row });
-
-/**
- * Convert a family row to the generic record accepted by the field-tier projector.
- *
- * @example
- * ```ts
- * import { familyToolRecord } from "@beep/law-practice-server"
- *
- * console.log(typeof familyToolRecord) // "function"
- * ```
- * @category mappers
- * @since 0.0.0
- */
-export const familyToolRecord = (row: PracticeKgFamilyToolRow): Record<string, unknown> => ({ ...row });
-
-/**
- * Convert a document row to the generic record accepted by the field-tier projector.
- *
- * @example
- * ```ts
- * import { documentToolRecord } from "@beep/law-practice-server"
- *
- * console.log(typeof documentToolRecord) // "function"
- * ```
- * @category mappers
- * @since 0.0.0
- */
-export const documentToolRecord = (row: PracticeKgDocumentToolRow): Record<string, unknown> => ({ ...row });
-
-/**
- * Convert an email row to the generic record accepted by the field-tier projector.
- *
- * @example
- * ```ts
- * import { emailToolRecord } from "@beep/law-practice-server"
- *
- * console.log(typeof emailToolRecord) // "function"
- * ```
- * @category mappers
- * @since 0.0.0
- */
-export const emailToolRecord = (row: PracticeKgEmailToolRow): Record<string, unknown> => ({ ...row });
-
-/**
- * Convert a candidate-claim row to the generic record accepted by the field-tier projector.
- *
- * @example
- * ```ts
- * import { candidateClaimToolRecord } from "@beep/law-practice-server"
- *
- * console.log(typeof candidateClaimToolRecord) // "function"
- * ```
- * @category mappers
- * @since 0.0.0
- */
-export const candidateClaimToolRecord = (row: PracticeKgCandidateClaimToolRow): Record<string, unknown> => ({ ...row });
+export const toToolRecord = <Row extends object>(row: Row): { [K in keyof Row]: Row[K] } => ({ ...row });
 
 /**
  * Resolve optional external-corpus pointers with the platform path service.

--- a/packages/law-practice/server/src/PracticeKg.schemas.ts
+++ b/packages/law-practice/server/src/PracticeKg.schemas.ts
@@ -19,6 +19,16 @@ import type { Path } from "effect";
 
 const $I = $LawPracticeServerId.create("PracticeKg.schemas");
 
+/*
+ * Constructor-only default: these projection classes are written exclusively
+ * by the deterministic spine (SPEC D-2a), so the settled label is the
+ * invariant, not a guess — candidate rows live in the epistemic tables and
+ * must never be written through kg_node/kg_edge.
+ */
+const spineEpistemicStatus = PracticeKgEpistemicStatus.pipe(
+  SchemaUtils.withConstantDefault<PracticeKgEpistemicStatus>("derived-from-official-records")
+);
+
 /**
  * Practice knowledge-graph literal domains, re-exported from the domain tier
  * where they are defined alongside {@link KgNodeKind}.
@@ -32,11 +42,12 @@ export { PracticeKgEpistemicStatus, PracticeKgProvenanceKind } from "@beep/law-p
  * Validated options used by `corpus graph`.
  *
  * @remarks
- * `bundleOut` is the only optional key: omitting it puts the bundle under
- * `<corpusRoot>/staging/practice-kg-bundle` (see {@link PracticeKgOptions.resolveBundleOut}).
- * `maxTextBytes` is a positive byte budget defaulting to 2 MiB. `overwrite` is
- * what distinguishes a rebuild from an accidental clobber — without it a build
- * refuses to run against an existing bundle.
+ * Omitting `bundleOut` puts the bundle under
+ * `<corpusRoot>/staging/practice-kg-bundle` (see {@link PracticeKgOptions.resolveBundleOut}),
+ * and omitting `maxTextBytes` applies the 2 MiB positive byte budget for both
+ * construction and decode. `overwrite` is what distinguishes a rebuild from an
+ * accidental clobber — without it a build refuses to run against an existing
+ * bundle.
  *
  * @example
  * ```ts
@@ -124,7 +135,9 @@ export type PracticeKgBundleOutInput = Pick<PracticeKgOptions, "bundleOut" | "co
  * `iri` is the node's identity across the whole graph and the join target for
  * both edge endpoints; `naturalKey` is the human-facing key it was minted from.
  * `client` and `docketFamily` are absent — not empty — for nodes that belong to
- * neither, such as an email archive.
+ * neither, such as an email archive. `epistemicStatus` defaults at construction
+ * to the settled spine label because these rows are written only by the
+ * deterministic projection; candidate material never flows through this class.
  *
  * @example
  * ```ts
@@ -153,9 +166,7 @@ export class PracticeKgNodeRow extends S.Class<PracticeKgNodeRow>($I`PracticeKgN
   {
     client: S.optionalKey(S.String),
     docketFamily: S.optionalKey(S.String),
-    epistemicStatus: PracticeKgEpistemicStatus.pipe(
-      SchemaUtils.withConstantDefault<PracticeKgEpistemicStatus>("derived-from-official-records")
-    ),
+    epistemicStatus: spineEpistemicStatus,
     iri: S.NonEmptyString,
     kind: KgNodeKind,
     label: S.String,
@@ -175,7 +186,8 @@ export class PracticeKgNodeRow extends S.Class<PracticeKgNodeRow>($I`PracticeKgN
  * @remarks
  * The `(subjectIri, predicate, objectIri)` triple is the row's identity, so the
  * same assertion derived twice collapses to one edge. Both IRIs must name nodes
- * that exist in the same bundle.
+ * that exist in the same bundle. `epistemicStatus` carries the same
+ * spine-writers-only constructor default as {@link PracticeKgNodeRow}.
  *
  * @example
  * ```ts
@@ -198,9 +210,7 @@ export class PracticeKgNodeRow extends S.Class<PracticeKgNodeRow>($I`PracticeKgN
  */
 export class PracticeKgEdgeRow extends S.Class<PracticeKgEdgeRow>($I`PracticeKgEdgeRow`)(
   {
-    epistemicStatus: PracticeKgEpistemicStatus.pipe(
-      SchemaUtils.withConstantDefault<PracticeKgEpistemicStatus>("derived-from-official-records")
-    ),
+    epistemicStatus: spineEpistemicStatus,
     objectIri: S.NonEmptyString,
     predicate: KgEdgePredicate,
     provenanceKind: PracticeKgProvenanceKind,

--- a/packages/law-practice/server/src/PracticeKg.schemas.ts
+++ b/packages/law-practice/server/src/PracticeKg.schemas.ts
@@ -6,36 +6,51 @@
  */
 
 import { $LawPracticeServerId } from "@beep/identity/packages";
-import { KgEdgePredicate, KgNodeKind } from "@beep/law-practice-domain/values";
-import { LiteralKit, NonNegativeInt, UnknownRecord } from "@beep/schema";
+import {
+  KgEdgePredicate,
+  KgNodeKind,
+  PracticeKgEpistemicStatus,
+  PracticeKgProvenanceKind,
+} from "@beep/law-practice-domain/values";
+import { LiteralKit, NonNegativeInt, PosInt, SchemaUtils, UnknownRecord } from "@beep/schema";
+import { dual } from "effect/Function";
 import * as S from "effect/Schema";
+import type { Path } from "effect";
 
 const $I = $LawPracticeServerId.create("PracticeKg.schemas");
+
+/**
+ * Practice knowledge-graph literal domains, re-exported from the domain tier
+ * where they are defined alongside {@link KgNodeKind}.
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export { PracticeKgEpistemicStatus, PracticeKgProvenanceKind } from "@beep/law-practice-domain/values";
 
 /**
  * Validated options used by `corpus graph`.
  *
  * @remarks
  * `bundleOut` is the only optional key: omitting it puts the bundle under
- * `<corpusRoot>/staging/practice-kg-bundle`. `overwrite` is what distinguishes a
- * rebuild from an accidental clobber — without it a build refuses to run against
- * an existing bundle.
+ * `<corpusRoot>/staging/practice-kg-bundle` (see {@link PracticeKgOptions.resolveBundleOut}).
+ * `maxTextBytes` is a positive byte budget defaulting to 2 MiB. `overwrite` is
+ * what distinguishes a rebuild from an accidental clobber — without it a build
+ * refuses to run against an existing bundle.
  *
  * @example
  * ```ts
  * import { PracticeKgOptions } from "@beep/law-practice-server"
- * import { NonNegativeInt } from "@beep/schema"
  *
  * const options = PracticeKgOptions.make({
  *   corpusRoot: "/corpus",
  *   includeRefresh: true,
- *   maxTextBytes: NonNegativeInt.make(2_097_152),
  *   overwrite: false,
  *   skipEmails: false
  * })
  *
  * console.log(options.bundleOut) // undefined — defaults under the corpus root
- * console.log(options.maxTextBytes) // 2097152
+ * console.log(options.maxTextBytes) // 2097152 — schema default
  * ```
  *
  * @category models
@@ -46,112 +61,61 @@ export class PracticeKgOptions extends S.Class<PracticeKgOptions>($I`PracticeKgO
     bundleOut: S.optionalKey(S.String),
     corpusRoot: S.String,
     includeRefresh: S.Boolean,
-    maxTextBytes: NonNegativeInt,
+    maxTextBytes: PosInt.pipe(SchemaUtils.withKeyDefaults(PosInt.make(2_097_152))),
     overwrite: S.Boolean,
     skipEmails: S.Boolean,
   },
   $I.annote("PracticeKgOptions", {
     description: "Validated options used to build a deterministic practice knowledge-graph bundle.",
   })
-) {}
+) {
+  /**
+   * Resolve the effective bundle destination for a corpus root, applying the
+   * canonical `<corpusRoot>/staging/practice-kg-bundle` default.
+   *
+   * @example
+   * ```ts
+   * import { PracticeKgOptions } from "@beep/law-practice-server"
+   * import { Effect, Path } from "effect"
+   *
+   * const program = Effect.gen(function* () {
+   *   const path = yield* Path.Path
+   *   return PracticeKgOptions.resolveBundleOut({ corpusRoot: "/corpus" }, path)
+   * })
+   *
+   * console.log(Effect.isEffect(program)) // true
+   * ```
+   *
+   * @category utilities
+   * @since 0.0.0
+   */
+  static readonly resolveBundleOut: {
+    (path: Path.Path): (options: PracticeKgBundleOutInput) => string;
+    (options: PracticeKgBundleOutInput, path: Path.Path): string;
+  } = dual(
+    2,
+    (options: PracticeKgBundleOutInput, path: Path.Path): string =>
+      options.bundleOut ?? path.join(options.corpusRoot, "staging", "practice-kg-bundle")
+  );
+}
 
 /**
- * Epistemic labels stored on graph projections.
- *
- * @remarks
- * The distinction is load-bearing rather than descriptive: rows labelled
- * `derived-from-official-records` are reconcilable against the corpus catalog,
- * while `candidate-unreviewed` rows come from enrichment and must not be
- * presented as settled fact.
+ * Corpus-root and optional bundle destination accepted by
+ * {@link PracticeKgOptions.resolveBundleOut} — the schema-derived subset of
+ * {@link PracticeKgOptions} the resolver reads.
  *
  * @example
  * ```ts
- * import { PracticeKgEpistemicStatus } from "@beep/law-practice-server"
- * import * as S from "effect/Schema"
+ * import type { PracticeKgBundleOutInput } from "@beep/law-practice-server"
  *
- * const status = S.decodeUnknownSync(PracticeKgEpistemicStatus)("candidate-unreviewed")
- * console.log(status) // "candidate-unreviewed"
- * console.log(PracticeKgEpistemicStatus.Enum["derived-from-official-records"])
- * // "derived-from-official-records"
- * ```
- *
- * @category schemas
- * @since 0.0.0
- */
-export const PracticeKgEpistemicStatus = LiteralKit(["derived-from-official-records", "candidate-unreviewed"]).pipe(
-  $I.annoteSchema("PracticeKgEpistemicStatus", {
-    description: "Authority label distinguishing deterministic spine rows from candidate claims.",
-  })
-);
-
-/**
- * Runtime type for {@link PracticeKgEpistemicStatus}.
- *
- * @example
- * ```ts
- * import type { PracticeKgEpistemicStatus } from "@beep/law-practice-server"
- *
- * const isSettled = (status: PracticeKgEpistemicStatus): boolean =>
- *   status === "derived-from-official-records"
- *
- * console.log(isSettled("candidate-unreviewed")) // false
- * ```
- *
- * @category models
- * @since 0.0.0
- */
-export type PracticeKgEpistemicStatus = typeof PracticeKgEpistemicStatus.Type;
-
-/**
- * Closed provenance-reference kinds stored on graph projections.
- *
- * @remarks
- * The kind tells a reader how to interpret the accompanying `provenanceRef`: a
- * `catalog-digest` ref is a content digest, a `uspto-anchor` ref is an
- * application number, and so on. Widening this set means teaching every consumer
- * a new ref format.
- *
- * @example
- * ```ts
- * import { PracticeKgProvenanceKind } from "@beep/law-practice-server"
- * import * as S from "effect/Schema"
- *
- * const kind = S.decodeUnknownSync(PracticeKgProvenanceKind)("uspto-anchor")
- * console.log(kind) // "uspto-anchor"
- * console.log(PracticeKgProvenanceKind.Enum["extract-operation"]) // "extract-operation"
- * ```
- *
- * @category schemas
- * @since 0.0.0
- */
-export const PracticeKgProvenanceKind = LiteralKit([
-  "catalog-digest",
-  "uspto-anchor",
-  "organize-row",
-  "extract-operation",
-]).pipe(
-  $I.annoteSchema("PracticeKgProvenanceKind", {
-    description: "Stable source-reference kinds accepted by the practice knowledge graph.",
-  })
-);
-
-/**
- * Runtime type for {@link PracticeKgProvenanceKind}.
- *
- * @example
- * ```ts
- * import type { PracticeKgProvenanceKind } from "@beep/law-practice-server"
- *
- * const refLabel = (kind: PracticeKgProvenanceKind): string =>
- *   kind === "uspto-anchor" ? "application number" : "corpus reference"
- *
- * console.log(refLabel("uspto-anchor")) // "application number"
+ * const input: PracticeKgBundleOutInput = { corpusRoot: "/corpus" }
+ * console.log(input.bundleOut) // undefined — resolves under the corpus root
  * ```
  *
  * @category models
  * @since 0.0.0
  */
-export type PracticeKgProvenanceKind = typeof PracticeKgProvenanceKind.Type;
+export type PracticeKgBundleOutInput = Pick<PracticeKgOptions, "bundleOut" | "corpusRoot">;
 
 /**
  * One persisted `kg_node` row.
@@ -189,7 +153,9 @@ export class PracticeKgNodeRow extends S.Class<PracticeKgNodeRow>($I`PracticeKgN
   {
     client: S.optionalKey(S.String),
     docketFamily: S.optionalKey(S.String),
-    epistemicStatus: PracticeKgEpistemicStatus,
+    epistemicStatus: PracticeKgEpistemicStatus.pipe(
+      SchemaUtils.withConstantDefault<PracticeKgEpistemicStatus>("derived-from-official-records")
+    ),
     iri: S.NonEmptyString,
     kind: KgNodeKind,
     label: S.String,
@@ -232,7 +198,9 @@ export class PracticeKgNodeRow extends S.Class<PracticeKgNodeRow>($I`PracticeKgN
  */
 export class PracticeKgEdgeRow extends S.Class<PracticeKgEdgeRow>($I`PracticeKgEdgeRow`)(
   {
-    epistemicStatus: PracticeKgEpistemicStatus,
+    epistemicStatus: PracticeKgEpistemicStatus.pipe(
+      SchemaUtils.withConstantDefault<PracticeKgEpistemicStatus>("derived-from-official-records")
+    ),
     objectIri: S.NonEmptyString,
     predicate: KgEdgePredicate,
     provenanceKind: PracticeKgProvenanceKind,

--- a/packages/law-practice/server/src/PracticeKg.tool-handlers.ts
+++ b/packages/law-practice/server/src/PracticeKg.tool-handlers.ts
@@ -6,8 +6,10 @@
  */
 
 import { DuckDb } from "@beep/duckdb";
+import { PracticeKgEpistemicStatus } from "@beep/law-practice-domain/values";
 import {
   PracticeKgCandidateClaimsNotLoadedResult,
+  PracticeKgGraphToolRow,
   PracticeKgToolError,
   PracticeKgToolkit,
   PracticeKgToolResult,
@@ -28,16 +30,12 @@ import { PracticeKgBundle } from "./PracticeKg.host.ts";
 import { PracticeKgQueries } from "./PracticeKg.queries.ts";
 import {
   addPracticeKgCorpusPointers,
-  candidateClaimToolRecord,
   decodePracticeKgCandidateClaimRows,
   decodePracticeKgDocumentRows,
   decodePracticeKgEmailRows,
   decodePracticeKgFamilyRows,
   decodePracticeKgGraphRows,
-  documentToolRecord,
-  emailToolRecord,
-  familyToolRecord,
-  graphToolRecord,
+  toToolRecord,
 } from "./PracticeKg.rows.ts";
 import type { FieldTierSet } from "@beep/mcp-kit";
 import type { Layer } from "effect";
@@ -45,10 +43,13 @@ import type * as S from "effect/Schema";
 import type * as Tool from "effect/unstable/ai/Tool";
 import type * as SqlClient from "effect/unstable/sql/SqlClient";
 
-const spineStatus = "derived-from-official-records";
+const spineStatus = PracticeKgEpistemicStatus.Enum["derived-from-official-records"];
 const emailLinkageNote =
   "Matter linkage is archive-level confidence only; a matching message header is not message-level matter proof.";
 const tierOrder = A.reverse(FieldTierName.Options);
+
+const likePattern = (value: string | undefined): string | null =>
+  O.map(O.fromUndefinedOr(value), (fragment) => `%${fragment}%`).pipe(O.getOrNull);
 
 const projectRows = (
   rows: ReadonlyArray<Record<string, unknown>>,
@@ -56,37 +57,35 @@ const projectRows = (
   budgetBytes: number,
   bundleVersion: string,
   note?: string | undefined,
-  epistemicStatus = spineStatus
+  epistemicStatus: PracticeKgEpistemicStatus = spineStatus
 ): PracticeKgToolResult => {
-  for (const tier of tierOrder) {
-    const data = toColumnarEnvelope(A.map(rows, (row) => projectFieldTier(row, tier, tiers)));
-    if (estimateJsonSize(data) <= budgetBytes) {
-      return PracticeKgToolResult.make({
-        bundle_version: bundleVersion,
-        data,
-        epistemic_status: epistemicStatus,
-        ...OptionUtils.getSomesStruct({ note: O.fromUndefinedOr(note) }),
-        tier,
-        total: NonNegativeInt.make(A.length(rows)),
-        truncated: false,
-      });
-    }
-  }
-
-  const minimalRows = A.map(rows, (row) => projectFieldTier(row, "minimal", tiers));
-  const fitting = A.findFirst(
-    A.reverse(A.range(0, A.length(minimalRows))),
-    (count) => estimateJsonSize(toColumnarEnvelope(A.take(minimalRows, count))) <= budgetBytes
-  ).pipe(O.getOrElse(() => 0));
-  return PracticeKgToolResult.make({
+  const shared = {
     bundle_version: bundleVersion,
-    data: toColumnarEnvelope(A.take(minimalRows, fitting)),
     epistemic_status: epistemicStatus,
     ...OptionUtils.getSomesStruct({ note: O.fromUndefinedOr(note) }),
-    tier: "minimal",
     total: NonNegativeInt.make(A.length(rows)),
-    truncated: fitting < A.length(rows),
-  });
+  };
+  return A.findFirst(tierOrder, (tier) => {
+    const data = toColumnarEnvelope(A.map(rows, projectFieldTier(tier, tiers)));
+    return estimateJsonSize(data) <= budgetBytes ? O.some({ data, tier }) : O.none();
+  }).pipe(
+    O.match({
+      onNone: () => {
+        const minimalRows = A.map(rows, projectFieldTier("minimal", tiers));
+        const fitting = A.findFirst(
+          A.reverse(A.range(0, A.length(minimalRows))),
+          (count) => estimateJsonSize(toColumnarEnvelope(A.take(minimalRows, count))) <= budgetBytes
+        ).pipe(O.getOrElse(() => 0));
+        return PracticeKgToolResult.make({
+          ...shared,
+          data: toColumnarEnvelope(A.take(minimalRows, fitting)),
+          tier: "minimal",
+          truncated: fitting < A.length(rows),
+        });
+      },
+      onSome: ({ data, tier }) => PracticeKgToolResult.make({ ...shared, data, tier, truncated: false }),
+    })
+  );
 };
 
 const toolFailure =
@@ -137,7 +136,7 @@ export const PracticeKgToolkitHandlersLive: Layer.Layer<
         const rows = yield* queryPglite(sql, PracticeKgQueries.clients, [], decodePracticeKgGraphRows).pipe(
           Effect.mapError(toolFailure("kg_clients"))
         );
-        return projectRows(A.map(rows, graphToolRecord), practiceKgGraphFieldTiers, request.budgetBytes, version);
+        return projectRows(A.map(rows, toToolRecord), practiceKgGraphFieldTiers, request.budgetBytes, version);
       }),
       kg_docket_family: Effect.fn("PracticeKgTools.kg_docket_family")(function* (request) {
         const rows = yield* queryPglite(
@@ -146,7 +145,7 @@ export const PracticeKgToolkitHandlersLive: Layer.Layer<
           [request.family],
           decodePracticeKgFamilyRows
         ).pipe(Effect.mapError(toolFailure("kg_docket_family")));
-        return projectRows(A.map(rows, familyToolRecord), practiceKgFamilyFieldTiers, request.budgetBytes, version);
+        return projectRows(A.map(rows, toToolRecord), practiceKgFamilyFieldTiers, request.budgetBytes, version);
       }),
       kg_application_lookup: Effect.fn("PracticeKgTools.kg_application_lookup")(function* (request) {
         const rows = yield* queryPglite(
@@ -155,7 +154,7 @@ export const PracticeKgToolkitHandlersLive: Layer.Layer<
           [request.application_number ?? null, request.patent_number ?? null, request.docket ?? null],
           decodePracticeKgGraphRows
         ).pipe(Effect.mapError(toolFailure("kg_application_lookup")));
-        return projectRows(A.map(rows, graphToolRecord), practiceKgGraphFieldTiers, request.budgetBytes, version);
+        return projectRows(A.map(rows, toToolRecord), practiceKgGraphFieldTiers, request.budgetBytes, version);
       }),
       kg_find: Effect.fn("PracticeKgTools.kg_find")(function* (request) {
         const rows = yield* queryPglite(
@@ -164,7 +163,7 @@ export const PracticeKgToolkitHandlersLive: Layer.Layer<
           [`%${request.query}%`],
           decodePracticeKgGraphRows
         ).pipe(Effect.mapError(toolFailure("kg_find")));
-        return projectRows(A.map(rows, graphToolRecord), practiceKgGraphFieldTiers, request.budgetBytes, version);
+        return projectRows(A.map(rows, toToolRecord), practiceKgGraphFieldTiers, request.budgetBytes, version);
       }),
       corpus_search_text: Effect.fn("PracticeKgTools.corpus_search_text")(function* (request) {
         const rows = yield* duckdb
@@ -174,32 +173,35 @@ export const PracticeKgToolkitHandlersLive: Layer.Layer<
             Effect.map((rows) => addPracticeKgCorpusPointers(rows, bundle.corpusRoot, path)),
             Effect.mapError(toolFailure("corpus_search_text"))
           );
-        return projectRows(A.map(rows, documentToolRecord), practiceKgDocumentFieldTiers, request.budgetBytes, version);
+        return projectRows(A.map(rows, toToolRecord), practiceKgDocumentFieldTiers, request.budgetBytes, version);
       }),
       corpus_get_document: Effect.fn("PracticeKgTools.corpus_get_document")(function* (request) {
         const rows = yield* duckdb
           .query(PracticeKgQueries.getDocument, [
             request.digest ?? null,
             request.organized_path ?? null,
-            request.range?.start ?? 1,
-            request.range?.length ?? 2_097_152,
+            request.range.start,
+            request.range.length,
           ])
           .pipe(
             Effect.flatMap(decodePracticeKgDocumentRows),
             Effect.map((rows) => addPracticeKgCorpusPointers(rows, bundle.corpusRoot, path)),
             Effect.mapError(toolFailure("corpus_get_document"))
           );
-        return projectRows(A.map(rows, documentToolRecord), practiceKgDocumentFieldTiers, request.budgetBytes, version);
+        return projectRows(A.map(rows, toToolRecord), practiceKgDocumentFieldTiers, request.budgetBytes, version);
       }),
       email_search: Effect.fn("PracticeKgTools.email_search")(function* (request) {
-        const like = O.map(O.fromUndefinedOr(request.query), (query) => `%${query}%`).pipe(O.getOrNull);
-        const sender = O.map(O.fromUndefinedOr(request.sender), (value) => `%${value}%`).pipe(O.getOrNull);
-        const family = O.map(O.fromUndefinedOr(request.family), (value) => `%${value}%`).pipe(O.getOrNull);
         const rows = yield* duckdb
-          .query(PracticeKgQueries.email, [like, sender, request.after ?? null, request.before ?? null, family])
+          .query(PracticeKgQueries.email, [
+            likePattern(request.query),
+            likePattern(request.sender),
+            request.after ?? null,
+            request.before ?? null,
+            likePattern(request.family),
+          ])
           .pipe(Effect.flatMap(decodePracticeKgEmailRows), Effect.mapError(toolFailure("email_search")));
         return projectRows(
-          A.map(rows, emailToolRecord),
+          A.map(rows, toToolRecord),
           practiceKgEmailFieldTiers,
           request.budgetBytes,
           version,
@@ -224,7 +226,7 @@ export const PracticeKgToolkitHandlersLive: Layer.Layer<
             decodePracticeKgCandidateClaimRows
           );
           return projectRows(
-            A.map(rows, candidateClaimToolRecord),
+            A.map(rows, toToolRecord),
             practiceKgCandidateClaimFieldTiers,
             request.budgetBytes,
             version,
@@ -238,7 +240,7 @@ export const PracticeKgToolkitHandlersLive: Layer.Layer<
         function* (request) {
           const hasKey = request.iri !== undefined || request.natural_key !== undefined || request.digest !== undefined;
           if (!hasKey) {
-            const statusRow: Record<string, unknown> = {
+            const statusRow = PracticeKgGraphToolRow.make({
               client: null,
               count: bundle.manifest.counts.nodes,
               docketFamily: null,
@@ -249,8 +251,8 @@ export const PracticeKgToolkitHandlersLive: Layer.Layer<
               naturalKey: version,
               provenanceKind: "bundle-manifest",
               provenanceRef: bundle.bundleDir,
-            };
-            return projectRows([statusRow], practiceKgGraphFieldTiers, request.budgetBytes, version);
+            });
+            return projectRows([toToolRecord(statusRow)], practiceKgGraphFieldTiers, request.budgetBytes, version);
           }
           if (request.digest !== undefined) {
             const documents = yield* duckdb.query(PracticeKgQueries.provenanceDocument, [request.digest]).pipe(
@@ -258,7 +260,7 @@ export const PracticeKgToolkitHandlersLive: Layer.Layer<
               Effect.map((rows) => addPracticeKgCorpusPointers(rows, bundle.corpusRoot, path))
             );
             return projectRows(
-              A.map(documents, documentToolRecord),
+              A.map(documents, toToolRecord),
               practiceKgDocumentFieldTiers,
               request.budgetBytes,
               version
@@ -270,7 +272,7 @@ export const PracticeKgToolkitHandlersLive: Layer.Layer<
             [request.iri ?? null, request.natural_key ?? null, null],
             decodePracticeKgGraphRows
           );
-          return projectRows(A.map(rows, graphToolRecord), practiceKgGraphFieldTiers, request.budgetBytes, version);
+          return projectRows(A.map(rows, toToolRecord), practiceKgGraphFieldTiers, request.budgetBytes, version);
         },
         Effect.mapError(toolFailure("kg_provenance"))
       ),

--- a/packages/law-practice/server/src/PracticeKg.tool-handlers.ts
+++ b/packages/law-practice/server/src/PracticeKg.tool-handlers.ts
@@ -44,6 +44,7 @@ import type * as Tool from "effect/unstable/ai/Tool";
 import type * as SqlClient from "effect/unstable/sql/SqlClient";
 
 const spineStatus = PracticeKgEpistemicStatus.Enum["derived-from-official-records"];
+const candidateStatus = PracticeKgEpistemicStatus.Enum["candidate-unreviewed"];
 const emailLinkageNote =
   "Matter linkage is archive-level confidence only; a matching message header is not message-level matter proof.";
 const tierOrder = A.reverse(FieldTierName.Options);
@@ -160,7 +161,7 @@ export const PracticeKgToolkitHandlersLive: Layer.Layer<
         const rows = yield* queryPglite(
           sql,
           PracticeKgQueries.find,
-          [`%${request.query}%`],
+          [likePattern(request.query)],
           decodePracticeKgGraphRows
         ).pipe(Effect.mapError(toolFailure("kg_find")));
         return projectRows(A.map(rows, toToolRecord), practiceKgGraphFieldTiers, request.budgetBytes, version);
@@ -215,7 +216,7 @@ export const PracticeKgToolkitHandlersLive: Layer.Layer<
             return PracticeKgCandidateClaimsNotLoadedResult.make({
               available: false,
               bundle_version: version,
-              epistemic_status: "candidate-unreviewed",
+              epistemic_status: candidateStatus,
               reason: "claims batch not yet loaded",
             });
           }
@@ -231,7 +232,7 @@ export const PracticeKgToolkitHandlersLive: Layer.Layer<
             request.budgetBytes,
             version,
             undefined,
-            "candidate-unreviewed"
+            candidateStatus
           );
         },
         Effect.mapError(toolFailure("kg_candidate_claims"))

--- a/packages/law-practice/server/test/PracticeKg.projections.test.ts
+++ b/packages/law-practice/server/test/PracticeKg.projections.test.ts
@@ -21,7 +21,6 @@ import {
   PracticeKgToolResult,
 } from "@beep/law-practice-use-cases/server";
 import * as Pglite from "@beep/pglite";
-import { NonNegativeInt } from "@beep/schema";
 import { provideScopedLayer } from "@beep/test-utils";
 import { NodeServices } from "@effect/platform-node";
 import { describe, expect, it } from "@effect/vitest";
@@ -335,7 +334,6 @@ const graphOptions = (corpusRoot: string, bundleOut: string) =>
     bundleOut,
     corpusRoot,
     includeRefresh: false,
-    maxTextBytes: NonNegativeInt.make(2_097_152),
     overwrite: false,
     skipEmails: false,
   });
@@ -690,7 +688,6 @@ describe("practice KG projections", () => {
           bundleOut,
           corpusRoot,
           includeRefresh: false,
-          maxTextBytes: NonNegativeInt.make(2_097_152),
           overwrite: true,
           skipEmails: true,
         }),
@@ -708,7 +705,6 @@ describe("practice KG projections", () => {
           bundleOut: refreshBundleOut,
           corpusRoot,
           includeRefresh: true,
-          maxTextBytes: NonNegativeInt.make(2_097_152),
           overwrite: true,
           skipEmails: true,
         }),

--- a/packages/law-practice/server/test/PracticeKg.projections.test.ts
+++ b/packages/law-practice/server/test/PracticeKg.projections.test.ts
@@ -370,6 +370,43 @@ describe("practice KG projections", () => {
     );
   });
 
+  it("pins the schema-absorbed defaults to their contract values", () => {
+    const options = PracticeKgOptions.make({
+      corpusRoot: "/corpus",
+      includeRefresh: false,
+      overwrite: false,
+      skipEmails: true,
+    });
+    expect(options.maxTextBytes).toBe(2_097_152);
+    expect(options.bundleOut).toBeUndefined();
+    const decoded = S.decodeUnknownSync(PracticeKgOptions)({
+      corpusRoot: "/corpus",
+      includeRefresh: false,
+      overwrite: false,
+      skipEmails: true,
+    });
+    expect(decoded.maxTextBytes).toBe(2_097_152);
+    const spineRow = S.decodeUnknownSync(PracticeKgToolResult)({
+      bundle_version: "2026-07-27-01",
+      data: { columns: ["family"], rows: [["10008"]] },
+      epistemic_status: "derived-from-official-records",
+      tier: "minimal",
+      total: 1,
+      truncated: false,
+    });
+    expect(spineRow.epistemic_status).toBe("derived-from-official-records");
+    expect(() =>
+      S.decodeUnknownSync(PracticeKgToolResult)({
+        bundle_version: "2026-07-27-01",
+        data: { columns: [], rows: [] },
+        epistemic_status: "settled-fact",
+        tier: "minimal",
+        total: 0,
+        truncated: false,
+      })
+    ).toThrow();
+  });
+
   it.effect(
     "builds byte-identical ordered dumps with stable IRIs and complete provenance",
     Effect.fnUntraced(function* () {

--- a/packages/law-practice/use-cases/src/PracticeKg.tools.ts
+++ b/packages/law-practice/use-cases/src/PracticeKg.tools.ts
@@ -9,6 +9,7 @@
  */
 
 import { $LawPracticeUseCasesId } from "@beep/identity/packages";
+import { KgNodeKind, PracticeKgEpistemicStatus, PracticeKgProvenanceKind } from "@beep/law-practice-domain/values";
 import {
   annotateFourHints,
   ColumnarEnvelope,
@@ -22,6 +23,15 @@ import { Tool } from "effect/unstable/ai";
 
 const $I = $LawPracticeUseCasesId.create("PracticeKg.tools");
 const defaultBudgetBytes = PosInt.make(8000);
+
+/*
+ * Tool rows admit the persisted domain literals plus the synthetic members the
+ * bundle-status row uses when kg_provenance is called without an identity —
+ * "bundle" is not a kg_node kind and "bundle-manifest" is not a stored
+ * provenance kind, so the domain kits stay closed.
+ */
+const PracticeKgToolNodeKind = S.Union([KgNodeKind, S.Literal("bundle")]);
+const PracticeKgToolProvenanceKind = S.Union([PracticeKgProvenanceKind, S.Literal("bundle-manifest")]);
 
 const BudgetBytes = PosInt.pipe(SchemaUtils.withKeyDefaults(defaultBudgetBytes)).annotateKey({
   description: "Maximum serialized response size in bytes. Defaults to 8000.",
@@ -78,12 +88,15 @@ class DocumentRange extends S.Class<DocumentRange>($I`DocumentRange`)(
   $I.annote("DocumentRange", { description: "One-based text start and positive character length." })
 ) {}
 
+/* Whole-document read: start at 1 with a 2 MiB character budget. */
+const defaultDocumentRange = DocumentRange.make({ length: PosInt.make(2_097_152), start: PosInt.make(1) });
+
 class GetDocumentParams extends S.Class<GetDocumentParams>($I`GetDocumentParams`)(
   {
     budgetBytes: BudgetBytes,
     digest: S.optionalKey(S.NonEmptyString),
     organized_path: S.optionalKey(S.NonEmptyString),
-    range: S.optionalKey(DocumentRange),
+    range: DocumentRange.pipe(SchemaUtils.withKeyDefaults(defaultDocumentRange)),
   },
   $I.annote("GetDocumentParams", { description: "Document lookup by digest or organized corpus path." })
 ) {}
@@ -173,7 +186,7 @@ export class PracticeKgToolResult extends S.Class<PracticeKgToolResult>($I`Pract
   {
     bundle_version: S.NonEmptyString,
     data: ColumnarEnvelope,
-    epistemic_status: S.NonEmptyString,
+    epistemic_status: PracticeKgEpistemicStatus,
     note: S.optionalKey(S.String),
     tier: FieldTierName,
     total: NonNegativeInt,
@@ -281,12 +294,12 @@ export class PracticeKgGraphToolRow extends S.Class<PracticeKgGraphToolRow>($I`P
     client: S.NullOr(S.String),
     count: S.NullOr(S.Finite),
     docketFamily: S.NullOr(S.String),
-    epistemicStatus: S.String,
+    epistemicStatus: PracticeKgEpistemicStatus,
     iri: S.String,
-    kind: S.String,
+    kind: PracticeKgToolNodeKind,
     label: S.String,
     naturalKey: S.String,
-    provenanceKind: S.String,
+    provenanceKind: PracticeKgToolProvenanceKind,
     provenanceRef: S.String,
   },
   $I.annote("PracticeKgGraphToolRow", { description: "Decoded graph row exposed through practice KG tools." })
@@ -792,16 +805,3 @@ export const KgProvenanceTool = readTool(
   ProvenanceParams,
   PracticeKgToolResult
 );
-
-/**
- * Complete nine-tool read-only practice KG toolkit declaration.
- *
- * @example
- * ```ts
- * import { PracticeKgToolkit } from "@beep/law-practice-use-cases/server"
- * console.log(Object.keys(PracticeKgToolkit.tools).length) // 9
- * ```
- *
- * @category tools
- * @since 0.0.0
- */

--- a/standards/dual-arity.inventory.jsonc
+++ b/standards/dual-arity.inventory.jsonc
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedOn": "2026-07-29",
+  "generatedOn": "2026-07-30",
   "scope": ["apps/**/*.{ts,tsx}", "packages/**/*.{ts,tsx}", "infra/**/*.ts"],
   "enforcedRoots": [
     "packages/tooling/tool/cli/src/commands/Laws/DualArity.ts",


### PR DESCRIPTION
## Summary

Quality pass over the practice-kg-mcp packet surface before the Tom-handoff artifact re-stage: a `/crispen full` refactor followed by a 10-role read-only reviewer panel (26 findings, zero blocking; cheap polish applied, backlog recorded in `goals/practice-kg-mcp/history/p4/`).

- **Literal-domain restoration**: `PracticeKgEpistemicStatus` / `PracticeKgProvenanceKind` move to `law-practice/domain` values; tool rows drop `S.String` widening for real domains, with the two synthetic bundle-status members admitted via a named union; the `kg_provenance` status row is now schema-constructed.
- **Schema defaults absorbed**: `maxTextBytes` (PosInt, 2 MiB key default — replaces a runtime `<= 0` guard), `corpus_get_document` range, node/edge `epistemicStatus` constructor default (spine-writers-only invariant recorded inline), dual `resolveBundleOut` static.
- **Helper walls deleted**: `nullable()`, five byte-identical record mappers → `toToolRecord`, imperative tier loop → `A.findFirst` fold, claims double-scans → `A.partition`, DDL split-on-`";"` → statement array, structural `GraphTextSourceSpec` bypass, `.mcpb` manifest via `JSON.stringify` with compile-time tool-description coverage.

## Freeze proofs

- Wire shape: regression suite green with fixtures untouched; schema-absorbed defaults now pinned by test.
- Persisted shape: live stdio probe against the staged real bundle answered `kg_provenance` / `kg_clients` / `kg_docket_family` / `corpus_search_text` / `kg_candidate_claims` / `email_search` with identical shapes, labels, tiers, and the linkage note; `bundle_version` untouched — the shipped 397 MB data bundle needs no rebuild.

## Verification

- `bun run beep yeet repair` + `verify`: outcome success, all lanes passed.
- Full local `bun run beep lint policy` green (docgen, schema-first, dual-arity, coverage, governance).
- law-practice server vitest suite + tsgo checks green on domain/use-cases/server/app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Claude-Session: https://claude.ai/code/session_01RKk1iM7CUaABjjK3EGi4qb

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/503"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787976030&installation_model_id=424656&pr_number=503&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F503&signature=12597aa2c850c249720d04df49b6917544b0f0ac1d511ed389a11087bce7fef8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->