### PR TITLE
chore(security): admit effect beta.104 subtree squash gitleaks fingerprints

### DIFF
--- a/.changeset/gitleaks-effect-beta104-fingerprints.md
+++ b/.changeset/gitleaks-effect-beta104-fingerprints.md
@@ -1,0 +1,5 @@
+---
+{}
+---
+
+chore(security): admit effect beta.104 subtree squash gitleaks fingerprints

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -83,3 +83,8 @@ goals/repo-crispening-orchestration/ops/inventory/S5/beep__shared-domain.json:ge
 # --squash` records upstream-relative paths, so the `.repos/effect/` allowlist
 # in .gitleaks.toml cannot match them.
 3d37b37f7710fa096e25e1711243e480917bf999:packages/effect/src/Config.ts:generic-api-key:1482
+
+# False positives in the immutable Effect subtree squash used by the
+# 4.0.0-beta.104 refresh. Same Config.redacted JSDoc sample, now at line 1484.
+cb5d50cf0a7e6ca0cf7b31be33f2ed931b36e92e:packages/effect/src/Config.ts:generic-api-key:1484
+.repos/effect/packages/effect/src/Config.ts:generic-api-key:1484


### PR DESCRIPTION
## Summary

Prerequisite for #607. The effect `4.0.0-beta.104` subtree refresh riding on that branch carries an immutable squash commit (`cb5d50cf0a`) whose `Config.redacted` JSDoc sample trips the `generic-api-key` gitleaks rule — the same false positive already admitted for the previous subtree squash at `Config.ts:1482`, now at line 1484.

The Secret Scanning gate deliberately pins `.gitleaksignore` to the base branch so a PR cannot suppress its own findings; these two fingerprints therefore must land on `main` before #607's scan can pass. #607 already carries the identical lines, so the eventual merge is clean.

## Changes

- two fingerprint lines + comment in `.gitleaksignore` (squash-commit path and worktree path variants)
- empty changeset (config-only, version-neutral)

## Test plan

- [ ] Hosted required checks green
- [ ] After merge: re-run Secret Scanning on #607 → green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788665663&installation_model_id=424656&pr_number=609&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F609&signature=2629e446f77506078237a341a7da8f1b57ffebcfe1a9b1df140543981f3acfab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->