### PR TITLE
fix(openclaw): run privileged applicator scripts on a trusted toolchain

### DIFF
--- a/.changeset/openclaw-stage-trusted-toolchain.md
+++ b/.changeset/openclaw-stage-trusted-toolchain.md
@@ -1,0 +1,20 @@
+---
+"@beep/infra": patch
+---
+
+Close two local privilege-escalation paths in the OpenClaw workstation applicator.
+
+The rendered privileged scripts ran through `/bin/bash -lc`. A login shell sources the
+user-writable `~/.bash_profile` before the first rendered line, so an unprivileged user could
+define a `sudo` shell function, or prepend a `PATH` entry, and intercept every `sudo -n` call
+while the operator's armed ticket was live. Scripts now render as
+`/bin/bash --noprofile --norc -p -c`, pin `PATH=/usr/bin:/bin` before any privileged call, invoke
+`/usr/bin/sudo` absolutely, and assert `sudo` is the real setuid binary rather than trusting a
+name lookup.
+
+Separately, staging prepended `nodeBinDir` to `PATH` for a privileged bare `npm install`, and the
+default pointed at a per-user mise directory, so a local user who could write there executed code
+as root during `pulumi up`. Staging now resolves the directory, `node`, and `npm` with
+`readlink -f`, requires every path component up to `/` to be uid 0 and not group- or
+world-writable, invokes the resolved absolute `npm`, and defaults to the root-owned
+`/opt/beep/openclaw/node/bin`.

--- a/.cspell/tech-terms.txt
+++ b/.cspell/tech-terms.txt
@@ -194,6 +194,8 @@ nocollapse
 nocompile
 nodir
 noembed
+noprofile
+norc
 noframes
 nohref
 nohup

--- a/goals/openclaw-workstation-agent/ops/handoffs/p2-slice-proof-runbook.md
+++ b/goals/openclaw-workstation-agent/ops/handoffs/p2-slice-proof-runbook.md
@@ -22,6 +22,46 @@ raw output).
 4. For the backup leg: Tailscale up, `dankserver` reachable over SSH with
    the local agent (`SSH_AUTH_SOCK`), and an `op://` ref for the backup
    passphrase resolvable via `op read`.
+5. A root-owned Node toolchain provisioned at `nodeBinDir` — see below.
+
+### Provision the root-owned Node toolchain
+
+Staging runs `npm install` as **root**. If the Node toolchain were writable by
+the workstation user, any user-level compromise could replace `npm` or `node`
+and execute arbitrary code as root during `pulumi up`. The stage script
+therefore resolves `nodeBinDir`, `node`, and `npm` with `readlink -f` and
+requires every path component up to `/` to be uid 0 and not group- or
+world-writable, failing closed with `STAGE-FAIL` (exit 73) otherwise.
+
+A per-user mise/nvm install can never satisfy this. Install the pinned Node
+tarball into the root-owned trusted tree instead (copy, never symlink — the
+guard resolves symlinks physically, so a link into `$HOME` still fails):
+
+```sh
+node_version=24.16.0   # must equal OPENCLAW_COMPATIBILITY_SET.nodeVersion
+tmp="$(mktemp -d)"
+curl -fsSL "https://nodejs.org/dist/v${node_version}/node-v${node_version}-linux-x64.tar.xz" \
+  -o "${tmp}/node.tar.xz"
+# Verify against the published SHASUMS256.txt before installing.
+sudo -n install -d -o root -g root -m 0755 /opt/beep /opt/beep/openclaw
+sudo -n tar -xJf "${tmp}/node.tar.xz" -C /opt/beep/openclaw
+sudo -n mv /opt/beep/openclaw/"node-v${node_version}-linux-x64" /opt/beep/openclaw/node
+sudo -n chown -R root:root /opt/beep/openclaw/node
+sudo -n chmod -R go-w /opt/beep/openclaw/node
+rm -rf "${tmp}"
+```
+
+Confirm the guard's own predicate before running `pulumi up`; every line must
+print `0` for owner and a mode with no group/other write bit:
+
+```sh
+for p in /opt /opt/beep /opt/beep/openclaw /opt/beep/openclaw/node \
+         /opt/beep/openclaw/node/bin /opt/beep/openclaw/node/bin/node \
+         /opt/beep/openclaw/node/bin/npm; do
+  stat -c '%n uid=%u mode=%a' "$p"
+done
+/opt/beep/openclaw/node/bin/node --version   # must equal the pinned version
+```
 
 ## 1. Stack init + config (one-time)
 
@@ -41,7 +81,9 @@ pulumi config set openclaw:gatewayAuthTokenRef "op://<vault>/<item>/<field>"
 pulumi config set openclaw:resolverCommandPath  "<abs op-resolver script>"
 pulumi config set openclaw:resolverOpBinaryPath "$(command -v op)"
 pulumi config set openclaw:resolverTrustedDir   "<abs trusted dir>"
-pulumi config set openclaw:nodeBinDir "$HOME/.local/share/mise/installs/node/24/bin"
+# nodeBinDir defaults to /opt/beep/openclaw/node/bin and must stay root-owned; see
+# "Provision the root-owned Node toolchain" below. Never point it at a mise/nvm path
+# under $HOME — staging runs npm as root and fails closed on a user-writable toolchain.
 # Paths (defaults: configRoot /etc/beep/openclaw, unitName openclaw.service)
 # Backup leg (optional now, required for the drill):
 pulumi config set openclaw:backupSshHost dankserver

--- a/goals/openclaw-workstation-agent/ops/handoffs/p3-live-agent-runbook.md
+++ b/goals/openclaw-workstation-agent/ops/handoffs/p3-live-agent-runbook.md
@@ -14,7 +14,12 @@ provider, Telegram, 1Password, or workstation mutation. Evidence goes under
 2. Require an unlocked 1Password desktop, successful `op whoami`, the hosted
    provider account, the selected loopback OpenAI-compatible server, a
    Telegram bot, and the intended owner present.
-3. Hard stop if any command, Pulumi value/state, tracked file, or evidence
+3. Provision the root-owned Node toolchain at `/opt/beep/openclaw/node/bin`
+   per the P2 runbook's "Provision the root-owned Node toolchain" section.
+   Staging runs `npm install` as root and fails closed with `STAGE-FAIL`
+   (exit 73) on a user-writable toolchain, so a mise/nvm path under `$HOME`
+   cannot be used.
+4. Hard stop if any command, Pulumi value/state, tracked file, or evidence
    would contain raw secrets or real client identities, documents, facts, or
    data. Only synthetic prompts and nonces are permitted.
 
@@ -57,7 +62,7 @@ pulumi config set openclaw:expectedHome       "$HOME"
 pulumi config set openclaw:expectedRuntimeDir "/run/user/$(id -u)"
 pulumi config set openclaw:configRoot /etc/beep/openclaw
 pulumi config set openclaw:stateDir /var/lib/beep/openclaw
-pulumi config set openclaw:nodeBinDir "$HOME/.local/share/mise/installs/node/24/bin"
+pulumi config set openclaw:nodeBinDir /opt/beep/openclaw/node/bin
 pulumi config set openclaw:resolverCommandPath /opt/beep/openclaw/op-resolver.sh
 pulumi config set openclaw:resolverOpBinaryPath /opt/beep/openclaw/bin/op
 pulumi config set openclaw:resolverTrustedDir /opt/beep/openclaw

--- a/infra/src/OpenClaw.ts
+++ b/infra/src/OpenClaw.ts
@@ -76,7 +76,10 @@ const defaultConfigRoot = "/etc/beep/openclaw";
 const defaultGatewayAuthTokenRef = "op://beep-openclaw/gateway/token";
 const defaultGatewayPort = 19_031;
 const defaultLogFilePath = "/var/lib/beep/openclaw/log/openclaw.log";
-const defaultNodeBinDir = "/home/elpresidank/.local/share/mise/installs/node/24/bin";
+// The staging step runs `npm install` as root, so the Node toolchain is part of the trust
+// boundary: it lives beside the resolver under the root-owned `/opt/beep/openclaw` tree rather
+// than in a user-writable per-user runtime manager directory.
+const defaultNodeBinDir = "/opt/beep/openclaw/node/bin";
 const defaultResolverCommandPath = "/opt/beep/openclaw/op-resolver.sh";
 const defaultResolverOpBinaryPath = "/opt/beep/openclaw/bin/op";
 const defaultResolverTrustedDir = "/opt/beep/openclaw";
@@ -198,7 +201,13 @@ const requiredConfigValue = <Value>(key: string, value: Value | undefined): Valu
 
 const shellQuote = (value: string): string => `'${pipe(value, Str.replace(/'/gu, `'"'"'`))}'`;
 
-const bashScript = (lines: ReadonlyArray<string>): string => `/bin/bash -lc ${shellQuote(A.join(lines, "\n"))}`;
+// Never a login shell. `-l` sources /etc/profile and the user-writable ~/.bash_profile before the
+// first rendered line runs, so an unprivileged user could define a `sudo` shell function (or
+// prepend a PATH entry) and intercept every privileged command while the operator's ticket is
+// live. `--noprofile --norc` drops the startup files and `-p` refuses functions exported through
+// the environment, which is the only other way to inject one.
+const bashScript = (lines: ReadonlyArray<string>): string =>
+  `/bin/bash --noprofile --norc -p -c ${shellQuote(A.join(lines, "\n"))}`;
 
 const heredocLines = (input: {
   readonly content: string;
@@ -884,8 +893,14 @@ const stagedOpenclawBinary = (generation: OpenClawGeneration): string =>
 
 const healthUrl = (generation: OpenClawGeneration): string => `http://127.0.0.1:${generation.gatewayPort}/health`;
 
+// Pinned before anything else runs: the Pulumi process inherits the operator's PATH, which on a
+// developer workstation routinely leads with user-writable runtime-manager directories. Scripts
+// that need the pinned Node toolchain export their own PATH after this line.
+const trustedBasePath = "export PATH=/usr/bin:/bin";
+
 const scriptPreamble = (generation: OpenClawGeneration): ReadonlyArray<string> => [
   "set -euo pipefail",
+  trustedBasePath,
   `export XDG_RUNTIME_DIR=${shellQuote(generation.runtimeDir)}`,
   `export DBUS_SESSION_BUS_ADDRESS=${shellQuote(`unix:path=${generation.runtimeDir}/bus`)}`,
 ];
@@ -1361,9 +1376,13 @@ export const renderOpenClawPreflightScript = ({
     ...scriptPreamble(generation),
     "fail() { printf 'PREFLIGHT-FAIL: %s\\n' \"$1\" >&2; exit 78; }",
     ...A.map(
-      ["curl", "install", "loginctl", "sha256sum", "sqlite3", "sudo", "systemctl"],
+      ["curl", "install", "loginctl", "sha256sum", "sqlite3", "systemctl"],
       (binary) => `command -v ${binary} >/dev/null || fail ${shellQuote(`${binary} is not installed on the target`)}`
     ),
+    // `sudo` is asserted as the real setuid-root binary at its absolute path rather than by name:
+    // a name lookup is satisfied by any shim earlier on PATH, which is precisely what the
+    // privileged scripts must never call.
+    "[ -u /usr/bin/sudo ] || fail '/usr/bin/sudo is missing or not setuid root'",
     ...A.flatMap(identityChecks(identity), identityAssertionLines),
     `linger="$(loginctl show-user ${shellQuote(identity.username)} -p Linger --value || printf '')"`,
     `[ "\${linger}" = yes ] || fail "linger not enabled for ${identity.username} (Linger=\${linger})"`,
@@ -1386,11 +1405,54 @@ export const renderOpenClawPreflightScript = ({
       unixSocketPathLimit
     )}-byte UNIX socket cap: \${candidate}"`,
     "done",
-    `sudo -n -v 2>/dev/null || fail ${shellQuote(
+    `/usr/bin/sudo -n -v 2>/dev/null || fail ${shellQuote(
       "no armed sudo ticket; re-run pulumi up inside an armed pty (ops/handoffs/sudo-session.sh) so privileged steps stay non-interactive"
     )}`,
     `printf 'PREFLIGHT-OK generation=${generation.generationId} machine=%s host=%s uid=%s home=%s runtime=%s linger=%s units_load=%s manager=%s\\n' "\${actual_expected_machine_id}" "\${actual_expected_hostname}" "\${actual_expected_uid}" "\${actual_expected_home}" "\${XDG_RUNTIME_DIR}" "\${linger}" "\${units_load_timestamp}" "\${manager_state}"`,
   ]);
+
+/**
+ * Guard lines proving the Node toolchain the privileged staging step executes is root-owned.
+ *
+ * Staging runs `npm install` under `sudo`, so every path that decides which `npm` and `node`
+ * actually execute is inside the root trust boundary. Each candidate is fully resolved with
+ * `readlink -f` (which collapses every symlink component) and then walked to `/`, requiring each
+ * component to be uid 0 and not group- or world-writable. `--ignore-scripts` is no defense when
+ * the package manager binary itself is writable, and the pinned `npm` is commonly a wrapper that
+ * execs a sibling `node`, so the directory and both binaries are proven, not just `npm`.
+ */
+const trustedToolchainLines = (generation: OpenClawGeneration): ReadonlyArray<string> => [
+  "fail() { printf 'STAGE-FAIL: %s\\n' \"$1\" >&2; exit 73; }",
+  "assert_trusted_path() {",
+  '  probe="$1"',
+  '  label="$2"',
+  "  while :; do",
+  '    metadata="$(/usr/bin/stat -c \'%u %a\' "${probe}")" || fail "cannot inspect ${label}: ${probe}"',
+  '    owner="${metadata%% *}"',
+  '    mode="${metadata##* }"',
+  '    [ "${owner}" = 0 ] || fail "${label} is not root-owned: ${probe}"',
+  // Both operands are written `8#` explicitly: a bare `022` is octal in bash but decimal in some
+  // other shells, and this comparison decides whether root executes an attacker-writable binary.
+  '    [ "$(( 8#${mode} & 8#22 ))" -eq 0 ] || fail "${label} is group- or world-writable: ${probe}"',
+  '    if [ "${probe}" = / ]; then break; fi',
+  '    probe="$(/usr/bin/dirname "${probe}")"',
+  "  done",
+  "}",
+  `node_dir="$(/usr/bin/readlink -f ${shellQuote(
+    generation.nodeBinDir
+  )})" || fail 'cannot resolve the pinned node bin dir'`,
+  `node_bin="$(/usr/bin/readlink -f ${shellQuote(
+    `${generation.nodeBinDir}/node`
+  )})" || fail 'cannot resolve the pinned node binary'`,
+  `npm_bin="$(/usr/bin/readlink -f ${shellQuote(
+    `${generation.nodeBinDir}/npm`
+  )})" || fail 'cannot resolve the pinned npm binary'`,
+  "[ -x \"${node_bin}\" ] || fail 'the pinned node binary is not executable'",
+  "[ -x \"${npm_bin}\" ] || fail 'the pinned npm binary is not executable'",
+  "assert_trusted_path \"${node_dir}\" 'pinned node bin dir'",
+  "assert_trusted_path \"${node_bin}\" 'pinned node binary'",
+  "assert_trusted_path \"${npm_bin}\" 'pinned npm binary'",
+];
 
 /**
  * Render the staging script that materializes a generation tree.
@@ -1446,13 +1508,14 @@ export const renderOpenClawStageScript = (generation: OpenClawGeneration): strin
 
   return bashScript([
     ...scriptPreamble(generation),
+    ...trustedToolchainLines(generation),
     `[ ! -L ${shellQuote(generation.configRoot)} ] || { printf 'STAGE-FAIL: symlink parent %s\\n' ${shellQuote(
       generation.configRoot
     )} >&2; exit 73; }`,
-    `sudo -n install -d -o root -g root -m 0755 ${shellQuote(generation.configRoot)}`,
+    `/usr/bin/sudo -n install -d -o root -g root -m 0755 ${shellQuote(generation.configRoot)}`,
     ...heredocLines({
       content: "beep-openclaw\n",
-      install: "sudo -n install -o root -g root -m 0644",
+      install: "/usr/bin/sudo -n install -o root -g root -m 0644",
       path: `${generation.configRoot}/.beep-openclaw`,
       sentinel: "BEEP_OPENCLAW_MARKER",
     }),
@@ -1469,10 +1532,10 @@ export const renderOpenClawStageScript = (generation: OpenClawGeneration): strin
       ),
       " "
     )}; do [ ! -L "\${parent}" ] || { printf 'STAGE-FAIL: symlink parent %s\\n' "\${parent}" >&2; exit 73; }; done`,
-    `sudo -n install -d -o root -g root -m 0755 ${shellQuote(generationDir(generation))}`,
-    `sudo -n install -d -o root -g root -m 0755 ${shellQuote(`${generationDir(generation)}/workspace`)}`,
-    `sudo -n install -d -o root -g root -m 0755 ${shellQuote(`${generationDir(generation)}/workspace/skills`)}`,
-    `sudo -n install -d -o root -g root -m 0755 ${shellQuote(
+    `/usr/bin/sudo -n install -d -o root -g root -m 0755 ${shellQuote(generationDir(generation))}`,
+    `/usr/bin/sudo -n install -d -o root -g root -m 0755 ${shellQuote(`${generationDir(generation)}/workspace`)}`,
+    `/usr/bin/sudo -n install -d -o root -g root -m 0755 ${shellQuote(`${generationDir(generation)}/workspace/skills`)}`,
+    `/usr/bin/sudo -n install -d -o root -g root -m 0755 ${shellQuote(
       `${generationDir(generation)}/workspace/skills/${proofSkillName}`
     )}`,
     ...A.flatten(
@@ -1481,7 +1544,7 @@ export const renderOpenClawStageScript = (generation: OpenClawGeneration): strin
           O.map(R.get(tree, relativePath), (file) =>
             heredocLines({
               content: file.content,
-              install: `sudo -n install -o root -g root -m ${file.mode}`,
+              install: `/usr/bin/sudo -n install -o root -g root -m ${file.mode}`,
               path: `${generationDir(generation)}/${relativePath}`,
               sentinel,
             })
@@ -1489,10 +1552,12 @@ export const renderOpenClawStageScript = (generation: OpenClawGeneration): strin
         )
       )
     ),
-    `sudo -n env PATH=${shellQuote(`${generation.nodeBinDir}:/usr/bin:/bin`)} npm install --prefix ${shellQuote(
+    `/usr/bin/sudo -n env PATH=${shellQuote(
+      `${generation.nodeBinDir}:/usr/bin:/bin`
+    )} "\${npm_bin}" install --prefix ${shellQuote(
       generationDir(generation)
     )} --no-audit --no-fund --ignore-scripts ${shellQuote(`openclaw@${generation.openclawVersion}`)} >/dev/null`,
-    `staged_version="$(sudo -n cat ${shellQuote(
+    `staged_version="$(/usr/bin/sudo -n cat ${shellQuote(
       `${generationDir(generation)}/node_modules/openclaw/package.json`
     )} | sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\\([^"]*\\)".*/\\1/p' | head -n 1)"`,
     `[ "\${staged_version}" = ${shellQuote(generation.openclawVersion)} ] || { printf 'STAGE-FAIL: staged openclaw %s does not match the pinned %s\\n' "\${staged_version}" ${shellQuote(
@@ -1584,28 +1649,28 @@ export const renderOpenClawApplyScript = (generation: OpenClawGeneration): strin
     '  printf \'APPLY-ROLLBACK: restoring snapshot %s and prior pointer %s\\n\' "${snapshot}" "${prior_pointer}" >&2',
     '  systemctl --user stop "${unit}" || true',
     '  if [ -d "${snapshot}" ]; then',
-    '    sudo -n rm -rf -- "${state_dir}"',
-    '    sudo -n cp -a -- "${snapshot}" "${state_dir}"',
+    '    /usr/bin/sudo -n rm -rf -- "${state_dir}"',
+    '    /usr/bin/sudo -n cp -a -- "${snapshot}" "${state_dir}"',
     "  fi",
     '  if [ -n "${prior_pointer}" ]; then',
-    '    sudo -n ln -s -- "${prior_pointer}" "${pointer}.rollback.$$"',
-    '    sudo -n mv -T -- "${pointer}.rollback.$$" "${pointer}"',
+    '    /usr/bin/sudo -n ln -s -- "${prior_pointer}" "${pointer}.rollback.$$"',
+    '    /usr/bin/sudo -n mv -T -- "${pointer}.rollback.$$" "${pointer}"',
     "  fi",
     "  systemctl --user daemon-reload || true",
     '  systemctl --user start "${unit}" || true',
     "}",
     'systemctl --user stop "${unit}" || true',
-    `sudo -n install -d -o root -g root -m 0700 ${shellQuote(`${generation.configRoot}/${snapshotsDirName}`)}`,
-    'sudo -n rm -rf -- "${snapshot}"',
+    `/usr/bin/sudo -n install -d -o root -g root -m 0700 ${shellQuote(`${generation.configRoot}/${snapshotsDirName}`)}`,
+    '/usr/bin/sudo -n rm -rf -- "${snapshot}"',
     'if [ -d "${state_dir}" ]; then',
-    '  sudo -n cp -a -- "${state_dir}" "${snapshot}"',
+    '  /usr/bin/sudo -n cp -a -- "${state_dir}" "${snapshot}"',
     "else",
-    '  sudo -n install -d -o root -g root -m 0700 "${snapshot}"',
+    '  /usr/bin/sudo -n install -d -o root -g root -m 0700 "${snapshot}"',
     "fi",
     'printf \'APPLY-SNAPSHOT: %s -> %s (stopped state, includes SQLite WAL sidecars)\\n\' "${state_dir}" "${snapshot}"',
-    'printf \'%s\\n\' "${prior_pointer}" | sudo -n install -o root -g root -m 0644 /dev/stdin "${previous_pointer_file}"',
-    `sudo -n ln -s -- ${shellQuote(generation.generationId)} "\${pointer}.tmp.$$"`,
-    'sudo -n mv -T -- "${pointer}.tmp.$$" "${pointer}"',
+    'printf \'%s\\n\' "${prior_pointer}" | /usr/bin/sudo -n install -o root -g root -m 0644 /dev/stdin "${previous_pointer_file}"',
+    `/usr/bin/sudo -n ln -s -- ${shellQuote(generation.generationId)} "\${pointer}.tmp.$$"`,
+    '/usr/bin/sudo -n mv -T -- "${pointer}.tmp.$$" "${pointer}"',
     'printf \'APPLY-POINTER: current -> %s\\n\' "$(readlink "${pointer}")"',
     "systemctl --user daemon-reload",
     'if ! systemctl --user start "${unit}"; then',
@@ -1630,8 +1695,8 @@ export const renderOpenClawApplyScript = (generation: OpenClawGeneration): strin
     )}s; snapshot and prior pointer restored\\n' >&2`,
     "  exit 70",
     "fi",
-    'printf \'%s\\n\' "$(state_user_version)" | sudo -n install -o root -g root -m 0644 /dev/stdin "${recorded_stamp}"',
-    `printf '%s\\n' ${shellQuote(generation.generationId)} | sudo -n install -o root -g root -m 0644 /dev/stdin ${shellQuote(
+    'printf \'%s\\n\' "$(state_user_version)" | /usr/bin/sudo -n install -o root -g root -m 0644 /dev/stdin "${recorded_stamp}"',
+    `printf '%s\\n' ${shellQuote(generation.generationId)} | /usr/bin/sudo -n install -o root -g root -m 0644 /dev/stdin ${shellQuote(
       `${generationDir(generation)}/.beep-openclaw-committed`
     )}`,
     `printf 'APPLY-OK generation=${generation.generationId} pointer=%s user_version=%s\\n' "$(readlink "\${pointer}")" "$(state_user_version)"`,
@@ -1688,11 +1753,11 @@ export const renderOpenClawRollbackScript = (generation: OpenClawGeneration): st
     'previous_pointer="$(tr -d \'[:space:]\' < "${previous_pointer_file}")"',
     "[ -n \"${previous_pointer}\" ] || { printf 'ROLLBACK-FAIL: recorded previous pointer is empty\\n' >&2; exit 66; }",
     'systemctl --user stop "${unit}" || true',
-    'sudo -n rm -rf -- "${state_dir}"',
-    'sudo -n cp -a -- "${snapshot}" "${state_dir}"',
+    '/usr/bin/sudo -n rm -rf -- "${state_dir}"',
+    '/usr/bin/sudo -n cp -a -- "${snapshot}" "${state_dir}"',
     'printf \'ROLLBACK-RESTORE: %s -> %s\\n\' "${snapshot}" "${state_dir}"',
-    'sudo -n ln -s -- "${previous_pointer}" "${pointer}.rollback.$$"',
-    'sudo -n mv -T -- "${pointer}.rollback.$$" "${pointer}"',
+    '/usr/bin/sudo -n ln -s -- "${previous_pointer}" "${pointer}.rollback.$$"',
+    '/usr/bin/sudo -n mv -T -- "${pointer}.rollback.$$" "${pointer}"',
     "systemctl --user daemon-reload",
     'systemctl --user start "${unit}"',
     "healthy=0",
@@ -1834,7 +1899,13 @@ export const renderOpenClawDriftAuditScript = (input: {
   readonly generation: OpenClawGeneration;
   readonly identity: OpenClawExpectedIdentity;
 }): string =>
-  bashScript(["set -uo pipefail", ...expectedUnitTextLines(input.generation), ...driftAuditLines(input), "exit 0"]);
+  bashScript([
+    "set -uo pipefail",
+    trustedBasePath,
+    ...expectedUnitTextLines(input.generation),
+    ...driftAuditLines(input),
+    "exit 0",
+  ]);
 
 /**
  * Render the acceptance probe script run after a successful apply.
@@ -1888,6 +1959,7 @@ export const renderOpenClawProbeScript = (input: {
 
   return bashScript([
     "set -uo pipefail",
+    trustedBasePath,
     `export XDG_RUNTIME_DIR=${shellQuote(generation.runtimeDir)}`,
     `export DBUS_SESSION_BUS_ADDRESS=${shellQuote(`unix:path=${generation.runtimeDir}/bus`)}`,
     ...expectedUnitTextLines(generation),
@@ -2062,6 +2134,7 @@ export const renderOpenClawBackupShipScript = ({
 
   return bashScript([
     "set -euo pipefail",
+    trustedBasePath,
     ...A.fromOption(O.map(backup.agentSocketPath, (socketPath) => `export SSH_AUTH_SOCK=${shellQuote(socketPath)}`)),
     `[ -n "\${${backupPassphraseEnvVar}:-}" ] || { printf 'BACKUP-FAIL: ${backupPassphraseEnvVar} is unset; resolve %s out of band before running pulumi up\\n' ${shellQuote(
       backup.passphraseSecretRef
@@ -2069,7 +2142,7 @@ export const renderOpenClawBackupShipScript = ({
     'work="$(mktemp -d)"',
     "trap 'rm -rf -- \"${work}\"' EXIT",
     `archive="\${work}/openclaw-${generation.generationId}-$(date -u +%Y%m%dT%H%M%SZ).tar"`,
-    `sudo -n tar -cf "\${archive}" -C ${shellQuote(generation.configRoot)} ${shellQuote(
+    `/usr/bin/sudo -n tar -cf "\${archive}" -C ${shellQuote(generation.configRoot)} ${shellQuote(
       `${snapshotsDirName}/${generation.generationId}`
     )}`,
     `printf '%s' "\${${backupPassphraseEnvVar}}" | gpg --batch --yes --symmetric --cipher-algo AES256 --pinentry-mode loopback --passphrase-fd 0 --output "\${archive}.gpg" "\${archive}"`,

--- a/infra/test/OpenClaw.test.ts
+++ b/infra/test/OpenClaw.test.ts
@@ -96,11 +96,13 @@ const parseDocument = (json: string): { readonly [key: string]: unknown } =>
   );
 
 /**
- * Unwrap a rendered `/bin/bash -lc '<body>'` command back into the body the
+ * Unwrap a rendered `/bin/bash --noprofile --norc -p -c '<body>'` command back into the body the
  * shell actually executes, so assertions read as the script an operator sees.
  */
+const scriptWrapperPrefix = "/bin/bash --noprofile --norc -p -c '";
+
 const scriptBody = (rendered: string): string =>
-  pipe(rendered, Str.slice("/bin/bash -lc '".length, -1), Str.replace(/'"'"'/gu, "'"));
+  pipe(rendered, Str.slice(scriptWrapperPrefix.length, -1), Str.replace(/'"'"'/gu, "'"));
 
 /** Index of the first line matching `needle`, or `-1` when absent. */
 const lineIndexOf = (script: string, needle: string): number =>
@@ -126,7 +128,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-Environment=PATH=/home/elpresidank/.local/share/mise/installs/node/24/bin:/usr/bin:/bin
+Environment=PATH=/opt/beep/openclaw/node/bin:/usr/bin:/bin
 Environment=HOME=/home/elpresidank
 Environment=OPENCLAW_CONFIG_PATH=/etc/beep/openclaw/current/openclaw.json
 Environment=OPENCLAW_STATE_DIR=/var/lib/beep/openclaw
@@ -312,7 +314,7 @@ describe("@beep/infra OpenClaw", () => {
 
     expect(encodedPaths).toEqual({
       configRoot: "/etc/beep/openclaw",
-      nodeBinDir: "/home/elpresidank/.local/share/mise/installs/node/24/bin",
+      nodeBinDir: "/opt/beep/openclaw/node/bin",
       stateDir: "/var/lib/beep/openclaw",
       unitName: "beep.service",
     });
@@ -410,20 +412,101 @@ describe("@beep/infra OpenClaw", () => {
     const script = scriptBody(renderOpenClawStageScript(defaultGeneration));
     const generationDir = `/etc/beep/openclaw/${defaultGeneration.generationId}`;
 
-    expect(script).toContain(`sudo -n install -o root -g root -m 0644 /dev/stdin '${generationDir}/openclaw.json'`);
-    expect(script).toContain(`sudo -n install -o root -g root -m 0644 /dev/stdin '${generationDir}/manifest.json'`);
-    expect(script).toContain(`sudo -n install -o root -g root -m 0755 /dev/stdin '${generationDir}/run.sh'`);
     expect(script).toContain(
-      `sudo -n install -o root -g root -m 0644 /dev/stdin '${generationDir}/${openClawSoulRelativePath}'`
+      `/usr/bin/sudo -n install -o root -g root -m 0644 /dev/stdin '${generationDir}/openclaw.json'`
     );
     expect(script).toContain(
-      `sudo -n install -o root -g root -m 0644 /dev/stdin '${generationDir}/${openClawProofSkillRelativePath}'`
+      `/usr/bin/sudo -n install -o root -g root -m 0644 /dev/stdin '${generationDir}/manifest.json'`
+    );
+    expect(script).toContain(`/usr/bin/sudo -n install -o root -g root -m 0755 /dev/stdin '${generationDir}/run.sh'`);
+    expect(script).toContain(
+      `/usr/bin/sudo -n install -o root -g root -m 0644 /dev/stdin '${generationDir}/${openClawSoulRelativePath}'`
+    );
+    expect(script).toContain(
+      `/usr/bin/sudo -n install -o root -g root -m 0644 /dev/stdin '${generationDir}/${openClawProofSkillRelativePath}'`
     );
     expect(script).toContain("STAGE-FAIL: symlink parent");
     expect(script).toContain("BEEP_OPENCLAW_CONFIG");
     expect(script).toContain("BEEP_OPENCLAW_MANIFEST");
     expect(script).toContain("BEEP_OPENCLAW_RUN");
     expect(script).toContain("BEEP_OPENCLAW_UNIT");
+  });
+
+  it("proves the node toolchain is root-owned before running the privileged install", () => {
+    const script = scriptBody(renderOpenClawStageScript(defaultGeneration));
+    const nodeBinDir = defaultGeneration.nodeBinDir;
+
+    // The privileged install must never resolve `npm` through PATH: a user-writable directory
+    // ahead of it would execute an attacker's package manager as root, and `--ignore-scripts`
+    // is no defense once the package manager binary itself is attacker-controlled.
+    expect(script).not.toMatch(/sudo -n env PATH=\S+ npm install/u);
+    expect(script).toContain('"${npm_bin}" install --prefix');
+    expect(script).toContain(`node_dir="$(/usr/bin/readlink -f '${nodeBinDir}')"`);
+    expect(script).toContain(`node_bin="$(/usr/bin/readlink -f '${nodeBinDir}/node')"`);
+    expect(script).toContain(`npm_bin="$(/usr/bin/readlink -f '${nodeBinDir}/npm')"`);
+    expect(script).toContain("assert_trusted_path \"${node_dir}\" 'pinned node bin dir'");
+    expect(script).toContain("assert_trusted_path \"${node_bin}\" 'pinned node binary'");
+    expect(script).toContain("assert_trusted_path \"${npm_bin}\" 'pinned npm binary'");
+    expect(script).toContain('[ "${owner}" = 0 ] || fail "${label} is not root-owned: ${probe}"');
+    expect(script).toContain('[ "$(( 8#${mode} & 8#22 ))" -eq 0 ]');
+    // The walk must terminate at the root inode, so a writable ancestor cannot be swapped.
+    expect(script).toContain('if [ "${probe}" = / ]; then break; fi');
+    // The guard runs before any privileged mutation the stage script performs.
+    const guard = lineIndexOf(script, 'assert_trusted_path "${npm_bin}"');
+    const install = lineIndexOf(script, "/usr/bin/sudo -n install -d");
+    const privilegedNpm = lineIndexOf(script, '"${npm_bin}" install --prefix');
+
+    expect(guard).toBeGreaterThanOrEqual(0);
+    expect(guard).toBeLessThan(install);
+    expect(guard).toBeLessThan(privilegedNpm);
+  });
+
+  it("pins the node toolchain default inside the root-owned trusted tree", () => {
+    expect(OpenClawWorkstationPaths.make({}).nodeBinDir).toBe("/opt/beep/openclaw/node/bin");
+  });
+
+  it("never renders a login shell and never resolves sudo by name", () => {
+    const rendered = [
+      renderOpenClawPreflightScript({ generation: defaultGeneration, identity }),
+      renderOpenClawStageScript(defaultGeneration),
+      renderOpenClawApplyScript(defaultGeneration),
+      renderOpenClawRollbackScript(defaultGeneration),
+      renderOpenClawDriftAuditScript({ generation: defaultGeneration, identity }),
+      renderOpenClawProbeScript({ generation: defaultGeneration, identity }),
+      renderOpenClawLiveAcceptanceScript(defaultGeneration),
+      renderOpenClawBackupShipScript({
+        backup: OpenClawBackupConfig.make({ passphraseSecretRef: "op://beep-openclaw/backup/passphrase" }),
+        generation: defaultGeneration,
+      }),
+    ];
+
+    for (const command of rendered) {
+      // A login shell sources the user-writable ~/.bash_profile before the first rendered line,
+      // which lets an unprivileged user define a `sudo` function and hijack the armed ticket.
+      expect(command.startsWith(scriptWrapperPrefix)).toBe(true);
+      expect(command).not.toContain("/bin/bash -lc");
+
+      const body = scriptBody(command);
+
+      // Every privilege-granting call is absolute: a bare `sudo` is satisfied by any shim
+      // earlier on PATH, and PATH is attacker-influenced until the pinned export runs.
+      expect(body).not.toMatch(/(?<!\/usr\/bin\/)\bsudo -n\b/u);
+      const pinnedPath = lineIndexOf(body, "export PATH=/usr/bin:/bin");
+      const firstSudo = lineIndexOf(body, "/usr/bin/sudo");
+
+      expect(pinnedPath).toBeGreaterThanOrEqual(0);
+      // PATH is pinned before the first privileged call, never after it.
+      if (firstSudo >= 0) {
+        expect(pinnedPath).toBeLessThan(firstSudo);
+      }
+    }
+  });
+
+  it("asserts sudo is the real setuid binary rather than trusting a name lookup", () => {
+    const script = scriptBody(renderOpenClawPreflightScript({ generation: defaultGeneration, identity }));
+
+    expect(script).toContain("[ -u /usr/bin/sudo ] || fail '/usr/bin/sudo is missing or not setuid root'");
+    expect(script).not.toContain("command -v sudo");
   });
 
   it("validates the candidate config with the candidate's own staged binary before apply", () => {
@@ -460,7 +543,7 @@ describe("@beep/infra OpenClaw", () => {
     expect(script).toContain("user bus round-trip failed (systemctl --user show)");
     expect(script).toContain("running|degraded|maintenance|starting) : ;;");
     expect(script).toContain("108-byte UNIX socket cap");
-    expect(script).toContain("sudo -n -v");
+    expect(script).toContain("/usr/bin/sudo -n -v");
     expect(script).toContain("no armed sudo ticket");
     expect(script).toContain("PREFLIGHT-OK");
   });
@@ -475,8 +558,8 @@ describe("@beep/infra OpenClaw", () => {
   it("orders apply as stop, snapshot, pointer switch, reload, start, health, commit", () => {
     const script = mainSequence(scriptBody(renderOpenClawApplyScript(defaultGeneration)));
     const stop = lineIndexOf(script, 'systemctl --user stop "${unit}" || true');
-    const snapshot = lineIndexOf(script, 'sudo -n cp -a -- "${state_dir}" "${snapshot}"');
-    const pointer = lineIndexOf(script, 'sudo -n mv -T -- "${pointer}.tmp.$$" "${pointer}"');
+    const snapshot = lineIndexOf(script, '/usr/bin/sudo -n cp -a -- "${state_dir}" "${snapshot}"');
+    const pointer = lineIndexOf(script, '/usr/bin/sudo -n mv -T -- "${pointer}.tmp.$$" "${pointer}"');
     const reload = lineIndexOf(script, "systemctl --user daemon-reload");
     const start = lineIndexOf(script, 'if ! systemctl --user start "${unit}"; then');
     const health = lineIndexOf(script, "for attempt in $(seq 1 30); do");
@@ -502,8 +585,8 @@ describe("@beep/infra OpenClaw", () => {
   it("switches the pointer atomically with ln -s followed by mv -T", () => {
     const script = scriptBody(renderOpenClawApplyScript(defaultGeneration));
 
-    expect(script).toContain(`sudo -n ln -s -- '${defaultGeneration.generationId}' "\${pointer}.tmp.$$"`);
-    expect(script).toContain('sudo -n mv -T -- "${pointer}.tmp.$$" "${pointer}"');
+    expect(script).toContain(`/usr/bin/sudo -n ln -s -- '${defaultGeneration.generationId}' "\${pointer}.tmp.$$"`);
+    expect(script).toContain('/usr/bin/sudo -n mv -T -- "${pointer}.tmp.$$" "${pointer}"');
     expect(script).toContain("APPLY-POINTER");
   });
 
@@ -512,8 +595,8 @@ describe("@beep/infra OpenClaw", () => {
 
     expect(script).toContain("restore_snapshot() {");
     expect(script).toContain("APPLY-ROLLBACK: restoring snapshot");
-    expect(script).toContain('sudo -n cp -a -- "${snapshot}" "${state_dir}"');
-    expect(script).toContain('sudo -n ln -s -- "${prior_pointer}" "${pointer}.rollback.$$"');
+    expect(script).toContain('/usr/bin/sudo -n cp -a -- "${snapshot}" "${state_dir}"');
+    expect(script).toContain('/usr/bin/sudo -n ln -s -- "${prior_pointer}" "${pointer}.rollback.$$"');
     expect(script.split("restore_snapshot").length - 1).toBeGreaterThanOrEqual(3);
     expect(script).toContain("APPLY-FAIL: unit failed to start; snapshot and prior pointer restored");
     expect(script).toContain("never succeeded within 30s; snapshot and prior pointer restored");
@@ -522,7 +605,7 @@ describe("@beep/infra OpenClaw", () => {
   it("refuses to start a generation older than the migrated live state", () => {
     const script = scriptBody(renderOpenClawApplyScript(defaultGeneration));
     const guard = lineIndexOf(script, "APPLY-REFUSED: downgrade guard");
-    const firstPrivilegedStep = lineIndexOf(script, "sudo -n");
+    const firstPrivilegedStep = lineIndexOf(script, "/usr/bin/sudo -n");
 
     expect(script).toContain("PRAGMA user_version;");
     expect(script).toContain('if [ "${candidate_user_version}" -lt "${live_user_version}" ]; then');
@@ -536,8 +619,8 @@ describe("@beep/infra OpenClaw", () => {
 
   it("restores state before switching binaries in the operator rollback script", () => {
     const script = scriptBody(renderOpenClawRollbackScript(defaultGeneration));
-    const restore = lineIndexOf(script, 'sudo -n cp -a -- "${snapshot}" "${state_dir}"');
-    const pointer = lineIndexOf(script, 'sudo -n mv -T -- "${pointer}.rollback.$$" "${pointer}"');
+    const restore = lineIndexOf(script, '/usr/bin/sudo -n cp -a -- "${snapshot}" "${state_dir}"');
+    const pointer = lineIndexOf(script, '/usr/bin/sudo -n mv -T -- "${pointer}.rollback.$$" "${pointer}"');
     const start = lineIndexOf(script, 'systemctl --user start "${unit}"');
 
     expect(script).toContain("ROLLBACK-FAIL: no snapshot at");
@@ -580,7 +663,7 @@ describe("@beep/infra OpenClaw", () => {
   it("mutates nothing in the drift audit", () => {
     const script = scriptBody(renderOpenClawDriftAuditScript({ generation: defaultGeneration, identity }));
 
-    expect(script).not.toContain("sudo -n");
+    expect(script).not.toContain("/usr/bin/sudo -n");
     expect(script).not.toContain("mv -T");
     expect(script).not.toContain("rm -rf");
     expect(script).not.toContain("install -o root");


### PR DESCRIPTION
## Summary

Closes two local privilege-escalation paths in the OpenClaw workstation applicator. Both were
reachable the first time an operator runs `pulumi up` in the armed sudo session, which has not
happened yet — nothing is deployed, so neither was live.

### 1. Privileged scripts ran in a login shell

`bashScript` rendered every script as `/bin/bash -lc`. A login shell sources `/etc/profile` and the
user-writable `~/.bash_profile` before the first rendered line, so an unprivileged local user could
define a `sudo` shell function, or prepend a `PATH` entry, and intercept all 28 `sudo -n` calls
while the operator's ticket was live. On the bound workstation `~/.bashrc` already prepends two
user-writable directories to `PATH` above the interactive guard, so this applied to every
non-interactive run.

- render as `/bin/bash --noprofile --norc -p -c` (no startup files; `-p` refuses functions
  exported through the environment)
- pin `PATH=/usr/bin:/bin` before any privileged call, in all four preambles — the drift-audit
  script uses `set -uo` rather than `set -euo` and is easy to miss
- invoke `/usr/bin/sudo` absolutely at all 28 sites
- preflight asserts `[ -u /usr/bin/sudo ]` instead of `command -v sudo`, which any shim satisfies

### 2. Staging installed openclaw with an untrusted npm as root

`sudo -n env PATH=<nodeBinDir>:/usr/bin:/bin npm install` ran `npm` as root with `nodeBinDir`
first on `PATH`, and the default was a per-user mise directory (`elpresidank:elpresidank`, 0755).
A user who could write there executed code as root. `--ignore-scripts` is no defense when the
package manager binary itself is attacker-controlled, and the pinned `npm` is a wrapper that execs
a sibling `node`, so validating `npm` alone is insufficient.

- resolve `nodeBinDir`, `node`, and `npm` with `readlink -f`, then require every path component up
  to `/` to be uid 0 and not group- or world-writable, failing closed with `STAGE-FAIL` (exit 73)
- run the guard before any privileged mutation, and invoke the resolved absolute `npm`
- default `nodeBinDir` to the root-owned `/opt/beep/openclaw/node/bin`, beside the existing
  resolver trusted dir

## Operator impact

`nodeBinDir` can no longer be a mise/nvm path under `$HOME`. Both runbooks gain a provisioning
section that installs the pinned Node tarball root-owned into `/opt/beep/openclaw/node`, plus a
verification loop to confirm the guard will pass before `pulumi up`. Copy, not symlink —
`readlink -f` resolves physically, so a link into `$HOME` still fails.

## Verification

- `bun run beep yeet verify` green (verdict `goals_openclaw-stage-trusted-toolchain-cb357309ea9c`)
- 59 infra tests pass; new regression tests assert, across all eight rendered scripts, that none
  is a login shell, none resolves `sudo` by name, and `PATH` is pinned before the first
  privileged call
- Exploit reproduced and confirmed blocked: a planted `sudo` function plus a fake `npm`/`node` in
  a user-writable directory never execute; the script exits 73
- Guard predicate checked against real paths: `/usr/bin` and `/opt` pass, `/home/elpresidank`
  rejected as not root-owned, `/tmp` rejected as world-writable despite the sticky bit
