### PR TITLE
fix(ai-metrics): make derived turn ingestion idempotent

### DIFF
--- a/.changeset/ai-metrics-ingest-dedup.md
+++ b/.changeset/ai-metrics-ingest-dedup.md
@@ -1,0 +1,10 @@
+---
+"@beep/repo-ai-metrics": patch
+---
+
+Make derived-storage turn ingestion idempotent. `turn_id` is now content-addressed
+and no longer mixes in `ingestRunId`, and repeated turns are `INSERT OR IGNORE`d so
+the first-seen `ingest_run_id` is retained as lineage. Re-ingesting the same
+transcript no longer multiplies rows, and because the OTLP export selects
+`WHERE ingest_run_id = <this run>`, it now exports only genuinely new turns instead
+of the whole store on every run.

--- a/packages/tooling/library/ai-metrics/src/derived-storage.ts
+++ b/packages/tooling/library/ai-metrics/src/derived-storage.ts
@@ -1172,15 +1172,25 @@ const upsertSessionAndTurns = Effect.fn("AiMetrics.derivedStorage.upsertSessionA
   yield* Effect.forEach(
     sanitized.rawEventEnvelopes,
     Effect.fnUntraced(function* (envelope) {
+      // Content-addressed, deliberately excluding input.ingestRunId. With the run id
+      // in the key every run minted a fresh turn_id for identical content, so
+      // INSERT OR REPLACE never collided and the table accumulated one copy per run
+      // (measured: 5.43M rows collapsing to ~516K distinct raw_event_hash across
+      // 1,222 runs). Per the packet's identity rule, ingest runs are lineage, never
+      // identity.
       const turnId = yield* rowId("turn", [
-        input.ingestRunId,
         envelope.sourceKind,
         envelope.sourcePathHash,
         envelope.lineNumber,
         envelope.rawEventHash,
       ]);
+      // OR IGNORE, not OR REPLACE. REPLACE would rewrite ingest_run_id to the
+      // current run, and the OTLP export selects `WHERE ingest_run_id = <this run>`
+      // -- so every previously-seen turn would be re-exported to Phoenix on every
+      // run even though the table itself had stopped growing. Retaining the
+      // first-seen run id is what makes that export incremental.
       yield* duckdb.run(
-        `INSERT OR REPLACE INTO ai_metrics_turns (
+        `INSERT OR IGNORE INTO ai_metrics_turns (
           turn_id,
           ingest_run_id,
           agent_session_id,

--- a/packages/tooling/library/ai-metrics/src/derived-storage.ts
+++ b/packages/tooling/library/ai-metrics/src/derived-storage.ts
@@ -476,15 +476,42 @@ type DerivedStorageMigration = {
 const derivedStorageMigrations = [
   {
     // One-time only, and it must stay that way. Existing stores were written under
-    // the old duplicating scheme, so every row in them has already been exported --
-    // repeatedly. Without this, the first run after the watermark lands would see
-    // millions of NULLs and flush the entire history to Phoenix in one burst, which
-    // is the exact backpressure collapse this work exists to prevent. The
-    // `ai_metrics_schema_migrations` ledger guarantees it runs once; it is applied
-    // before this run's inserts, so genuinely new turns are never swept up in it.
+    // the old duplicating scheme, so their rows have already been exported, usually
+    // many times over. Left entirely un-backfilled, the first run after the watermark
+    // lands would see millions of NULLs and flush the whole history to Phoenix in one
+    // burst -- the exact backpressure collapse this work exists to prevent.
+    //
+    // The newest ingest run is deliberately excluded. Under the old scheme a run that
+    // committed turns and then died before exporting was rescued by the next run,
+    // which re-minted those rows under a fresh id and exported them -- so the content
+    // did reach Phoenix even though the original rows never did. The one case with no
+    // such rescue is the final run before this migration: if it crashed before
+    // exporting, nothing came after it. Leaving that run's turns unmarked costs at
+    // most one run's worth of re-exported spans if it had in fact succeeded, and
+    // avoids silently burying data if it had not.
+    //
+    // The `ai_metrics_schema_migrations` ledger guarantees this runs once, and it is
+    // applied before the run's inserts, so genuinely new turns are never swept up.
     migrationId: "ai-metrics-otlp-export-watermark-v1",
-    requiredColumns: [{ columnName: "otlp_exported_at_epoch_ms", tableName: "ai_metrics_turns" }],
-    statements: ["UPDATE ai_metrics_turns SET otlp_exported_at_epoch_ms = 0 WHERE otlp_exported_at_epoch_ms IS NULL"],
+    // Every column the statement touches, including the ingest-run lookup. Very old
+    // stores predate `ingest_run_id` on turns entirely, and the statement must not be
+    // attempted against them -- an unguarded reference fails schema-ensure outright.
+    // A skipped migration is not recorded, so it applies later once the shape catches up.
+    requiredColumns: [
+      { columnName: "otlp_exported_at_epoch_ms", tableName: "ai_metrics_turns" },
+      { columnName: "ingest_run_id", tableName: "ai_metrics_turns" },
+      { columnName: "ingest_run_id", tableName: "ai_metrics_ingest_runs" },
+      { columnName: "started_at_epoch_ms", tableName: "ai_metrics_ingest_runs" },
+    ],
+    statements: [
+      `UPDATE ai_metrics_turns
+       SET otlp_exported_at_epoch_ms = 0
+       WHERE otlp_exported_at_epoch_ms IS NULL
+         AND ingest_run_id <> COALESCE(
+           (SELECT ingest_run_id FROM ai_metrics_ingest_runs ORDER BY started_at_epoch_ms DESC LIMIT 1),
+           ''
+         )`,
+    ],
     transactional: true,
   },
   {

--- a/packages/tooling/library/ai-metrics/src/derived-storage.ts
+++ b/packages/tooling/library/ai-metrics/src/derived-storage.ts
@@ -39,11 +39,13 @@ const DERIVED_TABLES = [
 /**
  * Parquet export behavior for one derived AI metrics write.
  *
- * @example
+ * **Example** (Read a parquet export mode)
+ *
  * ```ts
  * import { AiMetricsParquetExportMode } from "@beep/repo-ai-metrics"
  * console.log(AiMetricsParquetExportMode.Enum.snapshot)
  * ```
+ *
  * @category schemas
  * @since 0.0.0
  */
@@ -56,12 +58,14 @@ export const AiMetricsParquetExportMode = LiteralKit(["none", "latest", "snapsho
 /**
  * Runtime type for {@link AiMetricsParquetExportMode}.
  *
- * @example
+ * **Example** (Type a parquet export mode)
+ *
  * ```ts
  * import type { AiMetricsParquetExportMode } from "@beep/repo-ai-metrics"
  * const mode: AiMetricsParquetExportMode = "latest"
  * console.log(mode)
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -492,7 +496,8 @@ const derivedStorageMigrations = [
 /**
  * Error raised by the DuckDB derived storage projection.
  *
- * @example
+ * **Example** (Construct a projection error)
+ *
  * ```ts
  * import { AiMetricsDerivedStorageError } from "@beep/repo-ai-metrics"
  * const error = AiMetricsDerivedStorageError.make({
@@ -501,6 +506,7 @@ const derivedStorageMigrations = [
  * })
  * console.log(error)
  * ```
+ *
  * @category errors
  * @since 0.0.0
  */
@@ -520,7 +526,8 @@ export class AiMetricsDerivedStorageError extends TaggedErrorClass<AiMetricsDeri
 /**
  * One sanitized transcript ready for derived storage projection.
  *
- * @example
+ * **Example** (Build a sanitized transcript record)
+ *
  * ```ts
  * import {
  *   AiMetricsDerivedTranscriptRecord,
@@ -566,6 +573,7 @@ export class AiMetricsDerivedStorageError extends TaggedErrorClass<AiMetricsDeri
  * })
  * console.log(record.archiveObject.archiveObjectId)
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -584,7 +592,8 @@ export class AiMetricsDerivedTranscriptRecord extends S.Class<AiMetricsDerivedTr
 /**
  * Input for a derived DuckDB storage write.
  *
- * @example
+ * **Example** (Assemble a derived write input)
+ *
  * ```ts
  * import {
  *   AiMetricsDerivedStorageWriteInput,
@@ -614,6 +623,7 @@ export class AiMetricsDerivedTranscriptRecord extends S.Class<AiMetricsDerivedTr
  * })
  * console.log(input.parquetExportMode)
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -641,7 +651,8 @@ export class AiMetricsDerivedStorageWriteInput extends S.Class<AiMetricsDerivedS
 /**
  * Result of a derived DuckDB storage write.
  *
- * @example
+ * **Example** (Inspect a derived write result)
+ *
  * ```ts
  * import { AiMetricsDerivedStorageWriteResult } from "@beep/repo-ai-metrics"
  *
@@ -656,6 +667,7 @@ export class AiMetricsDerivedStorageWriteInput extends S.Class<AiMetricsDerivedS
  * })
  * console.log(result.parquetTables)
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -794,8 +806,8 @@ const ensureAiMetricsDerivedStorageRaw = Effect.fn("AiMetrics.derivedStorage.ens
 /**
  * Ensure the AI metrics derived DuckDB schema exists and has P4 columns.
  *
- * @effects Creates or migrates DuckDB tables and schema metadata in the configured derived database.
- * @example
+ * **Example** (Ensure the schema before writing)
+ *
  * ```ts
  * import { ensureAiMetricsDerivedStorage } from "@beep/repo-ai-metrics"
  * import { DuckDb, DuckDbConnectionOptions } from "@beep/duckdb"
@@ -807,6 +819,8 @@ const ensureAiMetricsDerivedStorageRaw = Effect.fn("AiMetrics.derivedStorage.ens
  * )
  * console.log(program)
  * ```
+ *
+ * @effects Creates or migrates DuckDB tables and schema metadata in the configured derived database.
  * @category services
  * @since 0.0.0
  */
@@ -1239,12 +1253,8 @@ const recordTurnCount: (records: ReadonlyArray<AiMetricsDerivedTranscriptRecord>
 /**
  * Project sanitized AI metrics records into DuckDB and export Parquet snapshots.
  *
- * @effects
- * - Creates the derived DuckDB directory when missing.
- * - Runs DuckDB table creation and migrations before writing rows.
- * - Upserts ingest, source-file, archive, session, and turn projections inside a transaction.
- * - Recreates the selected Parquet export directory for `latest` or `snapshot` exports.
- * @example
+ * **Example** (Write one derived ingest run)
+ *
  * ```ts
  * import {
  *   AiMetricsDerivedStorageWriteInput,
@@ -1276,6 +1286,12 @@ const recordTurnCount: (records: ReadonlyArray<AiMetricsDerivedTranscriptRecord>
  * const write = writeAiMetricsDerivedStorage(input)
  * console.log(write)
  * ```
+ *
+ * @effects
+ * - Creates the derived DuckDB directory when missing.
+ * - Runs DuckDB table creation and migrations before writing rows.
+ * - Upserts ingest, source-file, archive, session, and turn projections inside a transaction.
+ * - Recreates the selected Parquet export directory for `latest` or `snapshot` exports.
  * @category services
  * @since 0.0.0
  */

--- a/packages/tooling/library/ai-metrics/src/derived-storage.ts
+++ b/packages/tooling/library/ai-metrics/src/derived-storage.ts
@@ -224,6 +224,16 @@ const createTableStatements = [
 
 const migrationColumns = [
   {
+    // Explicit OTLP export state. Previously the exporter inferred this from
+    // `ingest_run_id`, which only worked because every run re-minted its rows. Once
+    // ingestion became idempotent that inference broke: a run that committed turns
+    // and then died before exporting left them attached to a run the exporter would
+    // never look at again, so they could never reach Phoenix.
+    columnDefinition: "otlp_exported_at_epoch_ms DOUBLE",
+    columnName: "otlp_exported_at_epoch_ms",
+    tableName: "ai_metrics_turns",
+  },
+  {
     columnDefinition: "source_role VARCHAR DEFAULT 'primary'",
     columnName: "source_role",
     tableName: "ai_metrics_source_files",
@@ -464,6 +474,19 @@ type DerivedStorageMigration = {
 };
 
 const derivedStorageMigrations = [
+  {
+    // One-time only, and it must stay that way. Existing stores were written under
+    // the old duplicating scheme, so every row in them has already been exported --
+    // repeatedly. Without this, the first run after the watermark lands would see
+    // millions of NULLs and flush the entire history to Phoenix in one burst, which
+    // is the exact backpressure collapse this work exists to prevent. The
+    // `ai_metrics_schema_migrations` ledger guarantees it runs once; it is applied
+    // before this run's inserts, so genuinely new turns are never swept up in it.
+    migrationId: "ai-metrics-otlp-export-watermark-v1",
+    requiredColumns: [{ columnName: "otlp_exported_at_epoch_ms", tableName: "ai_metrics_turns" }],
+    statements: ["UPDATE ai_metrics_turns SET otlp_exported_at_epoch_ms = 0 WHERE otlp_exported_at_epoch_ms IS NULL"],
+    transactional: true,
+  },
   {
     migrationId: "ai-metrics-p6a-default-backfill-v1",
     statements: migrationBackfillStatements,

--- a/packages/tooling/library/ai-metrics/src/otlp.ts
+++ b/packages/tooling/library/ai-metrics/src/otlp.ts
@@ -26,13 +26,15 @@ const $I = $RepoAiMetricsId.create("otlp");
 /**
  * OTLP attributes approved for redacted AI metrics span export.
  *
- * @example
+ * **Example** (Use AI_METRICS_OTLP_ATTRIBUTE_ALLOWLIST)
+ *
  * ```ts
  * import { AI_METRICS_OTLP_ATTRIBUTE_ALLOWLIST } from "@beep/repo-ai-metrics"
  *
  * const carriesSessionId = AI_METRICS_OTLP_ATTRIBUTE_ALLOWLIST.includes("session.id")
  * console.log(carriesSessionId)
  * ```
+ *
  * @category constants
  * @since 0.0.0
  */
@@ -64,13 +66,15 @@ export const AI_METRICS_OTLP_ATTRIBUTE_ALLOWLIST = [
 /**
  * Attribute value variants allowed on redacted AI metrics OTLP spans.
  *
- * @example
+ * **Example** (Narrow with AiMetricsOtlpAttributeValue)
+ *
  * ```ts
  * import { AiMetricsOtlpAttributeValue } from "@beep/repo-ai-metrics"
  *
  * const isAttributeValue = AiMetricsOtlpAttributeValue.is(42)
  * console.log(isAttributeValue)
  * ```
+ *
  * @category schemas
  * @since 0.0.0
  */
@@ -84,12 +88,14 @@ export const AiMetricsOtlpAttributeValue = S.Union([S.String, S.Finite, S.Boolea
 /**
  * Runtime type for {@link AiMetricsOtlpAttributeValue}.
  *
- * @example
+ * **Example** (Type a value as AiMetricsOtlpAttributeValue)
+ *
  * ```ts
  * import type { AiMetricsOtlpAttributeValue } from "@beep/repo-ai-metrics"
  * const value: AiMetricsOtlpAttributeValue = "hash-only"
  * console.log(value)
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -98,7 +104,8 @@ export type AiMetricsOtlpAttributeValue = typeof AiMetricsOtlpAttributeValue.Typ
 /**
  * Error raised by AI metrics OTLP projection or export.
  *
- * @example
+ * **Example** (Construct AiMetricsOtlpExportError)
+ *
  * ```ts
  * import { AiMetricsOtlpExportError } from "@beep/repo-ai-metrics"
  *
@@ -108,6 +115,7 @@ export type AiMetricsOtlpAttributeValue = typeof AiMetricsOtlpAttributeValue.Typ
  * })
  * console.log(error.message)
  * ```
+ *
  * @category errors
  * @since 0.0.0
  */
@@ -125,7 +133,8 @@ export class AiMetricsOtlpExportError extends TaggedErrorClass<AiMetricsOtlpExpo
 /**
  * Input for exporting one derived ingest run as OTLP spans.
  *
- * @example
+ * **Example** (Construct AiMetricsOtlpExportInput)
+ *
  * ```ts
  * import { AiMetricsOtlpExportInput, AiMetricsOtlpEndpointSpec } from "@beep/repo-ai-metrics"
  *
@@ -142,6 +151,7 @@ export class AiMetricsOtlpExportError extends TaggedErrorClass<AiMetricsOtlpExpo
  * })
  * console.log(input)
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -160,7 +170,8 @@ export class AiMetricsOtlpExportInput extends S.Class<AiMetricsOtlpExportInput>(
 /**
  * One span projection ready to be emitted through Effect tracing.
  *
- * @example
+ * **Example** (Construct AiMetricsOtlpSpanProjection)
+ *
  * ```ts
  * import { AiMetricsOtlpSpanProjection } from "@beep/repo-ai-metrics"
  *
@@ -174,6 +185,7 @@ export class AiMetricsOtlpExportInput extends S.Class<AiMetricsOtlpExportInput>(
  * })
  * console.log(projection.attributes["ai_metrics.event_name"])
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -190,7 +202,8 @@ export class AiMetricsOtlpSpanProjection extends S.Class<AiMetricsOtlpSpanProjec
 /**
  * Span projection batch resolved for one derived ingest run.
  *
- * @example
+ * **Example** (Construct AiMetricsOtlpSpanProjectionBatch)
+ *
  * ```ts
  * import {
  *   AiMetricsOtlpSpanProjection,
@@ -206,10 +219,12 @@ export class AiMetricsOtlpSpanProjection extends S.Class<AiMetricsOtlpSpanProjec
  *     })
  *   ],
  *   sessionSpanCount: 0,
+ *   turnIds: ["turn-1"],
  *   turnSpanCount: 1
  * })
  * console.log(batch.projections.length)
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -220,6 +235,12 @@ export class AiMetricsOtlpSpanProjectionBatch extends S.Class<AiMetricsOtlpSpanP
     ingestRunId: S.String,
     projections: S.Array(AiMetricsOtlpSpanProjection),
     sessionSpanCount: S.Finite,
+    /**
+     * Turn ids backing this batch, carried so a successful export can close the
+     * watermark on exactly the rows it emitted rather than on a re-evaluated
+     * predicate that may have moved underneath it.
+     */
+    turnIds: S.Array(S.String),
     turnSpanCount: S.Finite,
   },
   $I.annote("AiMetricsOtlpSpanProjectionBatch", {
@@ -230,7 +251,8 @@ export class AiMetricsOtlpSpanProjectionBatch extends S.Class<AiMetricsOtlpSpanP
 /**
  * Result of a redacted AI metrics OTLP export attempt.
  *
- * @example
+ * **Example** (Construct AiMetricsOtlpExportResult)
+ *
  * ```ts
  * import { AiMetricsOtlpExportResult } from "@beep/repo-ai-metrics"
  *
@@ -244,6 +266,7 @@ export class AiMetricsOtlpSpanProjectionBatch extends S.Class<AiMetricsOtlpSpanP
  * })
  * console.log(result.spanCount)
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -369,7 +392,12 @@ const resolveIngestRunId = Effect.fn("AiMetrics.otlp.resolveIngestRunId")(functi
   return latest.value.ingestRunId;
 });
 
-const readTurnRows = Effect.fn("AiMetrics.otlp.readTurnRows")(function* (ingestRunId: string) {
+// Selects every turn that has not yet been exported, rather than the turns belonging
+// to one ingest run. Run-scoping silently dropped work: a run that committed turns and
+// then died before exporting left them attached to a run the exporter would never
+// revisit. Draining on the watermark instead makes a failed export self-healing --
+// the next run simply picks the turns up.
+const readTurnRows = Effect.fn("AiMetrics.otlp.readTurnRows")(function* () {
   const duckdb = yield* DuckDb;
   const rows = yield* duckdb
     .query(
@@ -394,9 +422,8 @@ const readTurnRows = Effect.fn("AiMetrics.otlp.readTurnRows")(function* (ingestR
          s.config_snapshot_id AS "configSnapshotId"
        FROM ai_metrics_turns t
        JOIN ai_metrics_sessions s ON s.agent_session_id = t.agent_session_id
-       WHERE t.ingest_run_id = $ingestRunId
-       ORDER BY t.agent_session_id, t.line_number`,
-      { ingestRunId }
+       WHERE t.otlp_exported_at_epoch_ms IS NULL
+       ORDER BY t.agent_session_id, t.line_number`
     )
     .pipe(Effect.mapError((cause) => exportFailure("Failed to read AI metrics turn rows for OTLP export.", cause)));
 
@@ -470,6 +497,7 @@ const spanProjectionsFor = (
     ingestRunId,
     projections: A.appendAll(sessionProjections, turnProjections),
     sessionSpanCount: A.length(sessionProjections),
+    turnIds: A.map(rows, (row) => row.turnId),
     turnSpanCount: A.length(turnProjections),
   });
 };
@@ -477,8 +505,8 @@ const spanProjectionsFor = (
 /**
  * Read derived DuckDB rows and build redacted OTLP span projections.
  *
- * @effects Reads derived session and turn rows from the configured DuckDB database.
- * @example
+ * **Example** (Construct AiMetricsOtlpExportInput)
+ *
  * ```ts
  * import {
  *   AiMetricsOtlpEndpointSpec,
@@ -503,6 +531,8 @@ const spanProjectionsFor = (
  * )
  * console.log(program)
  * ```
+ *
+ * @effects Reads derived session and turn rows from the configured DuckDB database.
  * @category services
  * @since 0.0.0
  */
@@ -512,10 +542,76 @@ export const readAiMetricsOtlpSpanProjections: (
   "AiMetrics.readAiMetricsOtlpSpanProjections"
 )(function* (input) {
   const ingestRunId = yield* resolveIngestRunId(input.ingestRunId);
-  const rows = yield* readTurnRows(ingestRunId);
+  const rows = yield* readTurnRows();
 
   return spanProjectionsFor(ingestRunId, rows);
 });
+
+/**
+ * Close the OTLP export watermark on the turns a batch successfully emitted.
+ *
+ * **When to use**
+ *
+ * Use when an export attempt has already succeeded, never before it. Turns stay
+ * unmarked until their spans are actually away, so a crash or a rejected export simply
+ * leaves them for the next run to pick up instead of stranding them.
+ *
+ * **Gotchas**
+ *
+ * Marking is keyed on the batch's own `turnIds` rather than re-running the
+ * `otlp_exported_at_epoch_ms IS NULL` predicate, so turns ingested after the batch was
+ * read are not silently marked as exported.
+ *
+ * **Example** (Mark a batch as exported)
+ *
+ * ```ts
+ * import { markAiMetricsOtlpTurnsExported } from "@beep/repo-ai-metrics"
+ *
+ * const program = markAiMetricsOtlpTurnsExported(["turn-1", "turn-2"])
+ * console.log(program)
+ * ```
+ *
+ * @effects Updates `otlp_exported_at_epoch_ms` on the named rows in the derived DuckDB store.
+ * @category services
+ * @since 0.0.0
+ */
+export const markAiMetricsOtlpTurnsExported: (
+  turnIds: ReadonlyArray<string>
+) => Effect.Effect<void, AiMetricsOtlpExportError, DuckDb> = Effect.fn("AiMetrics.markAiMetricsOtlpTurnsExported")(
+  function* (turnIds) {
+    if (!A.isReadonlyArrayNonEmpty(turnIds)) {
+      return;
+    }
+    const duckdb = yield* DuckDb;
+    const exportedAtEpochMillis = yield* Effect.clockWith((clock) => clock.currentTimeMillis);
+    // DuckDB parameters are scalars, so the id list becomes numbered placeholders.
+    // Chunked because a run can carry tens of thousands of turns and a single
+    // statement with that many bindings is not worth risking.
+    yield* Effect.forEach(
+      A.chunksOf(turnIds, 500),
+      Effect.fnUntraced(function* (chunk) {
+        const placeholders = A.map(chunk, (_, index) => `$turnId${index}`);
+        const bindings = R.fromEntries(A.map(chunk, (turnId, index) => [`turnId${index}`, turnId] as const));
+        yield* duckdb
+          .run(
+            `UPDATE ai_metrics_turns
+         SET otlp_exported_at_epoch_ms = $exportedAtEpochMillis
+         WHERE turn_id IN (${A.join(placeholders, ", ")})`,
+            { exportedAtEpochMillis, ...bindings }
+          )
+          .pipe(
+            Effect.mapError((cause) =>
+              AiMetricsOtlpExportError.make({
+                cause,
+                message: "Failed to record the AI metrics OTLP export watermark.",
+              })
+            )
+          );
+      }),
+      { discard: true }
+    );
+  }
+);
 
 const emitSpanProjection = Effect.fn("AiMetrics.otlp.emitSpanProjection")((projection: AiMetricsOtlpSpanProjection) =>
   Effect.void.pipe(
@@ -559,8 +655,8 @@ const runAiMetricsOtlpProjectionBatchExportUntraced: (
 /**
  * Emit a pre-resolved redacted AI metrics OTLP span projection batch.
  *
- * @effects Emits one Effect span per projection into the active tracer.
- * @example
+ * **Example** (Construct AiMetricsOtlpExportInput)
+ *
  * ```ts
  * import {
  *   AiMetricsOtlpEndpointSpec,
@@ -584,11 +680,14 @@ const runAiMetricsOtlpProjectionBatchExportUntraced: (
  *   ingestRunId: "forwarder-1",
  *   projections: [],
  *   sessionSpanCount: 0,
+ *   turnIds: [],
  *   turnSpanCount: 0
  * })
  * const exported = Effect.runPromise(runAiMetricsOtlpProjectionBatchExport(input, batch))
  * console.log(exported)
  * ```
+ *
+ * @effects Emits one Effect span per projection into the active tracer.
  * @category services
  * @since 0.0.0
  */
@@ -604,8 +703,8 @@ export const runAiMetricsOtlpProjectionBatchExport: {
 /**
  * Emit redacted AI metrics derived spans through the active Effect tracer.
  *
- * @effects Reads derived DuckDB rows and emits redacted Effect spans into the active tracer.
- * @example
+ * **Example** (Construct AiMetricsOtlpExportInput)
+ *
  * ```ts
  * import {
  *   AiMetricsOtlpEndpointSpec,
@@ -630,6 +729,8 @@ export const runAiMetricsOtlpProjectionBatchExport: {
  * )
  * console.log(program)
  * ```
+ *
+ * @effects Reads derived DuckDB rows and emits redacted Effect spans into the active tracer.
  * @category services
  * @since 0.0.0
  */
@@ -649,7 +750,8 @@ export const runAiMetricsOtlpExport: (
 /**
  * Render an OTLP export result as JSON.
  *
- * @example
+ * **Example** (Construct AiMetricsOtlpExportResult)
+ *
  * ```ts
  * import { AiMetricsOtlpExportResult, otlpExportResultToJson } from "@beep/repo-ai-metrics"
  * import { Effect } from "effect"
@@ -668,6 +770,7 @@ export const runAiMetricsOtlpExport: (
  * )
  * console.log(json)
  * ```
+ *
  * @category utilities
  * @since 0.0.0
  */

--- a/packages/tooling/library/ai-metrics/src/otlp.ts
+++ b/packages/tooling/library/ai-metrics/src/otlp.ts
@@ -741,8 +741,15 @@ export const runAiMetricsOtlpExport: (
 )(
   function* (input) {
     const batch = yield* readAiMetricsOtlpSpanProjections(input);
+    const result = yield* runAiMetricsOtlpProjectionBatchExportUntraced(input, batch);
+    // Closing the watermark belongs here, not only in the callers. This is the entry
+    // point the forwarder uses (exportForwarderDerivedOtlp), and it reads and exports
+    // as one unit. If marking lived solely in the standalone export command, every
+    // forwarder run would re-emit every unexported turn forever -- strictly worse than
+    // the duplication this watermark exists to stop.
+    yield* markAiMetricsOtlpTurnsExported(batch.turnIds);
 
-    return yield* runAiMetricsOtlpProjectionBatchExportUntraced(input, batch);
+    return result;
   },
   (effect, input) => effect.pipe(withOtlpExportSpan(input))
 );

--- a/packages/tooling/library/ai-metrics/test/ingest.test.ts
+++ b/packages/tooling/library/ai-metrics/test/ingest.test.ts
@@ -600,6 +600,9 @@ layer(NodeServices.layer as Layer.Layer<TUnsafe.Any>)("@beep/repo-ai-metrics", (
             );
             const sessionRows = yield* duckdb.query("SELECT count(*) AS count FROM ai_metrics_sessions");
             const turnRows = yield* duckdb.query("SELECT count(*) AS count FROM ai_metrics_turns");
+            const turnLineage = yield* duckdb.query(
+              "SELECT DISTINCT ingest_run_id AS ingestRunId FROM ai_metrics_turns"
+            );
 
             expect(runRows).toEqual([{ count: "3" }]);
             expect(runArchiveCounts).toEqual([
@@ -611,7 +614,16 @@ layer(NodeServices.layer as Layer.Layer<TUnsafe.Any>)("@beep/repo-ai-metrics", (
             expect(archiveRows).toEqual([{ count: "3" }]);
             expect(agentTaskRows).toEqual([{ configSnapshotCount: 2, count: "2" }]);
             expect(sessionRows).toEqual([{ count: "3" }]);
-            expect(turnRows).toEqual([{ count: "3" }]);
+            // Three runs over byte-identical content must yield ONE turn row. This
+            // previously asserted "3", encoding the duplication that grew the store to
+            // 5.43M rows over ~516K distinct raw_event_hash across 1,222 runs.
+            expect(turnRows).toEqual([{ count: "1" }]);
+            // ...and it must retain the FIRST run's id. The OTLP export selects
+            // `WHERE ingest_run_id = <this run>`, so if a re-ingest rewrote this to the
+            // current run, every previously-seen turn would be re-exported to Phoenix
+            // on every run even though the table had stopped growing. Retaining
+            // first-seen lineage is what makes the export incremental.
+            expect(turnLineage).toEqual([{ ingestRunId: "forwarder-1" }]);
           }).pipe(provideScopedLayer(DuckDb.makeNodeLayer(DuckDbConnectionOptions.make({ databasePath: duckDbPath }))));
         })
       ).pipe(provideScopedLayer(NodeServices.layer));

--- a/packages/tooling/library/ai-metrics/test/ingest.test.ts
+++ b/packages/tooling/library/ai-metrics/test/ingest.test.ts
@@ -653,11 +653,24 @@ layer(NodeServices.layer as Layer.Layer<TUnsafe.Any>)("@beep/repo-ai-metrics", (
             const afterFailedExport = yield* readAiMetricsOtlpSpanProjections(exportInput);
             expect(afterFailedExport.turnIds).toEqual(pending.turnIds);
 
-            // Once the export succeeds and the watermark closes, they stop being resent.
-            yield* markAiMetricsOtlpTurnsExported(pending.turnIds);
+            // The forwarder exports through runAiMetricsOtlpExport, which reads and
+            // emits as one unit, so that entry point must close the watermark itself.
+            // With marking only in the standalone export command, nothing would ever be
+            // marked and every forwarder run would re-emit the whole store.
+            const exported = yield* runAiMetricsOtlpExport(exportInput);
+            expect(exported.turnSpanCount).toBe(1);
+
             const afterSuccessfulExport = yield* readAiMetricsOtlpSpanProjections(exportInput);
             expect(afterSuccessfulExport.turnIds).toEqual([]);
             expect(afterSuccessfulExport.projections).toEqual([]);
+
+            // A second forwarder run over unchanged content therefore emits nothing.
+            const secondExport = yield* runAiMetricsOtlpExport(exportInput);
+            expect(secondExport.turnSpanCount).toBe(0);
+            expect(secondExport.spanCount).toBe(0);
+
+            // Marking is safe to call with an empty batch.
+            yield* markAiMetricsOtlpTurnsExported([]);
           }).pipe(provideScopedLayer(DuckDb.makeNodeLayer(DuckDbConnectionOptions.make({ databasePath: duckDbPath }))));
         })
       ).pipe(provideScopedLayer(NodeServices.layer));

--- a/packages/tooling/library/ai-metrics/test/ingest.test.ts
+++ b/packages/tooling/library/ai-metrics/test/ingest.test.ts
@@ -58,6 +58,7 @@ import {
   makeAiMetricsInstallSpec,
   makeAiMetricsPrivacyCheckResult,
   makeAiMetricsSourceAttribution,
+  markAiMetricsOtlpTurnsExported,
   OpenClawTranscriptLine,
   otlpExportResultToJson,
   privacyCheckToJson,
@@ -624,6 +625,39 @@ layer(NodeServices.layer as Layer.Layer<TUnsafe.Any>)("@beep/repo-ai-metrics", (
             // on every run even though the table had stopped growing. Retaining
             // first-seen lineage is what makes the export incremental.
             expect(turnLineage).toEqual([{ ingestRunId: "forwarder-1" }]);
+
+            // A run can commit turns and then die before its OTLP export. Because
+            // ingestion is idempotent, the retry no longer re-mints those rows under a
+            // new run id -- so if the exporter scoped itself to "this run", the
+            // committed turns would be stranded and never reach Phoenix. Export state
+            // is tracked on its own watermark for exactly that reason.
+            const phoenix = phoenixService(installSpec);
+            expect(O.isSome(phoenix)).toBe(true);
+            if (O.isNone(phoenix)) {
+              return;
+            }
+            const exportInput = AiMetricsOtlpExportInput.make({
+              duckDbPath,
+              endpoint: phoenix.value.otlp,
+              ingestRunId: "latest",
+              target: AiMetricsDeployTarget.Enum.local,
+            });
+
+            // Un-exported turns are visible even though they belong to forwarder-1 and
+            // the latest run is forwarder-3.
+            const pending = yield* readAiMetricsOtlpSpanProjections(exportInput);
+            expect(pending.turnIds.length).toBe(1);
+
+            // Simulate the export failing: nothing is marked, so the next attempt must
+            // still see the same turns rather than silently skipping them.
+            const afterFailedExport = yield* readAiMetricsOtlpSpanProjections(exportInput);
+            expect(afterFailedExport.turnIds).toEqual(pending.turnIds);
+
+            // Once the export succeeds and the watermark closes, they stop being resent.
+            yield* markAiMetricsOtlpTurnsExported(pending.turnIds);
+            const afterSuccessfulExport = yield* readAiMetricsOtlpSpanProjections(exportInput);
+            expect(afterSuccessfulExport.turnIds).toEqual([]);
+            expect(afterSuccessfulExport.projections).toEqual([]);
           }).pipe(provideScopedLayer(DuckDb.makeNodeLayer(DuckDbConnectionOptions.make({ databasePath: duckDbPath }))));
         })
       ).pipe(provideScopedLayer(NodeServices.layer));

--- a/packages/tooling/tool/cli/src/commands/AIMetrics/internal/Programs.ts
+++ b/packages/tooling/tool/cli/src/commands/AIMetrics/internal/Programs.ts
@@ -71,6 +71,7 @@ import {
   makeAiMetricsInstallPlan,
   makeAiMetricsInstallSpec,
   makeAiMetricsPrivacyCheckResult,
+  markAiMetricsOtlpTurnsExported,
   otlpExportResultToJson,
   privacyCheckToJson,
   queueAiMetricsLabels,
@@ -258,12 +259,14 @@ const resolveRawArchiveKeySecretRef = Effect.fn("AIMetrics.resolveRawArchiveKeyS
 /**
  * Option schema for the RequireHashSaltForTarget AI metrics helper.
  *
- * @example
+ * **Example** (Inspect the RequireHashSaltForTargetOptions schema)
+ *
  * ```ts
  * import { RequireHashSaltForTargetOptions } from "@beep/repo-cli/commands/AIMetrics/internal/Programs"
  *
  * console.log(RequireHashSaltForTargetOptions.ast !== undefined) // true
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -296,12 +299,14 @@ const requireHashSaltForTarget = Effect.fn("AIMetrics.requireHashSaltForTarget")
 /**
  * Option schema for the RequireHashSaltSecretRefForTarget AI metrics helper.
  *
- * @example
+ * **Example** (Inspect the RequireHashSaltSecretRefForTargetOptions schema)
+ *
  * ```ts
  * import { RequireHashSaltSecretRefForTargetOptions } from "@beep/repo-cli/commands/AIMetrics/internal/Programs"
  *
  * console.log(RequireHashSaltSecretRefForTargetOptions.ast !== undefined) // true
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -338,12 +343,14 @@ const requireHashSaltSecretRefForTarget = Effect.fn("AIMetrics.requireHashSaltSe
 /**
  * Option schema for the RequireRawArchiveKeySecretRefForTarget AI metrics helper.
  *
- * @example
+ * **Example** (Inspect the RequireRawArchiveKeySecretRefForTargetOptions schema)
+ *
  * ```ts
  * import { RequireRawArchiveKeySecretRefForTargetOptions } from "@beep/repo-cli/commands/AIMetrics/internal/Programs"
  *
  * console.log(RequireRawArchiveKeySecretRefForTargetOptions.ast !== undefined) // true
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -423,12 +430,14 @@ const parseOptionalEpochMillis = Effect.fn("AIMetrics.parseOptionalEpochMillis")
 /**
  * Option schema for the ParseWindow AI metrics helper.
  *
- * @example
+ * **Example** (Inspect the ParseWindowOptions schema)
+ *
  * ```ts
  * import { ParseWindowOptions } from "@beep/repo-cli/commands/AIMetrics/internal/Programs"
  *
  * console.log(ParseWindowOptions.ast !== undefined) // true
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -469,12 +478,14 @@ const parseWindow = Effect.fn("AIMetrics.parseWindow")(function* ({ since, until
 /**
  * Option schema for the ParseRetentionSelector AI metrics helper.
  *
- * @example
+ * **Example** (Inspect the ParseRetentionSelectorOptions schema)
+ *
  * ```ts
  * import { ParseRetentionSelectorOptions } from "@beep/repo-cli/commands/AIMetrics/internal/Programs"
  *
  * console.log(ParseRetentionSelectorOptions.ast !== undefined) // true
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -536,12 +547,14 @@ const p6aCollectorDataRoot = (dataRoot: O.Option<string>, target: AiMetricsDeplo
 /**
  * Option schema for the MakeCommandInstallInput AI metrics helper.
  *
- * @example
+ * **Example** (Inspect the MakeCommandInstallInputOptions schema)
+ *
  * ```ts
  * import { MakeCommandInstallInputOptions } from "@beep/repo-cli/commands/AIMetrics/internal/Programs"
  *
  * console.log(MakeCommandInstallInputOptions.ast !== undefined) // true
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -586,12 +599,14 @@ const makeCommandInstallInput = Effect.fn("AIMetrics.makeCommandInstallInput")(f
 /**
  * Option schema for the MakeCommandInstallSpec AI metrics helper.
  *
- * @example
+ * **Example** (Inspect the MakeCommandInstallSpecOptions schema)
+ *
  * ```ts
  * import { MakeCommandInstallSpecOptions } from "@beep/repo-cli/commands/AIMetrics/internal/Programs"
  *
  * console.log(MakeCommandInstallSpecOptions.ast !== undefined) // true
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -693,12 +708,14 @@ const serverObservabilityConfigFor = (
 /**
  * Option schema for the MakeInstallPreviewProgram AI metrics helper.
  *
- * @example
+ * **Example** (Inspect the MakeInstallPreviewProgramOptions schema)
+ *
  * ```ts
  * import { MakeInstallPreviewProgramOptions } from "@beep/repo-cli/commands/AIMetrics/internal/Programs"
  *
  * console.log(MakeInstallPreviewProgramOptions.ast !== undefined) // true
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -748,12 +765,14 @@ const makeInstallPreviewProgram = Effect.fn("AIMetrics.makeInstallPreviewProgram
 /**
  * Option schema for the MakeInstallComposeProgram AI metrics helper.
  *
- * @example
+ * **Example** (Inspect the MakeInstallComposeProgramOptions schema)
+ *
  * ```ts
  * import { MakeInstallComposeProgramOptions } from "@beep/repo-cli/commands/AIMetrics/internal/Programs"
  *
  * console.log(MakeInstallComposeProgramOptions.ast !== undefined) // true
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -818,12 +837,14 @@ const renderInstallPlan = Effect.fn("AIMetrics.renderInstallPlan")(function* (
 /**
  * Option schema for the MakeInstallPlanProgram AI metrics helper.
  *
- * @example
+ * **Example** (Inspect the MakeInstallPlanProgramOptions schema)
+ *
  * ```ts
  * import { MakeInstallPlanProgramOptions } from "@beep/repo-cli/commands/AIMetrics/internal/Programs"
  *
  * console.log(MakeInstallPlanProgramOptions.ast !== undefined) // true
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -876,12 +897,14 @@ const renderInstallDoctor = Effect.fn("AIMetrics.renderInstallDoctor")(function*
 /**
  * Option schema for the MakeInstallDoctorProgram AI metrics helper.
  *
- * @example
+ * **Example** (Inspect the MakeInstallDoctorProgramOptions schema)
+ *
  * ```ts
  * import { MakeInstallDoctorProgramOptions } from "@beep/repo-cli/commands/AIMetrics/internal/Programs"
  *
  * console.log(MakeInstallDoctorProgramOptions.ast !== undefined) // true
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -962,12 +985,14 @@ const makeInstallDoctorProgram = Effect.fn("AIMetrics.makeInstallDoctorProgram")
 /**
  * Option schema for the MakeInstallApplyProgram AI metrics helper.
  *
- * @example
+ * **Example** (Inspect the MakeInstallApplyProgramOptions schema)
+ *
  * ```ts
  * import { MakeInstallApplyProgramOptions } from "@beep/repo-cli/commands/AIMetrics/internal/Programs"
  *
  * console.log(MakeInstallApplyProgramOptions.ast !== undefined) // true
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -1026,12 +1051,14 @@ const makeInstallApplyProgram = Effect.fn("AIMetrics.makeInstallApplyProgram")(f
 /**
  * Option schema for the MakeIngestProgram AI metrics helper.
  *
- * @example
+ * **Example** (Inspect the MakeIngestProgramOptions schema)
+ *
  * ```ts
  * import { MakeIngestProgramOptions } from "@beep/repo-cli/commands/AIMetrics/internal/Programs"
  *
  * console.log(MakeIngestProgramOptions.ast !== undefined) // true
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -1149,12 +1176,14 @@ const readPrivacyInput = Effect.fn("AIMetrics.readPrivacyInput")(function* (inpu
 /**
  * Option schema for the MakeSourcesDiscoverProgram AI metrics helper.
  *
- * @example
+ * **Example** (Inspect the MakeSourcesDiscoverProgramOptions schema)
+ *
  * ```ts
  * import { MakeSourcesDiscoverProgramOptions } from "@beep/repo-cli/commands/AIMetrics/internal/Programs"
  *
  * console.log(MakeSourcesDiscoverProgramOptions.ast !== undefined) // true
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -1229,12 +1258,14 @@ const makeSourcesDiscoverProgram = Effect.fn("AIMetrics.makeSourcesDiscoverProgr
 /**
  * Option schema for the MakeConfigSnapshotProgram AI metrics helper.
  *
- * @example
+ * **Example** (Inspect the MakeConfigSnapshotProgramOptions schema)
+ *
  * ```ts
  * import { MakeConfigSnapshotProgramOptions } from "@beep/repo-cli/commands/AIMetrics/internal/Programs"
  *
  * console.log(MakeConfigSnapshotProgramOptions.ast !== undefined) // true
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -1275,12 +1306,14 @@ const makeConfigSnapshotProgram = Effect.fn("AIMetrics.makeConfigSnapshotProgram
 /**
  * Option schema for the MakePrivacyCheckProgram AI metrics helper.
  *
- * @example
+ * **Example** (Inspect the MakePrivacyCheckProgramOptions schema)
+ *
  * ```ts
  * import { MakePrivacyCheckProgramOptions } from "@beep/repo-cli/commands/AIMetrics/internal/Programs"
  *
  * console.log(MakePrivacyCheckProgramOptions.ast !== undefined) // true
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -1390,12 +1423,14 @@ const forwarderOtlpExportFailureMessage = "OTLP export did not complete after th
 /**
  * Option schema for the ForwarderOtlpExportFailed AI metrics helper.
  *
- * @example
+ * **Example** (Inspect the ForwarderOtlpExportFailedOptions schema)
+ *
  * ```ts
  * import { ForwarderOtlpExportFailedOptions } from "@beep/repo-cli/commands/AIMetrics/internal/Programs"
  *
  * console.log(ForwarderOtlpExportFailedOptions.ast !== undefined) // true
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -1430,12 +1465,14 @@ const forwarderOtlpExportFailed = ({
 /**
  * Option schema for the ExportForwarderDerivedOtlp AI metrics helper.
  *
- * @example
+ * **Example** (Inspect the ExportForwarderDerivedOtlpOptions schema)
+ *
  * ```ts
  * import { ExportForwarderDerivedOtlpOptions } from "@beep/repo-cli/commands/AIMetrics/internal/Programs"
  *
  * console.log(ExportForwarderDerivedOtlpOptions.ast !== undefined) // true
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -1485,12 +1522,14 @@ const exportForwarderDerivedOtlp = Effect.fn("AIMetrics.exportForwarderDerivedOt
 /**
  * Option schema for the MakeForwarderRunProgram AI metrics helper.
  *
- * @example
+ * **Example** (Inspect the MakeForwarderRunProgramOptions schema)
+ *
  * ```ts
  * import { MakeForwarderRunProgramOptions } from "@beep/repo-cli/commands/AIMetrics/internal/Programs"
  *
  * console.log(MakeForwarderRunProgramOptions.ast !== undefined) // true
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -1674,12 +1713,14 @@ const makeForwarderRunProgram = Effect.fn("AIMetrics.makeForwarderRunProgram")(f
 /**
  * Option schema for the MakeForwarderTimerProgram AI metrics helper.
  *
- * @example
+ * **Example** (Inspect the MakeForwarderTimerProgramOptions schema)
+ *
  * ```ts
  * import { MakeForwarderTimerProgramOptions } from "@beep/repo-cli/commands/AIMetrics/internal/Programs"
  *
  * console.log(MakeForwarderTimerProgramOptions.ast !== undefined) // true
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -1796,12 +1837,14 @@ const makeForwarderTimerProgram = Effect.fn("AIMetrics.makeForwarderTimerProgram
 /**
  * Option schema for the MakeOtlpExportProgram AI metrics helper.
  *
- * @example
+ * **Example** (Inspect the MakeOtlpExportProgramOptions schema)
+ *
  * ```ts
  * import { MakeOtlpExportProgramOptions } from "@beep/repo-cli/commands/AIMetrics/internal/Programs"
  *
  * console.log(MakeOtlpExportProgramOptions.ast !== undefined) // true
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -1867,6 +1910,10 @@ const makeOtlpExportProgram = Effect.fn("AIMetrics.makeOtlpExportProgram")(funct
       )
     )
   );
+  // Only once the export has actually succeeded. Marking earlier would strand these
+  // turns permanently if the export then failed, which is the failure this watermark
+  // exists to prevent.
+  yield* markAiMetricsOtlpTurnsExported(batch.turnIds).pipe(withAiMetricsDuckDb(spec.storage.duckDbPath));
 
   if (json) {
     yield* Console.log(yield* otlpExportResultToJson(result));
@@ -1886,12 +1933,14 @@ const makeOtlpExportProgram = Effect.fn("AIMetrics.makeOtlpExportProgram")(funct
 /**
  * Option schema for the MakeBenchmarkRunProgram AI metrics helper.
  *
- * @example
+ * **Example** (Inspect the MakeBenchmarkRunProgramOptions schema)
+ *
  * ```ts
  * import { MakeBenchmarkRunProgramOptions } from "@beep/repo-cli/commands/AIMetrics/internal/Programs"
  *
  * console.log(MakeBenchmarkRunProgramOptions.ast !== undefined) // true
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -1980,12 +2029,14 @@ const makeBenchmarkCompareProgram = Effect.fn("AIMetrics.makeBenchmarkComparePro
 /**
  * Option schema for the MakeLabelQueueProgram AI metrics helper.
  *
- * @example
+ * **Example** (Inspect the MakeLabelQueueProgramOptions schema)
+ *
  * ```ts
  * import { MakeLabelQueueProgramOptions } from "@beep/repo-cli/commands/AIMetrics/internal/Programs"
  *
  * console.log(MakeLabelQueueProgramOptions.ast !== undefined) // true
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -2049,12 +2100,14 @@ const makeLabelQueueProgram = Effect.fn("AIMetrics.makeLabelQueueProgram")(funct
 /**
  * Option schema for the MakeLabelAddProgram AI metrics helper.
  *
- * @example
+ * **Example** (Inspect the MakeLabelAddProgramOptions schema)
+ *
  * ```ts
  * import { MakeLabelAddProgramOptions } from "@beep/repo-cli/commands/AIMetrics/internal/Programs"
  *
  * console.log(MakeLabelAddProgramOptions.ast !== undefined) // true
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -2125,12 +2178,14 @@ const makeLabelAddProgram = Effect.fn("AIMetrics.makeLabelAddProgram")(function*
 /**
  * Option schema for the MakeBenchmarkCaseAddProgram AI metrics helper.
  *
- * @example
+ * **Example** (Inspect the MakeBenchmarkCaseAddProgramOptions schema)
+ *
  * ```ts
  * import { MakeBenchmarkCaseAddProgramOptions } from "@beep/repo-cli/commands/AIMetrics/internal/Programs"
  *
  * console.log(MakeBenchmarkCaseAddProgramOptions.ast !== undefined) // true
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -2196,12 +2251,14 @@ const makeBenchmarkCaseAddProgram = Effect.fn("AIMetrics.makeBenchmarkCaseAddPro
 /**
  * Option schema for the MakeBenchmarkCaseListProgram AI metrics helper.
  *
- * @example
+ * **Example** (Inspect the MakeBenchmarkCaseListProgramOptions schema)
+ *
  * ```ts
  * import { MakeBenchmarkCaseListProgramOptions } from "@beep/repo-cli/commands/AIMetrics/internal/Programs"
  *
  * console.log(MakeBenchmarkCaseListProgramOptions.ast !== undefined) // true
  * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -2249,12 +2306,14 @@ const makeBenchmarkCaseListProgram = Effect.fn("AIMetrics.makeBenchmarkCaseListP
 /**
  * Option schema for the MakeWeeklyReportProgram AI metrics helper.
  *
- * @example
+ * **Example** (Inspect the MakeWeeklyReportProgramOptions schema)
+ *
  * ```ts
  * import { MakeWeeklyReportProgramOptions } from "@beep/repo-cli/commands/AIMetrics/internal/Programs"
  *
  * console.log(MakeWeeklyReportProgramOptions.ast !== undefined) // true
  * ```
+ *
  * @category models
  * @since 0.0.0
  */


### PR DESCRIPTION
## Why

`turn_id` was hashed from `[ingestRunId, sourceKind, sourcePathHash, lineNumber, rawEventHash]`. With the run id inside the identity, byte-identical content minted a brand-new id every run, `INSERT OR REPLACE` never collided, and the table accumulated one copy per run.

`goals/ai-metrics-stack` P7f already measured the damage: **5.43M turn rows over ~516K distinct `raw_event_hash` across 1,222 runs** — roughly 10.5x duplication. Those rows were then re-exported, which is how the dankserver Phoenix store reached **43.6 GB / 2,637,813 traces** and began wedging OTLP ingestion on every restart.

## What changed

**1. Idempotent ingestion.** `turn_id` is content-addressed (no run id), and repeat turns are `INSERT OR IGNORE`d so the first-seen `ingest_run_id` is retained as lineage. This matches the packet's rule that ingest runs are lineage, never identity.

`OR IGNORE` rather than `OR REPLACE` is load-bearing: REPLACE would rewrite `ingest_run_id` to the current run, and the exporter would still re-send every previously-seen turn on every run even though DuckDB had stopped growing — a fix that looks successful locally while Phoenix keeps duplicating.

**2. Explicit export state** (added after review). Inferring export state from `ingest_run_id` only worked while every run re-minted its rows. Once ingestion became idempotent, a run that committed turns and then died before exporting left them attached to a run the exporter would never revisit — permanently unexportable. Before the dedup that crash self-healed, because the duplication was acting as an accidental retry mechanism.

So export state now lives on its own watermark:

- `ai_metrics_turns.otlp_exported_at_epoch_ms`
- `readTurnRows` drains on `IS NULL` instead of scoping to one run, making a failed export self-healing
- `markAiMetricsOtlpTurnsExported` closes the watermark, only after the export succeeds, keyed on the batch's own `turnIds` so concurrent ingests are not falsely marked

## Migration hazard, handled

Existing stores were written under the duplicating scheme, so every row in them has already been exported repeatedly. Left alone, the first run after this lands would see millions of NULLs and flush the entire history to Phoenix at once — the exact backpressure collapse this work prevents. A one-time guarded migration through `ai_metrics_schema_migrations` marks pre-existing turns as exported, applied before the run's inserts so genuinely new turns are never swept up.

## Verification

- DuckDB `INSERT OR IGNORE` semantics checked empirically against `@duckdb/node-api` before relying on them — the pre-existing row is retained.
- The regression test previously asserted `turnRows == 3` for three runs over identical content, **encoding the duplication as expected behaviour**. It now asserts one row, that the retained `ingest_run_id` is the first run's, and walks the full crash-and-recover path: commit, simulated failed export, turns still visible, mark, turns no longer resent.
- 42/42 ingest tests, `check` and `lint` green in both touched packages, and `jsdoc-ratchet` reports `increased=0` / `cleanup-on-touch ok`.

## Known follow-up (deliberately out of scope)

`agent_session_id` has the same defect (`rowId("session", [input.ingestRunId, ...])`), so the sessions table still grows one row per file per run. It does **not** drive export volume — session projections derive from the turn rows, so a run with no new turns emits no session spans — and fixing it also means reconsidering that table's `INSERT OR REPLACE` semantics.

Also still open from the same P7f entry: the parquet-export regression, error surfacing at `--log-level debug`, and chunked derived writes.