### PR TITLE
fix(practice-kg-mcp): track the DuckDB win32 bindings bump in the MCPB pin

### DIFF
--- a/.changeset/practice-kg-duckdb-pin.md
+++ b/.changeset/practice-kg-duckdb-pin.md
@@ -1,0 +1,5 @@
+---
+{}
+---
+
+No release: track the DuckDB win32 bindings bump (1.5.5-r.2) in the MCPB packaging pin.

--- a/apps/practice-kg-mcp/src/package.ts
+++ b/apps/practice-kg-mcp/src/package.ts
@@ -24,15 +24,15 @@ import { Command, Flag } from "effect/unstable/cli";
 
 const $I = $PracticeKgMcpId.create("package");
 
-const DuckDbVersion = "1.5.5-r.1";
+const DuckDbVersion = "1.5.5-r.2";
 /*
  * sha512 integrity for the win32 bindings tarball, copied from bun.lock's
- * entry for @duckdb/node-bindings-win32-x64@1.5.5-r.1. The download is
+ * entry for @duckdb/node-bindings-win32-x64@1.5.5-r.2. The download is
  * verified against this pin before anything is extracted into a
  * user-installed artifact; a DuckDB catalog bump must update both constants.
  */
 const WindowsBindingsSha512 =
-  "7KAdShoWQz7YXKvUneIu9ujxIVCSSA6pJ5QSZBDkNUCW+7RBLV/aH2Uy3K0Vl04reaFedaS3aewfstX2SQS5XQ==";
+  "r5V6Q0zcv5HSHGDXsd6M+t3jakhm6S11TNH5vydKGeq8JBWj4v3ZTof/mF3R8Rly+90Z205KoI9ujblg/jN04g==";
 const WindowsBindingsUrl = `https://registry.npmjs.org/@duckdb/node-bindings-win32-x64/-/node-bindings-win32-x64-${DuckDbVersion}.tgz`;
 class BindingsManifest extends S.Class<BindingsManifest>($I`BindingsManifest`)(
   { version: S.String },


### PR DESCRIPTION
## Summary

#494 bumped `@duckdb` bindings to `1.5.5-r.2`; the windows MCPB packaging pin still verified the `r.1` tarball digest, so `package:mcpb --target windows-x64` fail-closed exactly as designed. This updates `DuckDbVersion` + `WindowsBindingsSha512` together from `bun.lock`.

## Verification

- `bun run src/package.ts --target windows-x64` — sha512 gate passes, archive gate clean.
- `bun run smoke:compiled` — COMPILED_SMOKE_OK, 9 tools listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Claude-Session: https://claude.ai/code/session_01RKk1iM7CUaABjjK3EGi4qb

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787976867&installation_model_id=424656&pr_number=505&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F505&signature=8d1e8557a14646378a4d20ceb496bbaa26222157ca28427a0b862e368ba0d592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->