### PR TITLE
docs: compound-engineering capture, ledger 79-83, friction-capture law

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,11 @@ workflows in skills.
   public.
 - same-PR packet-state flips: flip goal manifest/lifecycle status and land the
   closeout reflection in the same PR as the final work.
+- Friction is a first-class output: when work is slower, harder, or riskier
+  than it should be, record a receipt — what you were doing, the evidence
+  (command, error text, PR/file), what would have prevented it — in the
+  active packet's ledger (`research/OPPORTUNITIES.md`) at the moment it
+  happens, never saved for closeout.
 
 ## Agent Memory
 

--- a/explorations/compound-engineering/CAPTURE.md
+++ b/explorations/compound-engineering/CAPTURE.md
@@ -1,0 +1,90 @@
+# Capture — compound engineering
+
+Append-only. Never interrogated, never reorganized.
+
+## 2026-08-06 — the operator's framing
+
+> Eventually we will probably cross each ledger item off the list and this
+> highly productive ride will end... But what if it didn't have to? I've made
+> reflection a "relatively" standard practice for goals [...] the point of the
+> reflection is less a log of what happened during a goal and more "how could
+> we have made your job easier, faster, more efficient? What do you wish you'd
+> have known when you started? and what would have been nice for you to have?"
+> The goal being as things are done things get faster, easier, more efficient
+> and pleasant. [...] A "Compound Engineering" sort of a thing.
+>
+> It seems that if reflection is done at the back end of a thing some of the
+> valuable information, ideas & opportunities get lost in the noise which is
+> why that existing mechanism never seemed to land like it has in this
+> session. In this session it has been an active process. [...] I've
+> frequently had to ask you about what "ideas" you have. I would imagine that
+> many of our ledger items would not have been added unless I had asked. [...]
+> If I have to ask or we have to remind agents to reflect I might forget or
+> spend time writing the same instructions for each agent.
+
+And, on mechanizing the relay (buzz running always-on locally, routed through
+the existing Claude Code/Codex harnesses):
+
+> What is interesting about these is less the agent to agent communication but
+> more how it could be used as this place where these "points of friction"
+> could be fired off to where an agent that doesn't sleep can continuously
+> ingest them, add them to the ledger and work down that ledger in real time
+> [...] a frictionless way to add "opportunities" to the ledger without an
+> agent wasting time and tokens while also not interrupting the work they are
+> doing.
+
+## 2026-08-06 — the synthesis (from the speed-loop closeout)
+
+**Thesis.** Every unit of work emits two outputs: the deliverable, and
+information about how the work could have been better. The second output is
+perishable — it decays within minutes as context compacts and attention
+moves. Closeout-time reflection asks for it after decay (hence generic
+retrospective prose and `reflectionRequired` opt-outs); the speed-loop
+campaign's effectiveness came from capturing it at the moment of friction,
+with receipts, into a ledger a decision process actually consumes.
+
+**The loop.** CAPTURE (at friction time, receipts not summaries) →
+ACCUMULATE (one durable git ledger per campaign, numbered, statused) →
+SENTENCE (grills as evidence-sentencing, operator authority) → SHIP+DOGFOOD
+(speed-loop decision 49's ladder) → the shipped tooling lowers the cost of
+the next capture. Compounding lives in the return edge; an empty ledger
+refills as long as work happens.
+
+**Broken-station failure modes.** Capture without accumulation = chat that
+scrolls away. Accumulation without sentencing = graveyard (the likely fate
+of prior reflection outputs). Sentencing without the dogfood ladder =
+speculation.
+
+**The relay analysis (binding design constraint).** The operator's manual
+relaying between sessions provided three functions beyond transport:
+filtering (expensive channel → dense receipts), authority (operator relay =
+ratification weight), timing. Mechanizing the wire must relocate — not
+delete — the filter (a triage station with the admission rule "receipts,
+not vibes") and the authority (sentencing stays human). The operator moves
+up the stack: courier → judge.
+
+**Mechanization sketch (workstation-local; not repo doctrine).** Block's
+buzz runs always-on on the operator's workstation and routes through the
+existing harnesses/subscriptions. A `#friction` channel exists with the
+receipt protocol in its description. Phases, decision-49-gated: phase 0 —
+capture wire only, a session harvests → dedups → batched ledger docs-PRs +
+grill dockets; measure a week (capture rate vs relay-era, noise ratio)
+after researching buzz's actual mechanics first. Phase 1 — an always-on
+"compounder" agent, write scope docs/ledger only, system prompt carries
+"drop evidence-free messages without guilt". Phase 2 — the compounder works
+SENTENCED queue items under ownership claims; the collision half of that
+design belongs to the fleet-coordination packet and must be relayed there
+before phase 1.
+
+**Receipts held at capture.** The speed-loop ledger reached 83 items in
+three days run manually; sub-agent reflection riders produced unprompted
+reflections while orchestrator-level capture required operator asks — the
+asymmetry motivating the ambient AGENTS.md law shipped alongside this
+capture. The idle-without-reporting amendment (same batch) is the report-
+durability half of the same problem.
+
+Operator rulings at open (grilled 2026-08-06): packet seeded directly from
+the synthesis rather than an INBOX bullet; the AGENTS.md friction-capture
+law ships with this capture; the /reflect reframe (three questions +
+closeout-as-ledger-distillation) ships separately; buzz stays workstation
+doctrine until this packet graduates; nothing else is decided.

--- a/goals/speed-loop/research/GRILL-DECISIONS.md
+++ b/goals/speed-loop/research/GRILL-DECISIONS.md
@@ -444,3 +444,21 @@ decisions close them:
     ships before any lane-closing work so the gap is visible while being
     closed; PR-I's AgentBrief is dogfooded by generating briefs for this
     campaign's own waves before any fleet adoption.
+50. **Docs-batch grill (2026-08-06, compound-engineering batch).**
+    (a) Topology: two PRs — the ledger/capture/AGENTS.md batch ships
+    docs-only; the /reflect reframe ships separately (lint-validated
+    surface, own review round). (b) The compound-engineering capture
+    seeds `explorations/compound-engineering/` directly rather than
+    compressing a finished synthesis into an INBOX bullet; buzz and the
+    #friction wire stay workstation doctrine, out of the public repo,
+    until the packet graduates. (c) The sweep-dogfood receipts route to
+    a fast-follow fix PR (sweep `--branch` override + handoff-where;
+    decision 45(d) amended same-PR — its "a re-run completes the
+    deletion" is false as shipped, surfaced by the first real sweep).
+    (d) #81 ships as practice law (ambient via the closeout law) with
+    the closeout assertion designed but deferred to the next
+    Status/closeout touch. (e) The AGENTS.md friction law lands in
+    Docs & Knowledge, receipt-shaped. (f) The reflect reframe carries
+    the three questions AND the distillation contract — closeout
+    reflection is redefined as a distillation of the packet's
+    continuously-captured friction ledger; schema and lint untouched.

--- a/goals/speed-loop/research/OPPORTUNITIES.md
+++ b/goals/speed-loop/research/OPPORTUNITIES.md
@@ -845,6 +845,25 @@ validation for the reflection: the stale-base guard caught a real revert
 hazard pre-ship; the append-optional discipline is WHY the review P1s
 were findable; repair's config-sync → lint-fix → laws ordering is right.
 
+PR-I evidence amendment — idle-without-reporting (operator observation,
+2026-08-06, recurring across sessions): sub-agents finish or go idle
+without a final report, forcing orchestrators to re-derive WHAT was done
+(discovery cost, distinct from verification cost). Three observed loss
+modes for chat-borne reports: final turn ends on a tool call (gate green
+→ idle, no closing text); result-cap truncation (three of five fix-wave
+reports arrived cut mid-sentence); death/compaction near the end (the
+power outage left a journal saying "started" beside completed work).
+Sharpen #45: the report file is written INCREMENTALLY, before the final
+gate run — an end-composed file shares the chat message's failure modes;
+`beep agent report list` makes discovery independent of the last
+message. #52 rider: the brief carries "the report file is the
+deliverable; the final message is a pointer." Doctrine available today:
+report-bearing fan-outs go through Workflow agent() WITH schema (the
+harness forces validated structured output; free-text stages and
+teammate flows are where every observed loss occurred). Verify-don't-
+trust stays: reports are claims, gates are evidence (#71) — report
+durability fixes discovery, not trust.
+
 PR-E fix-wave reflection harvest (2026-08-05, #54 ritual; 5 agents, run
 wf_7d56b3bb-e06): new items #71–72 above. Also: adversarial-review
 findings should anchor on SYMBOL NAMES, not line numbers — three of four

--- a/goals/speed-loop/research/OPPORTUNITIES.md
+++ b/goals/speed-loop/research/OPPORTUNITIES.md
@@ -864,6 +864,87 @@ teammate flows are where every observed loss occurred). Verify-don't-
 trust stays: reports are claims, gates are evidence (#71) — report
 durability fixes discovery, not trust.
 
+79. **PR provenance + resume footer, stamped by yeet publish.** (Operator
+    pain, 2026-08-06: a four-terminal hunt for which session originated
+    #578; the recurring wrong-agent "fix PR #X" backtrack.) Every
+    yeet-created PR body — never the title, which is squash/commitlint
+    input — gains: clone, branch, session name + id, harness, a
+    machine-readable `<!-- yeet-provenance -->` twin, and a
+    copy-pasteable RESUME BLOCK (`cd <clone> && <harness> --resume
+    <session-id> <operator-flags>`) making any PR a durable bookmark
+    into its originating session — terminals die (2026-08-05 power
+    loss), PRs persist. Flags live in operator config templates per
+    harness, not code. Identity ladder: `BEEP_AGENT_SESSION` env from a
+    launch wrapper now, PR-I's #45/#52 identity later. Dogfooded:
+    #583's body carries the footer hand-stamped. Vehicle: small yeet
+    rider; graduates into PR-I.
+80. **Evaluate GitHub native stacked PRs (public preview).** The docs
+    claim the exact fixes for our recorded blockers: required checks run
+    for ALL stack layers as if against the default branch (would retire
+    the stacked-pr-skips-required-checks hazard), auto-retarget +
+    auto-rebase on merge, squash support, merge-queue aware. Maps to
+    lived pain: the #569→#571→#583 continuation chain was a hand-rolled
+    stack; workflow phases (schemas→engines→wiring) are natural layers
+    that would have shrunk #571's five cumulative-diff review rounds.
+    Decision-49 gate: one throwaway two-layer stack verifying the child
+    runs all 24 required checks under OUR ruleset before any adoption;
+    yeet is stack-unaware (stale-base, sweep deletion contract, --pr
+    creation all need riders); merge-queue interplay relays to the
+    fleet packet (#22, decision 34).
+81. **No silent resolutions.** (Operator question, 2026-08-06: fix
+    commits land but threads stay unmarked — or worse, get resolved
+    with no reply, unauditable.) The gate (#20, shipped) ensures threads
+    GET resolved; #81 requires resolutions to carry a receipt: replies
+    name the addressing commit sha or the reasoned by-design defense,
+    and resolutions go through `yeet reply` (which forces a body).
+    Practice is ambient via #583's AGENTS.md law; the mechanical
+    assertion is DESIGNED (thread query gains comments(last:1) author;
+    closeout gains --require-answered-resolutions) and deferred to the
+    next yeet Status/closeout touch — jumps the queue if silent
+    resolutions are actually observed.
+82. **Canonical terminal status line for publish (or `--summary`).**
+    (beep-effect14, 2026-08-06 — their top ask.) publish emits a large
+    stream including the lane JSON, so context-constrained agents MUST
+    pipe-filter, and piping destroys `$?` — producing "agent confidently
+    reports success on a failed run" (observed twice there; only the
+    zsh `${pipestatus[1]}` habit has protected this session). Contract:
+    the LAST line of publish output is one machine-parseable status
+    line (`yeet: publish OK pushed=<sha> pr=<n>` / `yeet: publish
+    FAILED lane=<id> remedy=<cmd>`), making filtering safe by
+    construction. Kin to #76; cheaper than reading verdict.json.
+83. **Status must reconcile the verdict against remote reality.**
+    (beep-effect14: after out-of-band remediation, status reported
+    `verdict: publish failure` + `next: git push` alongside 0 failing
+    checks — contradictory in one snapshot, the merge-ready disease.)
+    A verdict older than the branch tip or contradicted by remote state
+    renders as "stale (predates last push)" with the re-derivation
+    command, never as current truth — operators must not learn to
+    ignore the verdict line.
+
+Sweep-dogfood receipts (2026-08-06, first executeSweep on its own merged
+branch, exit 0, every rail honored): (a) the lockfile needs-operator
+handoff names the command but not the WHERE — "re-run the sweep" from a
+worktree that cannot refresh main (held elsewhere) loops forever; the
+handoff must name the worktree that can act. (b) Two-pass completion
+gap — sweep targets the CURRENT branch only, so after end-state moves
+off the merged branch the promised second pass cannot reach it; ratified
+decision 45(d)'s "a re-run completes the deletion" is FALSE as shipped.
+Both route to a fast-follow fix PR (sweep --branch override through
+guardLiteralArg + handoff text; decision 45(d) amended same-PR).
+
+beep-effect14 operator-feedback disposition (2026-08-06): new items
+#82–83 above. Amendments — #8 (ship porcelain): third verb gap
+receipt-confirmed, "commit exists, prove and push" has no name
+(--amend/--push-only both misused hunting for it); #77: the empty-index
+--amend error names the two-step remedy; #50: the missing-proof-state
+error lacks the Remedy: line stale-base has — the convention exists,
+applied non-uniformly (one-line fast-follow); #25 (PR-G build item):
+key refinement is (tree hash, MERGE-BASE) — changed-file and changeset
+lanes are base-relative; their byte-identical cherry-picked tree repaid
+a full proof. Kept-column: stale-base guard correct 4/4, --staged-only
+stash never misfired, sweep refused deleting an unpushed commit, reply
+posted nothing on a bot-auto-resolved thread.
+
 PR-E fix-wave reflection harvest (2026-08-05, #54 ritual; 5 agents, run
 wf_7d56b3bb-e06): new items #71–72 above. Also: adversarial-review
 findings should anchor on SYMBOL NAMES, not line numbers — three of four


### PR DESCRIPTION
Grilled batch (decision 50 records the rulings):

- **Seeds `explorations/compound-engineering/`** — friction as a first-class output: the capture → accumulate → sentence → ship+dogfood loop, the relay analysis as a binding design constraint, and decision-49-gated mechanization phases (workstation wire details stay out of the public repo).
- **Ledger #79–83**: PR provenance + resume footer; stacked-PRs evaluation (spike-gated); no silent resolutions; canonical publish status line; verdict-vs-remote reconciliation — the last two from beep-effect14's operator-feedback session, plus its #8/#77/#50/#25 amendments and kept-column calibration.
- **Sweep-dogfood receipts** from the first real `executeSweep` run, including the decision-45(d) two-pass gap (fix PR follows).
- **AGENTS.md** gains the receipt-shaped friction-capture law (Docs & Knowledge) and the earlier idle-without-reporting agent-kit amendment rides too.

The /reflect reframe ships separately per grill ruling 50(a).

---
🤖 **origin**: `beep-effect3-pra` · `docs/compound-engineering` · session **SPEED_UP_YEET_QUALITY_CHECKS_ORIGINAL** (claude)

**Resume this session:**
```bash
cd ~/YeeBois/projects/beep-effect3 && claude --resume 0f2b38a4-2679-4841-b477-957caa2d3057 --dangerously-skip-permissions
```

<!-- yeet-provenance clone=beep-effect3-pra session-home=beep-effect3 branch=docs/compound-engineering session-name=SPEED_UP_YEET_QUALITY_CHECKS_ORIGINAL session-id=0f2b38a4-2679-4841-b477-957caa2d3057 harness=claude -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/586"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788612514&installation_model_id=424656&pr_number=586&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F586&signature=bef49256bd410879970fc833a6968b29af0f25182349eb132b69749094097884"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
