### PR TITLE
docs(explorations): open effect-jsdoc-quality research packet

### DIFF
--- a/explorations/ATLAS.md
+++ b/explorations/ATLAS.md
@@ -40,6 +40,19 @@ The lego pieces already built. Authoritative inventories (link, never copy):
 
 ### Active
 
+- [`effect-jsdoc-quality`](./effect-jsdoc-quality/README.md) — research-stage:
+  close the JSDoc pedagogy gap so `@beep/*` IDE hovers teach like Effect
+  v4's. Opened 2026-07-30 from three WebStorm hover screenshots; same-day
+  mining found Effect's quality is a machine-enforced grammar
+  (`@effect/jsdocs`: **When to use**/**Details**/**Gotchas**/titled
+  **Example** sections, described `@see`, resolved `{@link}`) — and that v4
+  forbids `@example` and thereby lost example typechecking, which
+  `@beep/docgen` still has. Research artifacts + four options staged in
+  [`research/options.md`](./effect-jsdoc-quality/research/options.md)
+  (lead: grammar port riding the existing jsdoc-inventory ratchet);
+  next step is `/grill-with-docs`. Prior art cited:
+  `goals/jsdoc-worker-eval`, `goals/repo-codegraph-jsdoc`,
+  `goals/quality-gate-ratchets`.
 - [`agent-effectiveness-pulse`](./agent-effectiveness-pulse/README.md) — a
   data-driven pulse on repo agent friendliness/effectiveness (stage
   `graduate`, opened 2026-07-14, still active for wave 2): which skills are

--- a/explorations/effect-jsdoc-quality/BRIEF.md
+++ b/explorations/effect-jsdoc-quality/BRIEF.md
@@ -1,0 +1,63 @@
+# Brief
+
+<!--
+Stage 3 artifact, DRAFTED EARLY as grill preparation (stage is still
+`research`): /grill-with-docs interviews against a concrete plan, so this
+draft is the interview input. The human has NOT signed off; every section is
+provisional until DECISIONS.md records the grill outcomes.
+-->
+
+## Problem
+
+beep-effect's JSDoc is mechanically complete — every one of ~18k exports has
+a compilable `@example`, `@category`, `@since`, gated by a required ratchet —
+yet hovers don't teach. A 20-sample audit found 60% trivial examples, zero
+`// Output:` annotations, and `@see` is effectively unused (75 repo-wide).
+Effect v4 hovers teach because their conventions are a machine-enforced
+grammar (sections, titled examples, described resolved links). The gap is
+enumerable and portable; what's missing is a decision on carrier, hardness,
+and scope. Why now: the grammar was just reverse-engineered to path:line
+precision (`research/` legs), so a later goal can implement without
+re-mining Effect.
+
+## Appetite
+
+One goal packet, roughly two weeks of focused work including a 2-3 package
+pilot. Not a repo-wide migration — the ~18k-export surface is explicitly out
+of appetite; enforcement must be ratchet-on-touch.
+
+## Solution Sketch (= `research/options.md` Option B, pending grill)
+
+1. Rewrite `.patterns/jsdoc-documentation.md` + `jsdoc-annotation-specialist`
+   skill: adopt **When to use** / **Details** / **Gotchas** / titled example
+   sections, described-`@see`; resolve the `@remarks` collision; keep
+   namespace-import and `@since 0.0.0` laws.
+2. Port ~6-8 `Jsdocs.ts` grammar semantics as new `jsdoc-inventory` rules
+   riding the existing fail-on-growth baseline (no new CI lane).
+3. Example carrier per grill: B1 (keep `@example` tag) or B2 (`**Example**`
+   sections + teach `@beep/docgen` to harvest description fences — verified
+   localized). Either way example compilation is preserved.
+4. Pilot on `foundation/modeling/schema` + one tooling package + one
+   law-practice slice; acceptance = before/after WebStorm hover screenshots.
+5. Fast-track regardless: described-`@see` convention.
+
+## Rabbit Holes
+
+- Markdown-section parsing inside ts-morph comment text (fence-aware, not
+  regex-naive) — the validator's real complexity.
+- `@remarks` migration: 491 existing uses; grandfather vs migrate decides
+  churn.
+- `{@link}` resolution needs a checker program — most expensive rule; stage
+  last or defer to a follow-on goal.
+- Category vocabulary: 113 live values vs 80 canonical (`models` = 43%) — a
+  separate repair, do not let it infect this goal.
+
+## No-Gos
+
+- No mass rewrite of existing JSDoc; ratchet-on-touch only.
+- No dependency on `@effect/jsdocs` (private upstream package).
+- No `@example` ban without a compile-validation story (Effect's regression).
+- No real-semver `@since`; `0.0.0` policy stands.
+- No named-import example rule (repo namespace-import law wins).
+- No website/Jekyll chrome; `LLMS.md`-style corpus is a separate future goal
+  (Option D).

--- a/explorations/effect-jsdoc-quality/CAPTURE.md
+++ b/explorations/effect-jsdoc-quality/CAPTURE.md
@@ -1,0 +1,203 @@
+# Capture
+
+<!--
+Stage 0. Append-only raw dump: thoughts, links, screenshots (drop files in
+assets/ and reference them), half-sentences, contradictions. Nobody tidies
+this file; cleaning it up destroys provenance. New material goes under a new
+dated heading at the bottom.
+-->
+
+## 2026-07-30
+
+### Original brief (verbatim, from the kickoff session)
+
+> # Exploration: Effect-level JSDoc quality for beep-effect
+>
+> ## Mission
+>
+> Mine Effect v4's documentation system (source JSDoc style + tooling +
+> rendering story) and produce a concrete plan to close the quality gap between
+> our docs and theirs — so IDE hovers and generated docs for `@beep/*` feel like
+> Effect's: pedagogical, structured, example-rich, and visually crisp.
+>
+> This is **research → grill → goal**, not implementation. Do not start coding
+> docgen changes or mass-rewriting JSDoc until a `goals/` packet exists and is
+> approved.
+>
+> ## Why this exists
+>
+> [Effect](https://github.com/Effect-TS/effect) ships unusually good JSDoc. IDE
+> hovers look intentional, not mechanical. Examples teach; sections guide;
+> cross-links form a graph.
+>
+> Reference screenshots (local; open while researching):
+>
+> 1. `~/Pictures/Screenshots/Screenshot_20260730_095907.png` — `Option` type
+>    hover: problem statement + **When to use** bullets + `@see` graph +
+>    `@category` / `@since`
+> 2. `~/Pictures/Screenshots/Screenshot_20260730_100034.png` — `Option.none`
+>    hover: **When to use**, **Details**, titled **Example**, ASCII annotation
+>    in the example, console output comment
+> 3. `~/Pictures/Screenshots/Screenshot_20260730_100340.png` — `Schema.TaggedUnion`
+>    hover: dense one-paragraph summary with `{@link}`, titled example that
+>    exercises the full API (`match`), then `@see` / `@category` / `@since`
+>
+> Observable qualities I want (non-exhaustive; expand from evidence):
+>
+> | Signal | What Effect does (from screenshots) |
+> | --- | --- |
+> | Section structure | Bold markdown headings: **When to use**, **Details**, **Example (…)** |
+> | Pedagogy | Explains *when* and *why*, not just *what the name says* |
+> | Examples | Titled, compilable-looking, show result/output, sometimes ASCII diagrams |
+> | Cross-links | Multiple `@see` / `{@link}` forming a local API graph |
+> | Density | Short enough for hover; long enough to act without leaving the IDE |
+> | Metadata | Real `@category` + meaningful `@since` (not decorative) |
+>
+> We already adopt pieces of this (`@since`, `@category`, `@example`, docgen
+> compilation, quality inventory). Theirs still *looks and teaches better*. The
+> gap may be prose craft, markdown conventions, tooling, codegen, linter rules,
+> or all of the above — find out from evidence.
+>
+> ## Context you must load first
+>
+> ### Ours (baseline — do not rediscover from zero)
+>
+> | Area | Path / command |
+> | --- | --- |
+> | JSDoc standard of truth | `.patterns/jsdoc-documentation.md` |
+> | Annotation skill | `.agents/skills/jsdoc-annotation-specialist/` (+ `references/*`) |
+> | Docgen package | port of pre-v4 `@effect/docgen` → `@beep/docgen` (locate under `packages/`; root scripts `docgen`, `docgen:local`) |
+> | Quality tooling | `bun run beep docgen quality`, `bun run beep quality jsdoc-inventory`, `standards/jsdoc-documentation.inventory.*` |
+> | Custom tags | root `tsdoc.json` (`@effects`, `@precondition`, …) |
+> | Categories | `packages/tooling/tool/cli/src/commands/Shared/JSDocCategories.ts` |
+>
+> ### Theirs (primary mine)
+>
+> | Area | Path |
+> | --- | --- |
+> | Effect v4 checkout | `.repos/effect` (git subtree) |
+> | JSDoc source samples | Prefer symbols in the screenshots first: `Option` type, `none`/`some`, `Schema.TaggedUnion` — then expand to a representative set |
+> | Docs / docgen config | `.repos/effect/jsdocs.config.json`, `docs/`, `ai-docs/`, `LLMS.md`, `MIGRATION.md`, package scripts related to docs |
+> | Any remaining docgen / typedoc / api-extractor / website pipeline | Trace from `package.json` scripts and CI; Effect abandoned classic `@effect/docgen` post-v4 — document what replaced it |
+>
+> Also note: pre-v4 Effect used `@effect/docgen` for standards validation; we
+> ported that style into `@beep/docgen`. v4 moved on. Part of this exploration
+> is naming that migration precisely so we do not cargo-cult dead tooling.
+>
+> ## Research questions (answer with evidence, not vibes)
+>
+> 1. **Source shape** — What is the exact JSDoc/TSDoc template Effect authors use
+>    (tag order, markdown section names, example fencing, `{@link}` vs `@see`,
+>    release-stage tags)? Diff against `.patterns/jsdoc-documentation.md`.
+> 2. **Prose craft vs structure** — Which "quality" is *convention* (enforceable
+>    headings/tags) vs *editorial skill* (good sentences)? Separate the two;
+>    only the former is a good automation target.
+> 3. **Tooling stack (v4)** — What validates, compiles, renders, and publishes
+>    docs now? TypeDoc? Custom? Website? AI docs (`ai-docs/`, `LLMs.md`)? What
+>    was dropped with `@effect/docgen`?
+> 4. **IDE hover fidelity** — Which markdown features actually survive WebStorm /
+>    TS language service hovers (bold headings, lists, fenced code, links)?
+>    Anything we write that never appears in hover is lower priority for the
+>    "looks like Effect" goal.
+> 5. **Example quality bar** — How do they title examples, annotate types in
+>    comments, show outputs, and keep examples short? Compare to our
+>    "compilable `@example` required on every export" rule — keep, tighten, or
+>    split (e.g. type-only vs value exports).
+> 6. **Enforcement surface** — Lint rules, CI checks, docgen validators, skills,
+>    codegen (e.g. `$I.annote`)? Map Effect's enforcement to ours and list
+>    missing ratchet points.
+> 7. **Adoption path for beep** — Given our monorepo size and existing inventory/
+>    ratchet, what is the lowest-risk path to Effect-level quality:
+>    convention update only, skill/rubric update, docgen enhancements, partial
+>    codegen, pilot packages then ratchet, or something else?
+> 8. **Non-goals / traps** — What should we *not* copy (Effect-only website
+>    chrome, version numbers we cannot maintain, `@since` semantics that fight
+>    our `0.0.0` placeholder policy, etc.)?
+>
+> ## Method
+>
+> 1. **Orient** on our baseline files above; summarize current bar in ≤15 bullets.
+> 2. **Mine Effect** starting from the three screenshot symbols, then widen to a
+>    stratified sample (constructors, combinators, types, errors, Schema, modules
+>    with package docs). Prefer reading source over secondary blogs.
+> 3. **Trace tooling** from `.repos/effect` configs/scripts/CI — produce a
+>    one-page "how Effect docs ship in v4" map.
+> 4. **Diff** Effect vs beep on: tag set, section markdown, example shape,
+>    validation, rendering. Tabular preferred.
+> 5. **Score the gap** with a short quality rubric (what "Effect-level" means
+>    operationally for us) and mark each gap as: prose | convention | tooling |
+>    process.
+> 6. **Options** — 2–4 candidate approaches (minimal → ambitious) with tradeoffs,
+>    effort, and ratchet story. No single "the plan" yet.
+> 7. **Stop for human interview** — invoke `/grill-with-docs` before proposing a
+>    goal. Decisions to grill must include at least:
+>    - Keep vs evolve `@beep/docgen` vs lean on Effect's new stack
+>    - How hard we enforce markdown section templates
+>    - Whether every export still needs a compilable example
+>    - Pilot scope (which packages first)
+>    - Relationship to existing `jsdoc-inventory` / quality ratchet
+>    - Anything that would change `.patterns/jsdoc-documentation.md` law
+>
+> ## Deliverables (before goal creation)
+>
+> `CAPTURE.md`/`BRIEF.md`, `research/SOURCES.md`,
+> `research/effect-doc-pipeline.md`, `research/diff-effect-vs-beep.md`,
+> `research/quality-rubric.md`, `research/options.md`, `DECISIONS.md`
+> (pending grill), packet README + manifest. After grill and alignment:
+> graduate a `goals/<slug>/` packet implementable without re-mining Effect.
+>
+> ## Constraints
+>
+> - Schema → service → impl mindset for any new tooling service.
+> - Prefer effect-native / existing repo patterns; search before proposing new
+>   packages.
+> - Do NOT mass-edit package JSDoc in this exploration.
+> - Do NOT commit secrets; screenshots stay as local path references (or copy
+>   into the packet `assets/` if needed in-repo).
+> - Proof over assertion: every claim about Effect's stack cites a path or
+>   symbol under `.repos/effect` (or a config/script that proves absence).
+> - Context economy: distill findings to packet files.
+
+### Screenshot evidence read-out (WebStorm quick-doc hovers, 2026-07-30)
+
+Screenshots stay as local path references (public repo; they show the user's
+IDE and project tree). Copy into `assets/` only if the user opts in later.
+
+1. `~/Pictures/Screenshots/Screenshot_20260730_095907.png` — hover on
+   `O.Option<string>` (`import * as O from "effect/Option"` scratch file).
+   Renders: signature `type Option<A> = O.None<A> | O.Some<A>`; one dense
+   lead paragraph with inline-code tokens; bold **When to use** heading; a
+   lead sentence plus two bullets; three `@see` rows each with a purpose
+   phrase ("some — for creating a `Some`", "none — for creating a `None`",
+   "match — for pattern matching") rendered as links; `@category` — models;
+   `@since` — 2.0.0.
+2. `~/Pictures/Screenshots/Screenshot_20260730_100034.png` — hover on
+   `Option.none()`. Renders: **When to use** sentence; **Details** bullets
+   (`Option<never>` subtype note; singleton note); **Example** with
+   parenthesized title "(Creating an empty Option)"; fenced code with named
+   import, ASCII type-annotation arrow (`// ┌── Option<never>` / `// ▼`),
+   `console.log(noValue)` and `// Output: { _id: 'Option', _tag: 'None' }`.
+3. `~/Pictures/Screenshots/Screenshot_20260730_100340.png` — hover on
+   `S.TaggedUnion(...)`. Renders: dense one-paragraph summary with a working
+   `{@link TaggedStruct}` inline link and inline-code utility names (`cases`,
+   `guards`, `isAnyOf`, `match`); titled **Example** "(Pattern matching a
+   discriminated union)" exercising the full API (`Shape.match`); `@see` —
+   toTaggedUnion "to augment an existing union instead"; `@category` —
+   constructors; `@since` — 4.0.0.
+
+Conclusion baked in from the screenshots alone: bold section headings,
+bullets, fenced code (including ASCII art and output comments), `{@link}`
+inline links, and described `@see` tags ALL survive WebStorm's quick-doc
+renderer — so every "looks like Effect" convention is renderable on our side;
+nothing depends on Effect-only website tooling. Note the `@since` semantics
+visible in hovers: `2.0.0` on carried-over `Option`, `4.0.0` on new
+`Schema.TaggedUnion` — real history, unlike our `0.0.0` placeholder policy.
+
+### Stale-path corrections discovered while orienting (fix nothing yet; recorded for the goal)
+
+- The brief's categories path `packages/tooling/tool/cli/src/commands/Shared/JSDocCategories.ts`
+  does not exist; the real home is
+  `packages/tooling/library/repo-utils/src/schemas/JSDocCategories.ts`.
+- `.agents/skills/jsdoc-annotation-specialist` Source References cite the same
+  stale CLI path plus two `packages/common/schema/src/*` paths; `packages/common/`
+  is gone (real home `packages/foundation/modeling/schema/src/`).

--- a/explorations/effect-jsdoc-quality/DECISIONS.md
+++ b/explorations/effect-jsdoc-quality/DECISIONS.md
@@ -1,0 +1,15 @@
+# Decisions
+
+<!--
+Stage 2. The grilling log. One entry per resolved branch-closing question,
+newest last. Unresolved questions live in ops/manifest.json `openQuestions`
+until they land here.
+-->
+
+## Status: pending grill
+
+No decisions recorded yet. The six open questions live in
+`ops/manifest.json` `openQuestions`, mapped to evidence in
+`research/options.md` ("Grill decision axes"). The next session runs
+`/grill-with-docs` against `BRIEF.md` (drafted early as interview input) and
+records outcomes here.

--- a/explorations/effect-jsdoc-quality/MAP.md
+++ b/explorations/effect-jsdoc-quality/MAP.md
@@ -1,0 +1,28 @@
+# Map
+
+<!--
+Stage 4. Decomposition into candidate goal packets. This is the graduation
+surface: the definition-of-ready in explorations/README.md is checked against
+this file. Every major component cites an existing repo capability or is
+explicitly marked NET-NEW.
+-->
+
+## Candidate Goal Packets
+
+| Slug | Mission | Depends on | Capabilities cited |
+| --- | --- | --- | --- |
+| `<goal-slug>` | <one-liner> | <other slugs / none> | <`@beep/*` refs or NET-NEW> |
+
+## Sequencing
+
+<Order and why. Which candidate is the first bet, which are follow-ons, which
+are optional.>
+
+## First Vertical Slice
+
+<The smallest end-to-end proof for the first candidate: what a user/agent can
+do when it lands, and how we verify it.>
+
+## Open Risks Inherited From The Brief
+
+<Rabbit holes from BRIEF.md that graduate as constraints, one line each.>

--- a/explorations/effect-jsdoc-quality/README.md
+++ b/explorations/effect-jsdoc-quality/README.md
@@ -1,0 +1,47 @@
+# Effect-level JSDoc Quality
+
+## Status
+
+Stage: `research`
+Status: `active`
+
+Source: [`ops/manifest.json`](./ops/manifest.json)
+
+## Spark
+
+Effect v4's IDE hovers teach — structured **When to use** / **Details** / titled
+**Example** sections, described `@see` cross-links, output-annotated examples —
+while beep-effect's JSDoc is mechanically complete (100%-clean inventory,
+~18k documented exports) yet pedagogically thin. Close the gap so `@beep/*`
+hovers read like Effect's.
+
+## Next Open Question
+
+Run `/grill-with-docs` with the human against `BRIEF.md` (drafted early as
+interview input) + `research/options.md` (lead: Option B — grammar port with
+compile validation preserved); record outcomes in `DECISIONS.md` and flip the
+manifest stage. Before or during the grill: the 2-minute WebStorm hover
+eyeball of `scratchpad/jsdoc-hover-lab.ts` (fills the pending rows of the
+hover-fidelity matrix in `research/diff-effect-vs-beep.md` §10).
+
+## Read This First
+
+1. [`ops/manifest.json`](./ops/manifest.json) - machine state: stage, status, open questions.
+2. [`CAPTURE.md`](./CAPTURE.md) - raw dump (stage 0).
+3. [`RESEARCH.md`](./RESEARCH.md) - prior art + capability inventory (stage 1, if present).
+4. [`DECISIONS.md`](./DECISIONS.md) - grilling log (stage 2, if present).
+5. [`BRIEF.md`](./BRIEF.md) - shaped pitch (stage 3, if present).
+6. [`MAP.md`](./MAP.md) - decomposition (stage 4, if present).
+
+## Trail
+
+- 2026-07-30: research artifacts landed (pipeline map, diff, rubric, options
+  A-D with Option B lead, RESEARCH synthesis, SOURCES ledger); BRIEF drafted
+  early as grill input; DECISIONS pending grill; hover-fidelity lab written
+  to `scratchpad/jsdoc-hover-lab.ts` awaiting the user's WebStorm eyeball.
+  Stopped at the exploration's hard stop: no goal packet before
+  `/grill-with-docs`.
+- 2026-07-30: packet opened at research stage. Effect v4 mining banked: the
+  quality is a machine-enforced grammar (`@effect/jsdocs`), `@example` is
+  forbidden upstream, and v4 lost example typechecking (which `@beep/docgen`
+  still has). Gap-fill workflow + artifact authoring in progress.

--- a/explorations/effect-jsdoc-quality/RESEARCH.md
+++ b/explorations/effect-jsdoc-quality/RESEARCH.md
@@ -1,0 +1,86 @@
+# Research
+
+## External Landscape
+
+### 2026-07-30 — Effect v4 JSDoc grammar & docs pipeline (leg: `research/effect-doc-pipeline.md`)
+
+Effect v4's hover quality is the output of a machine-enforced grammar
+(`@effect/jsdocs`, private, ~30 diagnostics): one-paragraph description →
+**When to use** ("Use to/when/as/with" openers) → **Details** → **Gotchas** →
+titled **Example** sections with exactly one fence → a 5-tag whitelist in
+fixed order, with `{@link}` targets resolved against a real checker program.
+`@example` is forbidden upstream — and in that swap v4 **lost example
+typechecking entirely** (the old docgen compile machinery idles against zero
+tags). Their validator also does not fail CI (diagnostics gated behind a
+`--check` flag nobody passes). Classic `@effect/docgen` still generates the
+website markdown; a hand-authored, typechecked `ai-docs/` tree generates the
+committed `LLMS.md`. Full map with citations in the leg file.
+
+### 2026-07-30 — Effect vs beep diff + adoption reality (leg: `research/diff-effect-vs-beep.md`)
+
+The two systems optimize opposite halves: beep enforces presence+compilation
+with real CI teeth; Effect enforces pedagogy with no teeth and no compiler.
+Effect's own adoption is uneven (When-to-use 99% in Option.ts → 19% in
+Stream.ts; examples on only 14% of Schema.ts exports), which reframes
+"Effect-level" as their *target* state and argues for ratchet-on-touch here.
+One hard conflict found: Effect requires named imports in examples; our
+repo law requires namespace imports (`import * as S`) — ours wins.
+
+## In-Repo Capability Inventory
+
+Full table with dispositions in `research/SOURCES.md` §4. Highlights:
+
+- `@beep/repo-docgen` (`packages/tooling/tool/docgen/`) — compiles every
+  `@example` via `tsc --noEmit`; `extractFencedCodeBlocks` already exists
+  (`Core.ts:268`), so section-based harvesting is a localized change;
+  `runExamples` exists, default false.
+- JSDoc inventory (12 mechanical ts-morph rules) + fail-on-growth ratchet +
+  required "JSDoc Ratchet" CI lane — the enforcement chassis new grammar
+  rules ride on.
+- `deterministic-rubric-v1` (15 example-quality finding codes) — advisory
+  only, wired to no CI lane.
+- 80-slug `JSDocCategories` LiteralKit + alias/reject normalization — but
+  live source carries 113 distinct values (39 non-canonical, 511
+  occurrences, `models` alone is 43% of all categories).
+- Prior art: `goals/jsdoc-worker-eval` (LLM scoring verdicts + reusable
+  packet contract; write-mode explicitly non-goal),
+  `goals/repo-codegraph-jsdoc` tag-exhaustiveness audit (tag database with
+  `ASTDerivability`, category taxonomy — untypechecked, port-to-LiteralKit
+  if used), `goals/quality-gate-ratchets` (ratchet pattern).
+- Organic precedent: law-practice value models already write bold
+  `**Example**` headings (3 of 20 sampled examples).
+- NOT FOUND: any section-grammar rule, any `{@link}` resolution check, any
+  described-`@see` convention (verified — "When to use" appears nowhere in
+  `.patterns/jsdoc-documentation.md`).
+
+## Constraints Discovered
+
+- `@remarks` collision: current law routes details/gotchas semantics into
+  `@remarks` (`.patterns/jsdoc-documentation.md:183-186`); Effect's grammar
+  puts them in description-body sections. One must win before any validator
+  ships (491 existing `@remarks` uses to migrate or grandfather).
+- Import-style divergence: Effect's named-import example rule contradicts
+  the repo-wide namespace-import law — we keep ours; do not port
+  `example-import-style` as-is.
+- `@since` semantics: real semver requires release history we don't have;
+  the `0.0.0` placeholder policy stands (grill to confirm).
+- Unenforced conventions historically hit zero adoption here
+  (`@precondition`/`@postcondition`/`@throws` all 0) — Option A alone is
+  evidence-refuted.
+- Public repo: reference screenshots stay local-path-only in `CAPTURE.md`.
+- Exploration discipline: no mass JSDoc edits, no `goals/` packet before
+  `/grill-with-docs`.
+
+## Synthesis
+
+"Effect-level for beep" = **their grammar + our compiler + our ratchet**.
+The gap is precisely enumerable (diff §8): ~14 Effect diagnostics have no
+beep counterpart, of which ~6-8 are cheap inventory rules; example *quality*
+(60% trivial in our n=20 sample) already has a detector
+(`deterministic-rubric-v1`) that just lacks CI wiring; cross-linking is the
+cheapest visible win (75 `@see` repo-wide → described-`@see` convention).
+Everything else is editorial craft that belongs in the pattern doc's
+exemplars and the annotation skill, not in CI. Options bracketed in
+`research/options.md` (lead: Option B); operational rubric in
+`research/quality-rubric.md`; six decision axes staged for
+`/grill-with-docs`.

--- a/explorations/effect-jsdoc-quality/ops/manifest.json
+++ b/explorations/effect-jsdoc-quality/ops/manifest.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": "exploration-manifest/v1",
+  "exploration": {
+    "slug": "effect-jsdoc-quality",
+    "title": "Effect-level JSDoc quality",
+    "status": "active",
+    "stage": "research",
+    "openQuestions": [
+      "Keep and evolve @beep/docgen, or lean on Effect's v4 stack (a Jsdocs.ts-style grammar validator)? Evidence favors keeping ours: theirs is private, currently toothless in CI, and v4 lost example typechecking.",
+      "How hard do we enforce markdown section templates (**When to use** / **Details** / **Gotchas** / titled **Example**): advisory, ratchet-on-new-code, or required — and per which symbol kinds?",
+      "Does every export still need a compilable example, or do we split the rule by symbol kind (Effect's Schema.ts documents only 14% of exports with examples yet hovers stay excellent)?",
+      "Example carrier: keep the @example tag under new sections (zero docgen change), or move to **Example** (Title) sections and teach @beep/docgen Parser.ts to harvest description fences (verified-localized change)?",
+      "Pilot scope: which 2-3 packages get the first Effect-style rewrite (proposal: foundation/modeling/schema + one tooling package + one domain slice)?",
+      "How do new grammar rules ride the existing jsdoc-inventory + fail-on-growth ratchet, and which .patterns/jsdoc-documentation.md laws change (@remarks vs sections collision, tag order, described-@see, @since stays 0.0.0)?"
+    ],
+    "sources": ["research/SOURCES.md"],
+    "links": {
+      "goals": [],
+      "docs": [],
+      "supersededBy": null
+    },
+    "created": "2026-07-30",
+    "updated": "2026-07-30"
+  }
+}

--- a/explorations/effect-jsdoc-quality/research/SOURCES.md
+++ b/explorations/effect-jsdoc-quality/research/SOURCES.md
@@ -1,0 +1,98 @@
+# Effect-level JSDoc quality — Sources & Provenance
+
+<!--
+The provenance ledger for this packet. Start it in the `research` stage and keep
+it current through graduate; the graduated goal inherits a copy.
+
+RULES
+- Never fabricate a URL/DOI/repo link. Reproduce only sources that actually
+  appear on disk in RESEARCH.md / research/*.md; if a claim has no on-disk URL,
+  cite the RESEARCH.md section that carries it instead.
+- Licenses are load-bearing: copyleft upstream is CLEAN-ROOM reimplement only;
+  permissive (MIT/Apache/BSD) may be ported WITH attribution.
+- Register this file in ops/manifest.json `exploration.sources`.
+-->
+
+- **Cluster / origin:** kickoff brief + three WebStorm hover screenshots
+  (2026-07-30, referenced in `CAPTURE.md`); mining executed the same day by
+  three explorer passes plus a five-agent gap-fill workflow; every line-cite
+  below re-verified by a dedicated claim-verification pass.
+- **Provenance:** all evidence is on-disk in this repo (`.repos/effect`
+  subtree + beep sources); no external secondary sources were used.
+
+## 1. Mined source corpus
+
+All paths relative to `.repos/effect/` unless noted.
+
+| Source | Title | Upstream (repo) | Location (`file:line`) | Theme | Disposition |
+|--------|-------|-----------------|------------------------|-------|-------------|
+| `grammar-tag-order` | Tag order map | Effect-TS/effect | `packages/tools/jsdocs/src/Jsdocs.ts:425-431` | deprecated→default→see→category→since | port (semantics) |
+| `grammar-headings` | `standardHeadings` | Effect-TS/effect | `packages/tools/jsdocs/src/Jsdocs.ts:1020` | **When to use** / **Details** / **Gotchas** | port (semantics) |
+| `grammar-prefixes` | `whenToUsePrefixes` | Effect-TS/effect | `packages/tools/jsdocs/src/Jsdocs.ts:1024` | "Use to/when/as/with" openers | port (semantics) |
+| `grammar-allowed-tags` | Per-scope tag whitelist | Effect-TS/effect | `packages/tools/jsdocs/src/Jsdocs.ts:1395-1402` | 5-tag universe, scoped subsets | port (semantics) |
+| `grammar-example-ban` | `forbidden-tag` for `@example` | Effect-TS/effect | `packages/tools/jsdocs/src/Jsdocs.ts:1411-1413` | sections replace the tag | reference (grill decision) |
+| `grammar-since` | Stable-semver `@since` | Effect-TS/effect | `packages/tools/jsdocs/src/Jsdocs.ts:435,1460-1461` | real version history | reference (conflicts with our 0.0.0 policy) |
+| `grammar-links` | `{@link}` resolution via compiler | Effect-TS/effect | `packages/tools/jsdocs/src/Jsdocs.ts:1524-1545` | links must resolve to documented symbols | port (semantics) |
+| `bin-check-gate` | Diagnostics fail only under `--check` | Effect-TS/effect | `packages/tools/jsdocs/src/bin.ts:13,32-34` | toothless CI wiring | reference (anti-pattern) |
+| `jsdocs-config` | Validator config | Effect-TS/effect | `jsdocs.config.json:1-16` | include/exclude + `.data/jsdocs.json` cache | reference |
+| `docs-scripts` | Doc scripts | Effect-TS/effect | `package.json:23-27` | jsdocs-inside-lint, docgen, ai-docgen | reference |
+| `ci-lanes` | Lint / Docgen / AI-docgen lanes | Effect-TS/effect | `.github/workflows/check.yml:16-26,149-160,162-180` | AI lane fails on dirty tree | reference |
+| `dead-example-compile` | Idle `examplesCompilerOptions` | Effect-TS/effect | `packages/effect/docgen.json:5-8`; `packages/tools/docgen/src/Parser.ts:105` | v4 lost example typechecking | reference (do not copy) |
+| `style-option` | `Option` type / `none` / `some` JSDoc | Effect-TS/effect | `packages/effect/src/Option.ts:38-54,229-260,262-293` | showcase hover style (screenshots) | port-with-attribution (prose patterns) |
+| `style-taggedunion` | `Schema.TaggedUnion` JSDoc | Effect-TS/effect | `packages/effect/src/Schema.ts:6328-6354` | dense summary + titled example | port-with-attribution (prose patterns) |
+| `adoption-sample` | Section/tag frequency, 6 modules | Effect-TS/effect | `packages/effect/src/{Option,Effect,Schema,Layer,Stream,Cause}.ts` | uneven adoption; Schema=14% examples | evidence |
+| `ai-docs` | Typechecked LLM doc corpus | Effect-TS/effect | `ai-docs/`, `LLMS.md`, `tsconfig.packages.json:6` | committed generated artifact + dirty-tree gate | reference (future goal) |
+
+**How these inform this packet:** the `grammar-*` rows are the portable spec —
+they become candidate `jsdoc-inventory` rules and pattern-doc law; the
+`style-*` rows calibrate the prose rubric; `bin-check-gate` +
+`dead-example-compile` are the two upstream regressions we explicitly refuse
+to import; `adoption-sample` justifies ratchet-on-touch over retroactive
+migration.
+
+## 2. Upstream repositories & licenses
+
+| Repo | License | Port discipline | What we take |
+|------|---------|-----------------|--------------|
+| Effect-TS/effect (vendored subtree at `.repos/effect`) | MIT | port-with-attribution | Grammar semantics (headings, prefixes, tag order, link resolution), prose/section patterns, example idioms (ASCII type arrows, `// Output:` comments). We do NOT depend on `@effect/jsdocs` (private package) — semantics are re-implemented in our inventory. |
+
+## 3. External research sources
+
+No external URLs were consulted; all claims trace to on-disk sources. The
+only URL in the packet is the upstream repo home,
+<https://github.com/Effect-TS/effect> (also cited in `CAPTURE.md`). The three
+reference screenshots are local-only paths recorded in `CAPTURE.md`
+(deliberately not committed — public repo).
+
+## 4. In-repo capability references
+
+| Brick | Path | Disposition |
+|-------|------|-------------|
+| `@beep/repo-docgen` (pre-v4 `@effect/docgen` port; compiles `@example` via `tsc --noEmit`) | `packages/tooling/tool/docgen/` (`Parser.ts:163`, `Core.ts:268-271,450-456`, `Configuration.ts:99-126`) | extend (optionally harvest `**Example**` fences; `runExamples` exists, default false) |
+| JSDoc inventory + 12 mechanical rules | `packages/tooling/tool/cli/src/commands/Quality/internal/JSDocDocumentationInventory.ts:272-478` | extend (new grammar rule codes) |
+| Fail-on-growth ratchet + required CI lane | `standards/jsdoc-totals.regression-baseline.jsonc:12-19`; `.github/workflows/check.yml:499-528` ("JSDoc Ratchet" is a required check) | reuse (new codes ride the same baseline) |
+| Example-quality scorer `deterministic-rubric-v1` (15 finding codes, advisory-only) | `packages/tooling/tool/cli/src/commands/Docgen/internal/quality/Quality.schemas.ts:177-192`, `Quality.rubric.ts:340-352` | extend / wire to CI (Option D) |
+| Canonical category vocabulary (80 slugs, LiteralKit) + alias/reject normalization | `packages/tooling/library/repo-utils/src/schemas/JSDocCategories.ts:31-126,202-263` | reuse (note: 39 non-canonical values live in source today — see RESEARCH.md) |
+| Custom tag definitions (15 tags incl. `@effects`, `@precondition`) | `tsdoc.json:3-30` | extend / cleanup (`@module`/`@template` registered but banned by law) |
+| JSDoc law | `.patterns/jsdoc-documentation.md` (tag order :55-82, `@remarks` :183-186, copy-paste bug :848) | rewrite (the goal's main convention surface) |
+| Annotation skill | `.agents/skills/jsdoc-annotation-specialist/` (3 stale Source Reference paths noted in CAPTURE.md) | rewrite |
+| LLM worker eval (advisory scoring; verdicts + reusable packet contract) | `goals/jsdoc-worker-eval/SPEC.md:16-123,286-311` | reference (Option D input; write-mode explicitly non-goal) |
+| JSDoc tag exhaustiveness audit (tag database + `ASTDerivability`, SyntaxKind maps, category taxonomy) | `goals/repo-codegraph-jsdoc/history/outputs/jsdoc-exhaustiveness-audit/*.ts` | reference (port to LiteralKit forms if used; files are untypechecked prior art) |
+| Ratchet mechanism precedent | `goals/quality-gate-ratchets/` | reference |
+| In-repo titled-example precedent (bold `**Example**` headings) | `packages/law-practice/domain/src/values/{DurableLocator,NeutralCitation,StatutesAtLargeCitation}/*.ts` | evidence (the convention already grew locally) |
+| Hover-fidelity lab (WebStorm eyeball probe) | `scratchpad/jsdoc-hover-lab.ts` (uncommitted scratch) | evidence (RQ4) |
+
+NOT FOUND (net-new if chosen at grill): any section-grammar validation rule
+(no "When to use" anywhere in `.patterns/jsdoc-documentation.md` — verified);
+any `{@link}`-resolution check; any described-`@see` convention.
+
+## 5. Cross-links & provenance
+
+- This packet: `RESEARCH.md` (synthesis), `research/effect-doc-pipeline.md`,
+  `research/diff-effect-vs-beep.md`, `research/quality-rubric.md`,
+  `research/options.md`, `DECISIONS.md` (pending grill).
+- Exploration ↔ goal links: none yet — graduation happens only after
+  `/grill-with-docs` (see `ops/manifest.json` `links.goals`).
+- Sibling prior art: `goals/jsdoc-worker-eval`, `goals/repo-codegraph-jsdoc`,
+  `goals/quality-gate-ratchets`; killed packet `effect-capability-kg` (ATLAS
+  history — resume-as-fresh precedent).

--- a/explorations/effect-jsdoc-quality/research/diff-effect-vs-beep.md
+++ b/explorations/effect-jsdoc-quality/research/diff-effect-vs-beep.md
@@ -1,0 +1,131 @@
+# Effect v4 vs beep-effect: JSDoc conventions & tooling diff
+
+Dated 2026-07-30. Effect paths relative to `.repos/effect/`; beep paths
+relative to repo root. Line-cites verified (see `SOURCES.md`).
+
+## Verdict in one paragraph
+
+The two systems optimize opposite halves of the same problem. **beep enforces
+presence and compilation** (every export has `@example`/`@category`/`@since`;
+examples typecheck via `@beep/docgen`) but has **no pedagogical structure** —
+no section grammar, near-zero cross-links (75 `@see` across ~18k exports),
+and 60% of sampled examples are template-grade trivial. **Effect enforces
+pedagogical structure** (section grammar, described links that must resolve,
+titled examples with named imports) but **lost compilation** (the `@example`
+ban orphaned its example-typechecking machinery) and doesn't fail CI on
+violations. "Effect-level for beep" = their grammar + our compiler + our
+ratchet discipline.
+
+## 1. Tag universe & order
+
+| | Effect v4 | beep |
+| --- | --- | --- |
+| Allowed tags | Exactly 5, per-scope subsets: `@deprecated @default @see @category @since` (`Jsdocs.ts:1395-1402`) | 15 registered in `tsdoc.json:3-30` incl. custom `@effects @precondition @postcondition @invariant`; conditional tags default-omit |
+| Order | Fixed map `deprecated→default→see→category→since` (`Jsdocs.ts:425-431`), enforced (`tag-out-of-order`) | 14-position order in law (`.patterns/jsdoc-documentation.md:55-82`), enforced only in `packages/tooling/*/*/src` via `jsdoc/sort-tags` warn |
+| `@example` | **Forbidden** (`Jsdocs.ts:1411-1413`) — sections instead | **Mandatory on every export** (law :77-82; ratcheted) |
+| `@param`/`@returns`/`@throws` | Not allowed | Conditional; adoption: `@param` 1304, `@returns` 929, `@throws` **0** |
+| Custom agent tags | None | `@effects` 310, `@precondition`/`@postcondition` **0**, `@invariant` 13 — the aspirational half is unadopted |
+| Collision to resolve | — | Law routes details/gotchas semantics into `@remarks` (:183-186); Effect puts them in description-body sections. Both can't be canonical. |
+
+## 2. Section grammar (the core gap)
+
+| | Effect v4 | beep |
+| --- | --- | --- |
+| Description | Exactly one paragraph, no `#` headings, no leading/trailing blanks — 4 diagnostics | Free-form; `jsdoc/match-description` ≥20 chars warn (tooling packages only) |
+| Sections | `**When to use**` → `**Details**` → `**Gotchas**` in exact order (`Jsdocs.ts:1020`); empty/dup/out-of-order = diagnostics | **None exist in law** (verified: "When to use" appears nowhere in the pattern doc) |
+| When-to-use opener | Must start `Use to/when/as/with` (`Jsdocs.ts:1024`) | n/a |
+| Example sections | `**Example** (Title)` last in prose; exactly one ```ts fence; unique titles; `loose-ts-fence` ban | n/a (but an organic pocket exists: law-practice models use bold `**Example**` headings — 3/20 in our sample) |
+
+## 3. Example carrier & validation
+
+| | Effect v4 | beep |
+| --- | --- | --- |
+| Carrier | `**Example** (Title)` markdown sections | `@example` tag |
+| Typechecked? | **No — nothing compiles the fences** (docgen's `examplesCompilerOptions` idles, `packages/effect/docgen.json:5-8`; `Parser.ts:105` reads a tag that no longer exists) | **Yes** — extracted + `tsc --noEmit` (`Core.ts:450-456`), the surviving pre-v4 discipline |
+| Executed? | No (only hand-written `ai-docs/` compiles as real source) | No (`runExamples` exists, default false everywhere) — `// Output:` claims unverified on both sides |
+| Shape rules | Named imports required; one fence; titled | `no-any-in-examples`, `no-type-assertions-in-examples`, import-alias rules (inventory) |
+| Quality bar | Editorial (showcase modules teach; ASCII `┌───` arrows, `// Output:` comments) | `deterministic-rubric-v1` detects trivial examples (15 codes) but is **advisory, wired to no CI lane** |
+| Sampled reality | Titled + observable in showcase modules; Schema.ts only 14% examples | n=20 sample: 60% trivial, 0 `// Output:`, 3 titled, 0 `@see`; named imports 17/20 |
+
+## 4. Cross-linking
+
+| | Effect v4 | beep |
+| --- | --- | --- |
+| `@see` | Dense, each with a purpose phrase ("@see {@link some} for creating a `Some`"); bidirectional between siblings | **75 total** across ~18k documented exports |
+| `{@link}` in prose | Idiomatic; must resolve to a *documented* symbol via `ts.createProgram` (`Jsdocs.ts:1524-1545`); URLs banned inside `{@link}` | Occasional; no resolution check of any kind |
+
+## 5. Categories
+
+| | Effect v4 | beep |
+| --- | --- | --- |
+| Vocabulary | Free-form per-module lowercase; no check (capitalized outliers `Reducer`/`Combiner` in Option.ts prove it) | 80 canonical slugs via LiteralKit + alias map + reject list (`JSDocCategories.ts:31-126,202-263`) |
+| Usage reality | ~22 distinct values in Option.ts alone; fine-grained per-module navigation (`converting`, `sequencing`, `zipping`…) | 19,100 occurrences, 113 distinct values: 8,152 `models` (43%!), 39 non-canonical values (511 occurrences) of which some are tolerated aliases and ~25 normalize to "unknown" (`execution`, `filesystem`, `scoring`, `jsdoc`…); 6 canonical slugs have zero usage |
+| Read | Their free-form yields *navigational* categories inside a module; our vocabulary yields *architectural* categories but `models` is doing 43% of the work — under-differentiated where it matters | |
+
+## 6. `@since`
+
+| | Effect v4 | beep |
+| --- | --- | --- |
+| Semantics | Real history — `2.0.0` carried-over, `4.0.0` new v4, long 3.x tail; stable-semver regex enforced (`Jsdocs.ts:435,1460`) | Uniform `0.0.0` placeholder by deliberate policy until v1.0 |
+| Verdict | Do NOT copy — real semver is meaningful only with released version history; keep `0.0.0` (confirm at grill) | |
+
+## 7. Enforcement surfaces & CI
+
+| Surface | Effect v4 | beep |
+| --- | --- | --- |
+| Grammar/shape | `@effect/jsdocs` (private, ~30 diagnostics) inside `pnpm lint` — **but diagnostics fail only under `--check`, which CI never passes** (`bin.ts:13`) | 12 inventory rules (ts-morph) + presence checks |
+| Ratchet | None | Fail-on-growth baseline (`standards/jsdoc-totals.regression-baseline.jsonc`), **required** CI check "JSDoc Ratchet" |
+| Compile gate | None (dead) | docgen lane (required): `@since` + example compilation |
+| Lint plugins | None (no jsdoc/tsdoc eslint/oxlint plugins) | `tsdoc/syntax` warn repo-wide; strict `jsdoc/*` block only in `packages/tooling/*/*/src` |
+| Net | Stronger spec, weaker teeth | Weaker spec, stronger teeth |
+
+## 8. Effect diagnostic → beep mapping (grill input)
+
+| Effect diagnostic (Jsdocs.ts) | beep today | Proposed disposition |
+| --- | --- | --- |
+| `missing-jsdoc`, `missing-description` | inventory presence checks + rubric `missing-description` | HAVE |
+| `missing-tag` (@category), `invalid-since` | inventory + docgen `enforceVersion` | HAVE (different `@since` semantics) |
+| `multiple-description-paragraphs`, `leading-blank`, `trailing-blank`, `invalid-heading` | nothing | ADD (cheap regex/AST rules) |
+| `section-out-of-order`, `duplicate-section`, `empty-section`, `section-after-example` | nothing | ADD — the core port |
+| When-to-use prefix rule | nothing | ADD |
+| `malformed-example` (×5), `duplicate-example`, `loose-ts-fence` | nothing (different carrier today) | ADD (adapted to chosen carrier B1/B2) |
+| `example-import-style` (named imports) | import-alias inventory rules (namespace-style for `effect/*`!) | **CONFLICT** — our law mandates `import * as S from "effect/Schema"`; theirs mandates named. Keep OURS (repo-wide import law outranks doc style). |
+| `tag-out-of-order` | eslint warn (tooling only) | ADD repo-wide (inventory) |
+| `forbidden-tag` (@example) | opposite law | GRILL (B1 vs B2) |
+| `unresolved-link`, `undocumented-see-target`, `url-link`, `malformed-link` | nothing | ADD (staged — needs checker program; most expensive rule) |
+| `invalid-spacing` | `jsdoc/tag-lines` warn (tooling only) | ADD |
+
+## 9. Adoption reality, both sides
+
+Effect (denominator = `@since` per module): When-to-use 99% Option / 51%
+Effect / 31% Schema / 19% Stream; Examples 87-97% except **Schema 14%**;
+category+since ~universal. beep: presence universal (ratcheted), pedagogy
+near-zero (`@see` 75, `@throws` 0, `@precondition` 0), example quality 60%
+trivial in sample. Lesson: neither repo lives at its own target; enforcement
+design must assume incremental adoption (ratchet-on-touch), and the
+every-export example law should be re-examined per symbol kind (Schema
+precedent).
+
+## 10. Hover-fidelity matrix (RQ4 — WebStorm quick-doc)
+
+Proven by the reference screenshots (Effect sources render fully):
+
+| Feature | Renders in WebStorm? | Evidence |
+| --- | --- | --- |
+| Bold `**Section**` headings in description | YES | Screenshots 1-3 |
+| Bullet lists | YES | Screenshots 1-2 |
+| Fenced ```ts code in description sections | YES (syntax-highlighted) | Screenshots 2-3 |
+| ASCII `┌───`/`▼` arrows + `// Output:` comments | YES (inside fences) | Screenshot 2 |
+| `{@link X}` inline in prose | YES (rendered link) | Screenshot 3 |
+| `@see {@link X} purpose phrase` | YES ("@see — some for creating a `Some`") | Screenshot 1 |
+| `@category` / `@since` tag rows | YES | Screenshots 1-3 |
+
+Pending user eyeball (probe file `scratchpad/jsdoc-hover-lab.ts`, ~2 min):
+
+| Probe | Question |
+| --- | --- |
+| `hoverSectionsInDescription` | Same section rendering when authored on a beep export? |
+| `hoverRemarksWithHeadings` | Does `@remarks` content render, incl. markdown inside it? |
+| `hoverCustomTags` | Do `@effects`/`@precondition` render or vanish? (If invisible → lower priority for the "looks like Effect" goal) |
+| `hoverDescribedSee` | Described `@see` + inline `{@link}` on our side? |
+| `hoverExampleTagWithOutput` | `@example` tag with caption text vs Feature-1 section: which renders better? (Direct B1-vs-B2 evidence) |

--- a/explorations/effect-jsdoc-quality/research/effect-doc-pipeline.md
+++ b/explorations/effect-jsdoc-quality/research/effect-doc-pipeline.md
@@ -1,0 +1,143 @@
+# How Effect docs ship in v4
+
+Dated 2026-07-30. All paths relative to `.repos/effect/` (git subtree pinned in
+this repo). Every claim cites a path; line numbers re-verified by the packet's
+claim-verification pass (see `SOURCES.md` §1).
+
+## Headline
+
+Effect v4's documentation quality is not a style guide — it is a
+**machine-enforced grammar**. A private tool, `@effect/jsdocs`
+(`packages/tools/jsdocs/src/Jsdocs.ts`, ~3,360 lines), parses every public
+JSDoc block and emits ~30 diagnostic codes. The conventions we admired in the
+screenshots are the *output* of that validator plus editorial effort on
+flagship modules. Two consequences for us:
+
+1. The style is fully portable: it is a spec, not taste.
+2. In moving to this grammar, Effect **forbade the `@example` tag** — and in
+   the same move **lost example typechecking entirely** (nothing compiles
+   their fenced example code anymore). Our `@beep/docgen` still has that
+   capability. We should port the grammar, not the regression.
+
+## The four lanes
+
+### Lane 1 — JSDoc grammar validation (`@effect/jsdocs`, new in v4)
+
+- Tool: `packages/tools/jsdocs/` (private package, bin `effect-jsdocs`).
+- Config: root `jsdocs.config.json` — `tsconfig.packages.json`, includes
+  `packages/**/src/**/*.ts`, excludes `packages/tools/**`, `src/index.ts`
+  barrels, `*Generated.ts`, all `internal/`; caches a parsed JSDoc model to
+  `.data/jsdocs.json` keyed by input hash.
+- Wiring: script `"jsdocs": "effect-jsdocs"` runs inside
+  `"lint": "pnpm jsdocs && oxlint -f unix && dprint check"` → CI Lint lane
+  (`.github/workflows/check.yml`).
+- **Trap — currently toothless:** in `packages/tools/jsdocs/src/bin.ts`,
+  *diagnostics* set a failing exit code only when `--check` is passed
+  (`bin.ts:13`; a crash still fails unconditionally, `bin.ts:32-34`), and
+  neither the `lint` script nor CI passes `--check`. Grammar violations
+  print; builds do not fail. Do not copy this wiring.
+
+The grammar it enforces (the portable asset — key constants in
+`packages/tools/jsdocs/src/Jsdocs.ts`):
+
+1. **One-paragraph description**, required. Multiple paragraphs, leading or
+   trailing blanks, and markdown `#` headings are all diagnostics.
+2. **Optional sections in exact order:** `**When to use**` → `**Details**` →
+   `**Gotchas**` (`standardHeadings`). Out-of-order, duplicated, or empty
+   sections are diagnostics. The `**When to use**` body must begin with one
+   of `Use to` / `Use when` / `Use as` / `Use with` (`whenToUsePrefixes`).
+3. **`**Example** (Title)` sections** come last in the prose. Each contains
+   exactly one non-empty ` ```ts ` fence; titles are unique per block
+   (case-insensitive); a ts fence outside an Example section is a diagnostic
+   (`loose-ts-fence`). Examples must use **named imports**
+   (`import { Option } from "effect"`).
+4. **Tags last**, separated by one blank line, whitelisted and ordered:
+   `@deprecated` → `@default` → `@see` → `@category` → `@since` (`tagOrder`).
+   Nothing else is permitted — `@example` produces `forbidden-tag`:
+   *"@example is not allowed; use a canonical **Example** (Title) section"*.
+5. `@category` is required on public symbols; `@since` is required on module
+   blocks and must be **stable semver** (`\d+\.\d+\.\d+`, no prereleases).
+6. `{@link X}` must resolve to a real TS symbol that itself has public JSDoc
+   (`unresolved-link`, `undocumented-see-target`); URLs inside `{@link}` are
+   banned. Resolution runs against a real `ts.createProgram` — the compiler
+   is used for *link resolution and signature extraction*, **not** for
+   compiling example code.
+
+### Lane 2 — Markdown API docs + website (classic `@effect/docgen`, demoted, alive)
+
+- `"docgen": "pnpm --recursive --filter \"./packages/**/*\" exec docgen && node scripts/docs.mjs"`
+  still runs classic `@effect/docgen` (v4.0.0-beta.102,
+  `packages/tools/docgen/`, published) over 21 per-package `docgen.json`
+  files, emitting `packages/<pkg>/docs/modules/*.md`; `scripts/docs.mjs`
+  copies into the Jekyll `docs/` shell; `pages.yml` publishes.
+- Its parser still reads `@example` tags (`packages/tools/docgen/src/Parser.ts`)
+  and `packages/effect/docgen.json` still carries a full
+  `examplesCompilerOptions` block — but since the grammar bans `@example`,
+  **the example-compilation machinery runs over an empty set**. This is the
+  dead role: v4 has no example typechecking, only example *shape* checks from
+  Lane 1.
+
+### Lane 3 — LLM-facing docs (`ai-docs/` → `LLMS.md`)
+
+- `ai-docs/src/` is **hand-authored**: ~48 `.ts` + ~22 `.md` files in numbered
+  chapters (basics → streams → http → ai → cluster).
+- `ai-docs/` is a real TS project referenced from `tsconfig.packages.json`, so
+  `pnpm check` typechecks every example destined for `LLMS.md` as ordinary
+  source — this is where v4's "examples must compile" energy went.
+- `"ai-docgen": "effect-ai-docgen ai-docs/src -o LLMS.md"` (a private Effect
+  CLI app, `packages/tools/ai-docgen/`) concatenates the tree into the
+  committed `LLMS.md`; the CI AI-docs lane regenerates it and **fails on a
+  dirty git tree** — a committed-generated-artifact gate worth remembering.
+
+### Lane 4 — Linters: no JSDoc involvement
+
+`.oxlintrc.json` (+ `packages/tools/oxc/`) has **no jsdoc/tsdoc plugin**; no
+typedoc, no eslint-plugin-jsdoc, no api-extractor anywhere in
+devDependencies. All JSDoc shape enforcement is Lane 1.
+
+## What replaced pre-v4 `@effect/docgen`, role by role
+
+| Pre-v4 `@effect/docgen` role | v4 status | Where |
+| --- | --- | --- |
+| `@example` extraction + `tsc` compile | **DEAD — no replacement** | Machinery idles in `packages/tools/docgen`; grammar bans the tag |
+| Markdown API doc generation | Unchanged | `packages/tools/docgen` + 21 `docgen.json` |
+| Website publishing | Unchanged | `scripts/docs.mjs` → Jekyll `docs/` → `pages.yml` |
+| Tag/`@since` validation | Superseded and expanded | `@effect/jsdocs` grammar (Lane 1) |
+| — (no v3 equivalent) | New: full section/link grammar | `@effect/jsdocs` |
+| — (no v3 equivalent) | New: LLM corpus | `ai-docs/` → `effect-ai-docgen` → `LLMS.md` |
+
+## Adoption reality (stratified sample, `packages/effect/src`)
+
+Denominator = `@since` count per module (proxy for documented symbols).
+
+| Module | `@since` | **When to use** | **Details** | **Gotchas** | **Example** | `@category` | `@see {@link}` | `// Output:` | ASCII `┌───` |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Option.ts | 67 | 99% | 85% | 0 | 87% | 97% | 104 | 109 | 6 |
+| Effect.ts | 240 | 51% | 64% | 14 | 97% | 97% | 146 | 101 | 35 |
+| Schema.ts | 531 | 31% | 39% | 40 | **14%** | 98% | 220 | 2 | 0 |
+| Layer.ts | 55 | 58% | 65% | 1 | 67% | 98% | 43 | 0 | 0 |
+| Stream.ts | 243 | 19% | 35% | 7 | 93% | 100% | 33 | 145 | 0 |
+| Cause.ts | 76 | 57% | 30% | 6 | 79% | 95% | 66 | 0 | 0 |
+
+Honest read: `@category`/`@since` are universal (mechanically enforced);
+sections are the **target** state, not the current state — Option.ts is the
+freshly-rewritten showcase (99% When-to-use) while Stream.ts sits at 19%.
+Schema.ts proves hover quality does not require an example on every export.
+`@example` tags: **zero** across `packages/effect/src` (raw string hits are
+`alice@example.com` inside example code). `@experimental`: zero — not a v4
+convention. `@since` values are real history (`2.0.0` carried-over, `4.0.0`
+new v4 surface, long tail of 3.x).
+
+`@category` values are free-form per-module lowercase (Option.ts has 22
+distinct values, including capitalized outliers `Reducer`/`Combiner` that
+prove no vocabulary check) — unlike our 80-slug `LiteralKit` vocabulary.
+
+## Implications for beep (pointers, argued in `diff-effect-vs-beep.md` / `options.md`)
+
+- Port the grammar semantics into our existing `jsdoc-inventory` rules; do
+  not depend on `@effect/jsdocs` (private) or copy its toothless CI wiring.
+- Keep `@beep/docgen` example compilation — it is our advantage over v4.
+  The `@example`-tag-vs-`**Example**`-section carrier question is a grill
+  decision; both variants can preserve compilation.
+- Their uneven adoption argues for ratchet-on-touch (new/edited code), not a
+  retroactive sweep of ~18k exports.

--- a/explorations/effect-jsdoc-quality/research/options.md
+++ b/explorations/effect-jsdoc-quality/research/options.md
@@ -1,0 +1,100 @@
+# Options: closing the JSDoc quality gap (pre-grill)
+
+Dated 2026-07-30. Four candidates, minimal → ambitious. Recommendation up
+top per repo convention; nothing here is decided — `/grill-with-docs`
+resolves the axes at the end.
+
+## Recommendation
+
+**Lead with Option B** (grammar port, compile validation preserved,
+ratchet-on-new). It ports the only thing Effect actually has that we lack —
+the machine-checkable section grammar — while keeping the two things we have
+that Effect lost or never had: example compilation and CI teeth. Options A
+and C exist to bracket B at the grill; D is future-goal material.
+Independent of the winner: **fast-track the described-`@see` convention**
+(cheapest, highest-visibility change; needs no grammar debate).
+
+## Option A — Convention-only (floor)
+
+- **Change:** rewrite `.patterns/jsdoc-documentation.md` + the
+  `jsdoc-annotation-specialist` skill to adopt sections
+  (**When to use** / **Details** / **Gotchas** / titled examples) and
+  described-`@see`; resolve the `@remarks` collision. No tooling.
+- **Ratchet story:** none.
+- **Effort:** S (days).
+- **Evidence against it standing alone:** in this repo, unenforced
+  conventions hit zero adoption — `@precondition` 0, `@throws` 0,
+  `@postcondition` 0 despite 900+ lines of law and registered tags.
+- **Keep because:** every other option contains it; it is step 1 of B and C.
+
+## Option B — Grammar port, compile validation preserved (RECOMMENDED)
+
+- **Change:**
+  1. Option A's law + skill rewrite.
+  2. ~6-8 new `jsdoc-inventory` rules porting `Jsdocs.ts` semantics
+     (diff §8 ADD rows): description shape, section order/emptiness/dupes,
+     When-to-use prefix, example title+uniqueness+fence rules, described-@see,
+     tag order. `{@link}` resolution (A9) staged last or deferred — the only
+     rule needing a checker program.
+  3. New rule codes ride the existing fail-on-growth baseline
+     (`jsdoc-totals.regression-baseline.jsonc`) — **ratchet-on-new/touched
+     code, no retroactive sweep of ~18k exports**.
+  4. Pilot: 2-3 packages rewritten by `jsdoc-annotation-specialist`
+     (proposal: `packages/foundation/modeling/schema` + one tooling package +
+     one law-practice slice, which already grew titled examples organically);
+     acceptance = before/after WebStorm hover screenshots.
+- **Sub-decision for the grill (example carrier):**
+  - **B1 — keep `@example` tag** as the carrier, add section grammar around
+    it. Zero docgen change; hover renders both (lab probe confirms); slight
+    divergence from Effect's look (tag row instead of bold heading).
+  - **B2 — move to `**Example** (Title)` sections**, teach
+    `@beep/docgen` `Parser.ts` to harvest description fences
+    (`extractFencedCodeBlocks` already exists in `Core.ts:268` — verified
+    localized change), keep `tsc --noEmit`. Closer to Effect's look; touches
+    docgen + the mandatory-`@example` law + inventory presence checks.
+- **Ratchet story:** advisory first run → fold new codes into the baseline →
+  required lane unchanged ("JSDoc Ratchet" already required).
+- **Effort:** M (1-2 weeks incl. pilot).
+- **Risks:** markdown-section parsing subtleties in ts-morph comment text;
+  pilot scope creep; `@remarks` migration ambiguity (existing 491 uses).
+
+## Option C — Full validator + migration (ceiling)
+
+- **Change:** dedicated `beep quality jsdoc-grammar` at `Jsdocs.ts` parity
+  including resolved links; ban `@example` (full B2); migrate all ~18k
+  exports via codemod + agent passes; hard-required from day one.
+- **Effort:** XL (multi-week, all-package churn).
+- **Against:** we would enforce harder than Effect enforces on itself (their
+  CI doesn't fail on grammar violations; their own adoption is 19-99%);
+  review noise swamps signal; conflicts with parallel in-flight work.
+- **Keep because:** the grill should consciously reject or stage it, not
+  never see it.
+
+## Option D — Pedagogy infrastructure (park as future goals)
+
+Orthogonal to "looks like Effect"; each item is a separate goal candidate:
+
+- Wire `deterministic-rubric-v1` into an **advisory** CI lane (15 codes exist
+  today, zero teeth).
+- LLM example-quality scoring per `goals/jsdoc-worker-eval` verdicts
+  (hosted codex candidate-baseline; advisory-only; write-mode explicitly
+  non-goal per its SPEC).
+- `runExamples` pilot (runner exists, one config flag) to make `// Output:`
+  comments verified claims.
+- `ai-docs/`-style typechecked LLM corpus → generated `LLMS.md` analog.
+- Category vocabulary repair: 39 non-canonical values / 511 occurrences
+  normalize to alias/unknown today; either extend the 80-slug LiteralKit or
+  remediate — plus split the 43% `models` monolith with navigational
+  sub-categories.
+
+## Grill decision axes (mapped to evidence)
+
+| Axis | Evidence | Proposed default |
+| --- | --- | --- |
+| Keep/evolve `@beep/docgen` vs adopt Effect stack | Theirs: private, diagnostics-without-teeth, example compilation dead | Keep ours; port semantics only |
+| Section enforcement hardness | Unenforced = 0 adoption here; hard-gate = churn; Effect target-state ≠ actual-state | Ratchet-on-touch via existing baseline |
+| Every-export compilable example | Schema.ts 14% + our 60%-trivial sample: presence ≠ pedagogy | Keep presence law BUT re-examine per symbol kind; tighten quality on what exists |
+| Example carrier | B1 zero-tooling vs B2 Effect-look (verified-cheap docgen change); hover lab probe compares directly | Decide at grill with lab results |
+| Pilot scope | foundation/modeling/schema (highest reuse), tooling (already eslint-strict), law-practice (organic precedent) | 2-3 packages, hover-screenshot acceptance |
+| Inventory/ratchet relationship | New codes ride existing fail-on-growth baseline + required lane | No new CI lane needed |
+| Law changes | `@remarks` collision (:183-186); tag order rework; described-@see; `@since` stays `0.0.0`; import-style divergence from Effect stays | Rewrite pattern doc once, at goal start |

--- a/explorations/effect-jsdoc-quality/research/quality-rubric.md
+++ b/explorations/effect-jsdoc-quality/research/quality-rubric.md
@@ -1,0 +1,52 @@
+# What "Effect-level" means operationally for beep
+
+Dated 2026-07-30. The rubric splits every observed quality into
+**convention** (machine-checkable — a legitimate automation/ratchet target)
+vs **editorial** (prose craft — a skill/review target, never a CI gate).
+Marks per the brief: prose | convention | tooling | process.
+
+## A. Machine-checkable (convention/tooling — automatable)
+
+| # | Quality | Check | Gap class | Exists today? |
+| --- | --- | --- | --- | --- |
+| A1 | One-paragraph lead description (no heading soup, no blank padding) | paragraph count + blank-line + `#`-heading rules | convention | NO |
+| A2 | Sections in exact order **When to use** → **Details** → **Gotchas**, non-empty, non-duplicated | section parser over the description body | convention | NO |
+| A3 | **When to use** opens with `Use to/when/as/with` | prefix check | convention | NO |
+| A4 | Examples titled and unique: `**Example** (Title)` or `@example` caption (carrier per grill B1/B2) | title presence + per-block uniqueness | convention | NO (3/20 organic) |
+| A5 | Exactly one fence per example; no loose ts fences outside examples | fence counter | convention | NO |
+| A6 | Example **compiles** (`tsc --noEmit`) | `@beep/docgen` | tooling | **YES — keep; Effect lost this** |
+| A7 | Example shows an observable result (log/assert, not void-discard) | `deterministic-rubric-v1` codes (`example-lacks-observable-result`, `example-too-trivial`, …) | tooling | YES but advisory-only (0 CI teeth) |
+| A8 | Described `@see`: every `@see` carries a purpose phrase | tag-text non-empty after link | convention | NO (75 `@see` repo-wide) |
+| A9 | `{@link}` / `@see` targets resolve to real, documented symbols | checker-program resolution (most expensive rule; stage last) | tooling | NO |
+| A10 | Tag order + tag whitelist per repo law | inventory rule (exists as eslint warn only in tooling pkgs) | convention | PARTIAL |
+| A11 | `@category` canonical/alias (not "unknown") | `JSDocCategories` normalization — **today 39 non-canonical values / 511 occurrences live in src** | tooling | PARTIAL (vocabulary exists, gate tolerates unknowns) |
+| A12 | `@since` present (`0.0.0` policy stands) | docgen `enforceVersion` | tooling | YES |
+| A13 | Import style inside examples matches repo law (namespace `import * as S` — NOT Effect's named-import rule) | existing inventory import rules | convention | YES (keep ours; explicit divergence from Effect) |
+
+## B. Editorial (prose — skill/rubric/review, never a hard gate)
+
+| # | Quality | Where it lives |
+| --- | --- | --- |
+| B1 | Lead sentence teaches *when/why*, dense with inline-code tokens | pattern doc exemplars + `jsdoc-annotation-specialist` skill |
+| B2 | **Details** bullets state non-obvious semantics (subtyping, singletons, laws), not signature restatement | skill rubric |
+| B3 | ASCII type-annotation arrows (`┌───`/`▼`) where inference is non-obvious | skill; showcase idiom, not a rule |
+| B4 | `// Output:` comments truthful | editorial until `runExamples` pilot lands (Option D) |
+| B5 | Example exercises the *interesting* API surface (e.g. TaggedUnion demoing `match`) | skill + pilot review |
+| B6 | Cross-link graph curated (bidirectional sibling `@see`) | skill; A8/A9 check form, not judgment |
+
+## C. Proxies to track (process)
+
+- % of touched exports with **When to use** per package family (ratchet-on-touch metric).
+- Described-`@see` per 100 exports (baseline today: 0.4).
+- `deterministic-rubric-v1` score distribution per package (baseline: 60% trivial in the n=20 sample).
+- Pilot acceptance: before/after WebStorm hover screenshots on the pilot packages judged against the reference screenshots.
+
+## D. Explicit non-goals inside the rubric
+
+- Real-semver `@since` (needs release history we don't have; `0.0.0` policy stands).
+- Named-import examples (conflicts with repo-wide namespace-import law — A13).
+- Effect's free-form categories (our LiteralKit vocabulary stays; fix the
+  "unknown" leakage instead).
+- Universal example coverage as a *quality* metric — Schema.ts (14% examples,
+  excellent hovers) proves presence ≠ pedagogy; quality gates target the
+  examples that exist.


### PR DESCRIPTION
## Summary

Opens the research-stage exploration packet `explorations/effect-jsdoc-quality/` (+ ATLAS
registration). Docs-only; no changeset needed.

Mission: close the JSDoc pedagogy gap so `@beep/*` IDE hovers teach like Effect v4's.
Research -> grill -> goal; this PR lands the research artifacts and stops at the packet's
hard stop: no `goals/` packet, no `.patterns/` law edits, no JSDoc rewrites until
`/grill-with-docs` completes.

Key findings (all path:line-verified in the packet):

- Effect v4's hover quality is a machine-enforced grammar (`@effect/jsdocs`, ~30 diagnostics):
  When to use / Details / Gotchas sections, titled Example sections, described `@see`,
  `{@link}` resolved against a checker program.
- Effect v4 forbids `@example` outright - and thereby lost example typechecking, which
  `@beep/docgen` still has. Their grammar validator also does not fail their CI.
- Our system is the inverse: presence + compilation with real ratchet teeth, near-zero
  pedagogy (75 `@see` across ~18k exports; 60% trivial examples in a 20-sample audit).
- Four options staged in `research/options.md` (lead: Option B - port the grammar as new
  jsdoc-inventory rules riding the existing fail-on-growth baseline, keep compile validation).

## Artifacts

CAPTURE, RESEARCH synthesis, research/{SOURCES, effect-doc-pipeline, diff-effect-vs-beep,
quality-rubric, options}, BRIEF drafted early as grill input, DECISIONS pending grill,
manifest at stage `research`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788019738&installation_model_id=424656&pr_number=515&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F515&signature=6600ce93987d33f23f0be8a878565ea2c5699211c62f27d1c3ab56a2dbe010bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->