### PR TITLE
fix(security): ignore the Effect beta.103 subtree squash false positive

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -75,3 +75,11 @@ goals/repo-crispening-orchestration/ops/inventory/S5/beep__shared-domain.json:ge
 # False positives in the immutable Effect subtree squash used by PR #546.
 8657c68a54a437e3646c0d2291fdd259f2455b4d:packages/effect/src/Config.ts:generic-api-key:1461
 8657c68a54a437e3646c0d2291fdd259f2455b4d:packages/platform-node/test/NodeHttpServer.test.ts:generic-api-key:853
+
+# False positives in the immutable Effect subtree squash used by the
+# 4.0.0-beta.103 refresh. Same upstream JSDoc sample as the #546 entry above
+# (`API_KEY` in the Config.redacted example), moved to line 1482 by upstream's
+# ConfigProvider rework. Paths are subtree-relative because `git subtree pull
+# --squash` records upstream-relative paths, so the `.repos/effect/` allowlist
+# in .gitleaks.toml cannot match them.
+3d37b37f7710fa096e25e1711243e480917bf999:packages/effect/src/Config.ts:generic-api-key:1482


### PR DESCRIPTION
## Why

The Effect `4.0.0-beta.103` subtree refresh re-imports upstream's
`Config.redacted` JSDoc sample, whose placeholder `API_KEY` value trips
`generic-api-key`. Upstream's ConfigProvider rework moved that sample from line
1461 to 1482, so the existing PR #546 fingerprint no longer covers it and the
hosted secrets gate fails on the subtree squash commit.

This blocks the Effect beta.103 dependency PR, which cannot fix it itself:
`.github/workflows/check.yml` deliberately overwrites `.gitleaks.toml` and
`.gitleaksignore` with the **base branch's** copies on `pull_request` runs, so a
suppression must land in `main` first.

## What

One `.gitleaksignore` fingerprint, directly beneath the PR #546 entry it
mirrors.

## Why a fingerprint and not a `.gitleaks.toml` path allowlist

Two independent reasons, both verified against the pinned CI image
(`zricethezav/gitleaks@sha256:5d0147dc…`, v8.24.3):

1. **`git subtree pull --squash` records upstream-relative paths.** The range
   scan sees `packages/effect/src/Config.ts` with no `.repos/effect/` prefix, so
   the existing `^\.repos/effect/.*$` allowlist can never match a subtree commit.
   The two PR #546 entries above show the same shape (`packages/client/…`,
   `codex-rs/…`).
2. **A singular `[allowlist]` would match, but cannot coexist with the file's
   `[[allowlists]]` entries.** Current gitleaks rejects such a config outright
   (`[allowlist] is deprecated, it cannot be used alongside [[allowlists]]`),
   which would break every contributor's local scan while passing CI.

## Verification

| check | result |
| --- | --- |
| pinned CI image, `origin/main..deps-branch` | `no leaks found` |
| current local gitleaks, same range | `no leaks found` |
| planted `sk-live-` key outside the exempt path | still caught |
| `yeet verify` (21/21 lanes) | green |

A fingerprint is `commit:file:rule:line`, so it cannot suppress anything beyond
the exact upstream line it names.

## Follow-up (not in this PR)

While verifying, I found that **none of the seven `[[allowlists]]` blocks in
`.gitleaks.toml` apply in CI at all** — the pinned v8.24.3 honours only the
singular `[allowlist]` form and silently ignores the plural one. CauseRedaction,
the law-practice fixtures, `@beep/data` generated, SOURCES.md, and the
evidence-digest entries are therefore no-ops on the hosted gate today.

Fixing that means either collapsing all seven into one singular block — which
loses the `condition = "AND"` scoping on the evidence-digest entry and would make
bare 64-char hex globally exempt — or bumping the pinned scanner image. Both need
planted-secret negative tests, so it belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJBPsBLEJ1WRwMTEy1x8vz

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/566"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788577486&installation_model_id=424656&pr_number=566&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F566&signature=dc6046fef8212764b6ddc98c0ccd7cf179f42600625e8fd8fcbedb8d4002a3f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->