### PR TITLE
docs(speed-loop): ratify grill #4 merge-loop, soundness, and parity decisions

### DIFF
--- a/goals/speed-loop/research/GRILL-DECISIONS.md
+++ b/goals/speed-loop/research/GRILL-DECISIONS.md
@@ -58,3 +58,158 @@ allow-marker workaround once the [[allowlists]] syntax is honored hosted-side.
 12. **Spike order: cross-clone LAN cache → grit collector → single-process
     battery → vitest projects → stage-3 html** (stage-3 keeps its ≤8M exit
     gate; battery waits for PR-A timing fields).
+
+## Grill #4 — merge loop, soundness, agent kit, parity (2026-08-04)
+
+Eleven decisions over the full ledger docket (#21–#54). Shipped state at
+grill time: PR-A merged (#551), #548/#549/#547 merged, PR-B/PR-C queued from
+grills #2–#3.
+
+13. **Queue topology: PR-E jumps.** Order: PR-E "merge loop" → (PR-B in
+    parallel; execution-only, disjoint surfaces) → PR-F "soundness" → PR-I
+    "agent kit" → PR-C "pipeline 2" → PR-G "preflight parity" → PR-H "teach
+    pack" → repo-wide jsdoc codemod PR. Rationale: closeout friction taxed
+    all four merges this week; the kit serves C/G/H's own implementation
+    waves.
+14. **PR-E "merge loop".** (a) `beep yeet merge` porcelain: merge WITHOUT
+    `--delete-branch` → verify MERGED via API → sweep tail; operator-
+    authorized only, never auto-invoked. (b) `yeet sweep` (#39): SweepPlan +
+    SweepReport schema pair, `--plan` dry-run, worktree-aware safety rails,
+    "merged, cleanup skipped: reason" = success; auto-runs on monitor's
+    merged detection and stands alone. (c) `yeet monitor --until-merged`
+    (#42): opt-in flag, follows new SHAs, known-flake fingerprints
+    (ts2589-no-location, CI-timeout) get ONE `gh run rerun --failed` per
+    lane/SHA (#23), other reds report "needs code fix"; surfaces the
+    `mergeReady` verdict (criteria per decision-track #20: checks green +
+    threads resolved hard, Greptile displayed target). (d) `yeet reply`
+    (#51): ReplyDrafts → validate against live threads → post + resolve
+    (GraphQL mutation) → ReplyReport; runnable by either party. (e) Verdict
+    encode fix: YeetVerdict gains a Json codec (FlakeQuarantineArtifactJson
+    pattern) + round-trip test — LAW: every yeet artifact writes through
+    `S.encode`. (f) Rider: dead `"tooling"` testSearchRoots entry removed
+    (#38 bonus).
+15. **PR-F "soundness pair".** #37 durable remedy = sentinel ambient `.d.ts`
+    emitted by tsconfig-sync codegen carrying the plugins-block content hash
+    (global-scope change → full per-file diagnostic invalidation); fallback
+    if flaky: wrapper drift-detect + `tsgo -b --force`. Plus #34
+    append-optional lint: version-carrying S.Class schemas may not gain
+    required fields vs origin/main without a version bump; failure output
+    teaches `S.OptionFromOptionalKey` + `SchemaUtils.withNoneDefault`. Plus
+    #31: cleanup-on-touch exempts `*.generated.ts`/`_generated/**`
+    (generators get a one-time upgrade). One-time unmask chore (forced
+    rebuild + turbo cache bust on main) runs this week, independent of the
+    PR.
+16. **PR-I "agent kit".** #45 `beep agent report` write/check (completion
+    packet gains an `opportunities` field — durable home of the #54
+    reflection rider), #48 `beep worktree ready`, #49 wave partition
+    manifests + `beep wave lint`, #52 `beep agent brief` including #53a's
+    needs-operator operation list. Definition-of-done rider applies: each
+    command ships its awareness surface (AGENTS.md tool-routing block, skill
+    references, gate output naming the widget) in the same PR.
+17. **PR-C amendments.** #40 changed-scope jsdoc inventory REPLACES o1-A's
+    shard-cache design (origin/main...HEAD + dirty, docgen:local pattern;
+    sound because findings are per-file and untouched packages inherit
+    baseline by construction); full sweep moves to main/nightly — refines
+    decision 5, hosted PR lane goes scoped. #41 folds into the coverage
+    item: affected-only measurement + forensics on the 0/231 cache-hit
+    mystery. #44 rider: coverage failures print the corrected baseline hunk.
+18. **PR-B amendment.** #36 rides PR-B: hosted lanes embed their exact local
+    repro command in `$GITHUB_STEP_SUMMARY` — same check.yml surface as
+    #13's failure excerpts.
+19. **PR-G "preflight parity".** #28 preflight-before-push reorder + #29
+    changed-package vitest + #43 touched-package src+test overlay generator,
+    run concurrently (~2.5 min wall) + #46 `beep ci affected-lanes` and
+    per-gate JSON battery verdicts (retires ad-hoc battery.zsh) + #47
+    `beep ci logs <lane>` failure-region fetcher.
+20. **PR-H "teach pack" + codemod.** #33 `jsdoc-ratchet --fix` (the gate
+    carries its codemod) + #50 gate failure-output contract (findings +
+    repro command + doc pointer, schema-shaped; scaffold emits by default;
+    meta-lint audits existing gates). #32 lands as its own mass-diff PR
+    immediately after H by running the `--fix` repo-wide once.
+21. **Structural CI disposition.** #21 CLOSED (subsumed by #25). #24
+    workstation-runner pilot folds into the LAN-cache spike session ($0
+    hardware, hygiene rails per ledger; AWS variant waits for pilot data).
+    #25 `yeet predict-squash` read-only spike enters the queue. #22
+    merge-queue evaluation triggers on E-wave monitor data (treadmill tax
+    quantified), pairs with deferred lane consolidation. #26 capsule
+    protocol + #35 fingerprint lane-collapse → grill #5 design docket, after
+    B/G/E teach us the fields. #27 attestation parked behind #24 + #26.
+    Grit collector PARKED — #40's changed-scope collapsed its payback;
+    revivable only if nightly full-sweep cost matters. Updated spike order:
+    LAN cache + workstation runner → predict-squash → single-process battery
+    → vitest projects → stage-3 html.
+22. **Test-typecheck blindspot burn-down: passive + opportunistic.** The
+    ratchet (standards/test-typecheck.blindspot-baseline.jsonc) blocks new
+    blindspots; queued PRs wire test typecheck for packages they already
+    touch; no new gate (gates-diet doctrine), no dedicated burn-down series.
+    Upstream @effect/tsgo issue (MethodDeclaration owners +
+    callback-position functions) drafted by the agent, filed by the operator
+    this week; effect-fn law re-pruned after upstream ships.
+23. **Sub-agent reflection harvest (#54).** Standing prompt ritual effective
+    immediately: every sub-agent reports friction/opportunities before
+    finishing; orchestrator harvests into the ledger. Structured home is
+    #45's `opportunities` field once PR-I lands.
+
+## Grill #4b — per-item design pass (2026-08-04, same session)
+
+Operator asked for per-item coverage before implementation begins; the audit
+found #17–#19 unplaced and design trees open on PR-I/C/G/H. Ten more
+decisions close them:
+
+24. **#17–#19 placement.** #18 hot-barrel advisory → PR-F rider (advisory
+    severity, changed-scope, curated hot-barrel list — schema root, html
+    root, agents-use-cases public/server). #19 `beep quality probe <file>` →
+    PR-G, sharing #43's overlay-generator internals so measurements stay
+    method-identical. #17 `beep architecture add-leaf` → triggered: opening
+    commits of the first stage-2/protocol-boundary PR, proving the codegen
+    against a live boundary in the same diff.
+25. **#55 fallow advisory self-heal.** Stale or mode-mismatched envelopes
+    are purged and the phase skips with a verdict note — an advisory phase
+    never exits 1 (precedent: decision 2). PR-E rider.
+26. **#52 `beep agent brief`.** AgentBrief S.Class → fenced-markdown render
+    (+`--json`); contents: env facts (tool paths, zsh -ic wrapper), git
+    facts, PR facts, boundaries, scratchpad path, canonical gate commands,
+    and the #53a needs-operator list as a curated in-code LiteralKit domain.
+    PR enrichment default-on behind a short-TTL per-branch cache;
+    `--no-remote` opt-out.
+27. **#45 `beep agent report`.** Packet at `.beep/agents/<name>/report.json`:
+    agentName, waveId?, status (complete|partial|blocked), filesTouched,
+    gatesRun {command, exitCode, excerpt, durationMs}, outOfScope
+    encountered, open questions, opportunities {kind: friction|wish, text}
+    (#54's structured home). `check` validates schema + file-claim drift by
+    default; `check --prove` re-runs claimed gates. Rule 4 becomes
+    machine-checkable without a 2× gate tax per wave.
+28. **#49 wave manifests + lint.** WaveManifest at
+    `.beep/waves/<id>/manifest.json`: glob ownership (most-specific claim
+    wins) + shared bucket (changesets, lockfile); drift = dirty files
+    outside all claims; attribution joins the manifest with #45 reports to
+    name the straying agent; report-only posture with a signaling exit code
+    — no blocking hook.
+29. **#48 `beep worktree ready`.** Idempotent create-or-refresh (new
+    branches cut from origin/main after fetch); `bun install` iff bun.lock
+    hash ≠ per-worktree stamp; turbo-cache verify-and-report with
+    `--isolate-cache` opt-in; finishes by emitting the #52 brief. Never
+    mutates a dirty worktree.
+30. **#11 docgen escalation narrowing.** turbo.json docgen-slice hash +
+    bun.lock moved-entry dependent-closure attribution; escalates to the
+    full proof whenever narrowness is unprovable (parse failure, closure
+    escaping the changed set). o3-B ship porcelain and o4-B coverage
+    designs stand as grilled in #3, with #41 forensics and #44 rider folded
+    in.
+31. **PR-G posture + consistency locks.** Preflight red blocks the push;
+    `--push-anyway` proceeds and records the overridden findings in the
+    verdict. Battery verdicts reuse #45's GateRun shape (one schema, two
+    consumers); `ci affected-lanes` derives from the hosted lane
+    definitions (single source of truth); #43 overlays generate into
+    gitignored `.beep/overlays/`.
+32. **#50 contract enforcement: ratcheted advisory.** GateFailure schema
+    (findings + exact repro + binding-doc pointer; text render for humans,
+    S.encode JSON for agents); baseline file freezes existing non-compliant
+    gates; the new-gate scaffold emits the contract so new gates are born
+    compliant and the ratchet blocks new baseline entries; existing gates
+    migrate cleanup-on-touch. `--fix` default-off, in-place, diff-reviewed;
+    #32's repo-wide run stays its own mass-diff PR.
+33. **Coverage audit result.** With 24–32 locked, every ledger item #1–#55
+    holds a shipped state, a design + vehicle, a trigger, or an explicit
+    parking. Per-item grill coverage is complete; implementation may start
+    at PR-E.

--- a/goals/speed-loop/research/GRILL-DECISIONS.md
+++ b/goals/speed-loop/research/GRILL-DECISIONS.md
@@ -213,3 +213,30 @@ decisions close them:
     holds a shipped state, a design + vehicle, a trigger, or an explicit
     parking. Per-item grill coverage is complete; implementation may start
     at PR-E.
+
+## Fleet-coordination amendments (2026-08-04, beep-effect5 session)
+
+34. **#22 split, #16 transferred.** The fleet-coordination session
+    (beep-effect5, 13-clone/one-machine scope; cross-machine out of scope
+    per operator) owns the merge-queue design half — mechanism, cost, batch
+    bisection under a 13-agent fleet. Speed-loop keeps only the E-wave
+    treadmill-tax measurement feeding that design, and opens no grill #5
+    item re-deriving merge-queue mechanics. #16 fleet housekeeping
+    transfers: the fleet session's scan produces the staleness inventory.
+35. **PR-I schema reservations for fleet reuse (implement now, no hold).**
+    (a) #49: the ownership-claim record splits out as its own named schema
+    — OwnershipClaim (owner, ownedPaths, doNotTouch) — with waveId living
+    on WaveManifest, never on the claim, so a fleet-scoped registry reuses
+    the record instead of forking it. (b) #52: AgentBrief carries an
+    optional fleet extension block from day one; the PR-enrichment TTL
+    cache is keyed generically rather than branch-hardcoded. (c) #45:
+    report paths stay deterministic (.beep/agents/<name>/report.json) and
+    `beep agent report list` enumerates them, so out-of-session readers
+    discover reports without the writer's context. PR-I ships in its queue
+    slot with these shapes — one extra named schema, no wait on the fleet
+    grill.
+36. **Worktree detection law (fleet finding).** `[ -d "$d/.git" ]`
+    silently skips linked worktrees — `.git` is a FILE there. #39 sweep,
+    #48 worktree ready, and any future worktree-aware step detect via
+    `git rev-parse --git-dir` / `git worktree list`, never a .git-directory
+    existence check.

--- a/goals/speed-loop/research/GRILL-DECISIONS.md
+++ b/goals/speed-loop/research/GRILL-DECISIONS.md
@@ -76,10 +76,17 @@ grills #2–#3.
     authorized only, never auto-invoked. (b) `yeet sweep` (#39): SweepPlan +
     SweepReport schema pair, `--plan` dry-run, worktree-aware safety rails,
     "merged, cleanup skipped: reason" = success; auto-runs on monitor's
-    merged detection and stands alone. (c) `yeet monitor --until-merged`
-    (#42): opt-in flag, follows new SHAs, known-flake fingerprints
-    (ts2589-no-location, CI-timeout) get ONE `gh run rerun --failed` per
-    lane/SHA (#23), other reds report "needs code fix"; surfaces the
+    merged detection and stands alone. Branch deletion contract: `-d` for
+    ancestry-merged; `-D` only when the branch's PR is MERGED AND the
+    local tip equals the PR's recorded head SHA AND no worktree holds the
+    branch (remote deletion needs the same tip match); otherwise
+    skip-and-report. (c) `yeet monitor --until-merged` (#42): opt-in flag,
+    follows new SHAs, known-flake fingerprints (ts2589-no-location,
+    CI-timeout) get ONE job-scoped rerun per job per SHA via
+    `gh run rerun --job <databaseId>` (#23) — never `--failed`, which
+    reruns every failed job and would re-execute coexisting genuine reds,
+    breaking the bounded budget; other reds report "needs code fix";
+    surfaces the
     `mergeReady` verdict (criteria per decision-track #20: checks green +
     threads resolved hard, Greptile displayed target). (d) `yeet reply`
     (#51): ReplyDrafts → validate against live threads → post + resolve
@@ -109,8 +116,12 @@ grills #2–#3.
 17. **PR-C amendments.** #40 changed-scope jsdoc inventory REPLACES o1-A's
     shard-cache design (origin/main...HEAD + dirty, docgen:local pattern;
     sound because findings are per-file and untouched packages inherit
-    baseline by construction); full sweep moves to main/nightly — refines
-    decision 5, hosted PR lane goes scoped. #41 folds into the coverage
+    baseline by construction — sound ONLY while analyzer inputs are
+    unchanged: edits to the inventory scanner, its policy/config, or other
+    global inputs escalate the PR lane to the full repo-wide sweep, same
+    conservative posture as #11's docgen levers, review-hardened on #558);
+    full sweep moves to main/nightly — refines decision 5, hosted PR lane
+    goes scoped. #41 folds into the coverage
     item: affected-only measurement + forensics on the 0/231 cache-hit
     mystery. #44 rider: coverage failures print the corrected baseline hunk.
 18. **PR-B amendment.** #36 rides PR-B: hosted lanes embed their exact local
@@ -181,15 +192,21 @@ decisions close them:
     machine-checkable without a 2× gate tax per wave.
 28. **#49 wave manifests + lint.** WaveManifest at
     `.beep/waves/<id>/manifest.json`: glob ownership (most-specific claim
-    wins) + shared bucket (changesets, lockfile); drift = dirty files
-    outside all claims; attribution joins the manifest with #45 reports to
-    name the straying agent; report-only posture with a signaling exit code
-    — no blocking hook.
+    wins) + shared bucket (changesets, lockfile); drift has TWO detectors —
+    (a) dirty files outside every claim, and (b) any agent report's
+    filesTouched escaping that agent's own resolved claims, which catches
+    the cross-owner case where A edits a file validly claimed by B
+    (review-hardened on #558); attribution joins the manifest with #45
+    reports to name the straying agent; report-only posture with a
+    signaling exit code — no blocking hook.
 29. **#48 `beep worktree ready`.** Idempotent create-or-refresh (new
     branches cut from origin/main after fetch); `bun install` iff bun.lock
-    hash ≠ per-worktree stamp; turbo-cache verify-and-report with
-    `--isolate-cache` opt-in; finishes by emitting the #52 brief. Never
-    mutates a dirty worktree.
+    hash ≠ per-worktree stamp OR the install-health probe fails
+    (node_modules missing, or a sentinel binary such as
+    `node_modules/.bin/tsgo` absent) — a matching stamp must never mask a
+    deleted or gutted node_modules (review-hardened on #558); turbo-cache
+    verify-and-report with `--isolate-cache` opt-in; finishes by emitting
+    the #52 brief. Never mutates a dirty worktree.
 30. **#11 docgen escalation narrowing.** turbo.json docgen-slice hash +
     bun.lock moved-entry dependent-closure attribution; escalates to the
     full proof whenever narrowness is unprovable (parse failure, closure
@@ -240,3 +257,21 @@ decisions close them:
     #48 worktree ready, and any future worktree-aware step detect via
     `git rev-parse --git-dir` / `git worktree list`, never a .git-directory
     existence check.
+37. **OwnershipClaim stays provenance-free; fleet wraps.** Decided against
+    a `provenance: declared | derived` discriminant on OwnershipClaim: the
+    record describes WHAT is claimed; how a claim came to be known
+    (scannedAt, signal, liveness, expiry) is knowledge about the claim and
+    lives on the fleet layer's wrapper (FleetClaim { claim, ... }). Wave-
+    side the discriminant would be a constant `declared`; derived claims'
+    differing expiry semantics is the signature of decoration, not
+    discrimination. If a mixed-collection consumer ever needs provenance on
+    the record, #34's append-optional lint makes that a safe versioned
+    addition — reserving the field now buys nothing. PR-I implementers: do
+    not add provenance "helpfully."
+38. **#56 ↔ #22 sequencing coupling (fleet cost-model finding).** Scoped PR
+    checks (#56) + full gauntlet at merge-group time dissolves most of the
+    "24 required checks serialize a 13-agent fleet" objection to a merge
+    queue. #56 therefore sequences BEFORE any #22 adoption and the two are
+    evaluated as a composition, not independently; the fleet session names
+    the specific flip condition so the E-wave treadmill data settles
+    adoption without reopening design.

--- a/goals/speed-loop/research/OPPORTUNITIES.md
+++ b/goals/speed-loop/research/OPPORTUNITIES.md
@@ -292,3 +292,248 @@ consolidation (deferred pending cache measurements). Per-lane proof resume
     (Quality.command.ts:269), and 69 packages still lack per-package test
     typecheck in `check` (already ratcheted:
     standards/test-typecheck.blindspot-baseline.jsonc, 65 findings).
+
+39. **Post-merge workspace reset (`yeet sweep`).** After the merge lands via
+    gh CLI, the local clone is left stale and the NEXT yeet run pays for it:
+    the feature branch lingers, origin refs are unpruned, local main is
+    behind (stale-base → rebase treadmill), and a lockfile-moving main means
+    stale node_modules phantom failures. Add a closeout step (or standalone
+    `beep yeet sweep`) that leaves the clone ready to go: (a) `git fetch
+    --prune`; (b) FF-only main update — worktree-aware: when main is not
+    checked out anywhere use `git fetch origin main:main`, when another
+    worktree holds main skip-and-report rather than checkout; (c) delete
+    local branches fully merged into origin/main (`git branch -d`, never
+    `-D`; skip any branch checked out in a worktree, skip branches with
+    unpushed commits); (d) diff the lockfile across the main update and run
+    `bun install` when it moved; (e) end on main (or report why not).
+    Safety rails: never touch a dirty worktree, report every skip with its
+    reason, and never force-delete — unmerged local work is sacred. Natural
+    wiring: the tail of `yeet monitor`'s merged-PR path and/or closeout.
+
+    *Live evidence (#551 merge, 2026-08-04):* `gh pr merge --squash
+    --delete-branch` from the agent worktree API-merged successfully, then
+    its LOCAL cleanup failed (`fatal: 'main' is already used by worktree at
+    …/beep-effect3`), exited nonzero — mimicking a failed merge — and
+    silently ABORTED the remote branch deletion. Sweep must therefore own
+    the whole post-merge sequence itself: merge WITHOUT `--delete-branch`,
+    verify merged state via API, then do remote deletion + ref updates +
+    local cleanup as its own worktree-aware plan steps, classifying
+    "merged, cleanup skipped: <reason>" as success. Also confirmed:
+    `git fetch origin main:main` correctly refuses when main is checked out
+    elsewhere — the skip-and-report branch of (b) is reachable and needed.
+    Squash-merge detection note for (c): merged branch tips are NOT
+    ancestors of origin/main, so `git branch -d` will refuse; deletion must
+    key on the branch's PR being MERGED (then `-D`, with the report citing
+    the PR).
+
+## Discussion harvest (2026-08-04, while driving #551's fix waves to green)
+
+40. **Changed-scope jsdoc inventory.** The ci lane spends 242s generating the
+    repo-wide inventory (`quality jsdoc-inventory`) to feed a 2s ratchet —
+    7m26s hosted lane total on #551. The ratchet needs only tracked-package
+    baseline counts plus findings on touched files; scope inventory to
+    `origin/main...HEAD` + dirty exactly like docgen:local, and reserve the
+    repo-wide inventory for main/nightly. Likely the cheapest large
+    lane-time cut currently on the board.
+41. **Coverage lane affected-scoping + cache forensics.** Longest pole on
+    #551's run: 18m28s, and 0 of 231 turbo coverage tasks were cache hits.
+    Two independent levers: (a) measure coverage only for affected packages —
+    the per-package ratchet comparison for untouched packages is a no-op by
+    construction; (b) find out why coverage tasks never cache (outputs not
+    declared? TURBO_FORCE? instrumentation nondeterminism?) — either lever
+    alone is minutes off every PR.
+42. **Merge-readiness as data + a monitor that survives pushes.** The merge
+    protocol (checks pass + threads resolved + Greptile 5/5) is enforced by a
+    human reading three surfaces, but monitor/status already fetches all
+    three: emit a single `mergeReady` verdict naming the failing criterion.
+    And `yeet monitor` exits 1 on first red, forcing a manual re-arm after
+    every push — add `--until-merged`: follow new SHAs, keep babysitting
+    through fix waves, end merged-or-abandoned. Natural pair with #39's
+    sweep as the merged-path tail.
+43. **Touched-package src+test typecheck in the pre-push wave.** #551's
+    Check-lane red (verdict-fixture TS2739) was only catchable on hosted CI
+    because local overlays checked `src/` while test files live solely in
+    the `check:tsgo:tests` program. A combined src+test overlay per touched
+    package (~90s for repo-cli) generated into the #28 cheap wave kills this
+    failure class pre-push. Deliverable: an overlay generator, not a doc.
+44. **Coverage failures emit their own baseline patch.** Truing up the
+    repo-cli baseline meant fishing 58.81/67.69 out of a 10k-line job log.
+    The lane computes those exact values — print the corrected
+    `coverage.regression-baseline.jsonc` hunk (or write a patch artifact)
+    next to the failure. Teach-at-point-of-failure (#33/#36 family),
+    near-zero cost.
+
+## Agent-ergonomics harvest (2026-08-04, operator wishlist — each grounded in a real incident from the #551 waves)
+
+45. **Agent completion reports as schema-validated artifacts.** Three times
+    this session a subagent went idle with no final report (fallow-fixes ×2,
+    jsdoc-migrate, yeet-batch), forcing gate-based re-verification of unknown
+    state. Widget: `beep agent report write` — agent writes a completion
+    packet (files touched, gates run WITH exit codes and output excerpts,
+    out-of-scope files encountered, open questions) to a known path before
+    idling; `beep agent report check <agent>` validates it exists and its
+    claimed gates actually pass. Makes partition-protocol rule 4 ("reports
+    are not proof") machine-checkable instead of tribal.
+46. **Lane-parity local proof: `beep ci affected-lanes` + structured battery
+    verdicts.** The "why weren't these caught locally" class recurred twice
+    today (test-file TS2739, coverage dip) because local proof and hosted
+    lanes are different surfaces. Hosted lanes are already locally invokable
+    (`beep ci lane jsdoc-ratchet` worked); missing pieces: (a) `beep ci
+    affected-lanes` — list exactly which hosted lanes the current diff will
+    trigger, with expected durations, so the operator runs them BY NAME
+    pre-push; (b) battery runs emit a per-gate JSON verdict (pass/fail,
+    duration, first-error, repro command) instead of agents hand-rolling
+    zsh scripts and grepping tails. Subsumes the ad-hoc battery.zsh pattern.
+47. **`beep ci logs <lane>` — failure-region fetcher.** Fetching one job log
+    today took the `gh api .../logs --allow-escape-sequences | sed` incanta-
+    tion, failed silently once with wrong flags, and returned 10k lines to
+    grep for 3 relevant ones. Widget: resolve lane → job id for the current
+    PR/SHA, fetch, strip ANSI, extract the failure region (first error +
+    context + the lane's repro command), print attribution hints
+    (introduced/inherited per #35's fingerprints).
+48. **`beep worktree ready <branch>` — agent workspace provisioner.** Known
+    failure classes when provisioning agent worktrees: missing node_modules
+    (ENOENT on relative .bin paths), stale node_modules after lock-moving
+    updates, shared-turbo-cache contamination. One command: create/refresh
+    worktree, bun install iff lockfile differs, verify cache isolation,
+    print the env-facts block (tool paths, branch, PR state) agents need.
+49. **Wave partition manifests as data + `beep wave lint`.** Fix-wave
+    partitions live in prose briefs today; enforcement is the orchestrator
+    eyeballing diffs. Widget: orchestrator writes the partition (agent →
+    owned file-set → do-not-touch) as a schema-validated manifest;
+    `beep wave lint` diffs actual dirty files against claims and reports
+    drift ("jsdoc-migrate touched Handler.ts — owned by yeet-batch"). Turns
+    partition-protocol rules 1-3 from discipline into a gate.
+50. **Gate failure-output contract (generalize #30).** jsdoc-ratchet now
+    teaches at point of failure because we hand-built that output; every
+    other gate still fails with bare findings. Convention + shared helper:
+    a gate failure renders findings, the exact local repro command, and the
+    binding law/doc pointer — schema-shaped so agents parse it. New-gate
+    scaffold emits the contract by default; a meta-lint checks existing
+    gates against it.
+51. **`beep yeet reply` — auditable review-thread reply/resolve.** The
+    operator cannot post PR thread replies (API write denied), so six
+    verified fixes ended as paste-these-drafts handoffs. Widget: a drafts
+    file (thread id → reply body) posted via the user's gh auth through a
+    repo CLI command — auditable, permission-scoped, and it closes the
+    "comments resolved" merge criterion loop that #42's mergeReady verdict
+    checks.
+52. **`beep agent brief` — canonical subagent context preamble.** Every
+    subagent prompt this session hand-carried the same boilerplate: repo
+    root, worktree state, tool paths (tsgo, mise/zsh -ic wrapper), branch/PR
+    facts, do-not-touch dirs, scratchpad location. Generate that block from
+    live repo state on demand; orchestrators paste one command's output
+    instead of re-deriving env facts per prompt (and staleness bugs — wrong
+    branch, wrong worktree — die with the hand-copying).
+
+    **Definition-of-done rider for #45-52 (and any agent-facing widget):**
+    shipping the command is half the item — the other half is the awareness
+    surface, decided at grill time per item: an AGENTS.md law/tool-routing
+    line, a skill reference update, and/or gate output that names the widget
+    at the moment it's needed (#50's contract is the delivery vehicle for
+    that last one). A widget agents don't discover in-context is dead code
+    with extra steps; every one of these lands with its documentation in the
+    same PR.
+
+53. **Permission-envelope-aware handoffs.** Two denials this cycle (PR thread
+    replies, `git push origin --delete`) were each discovered by attempting
+    the operation mid-flow, failing, and falling back to a chat handoff — the
+    user then ran the deletion in seconds under his own auth. The envelope is
+    knowable in advance; make it data instead of discovered friction:
+    (a) `beep agent brief` (#52) ships a "needs-operator" operation list
+    (remote deletions, thread replies/resolves, anything else the session
+    denies by policy) so agents PLAN batched handoff blocks — "here are the
+    3 commands only you can run" — instead of serial try-fail-handoff;
+    (b) design cleanup/closeout commands like `yeet sweep` (#39) and
+    `yeet reply` (#51) to be equally runnable BY THE USER as one command:
+    the agent's deliverable is the validated plan artifact, and whoever
+    holds the permission executes it. Explicitly NOT in scope: widening the
+    agent's permissions — the widget is knowing the boundary, not moving it.
+
+54. **Sub-agent reflection harvest (operator directive, 2026-08-04).** Every
+    sub-agent prompt in future workflows carries a reflection rider: before
+    finishing, report tooling/process friction hit and widgets wished for —
+    "additional Opportunities" from the trench view. The orchestrator
+    harvests each report into this ledger on completion. Effective
+    immediately as a prompt ritual; the durable home is #45's completion
+    packet schema, which gains an `opportunities` field so the harvest is
+    structured data instead of prose scraping. Rationale: the operator sees
+    orchestration friction, sub-agents see execution friction — only they
+    know which env facts were missing, which gate output confused them,
+    which command they hand-rolled.
+
+## Grill #4 dispositions (2026-08-04 — full docket; GRILL-DECISIONS.md #13–23)
+
+Queue: PR-E "merge loop" → (PR-B ∥) → PR-F "soundness" → PR-I "agent kit" →
+PR-C "pipeline 2" → PR-G "preflight parity" → PR-H "teach pack" → jsdoc
+codemod PR. Spikes: LAN cache + workstation runner (one session) →
+predict-squash → battery → vitest → stage-3.
+
+- **PR-E**: verdict encode fix (Json-codec law for all yeet artifacts), #39
+  sweep (merge porcelain + auto-sweep + SweepPlan/SweepReport + --plan), #42
+  (--until-merged + mergeReady), #23 (fingerprint-gated rerun, once per
+  lane/SHA), #51 reply (ReplyDrafts/ReplyReport, post+resolve), #38a
+  testSearchRoots cleanup.
+- **PR-B** += #36 hosted repro commands (joins #13's step-summary surface).
+- **PR-F**: #37 sentinel ambient .d.ts remedy + #34 append-optional lint +
+  #31 generated-file exemption; one-time unmask chore this week.
+- **PR-I**: #45 report (+#54 opportunities field), #48 worktree ready, #49
+  wave manifests + wave lint, #52 brief (+#53a needs-operator list);
+  awareness surfaces ship same-PR per the rider.
+- **PR-C** += #40 changed-scope inventory (replaces o1-A shard cache;
+  nightly keeps full sweep), #41 affected coverage + cache forensics, #44
+  baseline-patch emission.
+- **PR-G**: #28 + #29 + #43 (concurrent preflight wave, ~2.5 min) + #46 +
+  #47.
+- **PR-H**: #33 --fix + #50 failure-output contract + meta-lint; #32 codemod
+  PR immediately after.
+- **Closed/parked**: #21 subsumed by #25; grit collector parked (#40
+  collapsed its payback); #27 parked behind #24/#26.
+- **Triggered dockets**: #22 merge-queue eval (on E-wave monitor data); #26
+  capsule + #35 lane-collapse (grill #5).
+- **#38b**: blindspot burn-down passive + opportunistic riders; upstream
+  @effect/tsgo issue drafted by agent, filed by operator this week.
+- **#24**: workstation-runner pilot rides the LAN-cache spike session; AWS
+  after pilot data.
+
+56. **Docs-only PRs short-circuit the inert lane family (operator idea,
+    2026-08-04).** Build/check/test/coverage/docgen lanes are provably inert
+    for `goals/**`/`explorations/**` markdown diffs, yet a docs-only PR pays
+    the full gauntlet. NOT the naive fix: `paths-ignore` triggers leave
+    required checks stuck "Expected" (unmergeable), and dummy-success twin
+    workflows drift. Design: lanes always trigger; one shared
+    `beep ci lane-scope` step computes diff ∩ lane input scope from a
+    conservative curated inert-path allowlist; empty intersection → lane
+    reports success immediately with a "no inputs in scope" conclusion in
+    its step summary — required-check semantics honest, logic in one
+    testable place. Never skips: gitleaks (secrets in prose; public repo),
+    goals/reflection governance lints (docs PRs are their use case),
+    commitlint. This is #21's input-hash idea in path-set form — the
+    degenerate case shippable before #25's tree-hash machinery, and it
+    retires into #25 when that lands. Evidence gate: after PR-B's
+    trusted-base turbo cache lands, measure a docs-only PR's gauntlet —
+    cache replay may already collapse the turbo-backed lanes (replay is
+    proof, not skipping); implement the short-circuit only for what
+    remains (likely coverage + non-turbo lanes). Vehicle: small hosted-CI
+    PR after PR-B, evidence-gated.
+
+Grill #4b per-item pass (same day; GRILL-DECISIONS.md #24–33): #18 → PR-F
+rider (advisory hot-barrel lint); #19 → PR-G (shares #43 overlay
+internals); #17 → triggered, opens the first stage-2/protocol-boundary PR;
+#55 → PR-E rider (advisory phase purges stale envelopes + skips, never
+exit 1); full designs locked for #52/#45/#49/#48 (agent kit), #11 (docgen
+narrowing levers), PR-G posture (preflight blocks push, --push-anyway
+audited), #50 (ratcheted-advisory contract). All 55 items now covered.
+
+55. **Fallow advisory phase: stale envelopes should regenerate, not fail the
+    run.** (Live incident, this PR's first publish attempt, 2026-08-04.)
+    PR-A's envelope mode-split upgraded the old poisoning failure
+    ("non-advisory envelope rejected") into a timestamp guard ("envelope(s)
+    older than the Yeet run start") — correct detection, wrong reaction: the
+    feedback phase fails the whole publish over gitignored, regenerable
+    state, and the operator recovery is still the manual `rm -rf
+    .beep/fallow` from the 2026-06 memory. The advisory phase should treat
+    stale/mode-mismatched envelopes as absent — delete and regenerate (or
+    skip with a note), never exit 1. Candidate vehicle: PR-E rider (it's the
+    yeet surface); also a #50 exhibit — the failure output taught neither
+    the fix nor the one command to run.

--- a/goals/speed-loop/research/OPPORTUNITIES.md
+++ b/goals/speed-loop/research/OPPORTUNITIES.md
@@ -517,6 +517,14 @@ predict-squash → battery → vitest → stage-3.
     remains (likely coverage + non-turbo lanes). Vehicle: small hosted-CI
     PR after PR-B, evidence-gated.
 
+Fleet-coordination amendments (same day, beep-effect5 session;
+GRILL-DECISIONS.md #34–36): #22 design half + #16 transfer to the fleet
+session (speed-loop keeps the E-wave treadmill-tax measurement); PR-I
+reserves fleet-ready shapes — named OwnershipClaim schema with waveId on
+the manifest only, AgentBrief fleet block + generic TTL cache,
+`agent report list` discovery; worktree detection law: never
+`[ -d .git ]` (a file in linked worktrees).
+
 Grill #4b per-item pass (same day; GRILL-DECISIONS.md #24–33): #18 → PR-F
 rider (advisory hot-barrel lint); #19 → PR-G (shares #43 overlay
 internals); #17 → triggered, opens the first stage-2/protocol-boundary PR;

--- a/goals/speed-loop/research/OPPORTUNITIES.md
+++ b/goals/speed-loop/research/OPPORTUNITIES.md
@@ -322,9 +322,15 @@ consolidation (deferred pending cache measurements). Per-lane proof resume
     `git fetch origin main:main` correctly refuses when main is checked out
     elsewhere — the skip-and-report branch of (b) is reachable and needed.
     Squash-merge detection note for (c): merged branch tips are NOT
-    ancestors of origin/main, so `git branch -d` will refuse; deletion must
-    key on the branch's PR being MERGED (then `-D`, with the report citing
-    the PR).
+    ancestors of origin/main, so `git branch -d` will refuse there. The
+    force-deletion contract (review-hardened on #558): `-d` stays the tool
+    for ancestry-merged branches; `-D` is permitted ONLY when ALL of
+    (i) the branch's PR is MERGED, (ii) the local tip equals that PR's
+    recorded head SHA (post-merge pushes make the MERGED state stale —
+    tip mismatch means local-only work exists), and (iii) the branch is
+    not checked out in any worktree. Remote deletion requires the same
+    tip match against the remote ref. Any precondition failing →
+    skip-and-report with the reason; unpushed/unmatched work is sacred.
 
 ## Discussion harvest (2026-08-04, while driving #551's fix waves to green)
 
@@ -515,7 +521,52 @@ predict-squash → battery → vitest → stage-3.
     cache replay may already collapse the turbo-backed lanes (replay is
     proof, not skipping); implement the short-circuit only for what
     remains (likely coverage + non-turbo lanes). Vehicle: small hosted-CI
-    PR after PR-B, evidence-gated.
+    PR after PR-B, evidence-gated. Coupling (fleet session, decisions
+    37-38): #56 sequences BEFORE any #22 merge-queue adoption — scoped PR
+    checks + full merge-group gauntlet is the composition that makes the
+    queue affordable at fleet scale; OwnershipClaim ships provenance-free
+    (fleet wraps, never mutates the record).
+
+57. **Work-item claims for parallel sessions (input to the fleet grill;
+    fleet-owned design).** The beep-effect5 ownership negotiation (#22/#16
+    transfers, PR-I schema reservations, a "say so before PR-I lands"
+    deadline) worked — but ran entirely through operator-relayed chat. The
+    fleet session's OwnershipClaim covers FILES; nothing covers WORK ITEMS:
+    ledger entries, design reservations, and their deadlines live in prose.
+    A small claims manifest (item → owning session/campaign, reservations,
+    expiry) would let parallel sessions discover "who has #22" without a
+    relay hop. Explicitly an input to the fleet-coordination docket, not a
+    speed-loop vehicle — recorded here so the trench evidence isn't lost.
+58. **Decisions-PR adversarial review as a design gate (ritual).** The #558
+    bot wave caught two P1 soundness holes (scoped-inventory unsound under
+    analyzer changes; `-D` authorized by stale MERGED state) plus five
+    hardening items — against PROSE, before any implementation existed.
+    Cheapest possible catch point. Ritual: decisions PRs are review
+    surfaces, not just records; review findings amend the decision text
+    with a "review-hardened on #NNN" provenance tag (started organically on
+    #558); implementers treat un-hardened decisions as less trustworthy
+    than hardened ones.
+59. **Thread triage context in status/monitor output (PR-E rider).**
+    `yeet status` lists unresolved threads as opaque GraphQL ids
+    (PRRT_...) + file paths; triaging #558's seven required a second REST
+    pass and hand-mapping thread ids ↔ comment ids by file. Carry author,
+    severity badge (parseable from bot bodies), first-line excerpt, and the
+    numeric comment id per thread — so the #51 drafts file is writable
+    straight from status output. Implementation note for #51: `yeet reply`
+    must accept EITHER the REST comment id or the GraphQL thread id and
+    resolve the mapping itself.
+60. **Generated-file conflicts resolve by regeneration, not merging
+    (sweep/rebase rider).** Live evidence: my INDEX.md heal raced the
+    operator's #555 heal — benign only because both regenerations were
+    deterministic and the rebase happened to converge. Repo-global
+    generated artifacts (goals/INDEX.md, law allowlist snapshots, docgen
+    aggregate, baselines) are guaranteed collision hotspots for parallel
+    sessions, and hand-merging them is always wrong. Widget: a
+    generated-path → regenerate-command map (data, not docs); rebase/merge
+    tooling and #39's sweep consult it to auto-resolve conflicts under
+    those paths by re-running the generator on the merged tree. The
+    goals:index gate already teaches its writer command — this generalizes
+    that contract into machine-consumable form (#50 family).
 
 Fleet-coordination amendments (same day, beep-effect5 session;
 GRILL-DECISIONS.md #34–36): #22 design half + #16 transfer to the fleet

--- a/goals/speed-loop/research/upstream-tsgo-effectfn-issue.md
+++ b/goals/speed-loop/research/upstream-tsgo-effectfn-issue.md
@@ -1,0 +1,67 @@
+# Upstream issue draft — @effect/tsgo effectFnOpportunity coverage gaps
+
+Status: DRAFT for operator filing (external-repo write is needs-operator).
+Target repo: the @effect/tsgo issue tracker (bundled language-service
+diagnostics). File under the operator's GitHub auth; paste body below.
+Origin: speed-loop probe harvest #38 (2026-08-04, 8-agent adversarially
+verified shape matrix); grill #4 decision 22.
+
+---
+
+**Title:** `effectFnOpportunity` never fires on method declarations or
+callback-position generator functions
+
+**Body:**
+
+The `effectFnOpportunity` diagnostic (suggest `Effect.fn`/`Effect.fnUntraced`
+for functions returning `Effect.gen(...)`) currently skips two shapes that
+account for a large share of real-world occurrences in Effect-heavy
+codebases:
+
+1. **MethodDeclaration owners.** A class or object-literal *method* whose
+   body returns `Effect.gen(function* () { ... })` produces no diagnostic;
+   the equivalent function declaration or arrow-function property does.
+
+   ```ts
+   class UserService {
+     // no effectFnOpportunity reported here
+     findById(id: UserId) {
+       return Effect.gen(function* () {
+         const repo = yield* UserRepo
+         return yield* repo.findById(id)
+       })
+     }
+   }
+   ```
+
+2. **Callback-position function expressions.** A function expression passed
+   as an argument (e.g. into a combinator, router handler, or test helper)
+   whose body returns `Effect.gen(...)` is not reported:
+
+   ```ts
+   route.handle("get", function (req) {
+     // no effectFnOpportunity reported here
+     return Effect.gen(function* () {
+       return yield* handleGet(req)
+     })
+   })
+   ```
+
+Both shapes are rewritable to `Effect.fn`/`Effect.fnUntraced` exactly like
+the covered declaration forms. We maintain a custom repo lint solely to
+cover these two cases (its test suite documents them as intentional
+coverage beyond the plugin); extending `effectFnOpportunity` to
+MethodDeclaration owners and callback-position function expressions would
+let downstream repos retire such custom lints entirely.
+
+For contrast, the directly-returned `Effect.gen(...).pipe(...)` shape IS
+handled by the plugin (with `pipeTransformations` configured) — the two
+shapes above appear to be the only remaining structural gaps.
+
+Happy to provide a reproduction workspace if useful.
+
+---
+
+Post-filing follow-ups (tracked in GRILL-DECISIONS.md #22): once an
+upstream release covers both shapes, re-run the effect-fn prune analysis
+and retire the repo law (~5.3s per battery).

--- a/goals/speed-loop/research/upstream-tsgo-effectfn-issue.md
+++ b/goals/speed-loop/research/upstream-tsgo-effectfn-issue.md
@@ -47,12 +47,18 @@ codebases:
    })
    ```
 
-Both shapes are rewritable to `Effect.fn`/`Effect.fnUntraced` exactly like
-the covered declaration forms. We maintain a custom repo lint solely to
-cover these two cases (its test suite documents them as intentional
-coverage beyond the plugin); extending `effectFnOpportunity` to
-MethodDeclaration owners and callback-position function expressions would
-let downstream repos retire such custom lints entirely.
+The callback-position shape is directly rewritable to
+`Effect.fn`/`Effect.fnUntraced` like the covered declaration forms. The
+class-method shape is NOT: rewriting a method to a
+`findById = Effect.fn(...)` field moves it from the prototype to a
+per-instance property, which can break `super` calls, overrides,
+decorators, and prototype consumers — so for MethodDeclaration owners we
+are asking for a **diagnostic-only** case (or a semantics-preserving
+suggestion, if one exists), not the standard auto-fix. We maintain a
+custom repo lint solely to cover these two cases (its test suite documents
+them as intentional coverage beyond the plugin); extending
+`effectFnOpportunity` to both would let downstream repos retire such
+custom lints entirely.
 
 For contrast, the directly-returned `Effect.gen(...).pipe(...)` shape IS
 handled by the plugin (with `pipeTransformations` configured) — the two


### PR DESCRIPTION
Docs-only decisions PR for the speed-loop campaign (grill #4 + #4b, 2026-08-04).

## What this ratifies

- GRILL-DECISIONS.md #13-33: queue topology (PR-E merge loop jumps; E -> B|| -> F -> I -> C -> G
  -> H -> codemod), full designs for the yeet merge/sweep/monitor/reply surfaces, the tsbuildinfo
  sentinel remedy + append-optional schema lint, the agent kit (brief/report/wave lint/worktree
  ready), changed-scope jsdoc inventory replacing the shard-cache design, preflight-blocks-push
  posture, and the ratcheted-advisory gate-output contract.
- OPPORTUNITIES.md grown to 56 items with per-item dispositions; every item now holds a shipped
  state, a design + vehicle, a trigger, or an explicit parking.
- Upstream @effect/tsgo issue draft (effectFnOpportunity coverage gaps) for operator filing.
- goals/INDEX.md regenerated (converged with the #555 heal after rebase).

Implementation starts at PR-E once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y66vimBGiye7U3YenpQEZy

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/558"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788450728&installation_model_id=424656&pr_number=558&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F558&signature=9166ba0d8918010be54bde963e85f83e08fcff1ede0bf2400d667c27823e945d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->