### PR TITLE
feat(repo-cli): add knowledge refs read-only census (knowledge-surface-automation P1)

### DIFF
--- a/.changeset/knowledge-refs-tree-census.md
+++ b/.changeset/knowledge-refs-tree-census.md
@@ -1,0 +1,10 @@
+---
+"@beep/repo-cli": patch
+---
+
+Add `bun run beep knowledge refs`, a read-only reference census over one Git tree: repository paths,
+machine-local host paths, and `repo://goal/*` identities are extracted, resolved against the tree's
+tracked entries alone, and classified by a pure twelve-class rule table. The shared Markdown scanning
+machinery — governed path normalization, fence-aware line reading, inline-span reading, and the
+length-prefixed digest discipline — moves into `Knowledge.refs.ts` so Stage-1 enforcement and the
+census read documents through one grammar.

--- a/goals/knowledge-surface-automation/ops/manifest.json
+++ b/goals/knowledge-surface-automation/ops/manifest.json
@@ -53,7 +53,8 @@
     "research/p1-refs-tree-design.md",
     "research/p1-bootstrap-adopt-plan-design.md",
     "research/p1-fp-eyeball-verdicts.md",
-    "research/p1-t2-mini-grill-decisions.md"
+    "research/p1-t2-mini-grill-decisions.md",
+    "research/p1-report-refs-tree.md"
   ],
   "agentLaunchers": [
     {

--- a/goals/knowledge-surface-automation/research/OPPORTUNITIES.md
+++ b/goals/knowledge-surface-automation/research/OPPORTUNITIES.md
@@ -112,3 +112,20 @@ measurement first). Reviewed at each grill.
    baseline. Nobody tightens it because the baseline file conflicts with every
    concurrent branch, so the slack accumulates. A CI-generated baseline-only PR
    (the pattern C8 already ratifies for sealed baselines) would fit here too.
+
+## Receipts from P1 refs census (2026-08-06, PR-A refs-tree)
+
+9. **The packet's own host-path verification grep was red on `main`.** `fixed-in-pr`
+
+   `! rg -n "<redacted-home-prefix>|<redacted-tilde-tree>" goals/knowledge-surface-automation …`
+   (the manifest's sixth verification command) failed against the checkout this
+   branch forked from: `research/p1-context-pruning-analysis.md:110` carried an
+   unredacted absolute home path, landed by an earlier PR without the command
+   being run. Redacted in the refs-tree PR; the census itself now reports the
+   same class (`actionable-host-path` / `archival-provenance`), so once the P3
+   gate consumes it this cannot silently recur.
+
+   **What would have prevented it:** manifest `verificationCommands` are prose
+   until something executes them; a lane that runs each packet's declared
+   commands on touched packets (Workstream E's doctor is the natural home) would
+   have caught this at the introducing PR.

--- a/goals/knowledge-surface-automation/research/p1-context-pruning-analysis.md
+++ b/goals/knowledge-surface-automation/research/p1-context-pruning-analysis.md
@@ -107,7 +107,7 @@ told agents to prefer `mui-mcp` with a specific `useMuiDocs`-then-`fetchDocs` ca
 order. That server is in no `.mcp.json` (this repo's has `chrome-devtools`, `fallow`,
 `next-devtools`, `nlp`, `serena`, `shadcn`, `webstorm`), and the only occurrence in
 `~/.claude.json` is at
-`projects > /home/elpresidank/YeeBois/projects/beep-effect > disabledMcpServers[15]`.
+`projects > <HOME>/YeeBois/projects/beep-effect > disabledMcpServers[15]`.
 MUI packages are genuinely used (`@mui/material`, `@mui/x-tree-view`), but the routing
 instruction was unusable for Claude Code and meaningless for Codex. Deleted. If the
 server is ever re-enabled, the guidance belongs in a skill or alongside the `.mcp.json`

--- a/goals/knowledge-surface-automation/research/p1-report-refs-tree.md
+++ b/goals/knowledge-surface-automation/research/p1-report-refs-tree.md
@@ -1,0 +1,195 @@
+# P1 report — knowledge refs live census (Workstream A phase 0)
+
+Live-repo run of `bun run beep knowledge refs --json` at HEAD
+`2162ebdc8ac02fd0e53ca15578cfea0f185ee81a` (2026-08-06), with a paired verification
+run at the frozen inventory baseline
+`58318884957ae02237099cc40666d30e3c2d943d`. Host-absolute paths quoted below are
+redacted to `<HOME>` placeholders per E4; the command itself emits real paths.
+
+## Headline numbers
+
+- 18,433 observations across 1,736 documents (repo-path bus) plus 332 documents
+  with host anchors; 9,322 live / 9,111 archival; 4 skipped tree entries, all
+  tracked symlinks (`.agents/agents`, `.agents/skills`, `CLAUDE.md`,
+  `explorations/CLAUDE.md`), reported and never followed per ratified A6.
+- By bus: 17,198 repo-path, 1,233 host-path, 2 goal-uri.
+- Exit status 0; the census gates nothing.
+
+| Classification | Live | Archival | Total |
+| --- | ---: | ---: | ---: |
+| `verified` | 8,481 | 6,949 | 15,432 |
+| `broken-target` | 547 | 1,217 | 1,764 |
+| `identity-mismatch` | 0 | 0 | 0 |
+| `producer-owned-target` | 0 | 0 | 0 |
+| `actionable-host-path` | 122 | 0 | 122 |
+| `portable-home-convention` | 19 | 0 | 19 |
+| `documented-temp-convention` | 1 | 0 | 1 |
+| `external-mirror-reference` | 117 | 0 | 117 |
+| `archival-provenance` | 0 | 729 | 729 |
+| `audit-pattern-literal` | 34 | 211 | 245 |
+| `ambiguous-ref-pairing` | 0 | 0 | 0 |
+| `ungoverned-syntax` | 1 | 3 | 4 |
+
+Host-anchor classes are live-only by construction except `audit-pattern-literal`,
+which deliberately outranks `archival-provenance` so an archival audit row (this
+packet's own inventory tables) classifies as pattern data rather than provenance.
+
+## Baseline agreement
+
+Run against the exact inventory snapshot commit, the census reproduces
+`research/surface-inventory.md` with zero unexplained delta:
+
+- Census host-path totals at the baseline tree: **1,158 occurrences / 291 files /
+  287 live / 871 archival**; per anchor 630 home-absolute, 382 home-relative,
+  122 temp, 24 encoded-home + bare-tree-name (14 + 10).
+- The inventory's published 1,741 / 406 / 298 / 1,443 decompose exactly as census
+  population (above) plus 583 occurrences in 115 files whose extensions the
+  census does not elect: `.log` 484, `.inventory` 38, `.sh` 32, `.txt` 15,
+  `.diff` 10, `.tsv` 4 — all archival but 11 occurrences in 4 files.
+- Zero elected-extension blobs fail strict UTF-8 at either commit, so `skipped`
+  carries no `malformed-utf8` rows on the real corpus.
+
+The committed baseline-agreement test (`test/knowledge-refs.test.ts`) re-derives
+both sides on every run: an independent in-test anchor counter over all scoped
+tracked blobs must reproduce the six published inventory numbers, and the census
+must equal that counter restricted to its elected population.
+
+At HEAD the host bus reads 1,233 occurrences / 332 files (293 live / 940
+archival); the +75 / +41 drift over the baseline is tree growth since
+2026-07-31 (new packet research and history landed by merged PRs), not extractor
+drift.
+
+## Highest-density documents
+
+252 `goals/repo-codegraph-jsdoc/history/outputs/compiled_sources/Semantic Code
+Graph – an information model to facilitate software comprehension.md` (converted
+paper, archival), 242 `standards/jsdoc-documentation.inventory.md`, 161
+`explorations/ontology-agent-surface/RESEARCH.md`, 160 `explorations/ATLAS.md`,
+130 `goals/goal-portfolio-driver/research/dependency-sweep-2.md`, 124
+`goals/INDEX.md`. Density concentrates in generated/converted corpora and
+portfolio indexes, as expected.
+
+## Sampled false-positive annotations
+
+**`broken-target` (1,764; the judgment-bearing bucket).** The census deliberately
+does not distinguish broken from speculative (no oracle for intent; ratified A1:
+prose paths must resolve, speculative trees belong in fences). Hand-annotating
+the 547 live rows (245 distinct targets):
+
+- Speculative or renamed packet references dominate: `goals/ip-law-knowledge-graph`
+  (31), `goals/ontology-modeling-foundation` (18), `goals/trustgraph-port` (17) —
+  design prose citing packets that were never created or were renamed. This is
+  the split-brain motivation for Workstream A, observed live.
+- True retirements: `standards/repo-exports.catalog.md` (10) — live docs still
+  cite the retired catalog that repo law says must never be consulted.
+- **Genuine false-positive class found:** MCP JSON-RPC method names `tools/call`
+  (22) and `tools/list` (13) read as repo paths because `tools` is a governed
+  bare root. Same shape: upstream-repo file paths quoted in research prose
+  (`scripts/generate.ts`, 25) that exist in the surveyed repository, not this
+  one. Neither is a broken reference in intent; both are exactly what the
+  phase-0 eyeball exists to catch before any gate wiring.
+- The archival 1,217 concentrate in converted papers and captured surveys whose
+  citation-style links never referenced this repository at all.
+
+**`audit-pattern-literal` (245).** The v1 lexical rule (line carries a table
+delimiter, regex group `(?`, regex class `[^`, `--glob`, or a word-bounded
+`rg`/`grep` invocation) fires correctly on security-finding regexes
+(`<HOME-USER>|YeeBois|/tmp/|/Users/|beep-effect2` in
+`goals/codex-security-findings-2026-07-08/findings/CSF-016.md`), on
+`research/surface-inventory.md`'s own rows, and on hook-pulse glob lines. Known
+coarseness: in table-heavy archival research, provenance rows inside Markdown
+tables absorb into this class instead of `archival-provenance` (e.g.
+`goals/ontology-workbench/research/ontosphere-survey-report.md` table rows).
+Both dispositions are "not a defect", so the coarseness costs triage precision,
+not correctness.
+
+**`portable-home-convention` (19).** All rows carry the four ratified prefixes
+(`~/.claude`, `~/.codex`, `~/.config`, `~/.bun`): CI cache paths in
+`.github/actions/setup-monorepo-ci/action.yml`, plan files under
+`~/.claude/plans/`, OBS config in the qa-session-ops skill. No mislabels found.
+
+**`documented-temp-convention` (1).** Exactly `/tmp/portless` in the portless
+skill. The set is deliberately minimal; see the eyeball ask.
+
+**`external-mirror-reference` (117).** Home paths outside any beep checkout:
+`<HOME>/YeeBois/dev/trustgraph/`, `<HOME>/YeeBois/dev/firecrawl`,
+`<HOME>/YeeBois/projects/effect-lexical-chat/`. Two annotated edges:
+`~/.openclaw/` (a product config-directory convention lexically indistinguishable
+from a mirror — a convention-set candidate) and `~/Downloads/...` (session
+provenance in a live doc, not a mirror; remediation "canonical URL" does not
+apply).
+
+**`actionable-host-path` (122).** The P3 rewrite target set: worktree paths in
+`standards/git-worktrees.md`, absolute checkout paths in
+`standards/effect-first-development.md` (`.repos/effect-v4` cited absolutely),
+executable worktree commands retained in `goals/ai-metrics-stack/ops/manifest.json`,
+and non-convention temp outputs (`/tmp/beep-jsdoc-quality-…json`,
+`/tmp/codex-security-findings-2026-06`). Fenced host paths are counted here by
+design (contract item 8): a fenced `cd <HOME>/…` is precisely what breaks a
+fresh clone.
+
+**`ungoverned-syntax` (4).** All absolute-repo-path spellings: `/docs`,
+`/docs/`, `/plugins`, `/packages/lexical-headless` (the last is an upstream
+monorepo's package quoted absolutely). Correctly outside the governed grammar.
+
+**`encoded-home` (17) / `bare-tree-name` (14).** Encoded session-directory
+literals (`/tmp/claude-1000/-home-…-beep-effect5/…`, `~/.claude/projects/-home-…`)
+split from plain bare tree names; the two sum to the inventory's combined bucket
+at the baseline (24), as required.
+
+## Goal-URI bus and identity-mismatch detection
+
+The live corpus carries exactly two `repo://goal/*` / `beep:ref` observations —
+this packet's own doctrine examples — and both verify: the design doc's bare URI,
+and the P2 grill record's A1 example, which pairs same-line with display path
+`goals/knowledge-surface-automation/PLAN.md`. Dual-write does not exist yet, so
+identity-mismatch detection is proven by the committed fixture matrix instead:
+manifest-id-agrees → `verified`, manifest present with a different
+`initiative.id` → `identity-mismatch` carrying `declaredId`, manifest absent →
+`broken-target`/`missing`, two refs on one line and orphan refs →
+`ambiguous-ref-pairing`, heading-scope pairing → `verified`. A tracked manifest
+that fails JSON parse or schema decode fails the run closed rather than
+downgrading to `missing` — the census may not silently convert an undecodable
+identity source into an absence.
+
+## v1 scope notes
+
+- Extension election (`.md`, `.json`, `.jsonc`, `.jsonl`, `.toml`, `.yml`,
+  `.yaml`) excludes 583 baseline occurrences (dominated by captured `.log`
+  proofs, all archival but 11); the baseline-agreement test pins this
+  attribution.
+- Repo paths are read from inline-code spans (Stage-1 grammar) and inline
+  Markdown link destinations (document-relative semantics); reference-style link
+  definitions are not read in v1.
+- JSON/JSONC is scanned line-wise as text (ratified A2); goal URIs are read from
+  Markdown only. Fragments are stripped, not validated (A4). `upstream://` stays
+  reserved (A5).
+- One placement deviation from the design doc: `knowledgeRefsCommand` registers
+  in `Knowledge.command.ts` beside the semantic-delta command (family
+  convention) because the design's refs-module placement would create an import
+  cycle — `Knowledge.refs.ts` is the shared-parser home the service imports
+  from, so it cannot also import the service tag back.
+
+## Eyeball ask
+
+Benjamin — the P3 unlock for Workstream A hangs on your verdict over the rule
+table, not the individual rows:
+
+1. `broken-target` disposition: confirm the ratified fence-decoy rule as the
+   only speculative-path mechanism, with the MCP-method (`tools/call`,
+   `tools/list`) and upstream-repo-path shapes accepted as known lexical FPs to
+   burn down in P3 (options: an extension requirement for bare `tools/…` and
+   `scripts/…` spellings, or leaving them to fences) — or send the question back
+   to a mini-grill.
+2. `audit-pattern-literal` lexical rule: accept the v1 signal set (and its
+   known table-absorption coarseness in archival research), or name the signals
+   you want added/removed before any gate consumes the class.
+3. Convention sets: `~/.openclaw` (and any other product config-dir prefixes)
+   into `portable-home-convention`? Additional documented `/tmp/…` prefixes into
+   `documented-temp-convention`? Widening is a deliberate CLI PR per A3.
+4. `external-mirror-reference` remediation text promises a canonical URL;
+   confirm that stands for mirror-shaped rows and that provenance-shaped rows
+   (`~/Downloads/…`) just ride along until P3 rewrites live surfaces.
+5. Confirm the live `actionable-host-path` set (122 rows, headlined by
+   `standards/git-worktrees.md` and the two manifests carrying absolute
+   commands) as the P3 mechanical-rewrite target list.

--- a/packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.command.ts
+++ b/packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.command.ts
@@ -1,22 +1,31 @@
 /**
- * `beep knowledge semantic-delta` command definitions.
+ * `beep knowledge` command definitions: the Stage-1 semantic delta and the phase-0 reference census.
  *
  * @packageDocumentation
  * @since 0.0.0
  */
 
 import { NonNegativeInt } from "@beep/schema";
-import { Console, Effect } from "effect";
+import { Console, Effect, Match, Order, pipe } from "effect";
 import * as A from "effect/Array";
 import * as O from "effect/Option";
+import * as R from "effect/Record";
+import * as Str from "effect/String";
 import { Command, Flag } from "effect/unstable/cli";
 import { KnowledgeIntroducedFindingsError, KnowledgeOperationalError } from "./Knowledge.errors.ts";
+import {
+  encodeKnowledgeRefsReportJson,
+  KnowledgeRefClassification,
+  KnowledgeRefSurface,
+  KnowledgeRefSurfaceFilter,
+} from "./Knowledge.refs.ts";
 import {
   encodeKnowledgeSemanticDeltaReportJson,
   KNOWLEDGE_PROBE_DEPENDENT_KINDS,
   KnowledgeProbePolicy,
 } from "./Knowledge.schemas.ts";
 import { KnowledgeService, KnowledgeServiceLive } from "./Knowledge.service.ts";
+import type { KnowledgeRef, KnowledgeRefObservation, KnowledgeRefsReport } from "./Knowledge.refs.ts";
 import type { KnowledgeFinding, KnowledgeSemanticDeltaReport } from "./Knowledge.schemas.ts";
 
 const baseFlag = Flag.string("base").pipe(
@@ -24,6 +33,19 @@ const baseFlag = Flag.string("base").pipe(
   Flag.withDefault("origin/main")
 );
 const jsonFlag = Flag.boolean("json").pipe(Flag.withDescription("Render the semantic delta as JSON"));
+const treeFlag = Flag.string("tree").pipe(
+  Flag.withDescription("Commit-ish whose tracked tree is censused; the command never fetches"),
+  Flag.withDefault("HEAD")
+);
+const surfaceFlag = Flag.choiceWithValue("surface", [
+  ["all", KnowledgeRefSurfaceFilter.Enum.all],
+  ["live", KnowledgeRefSurfaceFilter.Enum.live],
+  ["archival", KnowledgeRefSurfaceFilter.Enum.archival],
+]).pipe(
+  Flag.withDefault(KnowledgeRefSurfaceFilter.Enum.all),
+  Flag.withDescription("Narrow the detailed listing; summary counts stay whole-corpus")
+);
+const refsJsonFlag = Flag.boolean("json").pipe(Flag.withDescription("Render the whole census as JSON"));
 
 const renderFinding = (finding: KnowledgeFinding): string =>
   `  ${finding.findingId} ${finding.kind} ${finding.location.path}: ${finding.message}`;
@@ -146,6 +168,132 @@ export const knowledgeSemanticDeltaCommand = Command.make(
   Command.provide(KnowledgeServiceLive)
 );
 
+const TOP_DOCUMENT_COUNT = 10;
+
+const refSubject = (ref: KnowledgeRef): string =>
+  Match.value(ref).pipe(
+    Match.discriminatorsExhaustive("kind")({
+      "repo-path": (repoPath) => repoPath.normalized,
+      "host-path": (hostPath) => `${hostPath.anchor} ${hostPath.raw}`,
+      "goal-uri": (goalUri) => `repo://goal/${goalUri.slug}`,
+    })
+  );
+
+const renderObservation = (observation: KnowledgeRefObservation): string => {
+  const line = O.getOrElse(O.fromNullishOr(observation.location.line), () => 0);
+  const column = O.getOrElse(O.fromNullishOr(observation.location.column), () => 0);
+  return `  ${observation.classification} ${observation.location.path}:${line}:${column} ${refSubject(observation.ref)}`;
+};
+
+const classificationCounts = (report: KnowledgeRefsReport): ReadonlyArray<string> =>
+  A.map(KnowledgeRefClassification.Options, (classification) => {
+    const count = A.length(
+      A.filter(report.observations, (observation) => observation.classification === classification)
+    );
+    return `  ${Str.padEnd(26)(classification)} ${count}`;
+  });
+
+/** Highest observation density first, then path, so the census listing is stable across runs. */
+type DocumentDensity = {
+  readonly documentId: string;
+  readonly count: number;
+};
+
+const densityOrder: Order.Order<DocumentDensity> = Order.combine(
+  Order.mapInput(Order.Number, (row: DocumentDensity) => -row.count),
+  Order.mapInput(Order.String, (row: DocumentDensity) => row.documentId)
+);
+
+const topDocuments = (report: KnowledgeRefsReport): ReadonlyArray<string> =>
+  pipe(
+    A.groupBy(report.observations, (observation) => observation.documentId),
+    R.toEntries,
+    A.map(([documentId, group]): DocumentDensity => ({ documentId, count: A.length(group) })),
+    A.sort(densityOrder),
+    A.take(TOP_DOCUMENT_COUNT),
+    A.map((row) => `  ${row.count} ${row.documentId}`)
+  );
+
+const renderRefsReport = (report: KnowledgeRefsReport, surface: KnowledgeRefSurfaceFilter): string => {
+  const live = A.length(
+    A.filter(report.observations, (observation) => KnowledgeRefSurface.is.live(observation.surface))
+  );
+  const archival = A.length(report.observations) - live;
+  const listed = KnowledgeRefSurfaceFilter.is.all(surface)
+    ? report.observations
+    : A.filter(report.observations, (observation) => observation.surface === surface);
+  return A.join(
+    [
+      `knowledge refs @ ${report.treeish} (${report.commit})`,
+      `observations: ${A.length(report.observations)} (live ${live}, archival ${archival})`,
+      `skipped: ${A.length(report.skipped)}`,
+      ...A.map(report.skipped, (blob) => `  ${blob.reason} ${blob.path}`),
+      "classification:",
+      ...classificationCounts(report),
+      "top documents:",
+      ...topDocuments(report),
+      `observations (${surface}) (${A.length(listed)}):`,
+      ...A.map(listed, renderObservation),
+    ],
+    "\n"
+  );
+};
+
+const runRefs = Effect.fn("KnowledgeCommand.runRefs")(function* (options: {
+  readonly tree: string;
+  readonly surface: KnowledgeRefSurfaceFilter;
+  readonly json: boolean;
+}) {
+  const knowledge = yield* KnowledgeService;
+  const report = yield* knowledge.refsTree(options.tree);
+  if (options.json) {
+    const json = yield* encodeKnowledgeRefsReportJson(report).pipe(
+      KnowledgeOperationalError.mapError("Failed to encode the reference census JSON report.")
+    );
+    yield* Console.log(json);
+  } else {
+    yield* Console.log(renderRefsReport(report, options.surface));
+  }
+});
+
+/**
+ * The `beep knowledge refs` subcommand.
+ *
+ * **Details**
+ *
+ * A read-only census of every reference in the agent-facing corpus of one Git tree, resolved against
+ * that tree's tracked entries rather than against the working filesystem. `--tree` accepts any
+ * commit-ish and defaults to `HEAD`; no fetch ever occurs. Human output prints the whole-corpus
+ * totals, the count of every one of the twelve classes including the empty ones, the highest-density
+ * documents, and then the per-observation listing. `--json` emits the complete report on one line.
+ *
+ * **Gotchas**
+ *
+ * `--surface` narrows the detailed listing only — the totals and the class table stay whole-corpus,
+ * and `--json` always carries every observation — so a filtered run can never be mistaken for a
+ * smaller census. The command exits zero for every observation mix: it measures the corpus and gates
+ * nothing, which is what keeps it out of the policy lane until its false-positive rate is known.
+ *
+ * **Example** (Read the subcommand identity)
+ *
+ * ```ts
+ * import { knowledgeRefsCommand } from "@beep/repo-cli/commands/Knowledge/Knowledge.command"
+ *
+ * console.log(knowledgeRefsCommand.name) // "refs"
+ * ```
+ *
+ * @category cli-commands
+ * @since 0.0.0
+ */
+export const knowledgeRefsCommand = Command.make(
+  "refs",
+  { tree: treeFlag, surface: surfaceFlag, json: refsJsonFlag },
+  runRefs
+).pipe(
+  Command.withDescription("Census every reference in one tracked tree without gating on the result"),
+  Command.provide(KnowledgeServiceLive)
+);
+
 /**
  * The `beep knowledge` command family root.
  *
@@ -154,7 +302,7 @@ export const knowledgeSemanticDeltaCommand = Command.make(
  * Running it without a subcommand lists the available knowledge-surface verifications rather than
  * scanning, so the family root stays cheap and side-effect free.
  *
- * **Example** (Reach the semantic-delta subcommand from the family root)
+ * **Example** (Reach the subcommands from the family root)
  *
  * ```ts
  * import { knowledgeCommand } from "@beep/repo-cli/commands/Knowledge/Knowledge.command"
@@ -163,16 +311,19 @@ export const knowledgeSemanticDeltaCommand = Command.make(
  * const subcommands = A.flatMap(knowledgeCommand.subcommands, (group) => group.commands)
  *
  * console.log(knowledgeCommand.name) // "knowledge"
- * console.log(A.map(subcommands, (command) => command.name)) // [ "semantic-delta" ]
+ * console.log(A.map(subcommands, (command) => command.name)) // [ "refs", "semantic-delta" ]
  * ```
  *
- * @see {@link knowledgeSemanticDeltaCommand} for the only Stage-1 subcommand it exposes.
+ * @see {@link knowledgeRefsCommand} for the read-only phase-0 census.
+ * @see {@link knowledgeSemanticDeltaCommand} for the gating Stage-1 comparison.
  * @category cli-commands
  * @since 0.0.0
  */
 export const knowledgeCommand = Command.make("knowledge", {}, () =>
-  Console.log("Knowledge commands: semantic-delta [--base <ref>] [--json]")
+  Console.log(
+    "Knowledge commands: refs [--tree <rev>] [--surface live|archival|all] [--json], semantic-delta [--base <ref>] [--json]"
+  )
 ).pipe(
   Command.withDescription("Knowledge-surface verification commands"),
-  Command.withSubcommands([knowledgeSemanticDeltaCommand])
+  Command.withSubcommands([knowledgeRefsCommand, knowledgeSemanticDeltaCommand])
 );

--- a/packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.errors.ts
+++ b/packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.errors.ts
@@ -49,7 +49,10 @@ export const KNOWLEDGE_HISTORY_REMEDIATION =
  *
  * Git, archive extraction, UTF-8 decoding, command-probe, and index-probe failures all raise this
  * error rather than becoming synthetic findings. Emitting them as findings would let a broken
- * scanner look like a clean comparison, so they stay strictly in the error channel.
+ * scanner look like a clean comparison, so they stay strictly in the error channel. The reference
+ * census reuses the same error for tree resolution and for an undecodable goal manifest: one
+ * operational error per family beats a parallel hierarchy, and a census that cannot read the tree
+ * it was asked about must never report an empty one.
  *
  * **Example** (Fail a scan closed)
  *
@@ -75,7 +78,8 @@ export class KnowledgeOperationalError extends TaggedErrorClass<KnowledgeOperati
     cause: S.optionalKey(S.Defect({ includeStack: true })),
   },
   $I.annote("KnowledgeOperationalError", {
-    description: "A Git, archive, UTF-8, command-probe, or index-probe failure that must fail closed.",
+    description:
+      "A Git, tree-resolution, archive, UTF-8, manifest-decode, command-probe, or index-probe failure that must fail closed.",
   })
 ) {
   /**

--- a/packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.refs.ts
+++ b/packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.refs.ts
@@ -2376,7 +2376,10 @@ const resolveGoalSlug = Effect.fn("Knowledge.resolveGoalSlug")(function* (
 ) {
   const manifestPath = goalManifestPath(slug);
   const entry = HashMap.get(pathIndex, manifestPath);
-  if (O.isNone(entry)) {
+  // A manifest tracked as a symlink or a gitlink is recorded in `skipped` and never followed, so it
+  // is unavailable as an identity source rather than readable. Reading it anyway would fail the
+  // whole census on a blob the scan already decided not to open.
+  if (O.isNone(entry) || !isRegularBlob(entry.value)) {
     return KnowledgeRefMissing.make({});
   }
   const text = yield* Effect.flatMap(oracle.readBytes(manifestPath), (bytes) => decodeUtf8(bytes, manifestPath));
@@ -2427,7 +2430,9 @@ const entryPathOrder = Order.mapInput(Order.String, (entry: KnowledgeTrackedEntr
  * A blob whose bytes fail strict UTF-8 decoding is skipped and the run still succeeds; a goal
  * manifest that fails to parse or decode is an operational failure instead. The difference is
  * deliberate: the census may not silently downgrade an undecodable identity source into a missing
- * one, because that is exactly the split-brain state it exists to detect.
+ * one, because that is exactly the split-brain state it exists to detect. A manifest tracked as a
+ * symlink or gitlink is a third case: the scan never opens it, so it is unavailable rather than
+ * undecodable, and the reference resolves as missing while the link itself is recorded in `skipped`.
  *
  * **Example** (Census an empty tree)
  *

--- a/packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.refs.ts
+++ b/packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.refs.ts
@@ -1,0 +1,2554 @@
+/**
+ * Reference census schemas, the shared Markdown scanning machinery, the pure classifier, and the
+ * single-tree evaluator behind `beep knowledge refs`.
+ *
+ * This module owns the reference grammar the whole Knowledge family reads from: the governed
+ * repo-path normalizer, the fence-aware line reader, the inline-code span reader, and the
+ * length-prefixed digest discipline. `Knowledge.service.ts` imports them rather than keeping private
+ * copies, so Stage-1 enforcement and the phase-0 census can never drift apart on what a document
+ * line means.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { LiteralKit, NonNegativeInt, Sha256Hex, Sha256HexFromBytes } from "@beep/schema";
+import { Effect, flow, HashMap, HashSet, Match, MutableHashMap, Order, pipe } from "effect";
+import * as A from "effect/Array";
+import * as O from "effect/Option";
+import * as P from "effect/Predicate";
+import * as S from "effect/Schema";
+import * as Str from "effect/String";
+import { decodeGoalManifest } from "../Goals/Goals.schemas.ts";
+import { parseGoalManifestText } from "../Goals/Inventory.ts";
+import { KnowledgeOperationalError } from "./Knowledge.errors.ts";
+import { KnowledgeFindingLocation } from "./Knowledge.schemas.ts";
+import type { KnowledgeTrackedEntry } from "./Knowledge.schemas.ts";
+
+const $I = $RepoCliId.create("commands/Knowledge/Knowledge.refs");
+
+const REF_NORMALIZATION_VERSION = "knowledge-ref-normalization/v1";
+const REF_ID_PREFIX = "knowledge-ref/v1:";
+const textEncoder = new TextEncoder();
+const strictUtf8Decoder = new TextDecoder("utf-8", { fatal: true });
+const nfc = Str.normalize("NFC");
+
+/**
+ * Every reference bus the census can carry, including the reserved upstream domain.
+ *
+ * **Details**
+ *
+ * v1 emits `repo-path`, `host-path`, and `goal-uri` only. `upstream` is reserved by ratified
+ * decision A5: `upstream://owner/repo@sha` provenance belongs to Workstream B's `skills-lock/v2`
+ * bus, so the kind domain names it while no member class exists and no observation ever carries it.
+ *
+ * **Example** (Read the reference kind domain)
+ *
+ * ```ts
+ * import { KnowledgeRefKind } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ *
+ * console.log(KnowledgeRefKind.is["repo-path"]("repo-path")) // true
+ * console.log(KnowledgeRefKind.Options.length) // 4
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const KnowledgeRefKind = LiteralKit(["repo-path", "host-path", "goal-uri", "upstream"]).pipe(
+  $I.annoteSchema("KnowledgeRefKind", {
+    description: "Reference buses recognised by the census; upstream is reserved and never emitted.",
+  })
+);
+
+/**
+ * One reference bus, spanning the three emitted kinds and the reserved upstream domain.
+ *
+ * @see {@link KnowledgeRefKind} for the runtime schema and the reserved-member rule.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type KnowledgeRefKind = typeof KnowledgeRefKind.Type;
+
+/**
+ * Narrows an unknown value to a reference bus.
+ *
+ * **Example** (Reject an unregistered bus)
+ *
+ * ```ts
+ * import { isKnowledgeRefKind } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ *
+ * console.log(isKnowledgeRefKind("goal-uri")) // true
+ * console.log(isKnowledgeRefKind("goal-url")) // false
+ * ```
+ *
+ * @category guards
+ * @since 0.0.0
+ */
+export const isKnowledgeRefKind = S.is(KnowledgeRefKind);
+
+/**
+ * Lexical anchor that made a span machine-local.
+ *
+ * **Details**
+ *
+ * The five members reproduce the clone-agnosticism baseline exactly: absolute home prefixes,
+ * home-relative `~/` prefixes, `/tmp/`, encoded session-directory literals, and the bare machine
+ * tree name. The anchors are non-overlapping by construction, which is what makes census totals
+ * comparable with the inventory that established them.
+ *
+ * **Example** (Read the anchor domain)
+ *
+ * ```ts
+ * import { KnowledgeHostAnchor } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ *
+ * console.log(KnowledgeHostAnchor.is["home-relative"]("home-relative")) // true
+ * console.log(KnowledgeHostAnchor.Options.length) // 5
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const KnowledgeHostAnchor = LiteralKit([
+  "home-absolute",
+  "home-relative",
+  "temp",
+  "encoded-home",
+  "bare-tree-name",
+]).pipe(
+  $I.annoteSchema("KnowledgeHostAnchor", {
+    description: "Lexical anchor that made a span machine-local.",
+  })
+);
+
+/**
+ * The lexical anchor behind one machine-local reference.
+ *
+ * @see {@link KnowledgeHostAnchor} for the runtime schema and the non-overlap rule.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type KnowledgeHostAnchor = typeof KnowledgeHostAnchor.Type;
+
+/**
+ * Narrows an unknown value to a host anchor.
+ *
+ * **Example** (Reject an unregistered anchor)
+ *
+ * ```ts
+ * import { isKnowledgeHostAnchor } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ *
+ * console.log(isKnowledgeHostAnchor("temp")) // true
+ * console.log(isKnowledgeHostAnchor("tmp")) // false
+ * ```
+ *
+ * @category guards
+ * @since 0.0.0
+ */
+export const isKnowledgeHostAnchor = S.is(KnowledgeHostAnchor);
+
+/**
+ * Corpus disposition of the document that contains an observation.
+ *
+ * **Details**
+ *
+ * Stage-1 enforcement excludes archival directories; the census includes them and labels them
+ * instead, because the archival bucket is 83 percent of the baseline and rewriting captured
+ * provenance would rewrite history.
+ *
+ * **Example** (Read the surface domain)
+ *
+ * ```ts
+ * import { KnowledgeRefSurface } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ *
+ * console.log(KnowledgeRefSurface.is.archival("archival")) // true
+ * console.log(KnowledgeRefSurface.Options.length) // 2
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const KnowledgeRefSurface = LiteralKit(["live", "archival"]).pipe(
+  $I.annoteSchema("KnowledgeRefSurface", {
+    description: "Corpus disposition of the containing document.",
+  })
+);
+
+/**
+ * Whether the containing document is live guidance or a captured archival artifact.
+ *
+ * @see {@link KnowledgeRefSurface} for the runtime schema and the archival-inclusion rule.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type KnowledgeRefSurface = typeof KnowledgeRefSurface.Type;
+
+/**
+ * Narrows an unknown value to a corpus surface.
+ *
+ * **Example** (Reject an unregistered surface)
+ *
+ * ```ts
+ * import { isKnowledgeRefSurface } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ *
+ * console.log(isKnowledgeRefSurface("live")) // true
+ * console.log(isKnowledgeRefSurface("current")) // false
+ * ```
+ *
+ * @category guards
+ * @since 0.0.0
+ */
+export const isKnowledgeRefSurface = S.is(KnowledgeRefSurface);
+
+/**
+ * The surface selector a census listing can be narrowed to.
+ *
+ * **Details**
+ *
+ * `all` is the default and the only value that shows the whole corpus. The filter narrows the
+ * detailed listing only: summary counts are always whole-corpus, so a filtered run can never
+ * understate the census it reports.
+ *
+ * **Example** (Read the surface-filter domain)
+ *
+ * ```ts
+ * import { KnowledgeRefSurfaceFilter } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ *
+ * console.log(KnowledgeRefSurfaceFilter.is.all("all")) // true
+ * console.log(KnowledgeRefSurfaceFilter.Options.length) // 3
+ * ```
+ *
+ * @see {@link KnowledgeRefSurface} for the per-observation disposition it filters on.
+ * @category models
+ * @since 0.0.0
+ */
+export const KnowledgeRefSurfaceFilter = LiteralKit(["all", "live", "archival"]).pipe(
+  $I.annoteSchema("KnowledgeRefSurfaceFilter", {
+    description: "Surface selector narrowing a census listing without changing its counts.",
+  })
+);
+
+/**
+ * Which surfaces a census listing shows.
+ *
+ * @see {@link KnowledgeRefSurfaceFilter} for the runtime schema and the counts-stay-whole rule.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type KnowledgeRefSurfaceFilter = typeof KnowledgeRefSurfaceFilter.Type;
+
+/**
+ * Deterministic triage class assigned to one reference observation.
+ *
+ * **Details**
+ *
+ * The twelve classes are computed by a total rule table, never hand-labelled — phase 0 exists to
+ * eyeball the rule table rather than the individual rows. Four classes describe resolution outcomes
+ * (`verified`, `broken-target`, `identity-mismatch`, `producer-owned-target`), six describe host
+ * anchors, and two describe grammar failures.
+ *
+ * **Example** (Read the classification domain)
+ *
+ * ```ts
+ * import { KnowledgeRefClassification } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ *
+ * console.log(KnowledgeRefClassification.is["broken-target"]("broken-target")) // true
+ * console.log(KnowledgeRefClassification.Options.length) // 12
+ * ```
+ *
+ * @see {@link classifyKnowledgeRef} for the ordered rule table that assigns them.
+ * @category models
+ * @since 0.0.0
+ */
+export const KnowledgeRefClassification = LiteralKit([
+  "verified",
+  "broken-target",
+  "identity-mismatch",
+  "producer-owned-target",
+  "actionable-host-path",
+  "portable-home-convention",
+  "documented-temp-convention",
+  "external-mirror-reference",
+  "archival-provenance",
+  "audit-pattern-literal",
+  "ambiguous-ref-pairing",
+  "ungoverned-syntax",
+]).pipe(
+  $I.annoteSchema("KnowledgeRefClassification", {
+    description: "Deterministic triage class assigned to one reference observation.",
+  })
+);
+
+/**
+ * One deterministic triage class.
+ *
+ * @see {@link KnowledgeRefClassification} for the runtime schema and the rule-table discipline.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type KnowledgeRefClassification = typeof KnowledgeRefClassification.Type;
+
+/**
+ * Narrows an unknown value to a reference classification.
+ *
+ * **Example** (Reject an unregistered class)
+ *
+ * ```ts
+ * import { isKnowledgeRefClassification } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ *
+ * console.log(isKnowledgeRefClassification("audit-pattern-literal")) // true
+ * console.log(isKnowledgeRefClassification("false-positive")) // false
+ * ```
+ *
+ * @category guards
+ * @since 0.0.0
+ */
+export const isKnowledgeRefClassification = S.is(KnowledgeRefClassification);
+
+/**
+ * Resolution outcome of one reference against the requested tree.
+ *
+ * **Details**
+ *
+ * `not-applicable` is not a failure: every host path is unresolvable by construction rather than
+ * broken, and so is a reference whose pairing was ambiguous enough that guessing a target would
+ * violate the split-brain rule.
+ *
+ * **Example** (Read the resolution-status domain)
+ *
+ * ```ts
+ * import { KnowledgeRefResolutionStatus } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ *
+ * console.log(KnowledgeRefResolutionStatus.is["not-applicable"]("not-applicable")) // true
+ * console.log(KnowledgeRefResolutionStatus.Options.length) // 5
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const KnowledgeRefResolutionStatus = LiteralKit([
+  "resolved",
+  "missing",
+  "identity-mismatch",
+  "producer-owned",
+  "not-applicable",
+]).pipe(
+  $I.annoteSchema("KnowledgeRefResolutionStatus", {
+    description: "Tag domain of the reference resolution union.",
+  })
+);
+
+/**
+ * The tag of one reference resolution.
+ *
+ * @see {@link KnowledgeRefResolutionStatus} for the runtime schema and the not-applicable rule.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type KnowledgeRefResolutionStatus = typeof KnowledgeRefResolutionStatus.Type;
+
+/**
+ * Why a tracked blob under the scanned scope was recorded rather than read.
+ *
+ * **Details**
+ *
+ * Tracked symlinks are reported and never followed (ratified decision A6), so `.agents/skills` and
+ * `.claude/skills` stay independently auditable. Malformed UTF-8 skips the blob and keeps the run
+ * green: a census that dies on one undecodable file reports nothing about the other four thousand.
+ *
+ * **Example** (Read the skip-reason domain)
+ *
+ * ```ts
+ * import { KnowledgeSkipReason } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ *
+ * console.log(KnowledgeSkipReason.is.symlink("symlink")) // true
+ * console.log(KnowledgeSkipReason.Options.length) // 3
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const KnowledgeSkipReason = LiteralKit(["symlink", "gitlink", "malformed-utf8"]).pipe(
+  $I.annoteSchema("KnowledgeSkipReason", {
+    description: "Why a scoped tracked blob was recorded instead of scanned.",
+  })
+);
+
+/**
+ * Why one scoped tracked blob was skipped.
+ *
+ * @see {@link KnowledgeSkipReason} for the runtime schema and the never-follow-symlinks rule.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type KnowledgeSkipReason = typeof KnowledgeSkipReason.Type;
+
+/**
+ * Narrows an unknown value to a skip reason.
+ *
+ * **Example** (Reject an unregistered reason)
+ *
+ * ```ts
+ * import { isKnowledgeSkipReason } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ *
+ * console.log(isKnowledgeSkipReason("gitlink")) // true
+ * console.log(isKnowledgeSkipReason("binary")) // false
+ * ```
+ *
+ * @category guards
+ * @since 0.0.0
+ */
+export const isKnowledgeSkipReason = S.is(KnowledgeSkipReason);
+
+/**
+ * The Git commit object name a census was computed against.
+ *
+ * **Gotchas**
+ *
+ * This is a SHA-1 object name, forty lowercase hexadecimal characters — not a SHA-256 digest. The
+ * report carries both: `commit` pins the tree, while every `refId` carries a SHA-256 identity.
+ *
+ * **Example** (Validate a resolved commit)
+ *
+ * ```ts
+ * import { KnowledgeCommitSha } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ * import * as S from "effect/Schema"
+ *
+ * const isCommit = S.is(KnowledgeCommitSha)
+ *
+ * console.log(isCommit("2162ebdc8a2162ebdc8a2162ebdc8a2162ebdc8a")) // true
+ * console.log(isCommit("HEAD")) // false
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const KnowledgeCommitSha = S.String.check(
+  S.isPattern(/^[0-9a-f]{40}$/u, {
+    identifier: $I`KnowledgeCommitShaPatternCheck`,
+    title: "Knowledge Commit Sha Pattern",
+    description: "Lowercase forty-character hexadecimal Git commit object name.",
+    message: "Expected a lowercase forty-character hexadecimal Git commit id",
+  })
+).pipe(
+  $I.annoteSchema("KnowledgeCommitSha", {
+    description: "Forty-character lowercase hexadecimal Git commit object name.",
+  })
+);
+
+/**
+ * A forty-character lowercase hexadecimal Git commit object name.
+ *
+ * @see {@link KnowledgeCommitSha} for the runtime schema and the SHA-1-versus-SHA-256 distinction.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type KnowledgeCommitSha = typeof KnowledgeCommitSha.Type;
+
+/**
+ * Versioned SHA-256 identity of one normalized reference instance.
+ *
+ * **Details**
+ *
+ * The digest covers the length-prefixed normalization version, kind, document id, normalized
+ * subject, and duplicate occurrence index — never the display location — so reflowing a document
+ * cannot relabel the references inside it.
+ *
+ * **Example** (Validate a reference identity)
+ *
+ * ```ts
+ * import { KnowledgeRefId } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ * import * as S from "effect/Schema"
+ *
+ * const isRefId = S.is(KnowledgeRefId)
+ *
+ * console.log(
+ *   isRefId("knowledge-ref/v1:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+ * ) // true
+ * console.log(isRefId("knowledge-ref/v1:short")) // false
+ * ```
+ *
+ * @see {@link makeKnowledgeRefId} for the exact preimage it is computed from.
+ * @category models
+ * @since 0.0.0
+ */
+export const KnowledgeRefId = S.TemplateLiteral(["knowledge-ref/v1:", Sha256Hex]).pipe(
+  $I.annoteSchema("KnowledgeRefId", {
+    description: "SHA-256 identity of one normalized reference instance.",
+  })
+);
+
+/**
+ * A `knowledge-ref/v1:`-prefixed SHA-256 reference identity.
+ *
+ * @see {@link KnowledgeRefId} for the runtime schema and the digest preimage rule.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type KnowledgeRefId = typeof KnowledgeRefId.Type;
+
+/**
+ * A repository-root-relative target after governed normalization.
+ *
+ * **Gotchas**
+ *
+ * `normalized` carries a resolved repository path only when the spelling was governed. For an
+ * `ungoverned-syntax` observation it carries the best-effort cleaned spelling — the raw text minus
+ * its query and fragment — because there is no governed path to report.
+ *
+ * **Example** (Record a governed repository reference)
+ *
+ * ```ts
+ * import { KnowledgeRepoPathRef } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ *
+ * const ref = KnowledgeRepoPathRef.make({ raw: "./PLAN.md", normalized: "goals/example/PLAN.md" })
+ *
+ * console.log(ref.kind) // "repo-path"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class KnowledgeRepoPathRef extends S.Class<KnowledgeRepoPathRef>($I`KnowledgeRepoPathRef`)(
+  {
+    kind: S.tag("repo-path"),
+    raw: S.String,
+    normalized: S.String,
+  },
+  $I.annote("KnowledgeRepoPathRef", {
+    description: "Repo-root-relative target after governed normalization.",
+  })
+) {}
+
+/**
+ * A machine-local span that no tree can resolve.
+ *
+ * **Example** (Record a home-relative reference)
+ *
+ * ```ts
+ * import { KnowledgeHostPathRef } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ *
+ * const ref = KnowledgeHostPathRef.make({ raw: "~/.claude/memory", anchor: "home-relative" })
+ *
+ * console.log(ref.anchor) // "home-relative"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class KnowledgeHostPathRef extends S.Class<KnowledgeHostPathRef>($I`KnowledgeHostPathRef`)(
+  {
+    kind: S.tag("host-path"),
+    raw: S.String,
+    anchor: KnowledgeHostAnchor,
+  },
+  $I.annote("KnowledgeHostPathRef", {
+    description: "Machine-local span; never resolvable inside a tree.",
+  })
+) {}
+
+/**
+ * A `repo://goal/<slug>` identity plus the display path it was paired with.
+ *
+ * **Details**
+ *
+ * `displayPath` is absent for a heading-scope `beep:ref` and for an ambiguous pairing, because the
+ * split-brain rule forbids guessing which object an identity names.
+ *
+ * **Example** (Record a goal identity without a display path)
+ *
+ * ```ts
+ * import { KnowledgeGoalUriRef } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ *
+ * const ref = KnowledgeGoalUriRef.make({
+ *   raw: "repo://goal/knowledge-surface-automation",
+ *   slug: "knowledge-surface-automation",
+ * })
+ *
+ * console.log(ref.slug) // "knowledge-surface-automation"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class KnowledgeGoalUriRef extends S.Class<KnowledgeGoalUriRef>($I`KnowledgeGoalUriRef`)(
+  {
+    kind: S.tag("goal-uri"),
+    raw: S.String,
+    slug: S.String,
+    displayPath: S.optionalKey(S.String),
+  },
+  $I.annote("KnowledgeGoalUriRef", {
+    description: "repo://goal/<slug> identity plus its paired display path.",
+  })
+) {}
+
+/**
+ * One recognised reference across the typed buses.
+ *
+ * **Example** (Accept any emitted reference member)
+ *
+ * ```ts
+ * import { KnowledgeHostPathRef, KnowledgeRef } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ * import * as S from "effect/Schema"
+ *
+ * const isRef = S.is(KnowledgeRef)
+ *
+ * console.log(isRef(KnowledgeHostPathRef.make({ raw: "/tmp/portless", anchor: "temp" }))) // true
+ * console.log(isRef({ kind: "upstream" })) // false
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const KnowledgeRef = S.Union([KnowledgeRepoPathRef, KnowledgeHostPathRef, KnowledgeGoalUriRef]).pipe(
+  S.toTaggedUnion("kind"),
+  $I.annoteSchema("KnowledgeRef", {
+    description: "One recognised reference across the typed buses.",
+  })
+);
+
+/**
+ * Any emitted reference, discriminated by `kind`.
+ *
+ * @see {@link KnowledgeRef} for the runtime schema and its tagged-union narrowing.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type KnowledgeRef = typeof KnowledgeRef.Type;
+
+/**
+ * A reference whose target exists in the scanned tree.
+ *
+ * **Gotchas**
+ *
+ * `mode` and `objectId` are present for a file target and absent for a directory target: a directory
+ * has no blob of its own, and inventing one would make a directory hit indistinguishable from a file
+ * hit in the report.
+ *
+ * **Example** (Record a resolved file target)
+ *
+ * ```ts
+ * import { KnowledgeRefResolved } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ *
+ * const resolution = KnowledgeRefResolved.make({
+ *   targetPath: "docs/README.md",
+ *   mode: "100644",
+ *   objectId: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+ * })
+ *
+ * console.log(resolution.status) // "resolved"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class KnowledgeRefResolved extends S.Class<KnowledgeRefResolved>($I`KnowledgeRefResolved`)(
+  {
+    status: S.tag("resolved"),
+    targetPath: S.String,
+    mode: S.optionalKey(S.String),
+    objectId: S.optionalKey(S.String),
+  },
+  $I.annote("KnowledgeRefResolved", {
+    description: "Reference target found in the scanned tree, with blob identity for file targets.",
+  })
+) {}
+
+/**
+ * A reference whose target is absent from the scanned tree.
+ *
+ * **Example** (Record a missing target)
+ *
+ * ```ts
+ * import { KnowledgeRefMissing } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ *
+ * console.log(KnowledgeRefMissing.make({}).status) // "missing"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class KnowledgeRefMissing extends S.Class<KnowledgeRefMissing>($I`KnowledgeRefMissing`)(
+  {
+    status: S.tag("missing"),
+  },
+  $I.annote("KnowledgeRefMissing", {
+    description: "Reference target absent from the scanned tree and owned by no producer.",
+  })
+) {}
+
+/**
+ * A goal reference whose manifest exists but declares a different identity.
+ *
+ * **Details**
+ *
+ * This is the split-brain drift the specification names as Workstream A's load-bearing risk, which
+ * is why it is reported distinctly from a missing target rather than folded into it.
+ *
+ * **Example** (Record drifted goal identity)
+ *
+ * ```ts
+ * import { KnowledgeRefIdentityMismatch } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ *
+ * const resolution = KnowledgeRefIdentityMismatch.make({ declaredId: "another-slug" })
+ *
+ * console.log(resolution.declaredId) // "another-slug"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class KnowledgeRefIdentityMismatch extends S.Class<KnowledgeRefIdentityMismatch>(
+  $I`KnowledgeRefIdentityMismatch`
+)(
+  {
+    status: S.tag("identity-mismatch"),
+    declaredId: S.String,
+  },
+  $I.annote("KnowledgeRefIdentityMismatch", {
+    description: "Tracked goal manifest whose declared initiative id disagrees with the referenced slug.",
+  })
+) {}
+
+/**
+ * A missing target that a registered producer regenerates.
+ *
+ * **Details**
+ *
+ * The registry exists so the report says "run this" rather than "broken". v1 registers exactly one
+ * producer, `producer://goals/index`, which owns the generated `goals/INDEX.md` projection.
+ *
+ * **Example** (Record a producer-owned target)
+ *
+ * ```ts
+ * import { KnowledgeRefProducerOwned } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ *
+ * const resolution = KnowledgeRefProducerOwned.make({
+ *   producerId: "producer://goals/index",
+ *   command: "bun run beep goals index --write",
+ * })
+ *
+ * console.log(resolution.producerId) // "producer://goals/index"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class KnowledgeRefProducerOwned extends S.Class<KnowledgeRefProducerOwned>($I`KnowledgeRefProducerOwned`)(
+  {
+    status: S.tag("producer-owned"),
+    producerId: S.String,
+    command: S.String,
+  },
+  $I.annote("KnowledgeRefProducerOwned", {
+    description: "Absent target that a registered producer regenerates, carrying its exact command.",
+  })
+) {}
+
+/**
+ * A reference that no tree lookup can decide.
+ *
+ * **Example** (Record an unresolvable host path)
+ *
+ * ```ts
+ * import { KnowledgeRefNotApplicable } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ *
+ * console.log(KnowledgeRefNotApplicable.make({}).status) // "not-applicable"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class KnowledgeRefNotApplicable extends S.Class<KnowledgeRefNotApplicable>($I`KnowledgeRefNotApplicable`)(
+  {
+    status: S.tag("not-applicable"),
+  },
+  $I.annote("KnowledgeRefNotApplicable", {
+    description: "Reference unresolvable by construction rather than broken.",
+  })
+) {}
+
+/**
+ * How one reference resolved against the scanned tree.
+ *
+ * **Example** (Accept any resolution member)
+ *
+ * ```ts
+ * import { KnowledgeRefMissing, KnowledgeRefResolution } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ * import * as S from "effect/Schema"
+ *
+ * const isResolution = S.is(KnowledgeRefResolution)
+ *
+ * console.log(isResolution(KnowledgeRefMissing.make({}))) // true
+ * console.log(isResolution({ status: "pending" })) // false
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const KnowledgeRefResolution = S.Union([
+  KnowledgeRefResolved,
+  KnowledgeRefMissing,
+  KnowledgeRefIdentityMismatch,
+  KnowledgeRefProducerOwned,
+  KnowledgeRefNotApplicable,
+]).pipe(
+  S.toTaggedUnion("status"),
+  $I.annoteSchema("KnowledgeRefResolution", {
+    description: "Tree-resolution outcome of one reference observation.",
+  })
+);
+
+/**
+ * Any resolution outcome, discriminated by `status`.
+ *
+ * @see {@link KnowledgeRefResolution} for the runtime schema and its tagged-union narrowing.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type KnowledgeRefResolution = typeof KnowledgeRefResolution.Type;
+
+/**
+ * One scoped tracked blob the census recorded instead of scanning.
+ *
+ * **Example** (Record a tracked symlink)
+ *
+ * ```ts
+ * import { KnowledgeSkippedBlob } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ *
+ * const skipped = KnowledgeSkippedBlob.make({
+ *   path: ".agents/skills",
+ *   mode: "120000",
+ *   reason: "symlink",
+ * })
+ *
+ * console.log(skipped.reason) // "symlink"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class KnowledgeSkippedBlob extends S.Class<KnowledgeSkippedBlob>($I`KnowledgeSkippedBlob`)(
+  {
+    path: S.String,
+    mode: S.String,
+    reason: KnowledgeSkipReason,
+  },
+  $I.annote("KnowledgeSkippedBlob", {
+    description: "A scoped tracked blob recorded with a reason rather than scanned.",
+  })
+) {}
+
+/**
+ * One resolved, classified reference occurrence.
+ *
+ * **Details**
+ *
+ * Observations are not findings. They live in a separate identity space on purpose: the census
+ * measures the corpus, and the mapping onto gating finding classes belongs to a later evaluator that
+ * cannot be confused with this one.
+ *
+ * **Example** (Read the identity of an observation)
+ *
+ * ```ts
+ * import {
+ *   KnowledgeHostPathRef,
+ *   KnowledgeRefId,
+ *   KnowledgeRefNotApplicable,
+ *   KnowledgeRefObservation,
+ * } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ * import { KnowledgeFindingLocation } from "@beep/repo-cli/commands/Knowledge/Knowledge.schemas"
+ * import { NonNegativeInt } from "@beep/schema"
+ * import * as S from "effect/Schema"
+ *
+ * const observation = KnowledgeRefObservation.make({
+ *   refId: S.decodeUnknownSync(KnowledgeRefId)(
+ *     "knowledge-ref/v1:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+ *   ),
+ *   ref: KnowledgeHostPathRef.make({ raw: "/tmp/portless", anchor: "temp" }),
+ *   documentId: ".claude/skills/portless/SKILL.md",
+ *   occurrence: NonNegativeInt.make(0),
+ *   surface: "live",
+ *   classification: "documented-temp-convention",
+ *   resolution: KnowledgeRefNotApplicable.make({}),
+ *   location: KnowledgeFindingLocation.make({ path: ".claude/skills/portless/SKILL.md" }),
+ *   remediation: "None; the prefix is a documented temporary-path convention.",
+ * })
+ *
+ * console.log(observation.classification) // "documented-temp-convention"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class KnowledgeRefObservation extends S.Class<KnowledgeRefObservation>($I`KnowledgeRefObservation`)(
+  {
+    refId: KnowledgeRefId,
+    ref: KnowledgeRef,
+    documentId: S.String,
+    occurrence: NonNegativeInt,
+    surface: KnowledgeRefSurface,
+    classification: KnowledgeRefClassification,
+    resolution: KnowledgeRefResolution,
+    location: KnowledgeFindingLocation,
+    remediation: S.String,
+  },
+  $I.annote("KnowledgeRefObservation", {
+    description: "One resolved, classified reference occurrence.",
+  })
+) {}
+
+/**
+ * Versioned reference census for one Git tree.
+ *
+ * **Details**
+ *
+ * `observations` is sorted by document path, line, column, kind, and subject, and `skipped` is
+ * sorted by path, so permuting the oracle's tracked-entry order yields byte-identical JSON. That
+ * stability is what makes two census runs diffable.
+ *
+ * **Example** (Read an empty census envelope)
+ *
+ * ```ts
+ * import { KnowledgeRefsReport } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ *
+ * const report = KnowledgeRefsReport.make({
+ *   treeish: "HEAD",
+ *   commit: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4",
+ *   observations: [],
+ *   skipped: [],
+ * })
+ *
+ * console.log(report.schemaVersion) // "knowledge-refs/v1"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class KnowledgeRefsReport extends S.Class<KnowledgeRefsReport>($I`KnowledgeRefsReport`)(
+  {
+    schemaVersion: S.tag("knowledge-refs/v1"),
+    normalizationVersion: S.tag("knowledge-ref-normalization/v1"),
+    treeish: S.String,
+    commit: KnowledgeCommitSha,
+    observations: S.Array(KnowledgeRefObservation),
+    skipped: S.Array(KnowledgeSkippedBlob),
+  },
+  $I.annote("KnowledgeRefsReport", {
+    description: "Versioned reference census for one Git tree.",
+  })
+) {}
+
+/**
+ * Narrows an unknown value to a decoded {@link KnowledgeRefsReport}.
+ *
+ * **Example** (Reject a partially built report)
+ *
+ * ```ts
+ * import { isKnowledgeRefsReport } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ *
+ * console.log(isKnowledgeRefsReport({ treeish: "HEAD" })) // false
+ * ```
+ *
+ * @category guards
+ * @since 0.0.0
+ */
+export const isKnowledgeRefsReport = S.is(KnowledgeRefsReport);
+
+/**
+ * Encodes a {@link KnowledgeRefsReport} directly to its JSON string form.
+ *
+ * **When to use**
+ *
+ * Use when `beep knowledge refs --json` must emit one machine-readable line, instead of encoding to
+ * a record and stringifying separately.
+ *
+ * **Example** (Render an empty census as JSON)
+ *
+ * ```ts
+ * import {
+ *   encodeKnowledgeRefsReportJson,
+ *   KnowledgeRefsReport,
+ * } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ * import { Effect } from "effect"
+ *
+ * const json = Effect.runSync(
+ *   encodeKnowledgeRefsReportJson(
+ *     KnowledgeRefsReport.make({
+ *       treeish: "HEAD",
+ *       commit: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4",
+ *       observations: [],
+ *       skipped: [],
+ *     })
+ *   )
+ * )
+ *
+ * console.log(json.includes("\"knowledge-refs/v1\"")) // true
+ * ```
+ *
+ * @category encoding
+ * @since 0.0.0
+ */
+export const encodeKnowledgeRefsReportJson = S.encodeUnknownEffect(S.fromJsonString(KnowledgeRefsReport));
+
+/**
+ * Decodes one JSON census line back into a {@link KnowledgeRefsReport}.
+ *
+ * **When to use**
+ *
+ * Use when reading a census emitted by another run — a committed evidence artifact, or the
+ * `--json` output of a subprocess — where the wire shape has not yet been validated.
+ *
+ * **Example** (Surface a decode failure)
+ *
+ * ```ts
+ * import { decodeKnowledgeRefsReportJson } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ * import { Effect, Result } from "effect"
+ *
+ * const outcome = Effect.runSync(Effect.result(decodeKnowledgeRefsReportJson("{}")))
+ *
+ * console.log(Result.isFailure(outcome)) // true
+ * ```
+ *
+ * @category decoding
+ * @since 0.0.0
+ */
+export const decodeKnowledgeRefsReportJson = S.decodeUnknownEffect(S.fromJsonString(KnowledgeRefsReport));
+
+const decodeSha256 = S.decodeUnknownEffect(Sha256HexFromBytes);
+const decodeRefId = S.decodeUnknownEffect(KnowledgeRefId);
+const decodeCommitSha = S.decodeUnknownEffect(KnowledgeCommitSha);
+
+/**
+ * Length-prefixes one digest field so the concatenated preimage stays injective.
+ *
+ * **Details**
+ *
+ * The value is NFC-normalized first, then prefixed with its UTF-8 byte length and a colon. Without
+ * the prefix, two different field splits could concatenate to the same preimage and collide into one
+ * identity; with it, they cannot.
+ *
+ * **Example** (Prefix a document id)
+ *
+ * ```ts
+ * import { knowledgeLengthPrefix } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ *
+ * console.log(knowledgeLengthPrefix("CLAUDE.md")) // "9:CLAUDE.md"
+ * ```
+ *
+ * @param value - One digest field, in any Unicode normalization form.
+ * @returns The byte length, a colon, and the NFC-normalized value.
+ * @category identifiers
+ * @since 0.0.0
+ */
+export const knowledgeLengthPrefix = (value: string): string => {
+  const normalized = nfc(value);
+  return `${textEncoder.encode(normalized).byteLength}:${normalized}`;
+};
+
+/**
+ * Computes a lowercase SHA-256 digest, failing closed with the caller's own message.
+ *
+ * **Details**
+ *
+ * The message is a parameter because the two identity spaces report digest failures differently:
+ * Stage 1 names the semantic delta, the census names the reference bus. Sharing the computation
+ * while parameterizing the wording keeps one digest path without flattening two error surfaces into
+ * one.
+ *
+ * **Example** (Build the digest effect for empty input)
+ *
+ * ```ts
+ * import { knowledgeSha256Hex } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ * import { Effect } from "effect"
+ *
+ * const digest = knowledgeSha256Hex(new Uint8Array(), "Failed to digest census input.")
+ *
+ * console.log(Effect.isEffect(digest)) // true
+ * ```
+ *
+ * @param bytes - Exact preimage bytes.
+ * @param message - Operational-error message used when the digest cannot be computed.
+ * @returns The lowercase hexadecimal digest.
+ * @category identifiers
+ * @since 0.0.0
+ */
+export const knowledgeSha256Hex = Effect.fn("Knowledge.sha256Hex")(function* (bytes: Uint8Array, message: string) {
+  return yield* decodeSha256(bytes).pipe(KnowledgeOperationalError.mapError(message));
+});
+
+/**
+ * Computes the ratified v1 reference identity from its exact length-prefixed preimage.
+ *
+ * **Details**
+ *
+ * The preimage concatenates the byte-length-prefixed normalization version, kind, NFC-normalized
+ * document id, NFC-normalized subject, and occurrence index. Display location is deliberately
+ * absent, so moving a reference inside a document keeps its identity. Subjects are per-bus:
+ * `repo-path:<normalized>`, `host-path:<anchor>:<token>`, and `goal-uri:<slug>`.
+ *
+ * **Example** (Derive an identity for a repository reference)
+ *
+ * ```ts
+ * import { makeKnowledgeRefId } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ * import { Effect } from "effect"
+ *
+ * const refId = makeKnowledgeRefId("repo-path", "CLAUDE.md", "repo-path:goals/INDEX.md", 0)
+ *
+ * console.log(Effect.isEffect(refId)) // true
+ * ```
+ *
+ * @param kind - Reference bus the observation came from.
+ * @param documentId - NFC-normalized repository-relative path of the containing document.
+ * @param subject - Per-bus normalized subject.
+ * @param occurrence - Zero-based index among identical kind, document, and subject triples.
+ * @category identifiers
+ * @since 0.0.0
+ */
+export const makeKnowledgeRefId = Effect.fn("Knowledge.makeRefId")(function* (
+  kind: KnowledgeRefKind,
+  documentId: string,
+  subject: string,
+  occurrence: number
+) {
+  const preimage = A.join(
+    A.map([REF_NORMALIZATION_VERSION, kind, nfc(documentId), nfc(subject), `${occurrence}`], knowledgeLengthPrefix),
+    ""
+  );
+  const digest = yield* knowledgeSha256Hex(
+    textEncoder.encode(preimage),
+    "Failed to compute a knowledge reference SHA-256 digest."
+  );
+  return yield* decodeRefId(`${REF_ID_PREFIX}${digest}`).pipe(
+    KnowledgeOperationalError.mapError("Computed knowledge reference id failed schema validation.")
+  );
+});
+
+/**
+ * The ten repository roots every knowledge-surface scanner reads.
+ *
+ * **Details**
+ *
+ * Two root files and eight directories. Stage-1 enforcement narrows this further by excluding
+ * archival directories; the census keeps them and labels them instead.
+ *
+ * **Example** (Read the scanned roots)
+ *
+ * ```ts
+ * import { KNOWLEDGE_SCANNER_SCOPE } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ * import * as A from "effect/Array"
+ *
+ * console.log(A.length(KNOWLEDGE_SCANNER_SCOPE)) // 10
+ * console.log(A.contains(KNOWLEDGE_SCANNER_SCOPE, "standards")) // true
+ * ```
+ *
+ * @category constants
+ * @since 0.0.0
+ */
+export const KNOWLEDGE_SCANNER_SCOPE: ReadonlyArray<string> = [
+  "AGENTS.md",
+  "CLAUDE.md",
+  "goals",
+  "explorations",
+  "docs",
+  ".claude",
+  ".agents",
+  ".codex",
+  "standards",
+  ".github",
+];
+
+const SCANNER_ROOT_FILES = HashSet.make("AGENTS.md", "CLAUDE.md");
+const SCANNER_PREFIXES = A.map(A.drop(KNOWLEDGE_SCANNER_SCOPE, 2), (root) => `${root}/`);
+const EXCLUDED_PREFIXES: ReadonlyArray<string> = ["docs/generated/", "docs/_internal/"];
+const ARCHIVAL_SEGMENTS = HashSet.make(
+  "history",
+  "research",
+  "reviews",
+  "synthesis",
+  "findings",
+  "outputs",
+  "reflections",
+  "logs",
+  ".proofs"
+);
+
+/**
+ * Whether a repository path sits inside the scanned knowledge surface.
+ *
+ * **Details**
+ *
+ * True for the two governed root files and for anything under the eight scanned directories, minus
+ * the generated and private documentation trees. Archival directories stay in scope: the census
+ * labels them rather than dropping them.
+ *
+ * **Example** (Accept a scoped path and reject a generated one)
+ *
+ * ```ts
+ * import { isKnowledgeScopedPath } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ *
+ * console.log(isKnowledgeScopedPath("standards/ARCHITECTURE.md")) // true
+ * console.log(isKnowledgeScopedPath("docs/generated/api.md")) // false
+ * ```
+ *
+ * @param repoPath - Repository-relative path of a tracked entry.
+ * @returns Whether the path belongs to the scanned knowledge surface.
+ * @category predicates
+ * @since 0.0.0
+ */
+export const isKnowledgeScopedPath = (repoPath: string): boolean => {
+  if (HashSet.has(SCANNER_ROOT_FILES, repoPath)) {
+    return true;
+  }
+  if (!A.some(SCANNER_PREFIXES, (prefix) => Str.startsWith(prefix)(repoPath))) {
+    return false;
+  }
+  return !A.some(EXCLUDED_PREFIXES, (prefix) => Str.startsWith(prefix)(repoPath));
+};
+
+/**
+ * Whether a repository path sits below an archival directory segment.
+ *
+ * **Details**
+ *
+ * The archival segments are `history`, `research`, `reviews`, `synthesis`, `findings`, `outputs`,
+ * `reflections`, `logs`, and `.proofs`. The test is by exact path segment, so a file merely named
+ * `research-notes.md` is live.
+ *
+ * **Example** (Separate archival evidence from live guidance)
+ *
+ * ```ts
+ * import { isKnowledgeArchivalPath } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ *
+ * console.log(isKnowledgeArchivalPath("goals/example/research/notes.md")) // true
+ * console.log(isKnowledgeArchivalPath("goals/example/PLAN.md")) // false
+ * ```
+ *
+ * @param repoPath - Repository-relative path of a tracked entry.
+ * @returns Whether the path is a captured archival artifact.
+ * @category predicates
+ * @since 0.0.0
+ */
+export const isKnowledgeArchivalPath = (repoPath: string): boolean =>
+  A.some(Str.split("/")(repoPath), (segment) => HashSet.has(ARCHIVAL_SEGMENTS, segment));
+
+const GOVERNED_BARE_ROOTS = HashSet.make(
+  ".agents",
+  ".claude",
+  ".codex",
+  ".github",
+  "apps",
+  "docs",
+  "explorations",
+  "goals",
+  "infra",
+  "packages",
+  "plugins",
+  "scripts",
+  "standards",
+  "tools"
+);
+const GOVERNED_ROOT_FILES = HashSet.make(
+  "AGENTS.md",
+  "CLAUDE.md",
+  "README.md",
+  "package.json",
+  "bun.lock",
+  "turbo.json",
+  "tsconfig.json"
+);
+
+const stripQueryAndFragment = Str.replace(/[?#].*$/u, "");
+
+/**
+ * Spellings a governed path may never contain: whitespace, glob and shell syntax, ellipses, absolute
+ * roots, URLs.
+ *
+ * @param value - Query-and-fragment-stripped, NFC-normalized spelling read from a document.
+ * @returns True when the spelling carries syntax no tracked repository path can legitimately use.
+ */
+const hasUngovernedPathSyntax = (value: string): boolean =>
+  /[\s\\]/u.test(value) ||
+  /[*[\]{}<>|:]/u.test(value) ||
+  /(?:^|\/)\.\.\.(?:\/|$)/u.test(value) ||
+  Str.includes("…")(value) ||
+  Str.startsWith("/")(value) ||
+  Str.includes("://")(value);
+
+const isRelativePathSpelling = (value: string): boolean => Str.startsWith("./")(value) || Str.startsWith("../")(value);
+
+const isGovernedPathSpelling = (raw: string): boolean => {
+  const value = stripQueryAndFragment(nfc(raw));
+  if (Str.isEmpty(value) || hasUngovernedPathSyntax(value)) {
+    return false;
+  }
+  if (isRelativePathSpelling(value)) {
+    return true;
+  }
+  return O.match(A.head(Str.split("/")(value)), {
+    onNone: () => false,
+    onSome: (segment) => HashSet.has(GOVERNED_BARE_ROOTS, segment) || HashSet.has(GOVERNED_ROOT_FILES, value),
+  });
+};
+
+/**
+ * Applies one path segment to the resolved stack, or `O.none()` when `..` escapes the repository
+ * root.
+ *
+ * @param segments - Segments resolved so far, always rooted at the repository root.
+ * @param segment - Next raw segment; empty and `.` segments leave the stack untouched.
+ * @returns The extended stack, or `O.none()` when `..` would step above the repository root.
+ */
+const applyPathSegment = (segments: ReadonlyArray<string>, segment: string): O.Option<ReadonlyArray<string>> => {
+  if (segment === "" || segment === ".") {
+    return O.some(segments);
+  }
+  if (segment !== "..") {
+    return O.some(A.append(segments, segment));
+  }
+  return A.isReadonlyArrayEmpty(segments) ? O.none() : O.some(A.dropRight(segments, 1));
+};
+
+const resolvePathSegments = (base: ReadonlyArray<string>, value: string): O.Option<ReadonlyArray<string>> => {
+  let segments = base;
+  for (const segment of Str.split("/")(value)) {
+    const next = applyPathSegment(segments, segment);
+    if (O.isNone(next)) {
+      return O.none();
+    }
+    segments = next.value;
+  }
+  return O.some(segments);
+};
+
+/**
+ * Normalizes one governed path spelling to a safe POSIX repository-relative path.
+ *
+ * **Details**
+ *
+ * Only spellings the repo governs survive: a bare governed root, a governed root file, or a `./` and
+ * `../` path resolved against the containing document. URLs, globs, whitespace, ellipses, and
+ * absolute paths return `O.none()`, and so does any relative path that escapes the repository root.
+ *
+ * **Example** (Resolve a relative link and reject a URL)
+ *
+ * ```ts
+ * import { normalizeKnowledgeRepoPath } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ * import * as O from "effect/Option"
+ *
+ * console.log(O.getOrNull(normalizeKnowledgeRepoPath("docs/README.md", "./guides/intro.md")))
+ * // "docs/guides/intro.md"
+ * console.log(O.isNone(normalizeKnowledgeRepoPath("docs/README.md", "https://example.com/a.md")))
+ * // true
+ * ```
+ *
+ * @param documentPath - Repository-relative path of the document containing the spelling.
+ * @param raw - Path spelling exactly as written inside the document.
+ * @returns The normalized path when the spelling is governed and stays inside the repository.
+ * @category normalization
+ * @since 0.0.0
+ */
+export const normalizeKnowledgeRepoPath = (documentPath: string, raw: string): O.Option<string> => {
+  if (!isGovernedPathSpelling(raw)) {
+    return O.none();
+  }
+  const value = stripQueryAndFragment(nfc(raw));
+  const base = isRelativePathSpelling(value) ? A.dropRight(Str.split("/")(nfc(documentPath)), 1) : A.empty<string>();
+
+  return pipe(
+    resolvePathSegments(base, value),
+    O.filter(A.isReadonlyArrayNonEmpty),
+    O.map((segments) => nfc(A.join(segments, "/")))
+  );
+};
+
+/**
+ * Drains a global pattern over one line, preserving `exec` order.
+ *
+ * **Details**
+ *
+ * Source order is what keeps duplicate occurrence indices stable, so every extractor in the family
+ * reads its matches through this drain rather than through a one-shot match.
+ *
+ * **Example** (Read every match on one line)
+ *
+ * ```ts
+ * import { knowledgeLineMatches } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ * import * as A from "effect/Array"
+ *
+ * console.log(A.length(knowledgeLineMatches(/a/gu, "banana"))) // 3
+ * ```
+ *
+ * @param pattern - Global pattern whose `lastIndex` advances across the whole drain.
+ * @param text - One document line.
+ * @returns Every match in source order.
+ * @category parsing
+ * @since 0.0.0
+ */
+export const knowledgeLineMatches = (pattern: RegExp, text: string): ReadonlyArray<RegExpExecArray> => {
+  let matches = A.empty<RegExpExecArray>();
+  let match = pattern.exec(text);
+  while (match !== null) {
+    matches = A.append(matches, match);
+    match = pattern.exec(text);
+  }
+  return matches;
+};
+
+/**
+ * An inline code span and the 1-based column its opening backtick run starts at.
+ *
+ * @see {@link knowledgeInlineSpans} for the reader that produces them.
+ * @category models
+ * @since 0.0.0
+ */
+export type KnowledgeInlineSpan = {
+  readonly span: string;
+  readonly column: number;
+};
+
+/**
+ * Removes CommonMark inline-code padding: one leading and one trailing space, stripped only when both
+ * are present and the content is not entirely spaces.
+ *
+ * @param content - Raw text between the opening and closing backtick runs.
+ * @returns The span content a path or command reader sees.
+ */
+const stripInlineCodePadding = (content: string): string =>
+  Str.startsWith(" ")(content) && Str.endsWith(" ")(content) && !/^ +$/u.test(content)
+    ? Str.slice(1, -1)(content)
+    : content;
+
+const inlineSpanOf = (match: RegExpExecArray): O.Option<KnowledgeInlineSpan> => {
+  const prefix = match[1];
+  const content = match[3];
+  return P.isString(prefix) && P.isString(content)
+    ? O.some({ span: stripInlineCodePadding(content), column: match.index + Str.length(prefix) + 1 })
+    : O.none();
+};
+
+/**
+ * Reads every inline code span on one line, in source order.
+ *
+ * **Details**
+ *
+ * Backtick runs must match in length: an opening run of N backticks closes on the next run of
+ * exactly N, so a single-backtick span and a triple-backtick span are read the same way.
+ * CommonMark padding is stripped, and the reported column points at the opening run.
+ *
+ * **Example** (Read one span from a line)
+ *
+ * ```ts
+ * import { knowledgeInlineSpans } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ * import * as A from "effect/Array"
+ *
+ * console.log(A.map(knowledgeInlineSpans("see `docs/README.md` first"), (span) => span.span))
+ * // [ "docs/README.md" ]
+ * ```
+ *
+ * @param lineText - One document line, already known to sit outside every fence.
+ * @returns Every inline code span on the line, with 1-based columns.
+ * @category parsing
+ * @since 0.0.0
+ */
+export const knowledgeInlineSpans = (lineText: string): ReadonlyArray<KnowledgeInlineSpan> =>
+  A.getSomes(A.map(knowledgeLineMatches(/(^|[^`\\])(`+)([^\r\n]*?)\2(?!`)/gu, lineText), inlineSpanOf));
+
+/**
+ * Whether an inline span documents a `bun run beep` invocation rather than a path.
+ *
+ * **Details**
+ *
+ * A span qualifies only when it starts with the exact command prefix and carries no shell
+ * composition — pipes, sequencing, redirection, substitution, or a comment. Everything else is read
+ * by the path bus instead, which is why the two readers share this one predicate.
+ *
+ * **Example** (Separate a documented command from a path)
+ *
+ * ```ts
+ * import { isKnowledgeCommandSpan } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ *
+ * console.log(isKnowledgeCommandSpan("bun run beep goals doctor")) // true
+ * console.log(isKnowledgeCommandSpan("goals/INDEX.md")) // false
+ * ```
+ *
+ * @param span - Inline code span content, with CommonMark padding already stripped.
+ * @returns Whether the span should be read as a documented command.
+ * @category predicates
+ * @since 0.0.0
+ */
+export const isKnowledgeCommandSpan = (span: string): boolean =>
+  /^bun run beep(?:$|[ \t])/u.test(span) && !/[|;&<>]|\$\(|(?:^|[ \t])#/u.test(span);
+
+const FENCE_PATTERN = /^(`{3,}|~{3,})(.*)$/u;
+const QUOTE_PREFIX_PATTERN = /^(?:[ \t]*>[ \t]?)+/u;
+const LIST_PREFIX_PATTERN = /^[ \t]*(?:(?:[-+*]|[0-9]{1,9}[.)])[ \t]+)?/u;
+const stripListPrefix = Str.replace(LIST_PREFIX_PATTERN, "");
+
+/** One line split into the Markdown container it sits in and the body a fence delimiter is read from. */
+type ContainerLine = {
+  readonly depth: number;
+  readonly body: string;
+};
+
+/**
+ * Strips the Markdown container prefix so a fence nested in a blockquote or a list item is still
+ * recognized as a fence.
+ *
+ * Blockquote markers are removed first and counted, then list-item indentation and an optional
+ * bullet or ordered marker. Indentation is stripped without a depth limit, which is what makes a
+ * fence inside a deeply nested list item visible; the trade is that a four-space indented code block
+ * showing a literal fence now opens one, suppressing scanning rather than inventing findings.
+ *
+ * @param line - Raw document line.
+ * @returns The blockquote depth the prefix carried and the body the fence matcher reads.
+ */
+const containerLine = (line: string): ContainerLine => {
+  const quote = QUOTE_PREFIX_PATTERN.exec(line);
+  const quoted = quote === null ? "" : quote[0];
+  return {
+    depth: A.length(Str.split(">")(quoted)) - 1,
+    body: stripListPrefix(Str.slice(Str.length(quoted))(line)),
+  };
+};
+
+/** The open fence a line is inside: its container depth, marker character, and closing run length. */
+type OpenFence = {
+  readonly marker: string;
+  readonly length: number;
+  readonly depth: number;
+};
+
+const openedFence = (line: ContainerLine): O.Option<OpenFence> => {
+  const fence = FENCE_PATTERN.exec(line.body);
+  if (fence === null || !P.isString(fence[1]) || !P.isString(fence[1][0])) {
+    return O.none();
+  }
+  return O.some({ marker: fence[1][0], length: Str.length(fence[1]), depth: line.depth });
+};
+
+const closesFence = (line: ContainerLine, open: OpenFence): boolean => {
+  const fence = FENCE_PATTERN.exec(line.body);
+  return (
+    fence !== null &&
+    P.isString(fence[1]) &&
+    P.isString(fence[2]) &&
+    line.depth === open.depth &&
+    fence[1][0] === open.marker &&
+    Str.length(fence[1]) >= open.length &&
+    /^\s*$/u.test(fence[2])
+  );
+};
+
+/**
+ * Fence state after one line: `O.none()` outside a fence, `O.some` while inside one.
+ *
+ * @param fence - Fence state carried in from the preceding line.
+ * @param line - Container-stripped line whose delimiter may open or close the surrounding block.
+ * @returns The fence state the next line starts from.
+ */
+const advanceFence = (fence: O.Option<OpenFence>, line: ContainerLine): O.Option<OpenFence> =>
+  O.match(fence, {
+    onNone: () => openedFence(line),
+    onSome: (open) => (closesFence(line, open) ? O.none() : O.some(open)),
+  });
+
+/**
+ * One document line, numbered, with the fence verdict every Markdown reader keys on.
+ *
+ * @see {@link knowledgeDocumentLines} for the reader that produces them.
+ * @category models
+ * @since 0.0.0
+ */
+export type KnowledgeDocumentLine = {
+  readonly text: string;
+  readonly number: number;
+  readonly prose: boolean;
+};
+
+/**
+ * Splits a decoded document into numbered lines carrying the ratified fence verdict.
+ *
+ * **Details**
+ *
+ * `prose` is true only for a line that sits outside every fence and is not itself a fence delimiter,
+ * which is the exact "prose only" rule Stage-1 enforcement scans under. Both readers take their
+ * verdict from here, so a fenced speculative tree can never mean one thing to the gate and another
+ * to the census.
+ *
+ * **Gotchas**
+ *
+ * Host anchors deliberately ignore this verdict. A fenced `cd <HOME>/...` is precisely the guidance
+ * that breaks a fresh clone, and the clone-agnosticism baseline counted anchors line-wise, so
+ * exempting fences would make the census incomparable with the baseline it must reconcile against.
+ *
+ * **Example** (Read the fence verdict of a fenced line)
+ *
+ * The delimiter is assembled rather than written literally, because a fence cannot appear inside
+ * this documentation block.
+ *
+ * ```ts
+ * import { knowledgeDocumentLines } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ * import * as A from "effect/Array"
+ *
+ * const fence = A.join(A.replicate("~", 3), "")
+ * const lines = knowledgeDocumentLines(A.join(["intro", fence, "fenced", fence, "outro"], "\n"))
+ *
+ * console.log(A.map(lines, (line) => line.prose)) // [ true, false, false, false, true ]
+ * ```
+ *
+ * @param text - Whole decoded document text.
+ * @returns Every line, 1-based numbered, with its fence verdict.
+ * @category parsing
+ * @since 0.0.0
+ */
+export const knowledgeDocumentLines = (text: string): ReadonlyArray<KnowledgeDocumentLine> => {
+  // Single-allocation map with fence state threaded through the closure: per-line `A.append`
+  // re-copies the whole accumulator and turns a large document quadratic.
+  let fence = O.none<OpenFence>();
+  return A.map(Str.split(/\r?\n/u)(text), (lineText, index) => {
+    const nextFence = advanceFence(fence, containerLine(lineText));
+    // Prose only: fence delimiters and fenced content alike are excluded.
+    const prose = O.isNone(fence) && O.isNone(nextFence);
+    fence = nextFence;
+    return { text: lineText, number: index + 1, prose };
+  });
+};
+
+const MACHINE_TREE_NAME = "YeeBois";
+const ENCODED_HOME_MARKER = "-home-";
+const BEEP_CHECKOUT_MARKER = "beep-effect";
+const HOME_ABSOLUTE_PATTERN = /\/home\//gu;
+const HOME_RELATIVE_PATTERN = /~\//gu;
+const TEMP_PATTERN = /\/tmp\//gu;
+const NON_WHITESPACE_RUN_PATTERN = /\S+/gu;
+const HOST_TOKEN_LEADING_PATTERN = /^[`'"([{<]+/u;
+const HOST_TOKEN_TRAILING_PATTERN = /[`'")\]}>.,;:]+$/u;
+
+const trimHostToken: (token: string) => string = flow(
+  Str.replace(HOST_TOKEN_LEADING_PATTERN, ""),
+  Str.replace(HOST_TOKEN_TRAILING_PATTERN, "")
+);
+
+/**
+ * One machine-local anchor occurrence and the token that carried it.
+ *
+ * @see {@link extractKnowledgeHostAnchors} for the reader that produces them.
+ * @category models
+ * @since 0.0.0
+ */
+export type KnowledgeHostAnchorMatch = {
+  readonly anchor: KnowledgeHostAnchor;
+  readonly token: string;
+  readonly column: number;
+};
+
+/**
+ * Reads every machine-local anchor on one line.
+ *
+ * **Details**
+ *
+ * The four lexical rules reproduce the clone-agnosticism baseline exactly: `/home/`, `~/`, `/tmp/`,
+ * and a bare machine tree name not immediately preceded by a slash. The lookbehind on the last rule
+ * is what makes the rules textually disjoint, so `/home/<user>/<tree>` counts once under `/home/`
+ * and never again under the tree name. A token that carries the encoded session-directory marker is
+ * reported as `encoded-home` rather than as a bare tree name.
+ *
+ * **Gotchas**
+ *
+ * One token can legitimately carry two anchors — an encoded scratchpad literal holds both a `/tmp/`
+ * prefix and a bare tree name — and the baseline counted both. This reader reproduces that, so a
+ * single token can yield two observations.
+ *
+ * **Example** (Read the anchors on one line)
+ *
+ * ```ts
+ * import { extractKnowledgeHostAnchors } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ * import * as A from "effect/Array"
+ *
+ * const anchors = extractKnowledgeHostAnchors("run `~/.claude/hooks/pulse.ts` now")
+ *
+ * console.log(A.map(anchors, (match) => match.anchor)) // [ "home-relative" ]
+ * console.log(A.map(anchors, (match) => match.token)) // [ "~/.claude/hooks/pulse.ts" ]
+ * ```
+ *
+ * @param lineText - One document line, fenced or not.
+ * @returns Every anchor occurrence with its trimmed containing token and 1-based column.
+ * @category parsing
+ * @since 0.0.0
+ */
+export const extractKnowledgeHostAnchors = (lineText: string): ReadonlyArray<KnowledgeHostAnchorMatch> => {
+  const runs = knowledgeLineMatches(NON_WHITESPACE_RUN_PATTERN, lineText);
+  const tokenAt = (index: number): string =>
+    pipe(
+      A.findFirst(runs, (run) => run.index <= index && index < run.index + Str.length(run[0])),
+      O.match({ onNone: () => Str.empty, onSome: (run) => trimHostToken(run[0]) })
+    );
+  const anchored = (pattern: RegExp, anchor: KnowledgeHostAnchor): ReadonlyArray<KnowledgeHostAnchorMatch> =>
+    A.map(knowledgeLineMatches(pattern, lineText), (match) => ({
+      anchor,
+      token: tokenAt(match.index),
+      column: match.index + 1,
+    }));
+  const bare = A.map(
+    knowledgeLineMatches(new RegExp(`(?<!/)${MACHINE_TREE_NAME}`, "gu"), lineText),
+    (match): KnowledgeHostAnchorMatch => {
+      const token = tokenAt(match.index);
+      return {
+        anchor: Str.includes(ENCODED_HOME_MARKER)(token)
+          ? KnowledgeHostAnchor.Enum["encoded-home"]
+          : KnowledgeHostAnchor.Enum["bare-tree-name"],
+        token,
+        column: match.index + 1,
+      };
+    }
+  );
+  return A.flatten([
+    anchored(HOME_ABSOLUTE_PATTERN, KnowledgeHostAnchor.Enum["home-absolute"]),
+    anchored(HOME_RELATIVE_PATTERN, KnowledgeHostAnchor.Enum["home-relative"]),
+    anchored(TEMP_PATTERN, KnowledgeHostAnchor.Enum.temp),
+    bare,
+  ]);
+};
+
+const PORTABLE_HOME_CONVENTIONS = HashSet.make("~/.claude", "~/.codex", "~/.config", "~/.bun");
+const TEMP_CONVENTIONS = HashSet.make("/tmp/portless");
+
+const hasConventionPrefix = (conventions: HashSet.HashSet<string>, token: string): boolean =>
+  HashSet.some(conventions, (prefix) => token === prefix || Str.startsWith(`${prefix}/`)(token));
+
+/**
+ * Whether a line reads as rule, pattern, or inventory text rather than as guidance.
+ *
+ * **Details**
+ *
+ * This is the v1 lexical rule, and it is deliberately falsifiable rather than a judgement call: a
+ * table delimiter, a regex group or class, a `--glob` argument, or a word-bounded `rg`/`grep`
+ * invocation all mark the line as pattern text. The audit corpus is its own top offender — the
+ * worktree standard, the surface inventory, and this packet's own verification command all contain
+ * anchors as data — so without this rule the census reports its own instrumentation as debt.
+ *
+ * **Gotchas**
+ *
+ * The false-positive rate of this exact rule is what the phase-0 eyeball is for. Widening it is a
+ * deliberate change, not a maintenance detail.
+ *
+ * **Example** (Separate a table row from guidance)
+ *
+ * ```ts
+ * import { knowledgeRefPatternContext } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ *
+ * console.log(knowledgeRefPatternContext("| `/home/` | 1,060 | Absolute home paths |")) // true
+ * console.log(knowledgeRefPatternContext("Keep the checkout at ~/src/beep-effect.")) // false
+ * ```
+ *
+ * @param lineText - One document line.
+ * @returns Whether the anchor on that line is the subject of a rule rather than a reference.
+ * @category predicates
+ * @since 0.0.0
+ */
+export const knowledgeRefPatternContext = (lineText: string): boolean =>
+  Str.includes("|")(lineText) ||
+  Str.includes("(?")(lineText) ||
+  Str.includes("[^")(lineText) ||
+  Str.includes("--glob")(lineText) ||
+  /\b(?:rg|grep)\s/u.test(lineText);
+
+/**
+ * Everything the pure classifier reads about one reference occurrence.
+ *
+ * **Details**
+ *
+ * `anchor` and `token` are populated for host paths only; `pairingAmbiguous` for goal URIs only; and
+ * `ungoverned` for repository paths only. Keeping every field total — an `O.Option` rather than an
+ * absent key — is what lets the rule table stay one ordered cascade instead of three per-bus tables.
+ *
+ * @see {@link classifyKnowledgeRef} for the cascade that consumes it.
+ * @category models
+ * @since 0.0.0
+ */
+export type KnowledgeRefClassificationInput = {
+  readonly kind: KnowledgeRefKind;
+  readonly surface: KnowledgeRefSurface;
+  readonly resolutionStatus: KnowledgeRefResolutionStatus;
+  readonly anchor: O.Option<KnowledgeHostAnchor>;
+  readonly token: O.Option<string>;
+  readonly patternContext: boolean;
+  readonly pairingAmbiguous: boolean;
+  readonly ungoverned: boolean;
+};
+
+/**
+ * Rules 3c–3f of the cascade: a live, non-pattern host anchor judged by its convention and locus.
+ *
+ * @param anchor - Lexical anchor that made the span machine-local.
+ * @param token - Trimmed containing token the convention sets and checkout marker are tested on.
+ * @returns The convention, mirror, or actionable class for a live host anchor.
+ */
+const classifyLiveHostAnchor = (anchor: KnowledgeHostAnchor, token: string): KnowledgeRefClassification => {
+  if (KnowledgeHostAnchor.is["home-relative"](anchor) && hasConventionPrefix(PORTABLE_HOME_CONVENTIONS, token)) {
+    return KnowledgeRefClassification.Enum["portable-home-convention"];
+  }
+  if (KnowledgeHostAnchor.is.temp(anchor) && hasConventionPrefix(TEMP_CONVENTIONS, token)) {
+    return KnowledgeRefClassification.Enum["documented-temp-convention"];
+  }
+  const homeAnchored =
+    KnowledgeHostAnchor.is["home-absolute"](anchor) || KnowledgeHostAnchor.is["home-relative"](anchor);
+  return homeAnchored && !Str.includes(BEEP_CHECKOUT_MARKER)(token)
+    ? KnowledgeRefClassification.Enum["external-mirror-reference"]
+    : KnowledgeRefClassification.Enum["actionable-host-path"];
+};
+
+const classifyHostAnchor = (
+  anchor: KnowledgeHostAnchor,
+  token: string,
+  surface: KnowledgeRefSurface,
+  patternContext: boolean
+): KnowledgeRefClassification => {
+  if (patternContext) {
+    return KnowledgeRefClassification.Enum["audit-pattern-literal"];
+  }
+  return KnowledgeRefSurface.is.archival(surface)
+    ? KnowledgeRefClassification.Enum["archival-provenance"]
+    : classifyLiveHostAnchor(anchor, token);
+};
+
+/**
+ * Assigns the deterministic triage class of one reference observation.
+ *
+ * **Details**
+ *
+ * The cascade is ordered and total. Pairing ambiguity and ungoverned syntax are decided first, since
+ * neither leaves a target to resolve. Host paths are then decided lexically, and everything else
+ * falls through to the resolution outcome. Inside the host branch the pattern-literal rule is
+ * checked before the archival rule on purpose: an archival document that quotes an anchor as rule
+ * data must classify as `audit-pattern-literal`, which is only reachable if pattern text outranks
+ * archival provenance.
+ *
+ * **Gotchas**
+ *
+ * A `not-applicable` resolution outside the host bus can only come from a goal URI whose pairing was
+ * rejected, because the ungoverned repository case is caught two rules earlier. That is why the
+ * final arm maps it back to `ambiguous-ref-pairing` rather than inventing a thirteenth class.
+ *
+ * **Example** (Classify an archival host anchor and a broken repository path)
+ *
+ * ```ts
+ * import { classifyKnowledgeRef } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ * import * as O from "effect/Option"
+ *
+ * console.log(
+ *   classifyKnowledgeRef({
+ *     kind: "host-path",
+ *     surface: "archival",
+ *     resolutionStatus: "not-applicable",
+ *     anchor: O.some("home-absolute"),
+ *     token: O.some("/home/example/checkouts/beep-effect"),
+ *     patternContext: false,
+ *     pairingAmbiguous: false,
+ *     ungoverned: false,
+ *   })
+ * ) // "archival-provenance"
+ *
+ * console.log(
+ *   classifyKnowledgeRef({
+ *     kind: "repo-path",
+ *     surface: "live",
+ *     resolutionStatus: "missing",
+ *     anchor: O.none(),
+ *     token: O.none(),
+ *     patternContext: false,
+ *     pairingAmbiguous: false,
+ *     ungoverned: false,
+ *   })
+ * ) // "broken-target"
+ * ```
+ *
+ * @param input - Everything known about the occurrence before it is labelled.
+ * @returns The single class the rule table assigns.
+ * @category policies
+ * @since 0.0.0
+ */
+export const classifyKnowledgeRef = (input: KnowledgeRefClassificationInput): KnowledgeRefClassification => {
+  if (input.pairingAmbiguous) {
+    return KnowledgeRefClassification.Enum["ambiguous-ref-pairing"];
+  }
+  if (input.ungoverned) {
+    return KnowledgeRefClassification.Enum["ungoverned-syntax"];
+  }
+  if (KnowledgeRefKind.is["host-path"](input.kind)) {
+    return O.match(input.anchor, {
+      onNone: () => KnowledgeRefClassification.Enum["actionable-host-path"],
+      onSome: (anchor) =>
+        classifyHostAnchor(
+          anchor,
+          O.getOrElse(input.token, () => Str.empty),
+          input.surface,
+          input.patternContext
+        ),
+    });
+  }
+  return Match.value(input.resolutionStatus).pipe(
+    Match.when("resolved", () => KnowledgeRefClassification.Enum.verified),
+    Match.when("missing", () => KnowledgeRefClassification.Enum["broken-target"]),
+    Match.when("identity-mismatch", () => KnowledgeRefClassification.Enum["identity-mismatch"]),
+    Match.when("producer-owned", () => KnowledgeRefClassification.Enum["producer-owned-target"]),
+    Match.when("not-applicable", () => KnowledgeRefClassification.Enum["ambiguous-ref-pairing"]),
+    Match.exhaustive
+  );
+};
+
+/**
+ * The one-sentence remediation the report prints for a classified observation.
+ *
+ * **Details**
+ *
+ * Every class has a fixed sentence except `producer-owned-target`, which quotes the registered
+ * regeneration command so the report says "run this" rather than "broken". Classes that are not
+ * defects say so explicitly instead of leaving the column blank.
+ *
+ * **Example** (Read the remediation of a broken target)
+ *
+ * ```ts
+ * import {
+ *   KnowledgeRefMissing,
+ *   knowledgeRefRemediation,
+ * } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ *
+ * console.log(knowledgeRefRemediation("broken-target", KnowledgeRefMissing.make({})))
+ * // "Update the reference or add the tracked target."
+ * ```
+ *
+ * @param classification - Class assigned by {@link classifyKnowledgeRef}.
+ * @param resolution - Resolution the observation carries, read for the producer command.
+ * @returns One sentence of remediation guidance.
+ * @category policies
+ * @since 0.0.0
+ */
+export const knowledgeRefRemediation = (
+  classification: KnowledgeRefClassification,
+  resolution: KnowledgeRefResolution
+): string =>
+  Match.value(classification).pipe(
+    Match.when("verified", () => "None; the reference resolves in the tree."),
+    Match.when("broken-target", () => "Update the reference or add the tracked target."),
+    Match.when("identity-mismatch", () => "Reconcile the manifest initiative id with the referenced goal slug."),
+    Match.when("producer-owned-target", () => {
+      const command = resolution.status === "producer-owned" ? resolution.command : "the owning producer";
+      return `Run \`${command}\` and commit the regenerated output.`;
+    }),
+    Match.when("actionable-host-path", () => "Rewrite the machine-local path as a repo-relative reference."),
+    Match.when("portable-home-convention", () => "None; the prefix is a documented portable home convention."),
+    Match.when("documented-temp-convention", () => "None; the prefix is a documented temporary-path convention."),
+    Match.when("external-mirror-reference", () => "Replace the machine-local mirror with a canonical upstream URL."),
+    Match.when("archival-provenance", () => "None; rewriting captured provenance would rewrite history."),
+    Match.when("audit-pattern-literal", () => "None; the anchor is rule or inventory data rather than guidance."),
+    Match.when("ambiguous-ref-pairing", () => "Keep one `beep:ref` per line beside exactly one display path."),
+    Match.when("ungoverned-syntax", () => "Rewrite the spelling as a governed repository-relative path."),
+    Match.exhaustive
+  );
+
+/**
+ * Everything the census may read from one Git tree.
+ *
+ * **Details**
+ *
+ * The evaluator never touches the filesystem: both the live archive-backed implementation and the
+ * golden fixtures satisfy this shape, which is what keeps a fixture tree and a real tree
+ * indistinguishable to the scanning logic. `trackedEntries` is the only existence oracle, so an
+ * untracked working-copy file can never make a reference look valid.
+ *
+ * @see {@link scanKnowledgeRefsTree} for the evaluator that consumes it.
+ * @category services
+ * @since 0.0.0
+ */
+export interface KnowledgeTreeOracle {
+  readonly commit: string;
+  readonly readBytes: (repoPath: string) => Effect.Effect<Uint8Array, KnowledgeOperationalError>;
+  readonly trackedEntries: ReadonlyArray<KnowledgeTrackedEntry>;
+  readonly treeish: string;
+}
+
+const ELECTED_EXTENSIONS = HashSet.make(".md", ".json", ".jsonc", ".jsonl", ".toml", ".yml", ".yaml");
+const SYMLINK_MODE = "120000";
+const GITLINK_MODE = "160000";
+const MARKDOWN_EXTENSION = ".md";
+const HEADING_PATTERN = /^#{1,6}\s/u;
+const GOAL_URI_PATTERN = /repo:\/\/goal\/([a-z0-9][a-z0-9-]*)(\/[^\s`")\]]*)?/gu;
+const BEEP_REF_PATTERN = /<!-- beep:ref goal\/([a-z0-9][a-z0-9-]*) -->/gu;
+const LINK_DESTINATION_PATTERN = /(\[[^\]]*\]\()([^)\s]+)(?:\s+"[^"]*")?\)/gu;
+
+type ProducerRegistration = {
+  readonly producerId: string;
+  readonly targetPath: string;
+  readonly command: string;
+};
+
+const PRODUCER_REGISTRY: ReadonlyArray<ProducerRegistration> = [
+  {
+    producerId: "producer://goals/index",
+    targetPath: "goals/INDEX.md",
+    command: "bun run beep goals index --write",
+  },
+];
+
+const isRegularBlob = (entry: KnowledgeTrackedEntry): boolean => entry.mode === "100644" || entry.mode === "100755";
+
+const isElectedExtension = (repoPath: string): boolean =>
+  HashSet.some(ELECTED_EXTENSIONS, (extension) => Str.endsWith(extension)(repoPath));
+
+const ancestorPrefixes = (repoPath: string): ReadonlyArray<string> => {
+  const segments = A.dropRight(Str.split("/")(repoPath), 1);
+  return A.map(segments, (_, index) => A.join(A.take(segments, index + 1), "/"));
+};
+
+const skippedEntry = (entry: KnowledgeTrackedEntry): O.Option<KnowledgeSkippedBlob> => {
+  if (entry.mode === SYMLINK_MODE) {
+    return O.some(KnowledgeSkippedBlob.make({ path: entry.path, mode: entry.mode, reason: "symlink" }));
+  }
+  return entry.mode === GITLINK_MODE
+    ? O.some(KnowledgeSkippedBlob.make({ path: entry.path, mode: entry.mode, reason: "gitlink" }))
+    : O.none();
+};
+
+/**
+ * Decodes tracked bytes as strict UTF-8, failing closed with the caller's own message.
+ *
+ * **Details**
+ *
+ * The decoder is fatal: a blob that is not valid UTF-8 raises rather than silently substituting
+ * replacement characters, because a lossy decode would let a mangled document scan as a clean one.
+ * The message is a parameter for the same reason {@link knowledgeSha256Hex} takes one — Stage-1
+ * enforcement and the census name their corpora differently in the error they surface.
+ *
+ * **Example** (Decode fixture bytes)
+ *
+ * ```ts
+ * import { decodeKnowledgeUtf8 } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ * import { Effect } from "effect"
+ *
+ * const text = decodeKnowledgeUtf8(new TextEncoder().encode("ok"), "Malformed UTF-8 in a fixture.")
+ *
+ * console.log(Effect.runSync(text)) // "ok"
+ * ```
+ *
+ * @param bytes - Exact tracked blob bytes.
+ * @param message - Operational-error message used when the bytes are not valid UTF-8.
+ * @returns The decoded text.
+ * @category decoding
+ * @since 0.0.0
+ */
+export const decodeKnowledgeUtf8 = (
+  bytes: Uint8Array,
+  message: string
+): Effect.Effect<string, KnowledgeOperationalError> =>
+  Effect.try({
+    try: () => strictUtf8Decoder.decode(bytes),
+    catch: KnowledgeOperationalError.new(message),
+  });
+
+const decodeUtf8 = (bytes: Uint8Array, repoPath: string): Effect.Effect<string, KnowledgeOperationalError> =>
+  decodeKnowledgeUtf8(bytes, `Malformed UTF-8 in tracked file "${repoPath}".`);
+
+/** A repository-path spelling after the ratified tri-state read: governed, ungoverned, or ignored. */
+type RepoPathOutcome =
+  | { readonly _tag: "governed"; readonly normalized: string }
+  | { readonly _tag: "ungoverned"; readonly normalized: string }
+  | { readonly _tag: "ignored" };
+
+const IGNORED_OUTCOME: RepoPathOutcome = { _tag: "ignored" };
+
+const isAbsoluteGovernedSpelling = (value: string): boolean =>
+  Str.startsWith("/")(value) &&
+  O.exists(A.head(Str.split("/")(Str.slice(1)(value))), (segment) => HashSet.has(GOVERNED_BARE_ROOTS, segment));
+
+const isBackslashGovernedSpelling = (value: string): boolean =>
+  Str.includes("\\")(value) && isGovernedPathSpelling(Str.replaceAll("\\", "/")(value));
+
+/**
+ * The tri-state read of one path spelling: a governed target, an ungoverned spelling worth
+ * reporting, or nothing at all.
+ *
+ * `documentRelative` applies Markdown link semantics, where a bare `PLAN.md` destination means
+ * `./PLAN.md`. Inline spans never get that extension: they are read under the Stage-1 grammar alone.
+ *
+ * @param documentPath - Repository-relative path of the containing document.
+ * @param raw - Path spelling exactly as written inside the document.
+ * @param documentRelative - Whether a bare relative spelling resolves from the document's directory.
+ * @returns The governed, ungoverned, or ignored outcome for the spelling.
+ */
+const repoPathOutcome = (documentPath: string, raw: string, documentRelative: boolean): RepoPathOutcome => {
+  const cleaned = stripQueryAndFragment(nfc(raw));
+  if (Str.isEmpty(cleaned)) {
+    return IGNORED_OUTCOME;
+  }
+  if (isAbsoluteGovernedSpelling(cleaned) || isBackslashGovernedSpelling(cleaned)) {
+    return { _tag: "ungoverned", normalized: cleaned };
+  }
+  const spelling =
+    documentRelative && !isRelativePathSpelling(cleaned) && !isGovernedPathSpelling(cleaned) ? `./${cleaned}` : cleaned;
+  if (!isGovernedPathSpelling(spelling)) {
+    return IGNORED_OUTCOME;
+  }
+  return O.match(normalizeKnowledgeRepoPath(documentPath, spelling), {
+    // The spelling is governed, so the only remaining failure is a `..` escape above the root.
+    onNone: (): RepoPathOutcome => ({ _tag: "ungoverned", normalized: cleaned }),
+    onSome: (normalized): RepoPathOutcome => ({ _tag: "governed", normalized }),
+  });
+};
+
+/** One extracted reference occurrence, before resolution, classification, and identity assignment. */
+type RefCandidate = {
+  readonly kind: KnowledgeRefKind;
+  readonly subject: string;
+  readonly ref: KnowledgeRef;
+  readonly documentPath: string;
+  readonly line: number;
+  readonly column: number;
+  readonly surface: KnowledgeRefSurface;
+  readonly patternContext: boolean;
+  readonly pairingAmbiguous: boolean;
+  readonly ungoverned: boolean;
+  readonly anchor: O.Option<KnowledgeHostAnchor>;
+  readonly token: O.Option<string>;
+  readonly slug: O.Option<string>;
+  readonly normalized: O.Option<string>;
+};
+
+type RepoPathCandidate = {
+  readonly raw: string;
+  readonly column: number;
+  readonly outcome: RepoPathOutcome;
+};
+
+const goalUriRef = (raw: string, slug: string, displayPath: O.Option<string>): KnowledgeGoalUriRef =>
+  O.match(displayPath, {
+    onNone: () => KnowledgeGoalUriRef.make({ raw, slug }),
+    onSome: (value) => KnowledgeGoalUriRef.make({ raw, slug, displayPath: value }),
+  });
+
+const hostCandidates = (
+  documentPath: string,
+  line: KnowledgeDocumentLine,
+  surface: KnowledgeRefSurface
+): ReadonlyArray<RefCandidate> =>
+  A.map(extractKnowledgeHostAnchors(line.text), (match) => ({
+    kind: KnowledgeRefKind.Enum["host-path"],
+    subject: nfc(`host-path:${match.anchor}:${match.token}`),
+    ref: KnowledgeHostPathRef.make({ raw: match.token, anchor: match.anchor }),
+    documentPath,
+    line: line.number,
+    column: match.column,
+    surface,
+    patternContext: knowledgeRefPatternContext(line.text),
+    pairingAmbiguous: false,
+    ungoverned: false,
+    anchor: O.some(match.anchor),
+    token: O.some(match.token),
+    slug: O.none<string>(),
+    normalized: O.none<string>(),
+  }));
+
+const stripAngleWrapping = (destination: string): string =>
+  Str.startsWith("<")(destination) && Str.endsWith(">")(destination) ? Str.slice(1, -1)(destination) : destination;
+
+const isExternalDestination = (destination: string): boolean =>
+  Str.includes("://")(destination) || Str.startsWith("mailto:")(destination) || Str.startsWith("#")(destination);
+
+const repoPathCandidatesOn = (documentPath: string, lineText: string): ReadonlyArray<RepoPathCandidate> => {
+  const inlines = A.map(
+    A.filter(knowledgeInlineSpans(lineText), (inline) => !isKnowledgeCommandSpan(inline.span)),
+    (inline): RepoPathCandidate => ({
+      raw: inline.span,
+      column: inline.column,
+      outcome: repoPathOutcome(documentPath, inline.span, false),
+    })
+  );
+  const links = A.getSomes(
+    A.map(knowledgeLineMatches(LINK_DESTINATION_PATTERN, lineText), (match) => {
+      const prefix = match[1];
+      const raw = match[2];
+      if (!P.isString(prefix) || !P.isString(raw)) {
+        return O.none<RepoPathCandidate>();
+      }
+      const destination = stripAngleWrapping(raw);
+      return isExternalDestination(destination)
+        ? O.none<RepoPathCandidate>()
+        : O.some({
+            raw: destination,
+            column: match.index + Str.length(prefix) + 1,
+            outcome: repoPathOutcome(documentPath, destination, true),
+          });
+    })
+  );
+  return A.appendAll(inlines, links);
+};
+
+const repoPathCandidateRefs = (
+  documentPath: string,
+  line: KnowledgeDocumentLine,
+  surface: KnowledgeRefSurface,
+  candidates: ReadonlyArray<RepoPathCandidate>
+): ReadonlyArray<RefCandidate> =>
+  A.getSomes(
+    A.map(candidates, (candidate) => {
+      if (candidate.outcome._tag === "ignored") {
+        return O.none<RefCandidate>();
+      }
+      const ungoverned = candidate.outcome._tag === "ungoverned";
+      return O.some({
+        kind: KnowledgeRefKind.Enum["repo-path"],
+        subject: nfc(`repo-path:${candidate.outcome.normalized}`),
+        ref: KnowledgeRepoPathRef.make({ raw: candidate.raw, normalized: candidate.outcome.normalized }),
+        documentPath,
+        line: line.number,
+        column: candidate.column,
+        surface,
+        patternContext: knowledgeRefPatternContext(line.text),
+        pairingAmbiguous: false,
+        ungoverned,
+        anchor: O.none<KnowledgeHostAnchor>(),
+        token: O.none<string>(),
+        slug: O.none<string>(),
+        normalized: ungoverned ? O.none<string>() : O.some(candidate.outcome.normalized),
+      });
+    })
+  );
+
+const governedDisplayPaths = (candidates: ReadonlyArray<RepoPathCandidate>): ReadonlyArray<string> =>
+  A.getSomes(
+    A.map(candidates, (candidate) =>
+      candidate.outcome._tag === "governed" ? O.some(candidate.outcome.normalized) : O.none<string>()
+    )
+  );
+
+const followsHeading = (lines: ReadonlyArray<KnowledgeDocumentLine>, index: number): boolean =>
+  pipe(
+    A.take(lines, index),
+    A.reverse,
+    A.findFirst((line) => Str.isNonEmpty(Str.trim(line.text))),
+    O.exists((line) => HEADING_PATTERN.test(line.text))
+  );
+
+const goalUriCandidate = (
+  documentPath: string,
+  line: KnowledgeDocumentLine,
+  surface: KnowledgeRefSurface,
+  raw: string,
+  slug: string,
+  column: number,
+  displayPath: O.Option<string>,
+  pairingAmbiguous: boolean
+): RefCandidate => ({
+  kind: KnowledgeRefKind.Enum["goal-uri"],
+  subject: nfc(`goal-uri:${slug}`),
+  ref: goalUriRef(raw, slug, displayPath),
+  documentPath,
+  line: line.number,
+  column,
+  surface,
+  patternContext: knowledgeRefPatternContext(line.text),
+  pairingAmbiguous,
+  ungoverned: false,
+  anchor: O.none<KnowledgeHostAnchor>(),
+  token: O.none<string>(),
+  slug: pairingAmbiguous ? O.none<string>() : O.some(slug),
+  normalized: O.none<string>(),
+});
+
+const goalUriCandidates = (
+  documentPath: string,
+  line: KnowledgeDocumentLine,
+  surface: KnowledgeRefSurface
+): ReadonlyArray<RefCandidate> =>
+  A.getSomes(
+    A.map(knowledgeLineMatches(GOAL_URI_PATTERN, line.text), (match) => {
+      const slug = match[1];
+      if (!P.isString(slug)) {
+        return O.none<RefCandidate>();
+      }
+      const tail = match[2];
+      const displayPath = P.isString(tail) ? O.some(Str.slice(1)(tail)) : O.none<string>();
+      return O.some(goalUriCandidate(documentPath, line, surface, match[0], slug, match.index + 1, displayPath, false));
+    })
+  );
+
+const beepRefCandidates = (
+  documentPath: string,
+  lines: ReadonlyArray<KnowledgeDocumentLine>,
+  index: number,
+  line: KnowledgeDocumentLine,
+  surface: KnowledgeRefSurface,
+  displayPaths: ReadonlyArray<string>
+): ReadonlyArray<RefCandidate> => {
+  const refs = knowledgeLineMatches(BEEP_REF_PATTERN, line.text);
+  if (A.isReadonlyArrayEmpty(refs)) {
+    return A.empty<RefCandidate>();
+  }
+  // Ratified pairing rule A1: more than one reference on a line makes every reference on it
+  // ambiguous, because the tool must never guess which object an identity names.
+  const ambiguousLine = A.length(refs) > 1;
+  return A.getSomes(
+    A.map(refs, (match) => {
+      const slug = match[1];
+      if (!P.isString(slug)) {
+        return O.none<RefCandidate>();
+      }
+      const soleDisplayPath = A.length(displayPaths) === 1 ? A.head(displayPaths) : O.none<string>();
+      const alone = Str.isEmpty(Str.trim(Str.replace(match[0], "")(line.text)));
+      const ambiguous =
+        ambiguousLine ||
+        (A.isReadonlyArrayEmpty(displayPaths) ? !(alone && followsHeading(lines, index)) : O.isNone(soleDisplayPath));
+      return O.some(
+        goalUriCandidate(
+          documentPath,
+          line,
+          surface,
+          match[0],
+          slug,
+          match.index + 1,
+          ambiguous ? O.none<string>() : soleDisplayPath,
+          ambiguous
+        )
+      );
+    })
+  );
+};
+
+const extractDocumentRefs = (
+  documentPath: string,
+  text: string,
+  surface: KnowledgeRefSurface
+): ReadonlyArray<RefCandidate> => {
+  const lines = knowledgeDocumentLines(text);
+  const markdown = Str.endsWith(MARKDOWN_EXTENSION)(documentPath);
+  // One flatMap allocation for the whole document: accumulating with `A.appendAll` per line
+  // re-copies every prior candidate and turns a dense document quadratic.
+  return A.flatMap(lines, (line, index) => {
+    // Host anchors are counted line-wise on every elected file type; fences never exempt them.
+    const host = hostCandidates(documentPath, line, surface);
+    if (!markdown || !line.prose) {
+      return host;
+    }
+    const repoPaths = repoPathCandidatesOn(documentPath, line.text);
+    return A.flatten([
+      host,
+      repoPathCandidateRefs(documentPath, line, surface, repoPaths),
+      goalUriCandidates(documentPath, line, surface),
+      beepRefCandidates(documentPath, lines, index, line, surface, governedDisplayPaths(repoPaths)),
+    ]);
+  });
+};
+
+const resolveRepoPath = (
+  pathIndex: HashMap.HashMap<string, KnowledgeTrackedEntry>,
+  directoryPrefixes: HashSet.HashSet<string>,
+  normalized: string
+): KnowledgeRefResolution => {
+  const entry = HashMap.get(pathIndex, normalized);
+  if (O.isSome(entry)) {
+    return KnowledgeRefResolved.make({
+      targetPath: normalized,
+      mode: entry.value.mode,
+      objectId: entry.value.objectId,
+    });
+  }
+  if (HashSet.has(directoryPrefixes, normalized)) {
+    return KnowledgeRefResolved.make({ targetPath: normalized });
+  }
+  return O.match(
+    A.findFirst(PRODUCER_REGISTRY, (registration) => registration.targetPath === normalized),
+    {
+      onNone: (): KnowledgeRefResolution => KnowledgeRefMissing.make({}),
+      onSome: (registration): KnowledgeRefResolution =>
+        KnowledgeRefProducerOwned.make({ producerId: registration.producerId, command: registration.command }),
+    }
+  );
+};
+
+const goalManifestPath = (slug: string): string => `goals/${slug}/ops/manifest.json`;
+
+const resolveGoalSlug = Effect.fn("Knowledge.resolveGoalSlug")(function* (
+  oracle: KnowledgeTreeOracle,
+  pathIndex: HashMap.HashMap<string, KnowledgeTrackedEntry>,
+  slug: string
+) {
+  const manifestPath = goalManifestPath(slug);
+  const entry = HashMap.get(pathIndex, manifestPath);
+  if (O.isNone(entry)) {
+    return KnowledgeRefMissing.make({});
+  }
+  const text = yield* Effect.flatMap(oracle.readBytes(manifestPath), (bytes) => decodeUtf8(bytes, manifestPath));
+  const parsed = parseGoalManifestText(text);
+  if (O.isNone(parsed)) {
+    return yield* KnowledgeOperationalError.make({
+      message: `Tracked goal manifest "${manifestPath}" does not parse as JSON.`,
+    });
+  }
+  const manifest = yield* decodeGoalManifest(parsed.value).pipe(
+    KnowledgeOperationalError.mapError(`Tracked goal manifest "${manifestPath}" does not decode as a goal manifest.`)
+  );
+  return manifest.initiative.id === slug
+    ? KnowledgeRefResolved.make({
+        targetPath: manifestPath,
+        mode: entry.value.mode,
+        objectId: entry.value.objectId,
+      })
+    : KnowledgeRefIdentityMismatch.make({ declaredId: manifest.initiative.id });
+});
+
+const candidateOrder: Order.Order<RefCandidate> = Order.combineAll([
+  Order.mapInput(Order.String, (candidate: RefCandidate) => candidate.documentPath),
+  Order.mapInput(Order.Number, (candidate: RefCandidate) => candidate.line),
+  Order.mapInput(Order.Number, (candidate: RefCandidate) => candidate.column),
+  Order.mapInput(Order.String, (candidate: RefCandidate) => candidate.kind),
+  Order.mapInput(Order.String, (candidate: RefCandidate) => candidate.subject),
+]);
+
+const skippedOrder = Order.mapInput(Order.String, (blob: KnowledgeSkippedBlob) => blob.path);
+const entryPathOrder = Order.mapInput(Order.String, (entry: KnowledgeTrackedEntry) => entry.path);
+
+/**
+ * Censuses every reference in one fully injected Git tree.
+ *
+ * **Details**
+ *
+ * Scoped tracked entries are read once: non-regular blobs become `skipped` rows, elected-extension
+ * blobs become the scanned corpus in path order, and everything else is silently out of corpus.
+ * Each document is decoded strictly, scanned by the three buses, resolved against the tracked-entry
+ * oracle alone, and classified by the pure rule table. Observations are then sorted by document,
+ * line, column, kind, and subject, and duplicate occurrence ordinals are assigned in that same order
+ * before identities are minted — which is what makes permuting the oracle's entry order produce
+ * byte-identical output.
+ *
+ * **Gotchas**
+ *
+ * A blob whose bytes fail strict UTF-8 decoding is skipped and the run still succeeds; a goal
+ * manifest that fails to parse or decode is an operational failure instead. The difference is
+ * deliberate: the census may not silently downgrade an undecodable identity source into a missing
+ * one, because that is exactly the split-brain state it exists to detect.
+ *
+ * **Example** (Census an empty tree)
+ *
+ * ```ts
+ * import { scanKnowledgeRefsTree } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ * import { Effect } from "effect"
+ * import type { KnowledgeTreeOracle } from "@beep/repo-cli/commands/Knowledge/Knowledge.refs"
+ *
+ * const emptyTree: KnowledgeTreeOracle = {
+ *   treeish: "HEAD",
+ *   commit: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4",
+ *   trackedEntries: [],
+ *   readBytes: () => Effect.succeed(new Uint8Array()),
+ * }
+ *
+ * console.log(Effect.isEffect(scanKnowledgeRefsTree(emptyTree))) // true
+ * ```
+ *
+ * @param oracle - Everything the census may read from the requested tree.
+ * @returns The versioned census envelope for that tree.
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const scanKnowledgeRefsTree = Effect.fn("Knowledge.scanRefsTree")(function* (oracle: KnowledgeTreeOracle) {
+  const commit = yield* decodeCommitSha(oracle.commit).pipe(
+    KnowledgeOperationalError.mapError(
+      `Tree oracle commit "${oracle.commit}" is not a forty-character hexadecimal Git commit id.`
+    )
+  );
+  const pathIndex = HashMap.fromIterable(
+    A.map(oracle.trackedEntries, (entry): readonly [string, KnowledgeTrackedEntry] => [entry.path, entry])
+  );
+  const directoryPrefixes = HashSet.fromIterable(
+    A.flatMap(oracle.trackedEntries, (entry) => ancestorPrefixes(entry.path))
+  );
+  const scoped = A.filter(oracle.trackedEntries, (entry) => isKnowledgeScopedPath(entry.path));
+  const documents = pipe(
+    scoped,
+    A.filter((entry) => isRegularBlob(entry) && isElectedExtension(entry.path)),
+    A.sort(entryPathOrder)
+  );
+
+  let skipped = A.getSomes(A.map(scoped, skippedEntry));
+  // Per-document chunks flattened once: appending 18k candidates one document at a time re-copies
+  // the whole accumulator per document and turns the corpus scan quadratic.
+  let chunks = A.empty<ReadonlyArray<RefCandidate>>();
+  for (const entry of documents) {
+    const bytes = yield* oracle.readBytes(entry.path);
+    const decoded = yield* Effect.option(decodeUtf8(bytes, entry.path));
+    if (O.isNone(decoded)) {
+      skipped = A.append(
+        skipped,
+        KnowledgeSkippedBlob.make({ path: entry.path, mode: entry.mode, reason: "malformed-utf8" })
+      );
+      continue;
+    }
+    const surface = isKnowledgeArchivalPath(entry.path)
+      ? KnowledgeRefSurface.Enum.archival
+      : KnowledgeRefSurface.Enum.live;
+    chunks = A.append(chunks, extractDocumentRefs(entry.path, decoded.value, surface));
+  }
+  const candidates = A.flatten(chunks);
+
+  const slugs = pipe(A.getSomes(A.map(candidates, (candidate) => candidate.slug)), A.dedupe, A.sort(Order.String));
+  let slugResolutions = HashMap.empty<string, KnowledgeRefResolution>();
+  for (const slug of slugs) {
+    slugResolutions = HashMap.set(slugResolutions, slug, yield* resolveGoalSlug(oracle, pathIndex, slug));
+  }
+
+  const occurrences = MutableHashMap.empty<string, number>();
+  const toObservation = Effect.fnUntraced(function* (candidate: RefCandidate) {
+    const resolution = O.match(candidate.normalized, {
+      onNone: (): KnowledgeRefResolution =>
+        O.match(
+          O.flatMap(candidate.slug, (slug) => HashMap.get(slugResolutions, slug)),
+          {
+            onNone: () => KnowledgeRefNotApplicable.make({}),
+            onSome: (resolved) => resolved,
+          }
+        ),
+      onSome: (normalized) => resolveRepoPath(pathIndex, directoryPrefixes, normalized),
+    });
+    const classification = classifyKnowledgeRef({
+      kind: candidate.kind,
+      surface: candidate.surface,
+      resolutionStatus: resolution.status,
+      anchor: candidate.anchor,
+      token: candidate.token,
+      patternContext: candidate.patternContext,
+      pairingAmbiguous: candidate.pairingAmbiguous,
+      ungoverned: candidate.ungoverned,
+    });
+    const documentId = nfc(candidate.documentPath);
+    const key = A.join(A.map([candidate.kind, documentId, candidate.subject], knowledgeLengthPrefix), "");
+    const occurrence = O.getOrElse(MutableHashMap.get(occurrences, key), () => 0);
+    MutableHashMap.set(occurrences, key, occurrence + 1);
+    const refId = yield* makeKnowledgeRefId(candidate.kind, documentId, candidate.subject, occurrence);
+    return KnowledgeRefObservation.make({
+      refId,
+      ref: candidate.ref,
+      documentId,
+      occurrence: NonNegativeInt.make(occurrence),
+      surface: candidate.surface,
+      classification,
+      resolution,
+      location: KnowledgeFindingLocation.make({
+        path: candidate.documentPath,
+        line: NonNegativeInt.make(candidate.line),
+        column: NonNegativeInt.make(candidate.column),
+      }),
+      remediation: knowledgeRefRemediation(classification, resolution),
+    });
+  });
+  // Sequential forEach allocates the observation list once; per-observation `A.append` re-copies
+  // the whole accumulator and dominated the census runtime at corpus scale.
+  const observations = yield* Effect.forEach(A.sort(candidates, candidateOrder), toObservation);
+
+  return KnowledgeRefsReport.make({
+    treeish: oracle.treeish,
+    commit,
+    observations,
+    skipped: A.sort(skipped, skippedOrder),
+  });
+});

--- a/packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.service.ts
+++ b/packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.service.ts
@@ -7,7 +7,7 @@
 
 import { $RepoCliId } from "@beep/identity/packages";
 import { findRepoRoot } from "@beep/repo-utils";
-import { NonNegativeInt, Sha256HexFromBytes } from "@beep/schema";
+import { NonNegativeInt } from "@beep/schema";
 import { Context, Effect, FileSystem, HashSet, Layer, Match, MutableHashMap, Order, Path, pipe } from "effect";
 import * as A from "effect/Array";
 import * as O from "effect/Option";
@@ -26,6 +26,20 @@ import {
 } from "../../internal/repo-run/GitExec.ts";
 import { KNOWLEDGE_HISTORY_REMEDIATION, KnowledgeOperationalError } from "./Knowledge.errors.ts";
 import {
+  decodeKnowledgeUtf8,
+  isKnowledgeArchivalPath,
+  isKnowledgeCommandSpan,
+  isKnowledgeScopedPath,
+  KNOWLEDGE_SCANNER_SCOPE,
+  knowledgeDocumentLines,
+  knowledgeInlineSpans,
+  knowledgeLengthPrefix,
+  knowledgeLineMatches,
+  knowledgeSha256Hex,
+  normalizeKnowledgeRepoPath,
+  scanKnowledgeRefsTree,
+} from "./Knowledge.refs.ts";
+import {
   KnowledgeCommandOccurrence,
   KnowledgeCommandResolved,
   KnowledgeCommandUnknown,
@@ -42,70 +56,33 @@ import {
 import type { Crypto } from "effect/Crypto";
 import type { ChildProcessSpawner } from "effect/unstable/process";
 import type { GitCommandErrorAdapter } from "../../internal/repo-run/GitExec.ts";
+import type { KnowledgeInlineSpan, KnowledgeRefsReport, KnowledgeTreeOracle } from "./Knowledge.refs.ts";
 import type { KnowledgeCommandProbeResult } from "./Knowledge.schemas.ts";
 
 const $I = $RepoCliId.create("commands/Knowledge/Knowledge.service");
+
+/**
+ * Everything the reference census may read from one Git tree.
+ *
+ * **Details**
+ *
+ * Re-exported here because the tree oracle is the census counterpart of {@link KnowledgeArchiveOracle}
+ * and callers reach for both from one module. It is declared in `Knowledge.refs.ts`, which owns the
+ * evaluator that consumes it, so the runtime dependency graph stays acyclic.
+ *
+ * @category services
+ * @since 0.0.0
+ */
+export type { KnowledgeTreeOracle } from "./Knowledge.refs.ts";
 
 const NORMALIZATION_VERSION = "knowledge-normalization/v1";
 const FINDING_ID_PREFIX = "knowledge-finding/v1:";
 const INDEX_PATH = "goals/INDEX.md";
 const COMMAND_PREFIX = "bun run beep";
+const SEMANTIC_DELTA_DIGEST_FAILURE = "Failed to compute a semantic-delta SHA-256 digest.";
 const textEncoder = new TextEncoder();
-const strictUtf8Decoder = new TextDecoder("utf-8", { fatal: true });
 const bytesEquivalent = S.toEquivalence(S.Uint8Array);
-const decodeSha256 = S.decodeUnknownEffect(Sha256HexFromBytes);
 const decodeFindingId = S.decodeUnknownEffect(KnowledgeFindingId);
-
-const SCANNER_SCOPE: ReadonlyArray<string> = [
-  "AGENTS.md",
-  "CLAUDE.md",
-  "goals",
-  "explorations",
-  "docs",
-  ".claude",
-  ".agents",
-  ".codex",
-  "standards",
-  ".github",
-];
-
-const SCANNER_PREFIXES = A.map(A.drop(SCANNER_SCOPE, 2), (root) => `${root}/`);
-const ARCHIVAL_SEGMENTS = HashSet.make(
-  "history",
-  "research",
-  "reviews",
-  "synthesis",
-  "findings",
-  "outputs",
-  "reflections",
-  "logs",
-  ".proofs"
-);
-const GOVERNED_BARE_ROOTS = HashSet.make(
-  ".agents",
-  ".claude",
-  ".codex",
-  ".github",
-  "apps",
-  "docs",
-  "explorations",
-  "goals",
-  "infra",
-  "packages",
-  "plugins",
-  "scripts",
-  "standards",
-  "tools"
-);
-const GOVERNED_ROOT_FILES = HashSet.make(
-  "AGENTS.md",
-  "CLAUDE.md",
-  "README.md",
-  "package.json",
-  "bun.lock",
-  "turbo.json",
-  "tsconfig.json"
-);
 
 /**
  * Everything the scanner may read from one side of a comparison.
@@ -160,13 +137,16 @@ export interface KnowledgePairedOracleInput {
  * **Details**
  *
  * `scanPair` takes an already-materialized comparison boundary and stays pure; `semanticDelta` builds
- * that boundary from local Git history for a base ref and then delegates to it.
+ * that boundary from local Git history for a base ref and then delegates to it. `refsTree` is the
+ * single-tree read-only census: it shares the archive plumbing but compares nothing, so it gates
+ * nothing either.
  *
  * @see {@link KnowledgeService} for the service tag that carries this shape.
  * @category services
  * @since 0.0.0
  */
 export interface KnowledgeServiceShape {
+  readonly refsTree: (treeish: string) => Effect.Effect<KnowledgeRefsReport, KnowledgeOperationalError>;
   readonly scanPair: (
     input: KnowledgePairedOracleInput
   ) => Effect.Effect<KnowledgeSemanticDeltaReport, KnowledgeOperationalError>;
@@ -201,16 +181,7 @@ export class KnowledgeService extends Context.Service<KnowledgeService, Knowledg
 
 const nfc = Str.normalize("NFC");
 
-const sha256 = Effect.fn("Knowledge.sha256")(function* (bytes: Uint8Array) {
-  return yield* decodeSha256(bytes).pipe(
-    KnowledgeOperationalError.mapError("Failed to compute a semantic-delta SHA-256 digest.")
-  );
-});
-
-const lengthPrefix = (value: string): string => {
-  const normalized = nfc(value);
-  return `${textEncoder.encode(normalized).byteLength}:${normalized}`;
-};
+const sha256 = (bytes: Uint8Array) => knowledgeSha256Hex(bytes, SEMANTIC_DELTA_DIGEST_FAILURE);
 
 /**
  * Computes the ratified v1 finding identity from its exact length-prefixed preimage.
@@ -249,7 +220,7 @@ export const makeKnowledgeFindingId = Effect.fn("Knowledge.makeFindingId")(funct
   occurrence: number
 ) {
   const preimage = A.join(
-    A.map([NORMALIZATION_VERSION, kind, nfc(documentId), nfc(subject), `${occurrence}`], lengthPrefix),
+    A.map([NORMALIZATION_VERSION, kind, nfc(documentId), nfc(subject), `${occurrence}`], knowledgeLengthPrefix),
     ""
   );
   const digest = yield* sha256(textEncoder.encode(preimage));
@@ -258,21 +229,10 @@ export const makeKnowledgeFindingId = Effect.fn("Knowledge.makeFindingId")(funct
   );
 });
 
-const isScannerMarkdownPath = (repoPath: string): boolean => {
-  if (!Str.endsWith(".md")(repoPath)) {
-    return false;
-  }
-  if (repoPath === "AGENTS.md" || repoPath === "CLAUDE.md") {
-    return true;
-  }
-  if (!A.some(SCANNER_PREFIXES, (prefix) => Str.startsWith(prefix)(repoPath))) {
-    return false;
-  }
-  if (Str.startsWith("docs/generated/")(repoPath) || Str.startsWith("docs/_internal/")(repoPath)) {
-    return false;
-  }
-  return !A.some(Str.split("/")(repoPath), (segment) => HashSet.has(ARCHIVAL_SEGMENTS, segment));
-};
+// Stage-1 enforcement scans the census scope narrowed twice: Markdown only, and never below an
+// archival directory segment.
+const isScannerMarkdownPath = (repoPath: string): boolean =>
+  Str.endsWith(".md")(repoPath) && isKnowledgeScopedPath(repoPath) && !isKnowledgeArchivalPath(repoPath);
 
 const isRegularBlob = (entry: KnowledgeTrackedEntry): boolean => entry.mode === "100644" || entry.mode === "100755";
 
@@ -281,115 +241,8 @@ const trackedPathExists = (entries: ReadonlyArray<KnowledgeTrackedEntry>, repoPa
   return A.some(entries, (entry) => entry.path === repoPath || Str.startsWith(directoryPrefix)(entry.path));
 };
 
-const stripQueryAndFragment = Str.replace(/[?#].*$/u, "");
-
-/**
- * Spellings a governed path may never contain: whitespace, glob and shell syntax, ellipses, absolute
- * roots, URLs.
- *
- * @param value - Query-and-fragment-stripped, NFC-normalized spelling read from a document.
- * @returns True when the spelling carries syntax no tracked repository path can legitimately use.
- */
-const hasUngovernedPathSyntax = (value: string): boolean =>
-  /[\s\\]/u.test(value) ||
-  /[*[\]{}<>|:]/u.test(value) ||
-  /(?:^|\/)\.\.\.(?:\/|$)/u.test(value) ||
-  Str.includes("…")(value) ||
-  Str.startsWith("/")(value) ||
-  Str.includes("://")(value);
-
-const isRelativePathSpelling = (value: string): boolean => Str.startsWith("./")(value) || Str.startsWith("../")(value);
-
-const isGovernedPathSpelling = (raw: string): boolean => {
-  const value = stripQueryAndFragment(nfc(raw));
-  if (Str.isEmpty(value) || hasUngovernedPathSyntax(value)) {
-    return false;
-  }
-  if (isRelativePathSpelling(value)) {
-    return true;
-  }
-  return O.match(A.head(Str.split("/")(value)), {
-    onNone: () => false,
-    onSome: (segment) => HashSet.has(GOVERNED_BARE_ROOTS, segment) || HashSet.has(GOVERNED_ROOT_FILES, value),
-  });
-};
-
-/**
- * Applies one path segment to the resolved stack, or `O.none()` when `..` escapes the repository
- * root.
- *
- * @param segments - Segments resolved so far, always rooted at the repository root.
- * @param segment - Next raw segment; empty and `.` segments leave the stack untouched.
- * @returns The extended stack, or `O.none()` when `..` would step above the repository root.
- */
-const applyPathSegment = (segments: ReadonlyArray<string>, segment: string): O.Option<ReadonlyArray<string>> => {
-  if (segment === "" || segment === ".") {
-    return O.some(segments);
-  }
-  if (segment !== "..") {
-    return O.some(A.append(segments, segment));
-  }
-  return A.isReadonlyArrayEmpty(segments) ? O.none() : O.some(A.dropRight(segments, 1));
-};
-
-const resolvePathSegments = (base: ReadonlyArray<string>, value: string): O.Option<ReadonlyArray<string>> => {
-  let segments = base;
-  for (const segment of Str.split("/")(value)) {
-    const next = applyPathSegment(segments, segment);
-    if (O.isNone(next)) {
-      return O.none();
-    }
-    segments = next.value;
-  }
-  return O.some(segments);
-};
-
-/**
- * Normalizes one governed path spelling to a safe POSIX repository-relative path.
- *
- * **Details**
- *
- * Only spellings the repo governs survive: a bare governed root, a governed root file, or a `./` and
- * `../` path resolved against the containing document. URLs, globs, whitespace, ellipses, and
- * absolute paths return `O.none()`, and so does any relative path that escapes the repository root.
- *
- * **Example** (Resolve a relative link and reject a URL)
- *
- * ```ts
- * import { normalizeKnowledgeRepoPath } from "@beep/repo-cli/commands/Knowledge/Knowledge.service"
- * import * as O from "effect/Option"
- *
- * console.log(O.getOrNull(normalizeKnowledgeRepoPath("docs/README.md", "./guides/intro.md")))
- * // "docs/guides/intro.md"
- * console.log(O.isNone(normalizeKnowledgeRepoPath("docs/README.md", "https://example.com/a.md")))
- * // true
- * ```
- *
- * @param documentPath - Repository-relative path of the document containing the spelling.
- * @param raw - Path spelling exactly as written inside the document.
- * @returns The normalized path when the spelling is governed and stays inside the repository.
- * @category normalization
- * @since 0.0.0
- */
-export const normalizeKnowledgeRepoPath = (documentPath: string, raw: string): O.Option<string> => {
-  if (!isGovernedPathSpelling(raw)) {
-    return O.none();
-  }
-  const value = stripQueryAndFragment(nfc(raw));
-  const base = isRelativePathSpelling(value) ? A.dropRight(Str.split("/")(nfc(documentPath)), 1) : A.empty<string>();
-
-  return pipe(
-    resolvePathSegments(base, value),
-    O.filter(A.isReadonlyArrayNonEmpty),
-    O.map((segments) => nfc(A.join(segments, "/")))
-  );
-};
-
 const decodeUtf8 = (bytes: Uint8Array, repoPath: string): Effect.Effect<string, KnowledgeOperationalError> =>
-  Effect.try({
-    try: () => strictUtf8Decoder.decode(bytes),
-    catch: KnowledgeOperationalError.new(`Malformed UTF-8 in tracked Markdown file "${repoPath}".`),
-  });
+  decodeKnowledgeUtf8(bytes, `Malformed UTF-8 in tracked Markdown file "${repoPath}".`);
 
 const documentIdForBase = (repoPath: string): string => nfc(`base:${repoPath}`);
 
@@ -453,55 +306,9 @@ const failedAssertionCandidate = (
     remediation: "Update the assertion or add the tracked target.",
   });
 
-const isEligibleCommandSpan = (span: string): boolean =>
-  /^bun run beep(?:$|[ \t])/u.test(span) && !/[|;&<>]|\$\(|(?:^|[ \t])#/u.test(span);
-
 const commandWords = (span: string): ReadonlyArray<string> => {
   const tail = Str.trim(Str.slice(Str.length(COMMAND_PREFIX))(span));
   return Str.isEmpty(tail) ? A.empty<string>() : Str.split(/\s+/u)(tail);
-};
-
-/**
- * Drains a global pattern over one line, preserving `exec` order.
- *
- * @param pattern - Global pattern whose `lastIndex` advances across the whole drain.
- * @param text - One line of document prose, already excluded from any fenced block.
- * @returns Every match in source order, which is what keeps duplicate occurrence indices stable.
- */
-const matchesOf = (pattern: RegExp, text: string): ReadonlyArray<RegExpExecArray> => {
-  let matches = A.empty<RegExpExecArray>();
-  let match = pattern.exec(text);
-  while (match !== null) {
-    matches = A.append(matches, match);
-    match = pattern.exec(text);
-  }
-  return matches;
-};
-
-/** An inline code span and the 1-based column its opening backtick run starts at. */
-type InlineSpan = {
-  readonly span: string;
-  readonly column: number;
-};
-
-/**
- * Removes CommonMark inline-code padding: one leading and one trailing space, stripped only when both
- * are present and the content is not entirely spaces.
- *
- * @param content - Raw text between the opening and closing backtick runs.
- * @returns The span content a path or command reader sees.
- */
-const stripInlineCodePadding = (content: string): string =>
-  Str.startsWith(" ")(content) && Str.endsWith(" ")(content) && !/^ +$/u.test(content)
-    ? Str.slice(1, -1)(content)
-    : content;
-
-const inlineSpanOf = (match: RegExpExecArray): O.Option<InlineSpan> => {
-  const prefix = match[1];
-  const content = match[3];
-  return P.isString(prefix) && P.isString(content)
-    ? O.some({ span: stripInlineCodePadding(content), column: match.index + Str.length(prefix) + 1 })
-    : O.none();
 };
 
 /**
@@ -539,39 +346,33 @@ const assertionCandidate = (
 };
 
 const commandOccurrence = (
-  match: RegExpExecArray,
+  inline: KnowledgeInlineSpan,
   lineNumber: number,
   documentPath: string,
   documentId: string
 ): O.Option<KnowledgeCommandOccurrence> =>
-  pipe(
-    inlineSpanOf(match),
-    O.filter(({ span }) => isEligibleCommandSpan(span)),
-    O.map(({ column, span }) =>
-      KnowledgeCommandOccurrence.make({
-        documentId,
-        location: findingLocation(documentPath, lineNumber, column),
-        words: commandWords(span),
-      })
-    )
-  );
+  isKnowledgeCommandSpan(inline.span)
+    ? O.some(
+        KnowledgeCommandOccurrence.make({
+          documentId,
+          location: findingLocation(documentPath, lineNumber, inline.column),
+          words: commandWords(inline.span),
+        })
+      )
+    : O.none();
 
 const inlinePathCandidate = (
-  match: RegExpExecArray,
+  inline: KnowledgeInlineSpan,
   lineNumber: number,
   documentPath: string,
   documentId: string,
   entries: ReadonlyArray<KnowledgeTrackedEntry>
 ): O.Option<KnowledgeFindingCandidate> =>
-  pipe(
-    inlineSpanOf(match),
-    O.filter(({ span }) => !isEligibleCommandSpan(span)),
-    O.flatMap((inline) =>
-      O.map(brokenPathAt(inline.span, documentPath, entries), (repoPath) =>
+  isKnowledgeCommandSpan(inline.span)
+    ? O.none()
+    : O.map(brokenPathAt(inline.span, documentPath, entries), (repoPath) =>
         missingPathCandidate(documentId, documentPath, repoPath, lineNumber, inline.column)
-      )
-    )
-  );
+      );
 
 const extractLineFindings = (
   lineText: string,
@@ -580,95 +381,18 @@ const extractLineFindings = (
   documentId: string,
   entries: ReadonlyArray<KnowledgeTrackedEntry>
 ): readonly [ReadonlyArray<KnowledgeFindingCandidate>, ReadonlyArray<KnowledgeCommandOccurrence>] => {
-  const assertions = matchesOf(/<!-- beep:assert path-exists ([^\s]+) -->/gu, lineText);
-  // Equal-length backtick runs: an opening run of N closes on the next run of N, so `` `x` `` and
-  // ```` ```x``` ```` are extracted the same way a single-backtick span is.
-  const inlines = matchesOf(/(^|[^`\\])(`+)([^\r\n]*?)\2(?!`)/gu, lineText);
+  const assertions = knowledgeLineMatches(/<!-- beep:assert path-exists ([^\s]+) -->/gu, lineText);
+  const inlines = knowledgeInlineSpans(lineText);
   const candidates = A.appendAll(
     A.getSomes(A.map(assertions, (match) => assertionCandidate(match, lineNumber, documentPath, documentId, entries))),
-    A.getSomes(A.map(inlines, (match) => inlinePathCandidate(match, lineNumber, documentPath, documentId, entries)))
+    A.getSomes(A.map(inlines, (inline) => inlinePathCandidate(inline, lineNumber, documentPath, documentId, entries)))
   );
   const commands = A.getSomes(
-    A.map(inlines, (match) => commandOccurrence(match, lineNumber, documentPath, documentId))
+    A.map(inlines, (inline) => commandOccurrence(inline, lineNumber, documentPath, documentId))
   );
 
   return [candidates, commands];
 };
-
-const FENCE_PATTERN = /^(`{3,}|~{3,})(.*)$/u;
-const QUOTE_PREFIX_PATTERN = /^(?:[ \t]*>[ \t]?)+/u;
-const LIST_PREFIX_PATTERN = /^[ \t]*(?:(?:[-+*]|[0-9]{1,9}[.)])[ \t]+)?/u;
-const stripListPrefix = Str.replace(LIST_PREFIX_PATTERN, "");
-
-/** One line split into the Markdown container it sits in and the body a fence delimiter is read from. */
-type ContainerLine = {
-  readonly depth: number;
-  readonly body: string;
-};
-
-/**
- * Strips the Markdown container prefix so a fence nested in a blockquote or a list item is still
- * recognized as a fence.
- *
- * **Details**
- *
- * Blockquote markers are removed first and counted, then list-item indentation and an optional
- * bullet or ordered marker. Indentation is stripped without a depth limit, which is what makes a
- * fence inside a deeply nested list item visible; the trade is that a four-space indented code block
- * showing a literal fence now opens one, suppressing scanning rather than inventing findings.
- *
- * @param line - Raw document line.
- * @returns The blockquote depth the prefix carried and the body the fence matcher reads.
- */
-const containerLine = (line: string): ContainerLine => {
-  const quote = QUOTE_PREFIX_PATTERN.exec(line);
-  const quoted = quote === null ? "" : quote[0];
-  return {
-    depth: A.length(Str.split(">")(quoted)) - 1,
-    body: stripListPrefix(Str.slice(Str.length(quoted))(line)),
-  };
-};
-
-/** The open fence a line is inside: its container depth, marker character, and closing run length. */
-type OpenFence = {
-  readonly marker: string;
-  readonly length: number;
-  readonly depth: number;
-};
-
-const openedFence = (line: ContainerLine): O.Option<OpenFence> => {
-  const fence = FENCE_PATTERN.exec(line.body);
-  if (fence === null || !P.isString(fence[1]) || !P.isString(fence[1][0])) {
-    return O.none();
-  }
-  return O.some({ marker: fence[1][0], length: Str.length(fence[1]), depth: line.depth });
-};
-
-const closesFence = (line: ContainerLine, open: OpenFence): boolean => {
-  const fence = FENCE_PATTERN.exec(line.body);
-  return (
-    fence !== null &&
-    P.isString(fence[1]) &&
-    P.isString(fence[2]) &&
-    line.depth === open.depth &&
-    fence[1][0] === open.marker &&
-    Str.length(fence[1]) >= open.length &&
-    /^\s*$/u.test(fence[2])
-  );
-};
-
-/**
- * Fence state after one line: `O.none()` outside a fence, `O.some` while inside one.
- *
- * @param fence - Fence state carried in from the preceding line.
- * @param line - Container-stripped line whose delimiter may open or close the surrounding block.
- * @returns The fence state the next line starts from.
- */
-const advanceFence = (fence: O.Option<OpenFence>, line: ContainerLine): O.Option<OpenFence> =>
-  O.match(fence, {
-    onNone: () => openedFence(line),
-    onSome: (open) => (closesFence(line, open) ? O.none() : O.some(open)),
-  });
 
 const extractDocument = Effect.fn("Knowledge.extractDocument")(function* (
   oracle: KnowledgeArchiveOracle,
@@ -676,25 +400,16 @@ const extractDocument = Effect.fn("Knowledge.extractDocument")(function* (
   documentId: string
 ) {
   const text = yield* oracle.readBytes(entry.path).pipe(Effect.flatMap((bytes) => decodeUtf8(bytes, entry.path)));
-  const lines = Str.split(/\r?\n/u)(text);
   let candidates = A.empty<KnowledgeFindingCandidate>();
   let commands = A.empty<KnowledgeCommandOccurrence>();
-  let fence = O.none<OpenFence>();
 
-  for (let index = 0; index < A.length(lines); index += 1) {
-    const line = lines[index];
-    if (!P.isString(line)) {
+  for (const line of knowledgeDocumentLines(text)) {
+    if (!line.prose) {
       continue;
     }
-    const nextFence = advanceFence(fence, containerLine(line));
-    // Prose only: fence delimiters and fenced content alike stay out of the scan.
-    const scannable = O.isNone(fence) && O.isNone(nextFence);
-    fence = nextFence;
-    if (scannable) {
-      const extracted = extractLineFindings(line, index + 1, entry.path, documentId, oracle.trackedEntries);
-      candidates = A.appendAll(candidates, extracted[0]);
-      commands = A.appendAll(commands, extracted[1]);
-    }
+    const extracted = extractLineFindings(line.text, line.number, entry.path, documentId, oracle.trackedEntries);
+    candidates = A.appendAll(candidates, extracted[0]);
+    commands = A.appendAll(commands, extracted[1]);
   }
 
   return { candidates, commands };
@@ -787,7 +502,7 @@ const candidatesForSide = Effect.fn("Knowledge.candidatesForSide")(function* (
 });
 
 const candidateGroupKey = (candidate: KnowledgeFindingCandidate): string =>
-  A.join(A.map([candidate.kind, candidate.documentId, candidate.subject], lengthPrefix), "");
+  A.join(A.map([candidate.kind, candidate.documentId, candidate.subject], knowledgeLengthPrefix), "");
 
 const findingsFromCandidates = Effect.fn("Knowledge.findingsFromCandidates")(function* (
   candidates: ReadonlyArray<KnowledgeFindingCandidate>
@@ -921,6 +636,18 @@ const historyGitAdapter = (baseRef: string): GitCommandErrorAdapter<KnowledgeOpe
   onNonZeroExit: ({ commandLine, exitCode, output }) =>
     KnowledgeOperationalError.make({
       message: `Cannot resolve semantic-delta history with ${commandLine} (exit ${exitCode}). ${KNOWLEDGE_HISTORY_REMEDIATION}${Str.isEmpty(output) ? "" : `\n${output}`}`,
+    }),
+  onTruncated: O.none(),
+});
+
+const treeGitAdapter = (treeish: string): GitCommandErrorAdapter<KnowledgeOperationalError> => ({
+  onSpawnFailure: (commandLine) =>
+    KnowledgeOperationalError.new(
+      `Failed to spawn ${commandLine} while resolving census tree "${treeish}". ${KNOWLEDGE_HISTORY_REMEDIATION}`
+    ),
+  onNonZeroExit: ({ commandLine, exitCode, output }) =>
+    KnowledgeOperationalError.make({
+      message: `Cannot resolve census tree "${treeish}" with ${commandLine} (exit ${exitCode}). ${KNOWLEDGE_HISTORY_REMEDIATION}${Str.isEmpty(output) ? "" : `\n${output}`}`,
     }),
   onTruncated: O.none(),
 });
@@ -1304,8 +1031,13 @@ const semanticDeltaLive = Effect.fn("Knowledge.semanticDelta")(function* (baseRe
       const headTree = yield* readGitTree(repoRoot, headCommit, gitAdapter, () =>
         KnowledgeOperationalError.make({ message: "Malformed NUL-delimited HEAD ls-tree output." })
       );
-      const gitRenames = yield* readGitRenames(repoRoot, baseCommit, headCommit, SCANNER_SCOPE, gitAdapter, () =>
-        KnowledgeOperationalError.make({ message: "Malformed NUL-delimited rename-table output." })
+      const gitRenames = yield* readGitRenames(
+        repoRoot,
+        baseCommit,
+        headCommit,
+        KNOWLEDGE_SCANNER_SCOPE,
+        gitAdapter,
+        () => KnowledgeOperationalError.make({ message: "Malformed NUL-delimited rename-table output." })
       );
       const baseEntries = A.map(baseTree, (entry) =>
         KnowledgeTrackedEntry.make({ path: entry.path, mode: entry.mode, objectId: entry.objectId })
@@ -1327,6 +1059,76 @@ const semanticDeltaLive = Effect.fn("Knowledge.semanticDelta")(function* (baseRe
   );
 });
 
+/**
+ * Materializes one commit-ish as an injectable census oracle, scoped to a temporary archive root.
+ *
+ * **Details**
+ *
+ * The tree-ish is resolved to a verified commit, archived, and extracted, and the tracked-entry
+ * oracle is read from `git ls-tree` rather than from the extracted tree. That separation is what
+ * keeps the census honest: extraction drops links and other non-readable entry types, while the
+ * entry list still reports every tracked mode so symlinks and gitlinks can be recorded as skipped.
+ *
+ * **Gotchas**
+ *
+ * The archive root lives inside a scoped temporary directory, so the returned oracle is only valid
+ * inside the `Effect.scoped` region that built it. Reading through it afterwards fails on a missing
+ * file rather than returning stale bytes.
+ *
+ * **Example** (Build a census oracle for the working commit)
+ *
+ * ```ts
+ * import { makeKnowledgeTreeOracle } from "@beep/repo-cli/commands/Knowledge/Knowledge.service"
+ * import { Effect } from "effect"
+ *
+ * console.log(Effect.isEffect(Effect.scoped(makeKnowledgeTreeOracle("HEAD")))) // true
+ * ```
+ *
+ * @param treeish - Any commit-ish; no fetch ever occurs.
+ * @returns The tree oracle the census evaluator scans.
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const makeKnowledgeTreeOracle = Effect.fn("Knowledge.makeTreeOracle")(function* (treeish: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const runtime = yield* Effect.context<FileSystem.FileSystem | Path.Path>();
+  const repoRoot = yield* findRepoRoot().pipe(
+    KnowledgeOperationalError.mapError("Failed to locate the repository root for the reference census.")
+  );
+  const commit = yield* resolveGitCommit(repoRoot, treeish, treeGitAdapter(treeish));
+  const tempRoot = yield* fs
+    .makeTempDirectoryScoped({ prefix: "beep-knowledge-refs-" })
+    .pipe(KnowledgeOperationalError.mapError("Failed to create a reference-census temporary root."));
+  const archiveRoot = path.join(tempRoot, "tree");
+  const archivePath = path.join(tempRoot, "tree.tar");
+  yield* fs
+    .makeDirectory(archiveRoot)
+    .pipe(KnowledgeOperationalError.mapError("Failed to create the reference-census archive root."));
+  yield* writeGitArchive(repoRoot, commit, archivePath, gitAdapter);
+  yield* extractArchive(archivePath, archiveRoot);
+  const tree = yield* readGitTree(repoRoot, commit, gitAdapter, () =>
+    KnowledgeOperationalError.make({ message: "Malformed NUL-delimited census ls-tree output." })
+  );
+  const readBytes = Effect.fn("Knowledge.treeReadBytes")(function* (repoPath: string) {
+    return yield* fs
+      .readFile(path.join(archiveRoot, repoPath))
+      .pipe(KnowledgeOperationalError.mapError(`Failed to read archived tracked file "${repoPath}".`));
+  });
+
+  return {
+    treeish,
+    commit,
+    trackedEntries: A.map(tree, (entry) =>
+      KnowledgeTrackedEntry.make({ path: entry.path, mode: entry.mode, objectId: entry.objectId })
+    ),
+    readBytes: (repoPath: string) => readBytes(repoPath).pipe(Effect.provide(runtime)),
+  } satisfies KnowledgeTreeOracle;
+});
+
+const refsTreeLive = (treeish: string) =>
+  Effect.scoped(Effect.flatMap(makeKnowledgeTreeOracle(treeish), scanKnowledgeRefsTree));
+
 type KnowledgeServiceRequirements =
   | Crypto
   | FileSystem.FileSystem
@@ -1340,6 +1142,7 @@ const makeKnowledgeService = Effect.fn("KnowledgeService.make")(function* () {
     semanticDelta: Effect.fn("KnowledgeService.semanticDelta")((baseRef) =>
       semanticDeltaLive(baseRef).pipe(Effect.provide(runtime))
     ),
+    refsTree: Effect.fn("KnowledgeService.refsTree")((treeish) => refsTreeLive(treeish).pipe(Effect.provide(runtime))),
   });
 });
 

--- a/packages/tooling/tool/cli/src/commands/Knowledge/index.ts
+++ b/packages/tooling/tool/cli/src/commands/Knowledge/index.ts
@@ -20,6 +20,13 @@ export * from "./Knowledge.command.ts";
  */
 export * from "./Knowledge.errors.ts";
 /**
+ * Reference census schemas, shared scanning machinery, classifier, and tree evaluator.
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export * from "./Knowledge.refs.ts";
+/**
  * Versioned Stage-1 finding and delta-report schema surface.
  *
  * @category schemas

--- a/packages/tooling/tool/cli/test/knowledge-refs.test.ts
+++ b/packages/tooling/tool/cli/test/knowledge-refs.test.ts
@@ -1,0 +1,742 @@
+import {
+  classifyKnowledgeRef,
+  encodeKnowledgeRefsReportJson,
+  extractKnowledgeHostAnchors,
+  KnowledgeOperationalError,
+  KnowledgeRefSurface,
+  KnowledgeTrackedEntry,
+  makeKnowledgeTreeOracle,
+  scanKnowledgeRefsTree,
+} from "@beep/repo-cli/commands/Knowledge";
+import { provideScopedLayer } from "@beep/test-utils";
+import { NodeCrypto, NodeServices } from "@effect/platform-node";
+import { describe, expect, it } from "@effect/vitest";
+import { Crypto, Effect, Encoding, HashSet, Layer } from "effect";
+import * as A from "effect/Array";
+import * as O from "effect/Option";
+import * as R from "effect/Record";
+import * as Str from "effect/String";
+import type {
+  KnowledgeRefClassificationInput,
+  KnowledgeRefObservation,
+  KnowledgeRefsReport,
+  KnowledgeTreeOracle,
+} from "@beep/repo-cli/commands/Knowledge";
+
+const textEncoder = new TextEncoder();
+const FIXTURE_COMMIT = "0123456789abcdef0123456789abcdef01234567";
+
+/** The snapshot the clone-agnosticism inventory was published from. */
+const BASELINE_COMMIT = "58318884957ae02237099cc40666d30e3c2d943d";
+const BASELINE_TIMEOUT_MS = 600_000;
+
+type FixtureOptions = {
+  readonly modes?: Readonly<Record<string, string>>;
+  readonly objectIds?: Readonly<Record<string, string>>;
+  readonly bytes?: Readonly<Record<string, Uint8Array>>;
+  readonly unreadable?: ReadonlyArray<string>;
+  readonly order?: (paths: ReadonlyArray<string>) => ReadonlyArray<string>;
+};
+
+/**
+ * A tree oracle built from plain fixture text.
+ *
+ * `unreadable` is how a fixture proves a blob was never opened: a path listed there fails on read,
+ * so a run that still succeeds could not have touched it.
+ */
+const makeFixtureOracle = (
+  files: Readonly<Record<string, string>>,
+  options: FixtureOptions = {}
+): KnowledgeTreeOracle => {
+  const byteFiles = options.bytes ?? {};
+  const unreadable = HashSet.fromIterable(options.unreadable ?? A.empty<string>());
+  const paths = A.appendAll(R.keys(files), R.keys(byteFiles));
+  const ordered = O.match(O.fromNullishOr(options.order), {
+    onNone: () => paths,
+    onSome: (reorder) => reorder(paths),
+  });
+  const entries = A.map(ordered, (path) =>
+    KnowledgeTrackedEntry.make({
+      path,
+      mode: O.getOrElse(R.get(options.modes ?? {}, path), () => "100644"),
+      objectId: O.getOrElse(R.get(options.objectIds ?? {}, path), () => `oid:${path}`),
+    })
+  );
+
+  return {
+    treeish: "fixture",
+    commit: FIXTURE_COMMIT,
+    trackedEntries: entries,
+    readBytes: (repoPath) => {
+      if (HashSet.has(unreadable, repoPath)) {
+        return Effect.fail(
+          KnowledgeOperationalError.make({ message: `Fixture blob "${repoPath}" must never be read.` })
+        );
+      }
+      return O.match(R.get(byteFiles, repoPath), {
+        onNone: () =>
+          O.match(R.get(files, repoPath), {
+            onNone: () =>
+              Effect.fail(
+                KnowledgeOperationalError.make({ message: `Fixture is missing tracked bytes for ${repoPath}.` })
+              ),
+            onSome: (text) => Effect.succeed(textEncoder.encode(text)),
+          }),
+        onSome: Effect.succeed,
+      });
+    },
+  };
+};
+
+const census = (oracle: KnowledgeTreeOracle): Effect.Effect<KnowledgeRefsReport, KnowledgeOperationalError> =>
+  scanKnowledgeRefsTree(oracle).pipe(provideScopedLayer(NodeCrypto.layer));
+
+const scanFixture = (
+  files: Readonly<Record<string, string>>,
+  options: FixtureOptions = {}
+): Effect.Effect<KnowledgeRefsReport, KnowledgeOperationalError> => census(makeFixtureOracle(files, options));
+
+const inDocument = (report: KnowledgeRefsReport, path: string): ReadonlyArray<KnowledgeRefObservation> =>
+  A.filter(report.observations, (observation) => observation.location.path === path);
+
+/** The design doc's expected value for one fixture row: a classification and a resolution status. */
+const verdicts = (observations: ReadonlyArray<KnowledgeRefObservation>): ReadonlyArray<string> =>
+  A.map(observations, (observation) => `${observation.classification}/${observation.resolution.status}`);
+
+const anchorsOf = (observations: ReadonlyArray<KnowledgeRefObservation>): ReadonlyArray<string> =>
+  A.getSomes(
+    A.map(observations, (observation) => {
+      const ref = observation.ref;
+      return ref.kind === "host-path" ? O.some(ref.anchor) : O.none<string>();
+    })
+  );
+
+const displayPathOf = (observation: KnowledgeRefObservation): O.Option<string> => {
+  const ref = observation.ref;
+  return ref.kind === "goal-uri" ? O.fromNullishOr(ref.displayPath) : O.none<string>();
+};
+
+const goalManifestText = (id: string): string =>
+  `{"initiative":{"id":"${id}","status":"active"},"completionGate":{"operator":"yeet","requiresPullRequest":true,"requiresMergeable":true,"statement":"Ship via yeet.","grandfathered":false}}`;
+
+const independentDigestEffect = Effect.fn("KnowledgeRefsTest.independentDigest")(function* (text: string) {
+  const crypto = yield* Crypto.Crypto;
+  const digest = yield* crypto.digest("SHA-256", textEncoder.encode(text));
+  return Encoding.encodeHex(digest);
+});
+
+const independentDigest = (text: string): Effect.Effect<string> =>
+  independentDigestEffect(text).pipe(provideScopedLayer(NodeCrypto.layer), Effect.orDie);
+
+const lp = (value: string): string => {
+  const normalized = Str.normalize("NFC")(value);
+  return `${textEncoder.encode(normalized).byteLength}:${normalized}`;
+};
+
+const expectedRefId = Effect.fn("KnowledgeRefsTest.expectedRefId")(function* (
+  kind: string,
+  documentId: string,
+  subject: string,
+  occurrence = 0
+) {
+  const preimage = A.join(
+    A.map(["knowledge-ref-normalization/v1", kind, documentId, subject, `${occurrence}`], lp),
+    ""
+  );
+  return `knowledge-ref/v1:${yield* independentDigest(preimage)}`;
+});
+
+describe("knowledge refs golden fixture matrix", () => {
+  it.effect("verified inline span", () =>
+    Effect.gen(function* () {
+      const report = yield* scanFixture({
+        "docs/guide.md": "See `docs/README.md` for the layout.\n",
+        "docs/README.md": "ok\n",
+      });
+      expect(verdicts(inDocument(report, "docs/guide.md"))).toEqual(["verified/resolved"]);
+    })
+  );
+
+  it.effect("missing target", () =>
+    Effect.gen(function* () {
+      const report = yield* scanFixture({ "docs/guide.md": "See `packages/missing/src/index.ts`.\n" });
+      expect(verdicts(report.observations)).toEqual(["broken-target/missing"]);
+    })
+  );
+
+  it.effect("document-relative inline span resolves from the containing directory", () =>
+    Effect.gen(function* () {
+      const report = yield* scanFixture({
+        "goals/example/README.md": "See `./PLAN.md` next.\n",
+        "goals/example/PLAN.md": "ok\n",
+      });
+      const observations = inDocument(report, "goals/example/README.md");
+      expect(verdicts(observations)).toEqual(["verified/resolved"]);
+      expect(A.map(observations, (observation) => observation.resolution.status)).toEqual(["resolved"]);
+    })
+  );
+
+  it.effect("root escape is ungoverned syntax", () =>
+    Effect.gen(function* () {
+      const report = yield* scanFixture({ "docs/guide.md": "Never cite `../../etc/passwd` here.\n" });
+      expect(verdicts(report.observations)).toEqual(["ungoverned-syntax/not-applicable"]);
+    })
+  );
+
+  it.effect("link destination resolves", () =>
+    Effect.gen(function* () {
+      const report = yield* scanFixture({
+        "goals/example/README.md": "[PLAN](./PLAN.md)\n",
+        "goals/example/PLAN.md": "ok\n",
+      });
+      expect(verdicts(inDocument(report, "goals/example/README.md"))).toEqual(["verified/resolved"]);
+    })
+  );
+
+  it.effect("producer target reports the regeneration command", () =>
+    Effect.gen(function* () {
+      const report = yield* scanFixture({ "docs/guide.md": "See `goals/INDEX.md`.\n" });
+      expect(verdicts(report.observations)).toEqual(["producer-owned-target/producer-owned"]);
+      expect(A.map(report.observations, (observation) => observation.remediation)).toEqual([
+        "Run `bun run beep goals index --write` and commit the regenerated output.",
+      ]);
+    })
+  );
+
+  it.effect("live host path inside a beep checkout is actionable", () =>
+    Effect.gen(function* () {
+      const report = yield* scanFixture({
+        ".claude/skills/demo/SKILL.md": "Run it from /home/example/checkouts/beep-effect now.\n",
+      });
+      expect(verdicts(report.observations)).toEqual(["actionable-host-path/not-applicable"]);
+    })
+  );
+
+  it.effect("portable home convention is not a defect", () =>
+    Effect.gen(function* () {
+      const report = yield* scanFixture({
+        ".claude/skills/demo/SKILL.md": "Memory lives under ~/.claude/memory today.\n",
+      });
+      expect(verdicts(report.observations)).toEqual(["portable-home-convention/not-applicable"]);
+    })
+  );
+
+  it.effect("documented temp convention is not a defect", () =>
+    Effect.gen(function* () {
+      const report = yield* scanFixture({
+        ".claude/skills/demo/SKILL.md": "The proxy serves /tmp/portless sockets.\n",
+      });
+      expect(verdicts(report.observations)).toEqual(["documented-temp-convention/not-applicable"]);
+    })
+  );
+
+  it.effect("the same absolute path under an archival segment is provenance", () =>
+    Effect.gen(function* () {
+      const report = yield* scanFixture({
+        "goals/example/research/notes.md": "Run it from /home/example/checkouts/beep-effect now.\n",
+      });
+      expect(verdicts(report.observations)).toEqual(["archival-provenance/not-applicable"]);
+    })
+  );
+
+  it.effect("an anchor quoted as pattern data is an audit literal", () =>
+    Effect.gen(function* () {
+      const report = yield* scanFixture({
+        "standards/git-worktrees.md": 'The audit runs rg -n "/home/" over the tree.\n',
+      });
+      expect(verdicts(report.observations)).toEqual(["audit-pattern-literal/not-applicable"]);
+    })
+  );
+
+  it.effect("fences do not exempt host anchors", () =>
+    Effect.gen(function* () {
+      const report = yield* scanFixture({
+        ".claude/skills/demo/SKILL.md": "Setup:\n\n```bash\ncd /home/example/checkouts/beep-effect\n```\n",
+      });
+      expect(verdicts(report.observations)).toEqual(["actionable-host-path/not-applicable"]);
+      expect(A.map(report.observations, (observation) => observation.location.line)).toEqual([4]);
+    })
+  );
+
+  it.effect("a fenced repository path is a decoy and yields no observation", () =>
+    Effect.gen(function* () {
+      const report = yield* scanFixture({
+        "docs/guide.md": "Plan:\n\n```\nSee `packages/missing/src/index.ts`.\n```\n",
+      });
+      expect(report.observations).toEqual([]);
+    })
+  );
+
+  it.effect("goal URI whose manifest id matches is verified", () =>
+    Effect.gen(function* () {
+      const report = yield* scanFixture({
+        "docs/guide.md": "Tracks repo://goal/example-packet today.\n",
+        "goals/example-packet/ops/manifest.json": goalManifestText("example-packet"),
+      });
+      expect(verdicts(inDocument(report, "docs/guide.md"))).toEqual(["verified/resolved"]);
+    })
+  );
+
+  it.effect("goal URI whose manifest declares another id is an identity mismatch", () =>
+    Effect.gen(function* () {
+      const report = yield* scanFixture({
+        "docs/guide.md": "Tracks repo://goal/example-packet today.\n",
+        "goals/example-packet/ops/manifest.json": goalManifestText("another-packet"),
+      });
+      const observations = inDocument(report, "docs/guide.md");
+      expect(verdicts(observations)).toEqual(["identity-mismatch/identity-mismatch"]);
+      expect(
+        A.map(observations, (observation) =>
+          observation.resolution.status === "identity-mismatch" ? observation.resolution.declaredId : "unexpected"
+        )
+      ).toEqual(["another-packet"]);
+    })
+  );
+
+  it.effect("goal URI with no tracked manifest is a broken target", () =>
+    Effect.gen(function* () {
+      const report = yield* scanFixture({ "docs/guide.md": "Tracks repo://goal/example-packet today.\n" });
+      expect(verdicts(report.observations)).toEqual(["broken-target/missing"]);
+    })
+  );
+
+  it.effect("a beep:ref paired with one same-line display path records that path", () =>
+    Effect.gen(function* () {
+      const report = yield* scanFixture({
+        "goals/example-packet/ops/NOTES.md": "[PLAN](../PLAN.md) <!-- beep:ref goal/example-packet -->\n",
+        "goals/example-packet/PLAN.md": "ok\n",
+        "goals/example-packet/ops/manifest.json": goalManifestText("example-packet"),
+      });
+      const observations = inDocument(report, "goals/example-packet/ops/NOTES.md");
+      expect(verdicts(observations)).toEqual(["verified/resolved", "verified/resolved"]);
+      expect(A.getSomes(A.map(observations, displayPathOf))).toEqual(["goals/example-packet/PLAN.md"]);
+    })
+  );
+
+  it.effect("a beep:ref alone under a heading takes heading scope", () =>
+    Effect.gen(function* () {
+      const report = yield* scanFixture({
+        "goals/example-packet/README.md": "## Scope\n\n<!-- beep:ref goal/example-packet -->\n",
+        "goals/example-packet/ops/manifest.json": goalManifestText("example-packet"),
+      });
+      const observations = inDocument(report, "goals/example-packet/README.md");
+      expect(verdicts(observations)).toEqual(["verified/resolved"]);
+      expect(A.getSomes(A.map(observations, displayPathOf))).toEqual([]);
+    })
+  );
+
+  it.effect("two beep:refs on one line make every reference on it ambiguous", () =>
+    Effect.gen(function* () {
+      const report = yield* scanFixture({
+        "goals/example-packet/README.md": "<!-- beep:ref goal/example-packet --> <!-- beep:ref goal/other-packet -->\n",
+        "goals/example-packet/ops/manifest.json": goalManifestText("example-packet"),
+      });
+      expect(verdicts(inDocument(report, "goals/example-packet/README.md"))).toEqual([
+        "ambiguous-ref-pairing/not-applicable",
+        "ambiguous-ref-pairing/not-applicable",
+      ]);
+    })
+  );
+
+  it.effect("an orphan beep:ref is ambiguous", () =>
+    Effect.gen(function* () {
+      const report = yield* scanFixture({
+        "goals/example-packet/README.md": "Some prose paragraph.\n\n<!-- beep:ref goal/example-packet -->\n",
+        "goals/example-packet/ops/manifest.json": goalManifestText("example-packet"),
+      });
+      expect(verdicts(inDocument(report, "goals/example-packet/README.md"))).toEqual([
+        "ambiguous-ref-pairing/not-applicable",
+      ]);
+    })
+  );
+
+  it.effect("duplicate spans take ordinals 0 and 1 with distinct identities", () =>
+    Effect.gen(function* () {
+      const report = yield* scanFixture({
+        "docs/guide.md": "First `docs/missing.md` then `docs/missing.md` again.\n",
+      });
+      const observations = inDocument(report, "docs/guide.md");
+      expect(verdicts(observations)).toEqual(["broken-target/missing", "broken-target/missing"]);
+      expect(A.map(observations, (observation) => observation.occurrence)).toEqual([0, 1]);
+      expect(A.map(observations, (observation) => observation.refId)).toEqual([
+        yield* expectedRefId("repo-path", "docs/guide.md", "repo-path:docs/missing.md", 0),
+        yield* expectedRefId("repo-path", "docs/guide.md", "repo-path:docs/missing.md", 1),
+      ]);
+    })
+  );
+
+  it.effect("a binary blob on an elected extension is skipped and the run succeeds", () =>
+    Effect.gen(function* () {
+      const report = yield* scanFixture(
+        { "docs/guide.md": "See `docs/README.md`.\n", "docs/README.md": "ok\n" },
+        {
+          bytes: {
+            "goals/example/ops/data.json": new Uint8Array([0xff, 0xfe, 0x00, 0x01]),
+            "docs/diagram.png": new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
+          },
+          // A non-elected extension is out of corpus, so a run that succeeds never opened it.
+          unreadable: ["docs/diagram.png"],
+        }
+      );
+      expect(A.map(report.skipped, (blob) => `${blob.reason} ${blob.path}`)).toEqual([
+        "malformed-utf8 goals/example/ops/data.json",
+      ]);
+      expect(verdicts(report.observations)).toEqual(["verified/resolved"]);
+    })
+  );
+});
+
+describe("knowledge refs negative controls", () => {
+  const permutationFiles = {
+    "docs/guide.md": "See `docs/README.md` and `packages/missing/src/index.ts`.\n",
+    "docs/README.md": "ok\n",
+    ".claude/skills/demo/SKILL.md": "Memory lives under ~/.claude/memory today.\n",
+    "goals/example/research/notes.md": "Captured from /home/example/checkouts/beep-effect once.\n",
+    "goals/example/ops/manifest.json": goalManifestText("example"),
+    "goals/example/README.md": "Tracks repo://goal/example today.\n",
+  };
+
+  it.effect("permuting tracked entries yields byte-identical JSON", () =>
+    Effect.gen(function* () {
+      const forward = yield* scanFixture(permutationFiles);
+      const reversed = yield* scanFixture(permutationFiles, { order: A.reverse });
+      const encode = (report: KnowledgeRefsReport) => encodeKnowledgeRefsReportJson(report).pipe(Effect.orDie);
+      expect(yield* encode(reversed)).toEqual(yield* encode(forward));
+    })
+  );
+
+  it.effect("a tracked symlink is skipped and never followed", () =>
+    Effect.gen(function* () {
+      const report = yield* scanFixture(
+        { "CLAUDE.md": "Guidance citing /home/example/checkouts/beep-effect.\n" },
+        { modes: { "CLAUDE.md": "120000" }, unreadable: ["CLAUDE.md"] }
+      );
+      expect(A.map(report.skipped, (blob) => `${blob.reason} ${blob.path}`)).toEqual(["symlink CLAUDE.md"]);
+      expect(report.observations).toEqual([]);
+    })
+  );
+
+  it.effect("a gitlink is skipped", () =>
+    Effect.gen(function* () {
+      const report = yield* scanFixture(
+        { "docs/vendored.md": "ignored\n" },
+        { modes: { "docs/vendored.md": "160000" }, unreadable: ["docs/vendored.md"] }
+      );
+      expect(A.map(report.skipped, (blob) => `${blob.reason} ${blob.path}`)).toEqual(["gitlink docs/vendored.md"]);
+    })
+  );
+
+  it.effect("renaming a document changes documentId and identity but not classification", () =>
+    Effect.gen(function* () {
+      const text = "See `packages/missing/src/index.ts`.\n";
+      const before = yield* scanFixture({ "docs/guide.md": text });
+      const after = yield* scanFixture({ "docs/renamed.md": text });
+      expect(verdicts(after.observations)).toEqual(verdicts(before.observations));
+      expect(A.map(before.observations, (observation) => observation.documentId)).toEqual(["docs/guide.md"]);
+      expect(A.map(after.observations, (observation) => observation.documentId)).toEqual(["docs/renamed.md"]);
+      expect(A.map(after.observations, (observation) => observation.refId)).not.toEqual(
+        A.map(before.observations, (observation) => observation.refId)
+      );
+    })
+  );
+
+  it.effect("a live home path outside any beep checkout is an external mirror", () =>
+    Effect.gen(function* () {
+      const report = yield* scanFixture({
+        ".claude/skills/demo/SKILL.md": "Mirror lives at /home/example/src/other-project today.\n",
+      });
+      expect(verdicts(report.observations)).toEqual(["external-mirror-reference/not-applicable"]);
+    })
+  );
+
+  it.effect("an encoded session literal and a bare tree name take different anchors", () =>
+    Effect.gen(function* () {
+      const encoded = extractKnowledgeHostAnchors(
+        "Scratch lives at /tmp/claude-1000/-home-user-YeeBois-projects-demo/scratchpad now."
+      );
+      expect(A.map(encoded, (match) => match.anchor)).toEqual(["temp", "encoded-home"]);
+
+      const bare = extractKnowledgeHostAnchors("The YeeBois tree holds every checkout.");
+      expect(A.map(bare, (match) => match.anchor)).toEqual(["bare-tree-name"]);
+      expect(A.map(bare, (match) => match.token)).toEqual(["YeeBois"]);
+    })
+  );
+
+  it("a tree name immediately preceded by a slash is not a second anchor", () => {
+    const matches = extractKnowledgeHostAnchors("Checkout is /home/example/YeeBois/projects/beep-effect here.");
+    expect(A.map(matches, (match) => match.anchor)).toEqual(["home-absolute"]);
+  });
+
+  const archivalHostInput = (patternContext: boolean): KnowledgeRefClassificationInput => ({
+    kind: "host-path",
+    surface: "archival",
+    resolutionStatus: "not-applicable",
+    anchor: O.some("home-absolute"),
+    token: O.some("/home/example/checkouts/beep-effect"),
+    patternContext,
+    pairingAmbiguous: false,
+    ungoverned: false,
+  });
+
+  const grammarFailureInput = (
+    kind: KnowledgeRefClassificationInput["kind"],
+    failure: { readonly pairingAmbiguous: boolean; readonly ungoverned: boolean }
+  ): KnowledgeRefClassificationInput => ({
+    kind,
+    surface: "live",
+    resolutionStatus: "not-applicable",
+    anchor: O.none(),
+    token: O.none(),
+    patternContext: false,
+    pairingAmbiguous: failure.pairingAmbiguous,
+    ungoverned: failure.ungoverned,
+  });
+
+  it("pattern-literal context outranks archival provenance", () => {
+    expect(classifyKnowledgeRef(archivalHostInput(true))).toBe("audit-pattern-literal");
+    expect(classifyKnowledgeRef(archivalHostInput(false))).toBe("archival-provenance");
+  });
+
+  it("pairing ambiguity and ungoverned syntax outrank every resolution outcome", () => {
+    expect(classifyKnowledgeRef(grammarFailureInput("goal-uri", { pairingAmbiguous: true, ungoverned: false }))).toBe(
+      "ambiguous-ref-pairing"
+    );
+    expect(classifyKnowledgeRef(grammarFailureInput("repo-path", { pairingAmbiguous: false, ungoverned: true }))).toBe(
+      "ungoverned-syntax"
+    );
+  });
+
+  it.effect("an undecodable goal manifest fails the run closed", () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(
+        scanFixture({
+          "docs/guide.md": "Tracks repo://goal/example-packet today.\n",
+          "goals/example-packet/ops/manifest.json": '{"initiative":{"id":"example-packet","status":"active"}}',
+        })
+      );
+      expect(error.message).toContain("goals/example-packet/ops/manifest.json");
+      expect(error.message).toContain("does not decode");
+    })
+  );
+
+  it.effect("an unparseable goal manifest fails the run closed", () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(
+        scanFixture({
+          "docs/guide.md": "Tracks repo://goal/example-packet today.\n",
+          "goals/example-packet/ops/manifest.json": "not json at all",
+        })
+      );
+      expect(error.message).toContain("does not parse as JSON");
+    })
+  );
+});
+
+/**
+ * Independent anchor recount, written against the published inventory method rather than against the
+ * census implementation: every scoped regular blob at any extension, binary blobs skipped on a NUL
+ * byte, lossy UTF-8 decoding, and substring counts for the five baseline anchors.
+ */
+const BASELINE_SCOPE_ROOT_FILES = HashSet.make("AGENTS.md", "CLAUDE.md");
+const BASELINE_SCOPE_PREFIXES: ReadonlyArray<string> = [
+  "goals/",
+  "explorations/",
+  "docs/",
+  ".claude/",
+  ".agents/",
+  ".codex/",
+  "standards/",
+  ".github/",
+];
+const BASELINE_EXCLUDED_PREFIXES: ReadonlyArray<string> = ["docs/generated/", "docs/_internal/"];
+const BASELINE_ARCHIVAL_SEGMENTS = HashSet.make(
+  "history",
+  "research",
+  "reviews",
+  "synthesis",
+  "findings",
+  "outputs",
+  "reflections",
+  "logs",
+  ".proofs"
+);
+const BASELINE_ELECTED_EXTENSIONS: ReadonlyArray<string> = [
+  ".md",
+  ".json",
+  ".jsonc",
+  ".jsonl",
+  ".toml",
+  ".yml",
+  ".yaml",
+];
+
+const baselineInScope = (path: string): boolean =>
+  HashSet.has(BASELINE_SCOPE_ROOT_FILES, path) ||
+  (A.some(BASELINE_SCOPE_PREFIXES, (prefix) => Str.startsWith(prefix)(path)) &&
+    !A.some(BASELINE_EXCLUDED_PREFIXES, (prefix) => Str.startsWith(prefix)(path)));
+
+const baselineIsArchival = (path: string): boolean =>
+  A.some(Str.split("/")(path), (segment) => HashSet.has(BASELINE_ARCHIVAL_SEGMENTS, segment));
+
+const baselineIsElected = (path: string): boolean =>
+  A.some(BASELINE_ELECTED_EXTENSIONS, (extension) => Str.endsWith(extension)(path));
+
+const lossyDecoder = new TextDecoder("utf-8");
+
+const countOccurrences = (text: string, pattern: RegExp): number =>
+  O.match(Str.match(pattern)(text), { onNone: () => 0, onSome: A.length });
+
+type AnchorTally = {
+  readonly homeAbsolute: number;
+  readonly homeRelative: number;
+  readonly temp: number;
+  readonly runMedia: number;
+  readonly bareTree: number;
+};
+
+const emptyTally: AnchorTally = { homeAbsolute: 0, homeRelative: 0, temp: 0, runMedia: 0, bareTree: 0 };
+
+const tallyText = (text: string): AnchorTally => ({
+  homeAbsolute: countOccurrences(text, /\/home\//gu),
+  homeRelative: countOccurrences(text, /~\//gu),
+  temp: countOccurrences(text, /\/tmp\//gu),
+  runMedia: countOccurrences(text, /\/run\/media\//gu),
+  bareTree: countOccurrences(text, /(?<!\/)YeeBois/gu),
+});
+
+const tallyTotal = (tally: AnchorTally): number =>
+  tally.homeAbsolute + tally.homeRelative + tally.temp + tally.runMedia + tally.bareTree;
+
+const addTally = (left: AnchorTally, right: AnchorTally): AnchorTally => ({
+  homeAbsolute: left.homeAbsolute + right.homeAbsolute,
+  homeRelative: left.homeRelative + right.homeRelative,
+  temp: left.temp + right.temp,
+  runMedia: left.runMedia + right.runMedia,
+  bareTree: left.bareTree + right.bareTree,
+});
+
+type AnchorCensus = {
+  readonly tally: AnchorTally;
+  readonly occurrences: number;
+  readonly files: number;
+  readonly live: number;
+  readonly archival: number;
+};
+
+const emptyCensus: AnchorCensus = { tally: emptyTally, occurrences: 0, files: 0, live: 0, archival: 0 };
+
+const addFile = (census_: AnchorCensus, path: string, tally: AnchorTally): AnchorCensus => {
+  const total = tallyTotal(tally);
+  if (total === 0) {
+    return census_;
+  }
+  const archival = baselineIsArchival(path);
+  return {
+    tally: addTally(census_.tally, tally),
+    occurrences: census_.occurrences + total,
+    files: census_.files + 1,
+    live: archival ? census_.live : census_.live + total,
+    archival: archival ? census_.archival + total : census_.archival,
+  };
+};
+
+const countIndependently = Effect.fn("KnowledgeRefsTest.countIndependently")(function* (oracle: KnowledgeTreeOracle) {
+  const scoped = A.filter(
+    oracle.trackedEntries,
+    (entry) => baselineInScope(entry.path) && (entry.mode === "100644" || entry.mode === "100755")
+  );
+  let all = emptyCensus;
+  let elected = emptyCensus;
+  for (const entry of scoped) {
+    const bytes = yield* oracle.readBytes(entry.path);
+    if (bytes.includes(0)) {
+      continue;
+    }
+    const tally = tallyText(lossyDecoder.decode(bytes));
+    all = addFile(all, entry.path, tally);
+    if (baselineIsElected(entry.path)) {
+      elected = addFile(elected, entry.path, tally);
+    }
+  }
+  return { all, elected, population: A.length(scoped) };
+});
+
+const hostObservations = (report: KnowledgeRefsReport): ReadonlyArray<KnowledgeRefObservation> =>
+  A.filter(report.observations, (observation) => observation.ref.kind === "host-path");
+
+const anchorCount = (observations: ReadonlyArray<KnowledgeRefObservation>, anchor: string): number =>
+  A.length(A.filter(anchorsOf(observations), (value) => value === anchor));
+
+const baselineLayer = Layer.mergeAll(NodeServices.layer, NodeCrypto.layer);
+
+describe("knowledge refs baseline agreement", () => {
+  it.effect(
+    "the census reconciles with the published clone-agnosticism inventory",
+    () =>
+      Effect.gen(function* () {
+        const oracle = yield* makeKnowledgeTreeOracle(BASELINE_COMMIT);
+        const independent = yield* countIndependently(oracle);
+        const report = yield* scanKnowledgeRefsTree(oracle);
+
+        // Side one: the independent counter must reproduce every published inventory number.
+        expect(independent.population).toBe(3805 - 4);
+        expect({
+          occurrences: independent.all.occurrences,
+          files: independent.all.files,
+          live: independent.all.live,
+          archival: independent.all.archival,
+        }).toEqual({ occurrences: 1741, files: 406, live: 298, archival: 1443 });
+        expect(independent.all.tally).toEqual({
+          homeAbsolute: 1060,
+          homeRelative: 401,
+          temp: 195,
+          runMedia: 0,
+          bareTree: 85,
+        });
+
+        // Side two: the census must equal that counter restricted to the elected extensions.
+        const host = hostObservations(report);
+        const hostFiles = HashSet.size(HashSet.fromIterable(A.map(host, (observation) => observation.documentId)));
+        const hostLive = A.length(A.filter(host, (observation) => KnowledgeRefSurface.is.live(observation.surface)));
+        const observed = {
+          occurrences: A.length(host),
+          files: hostFiles,
+          live: hostLive,
+          archival: A.length(host) - hostLive,
+        };
+        expect(observed).toEqual({
+          occurrences: independent.elected.occurrences,
+          files: independent.elected.files,
+          live: independent.elected.live,
+          archival: independent.elected.archival,
+        });
+        expect(observed).toEqual({ occurrences: 1158, files: 291, live: 287, archival: 871 });
+        expect({
+          homeAbsolute: anchorCount(host, "home-absolute"),
+          homeRelative: anchorCount(host, "home-relative"),
+          temp: anchorCount(host, "temp"),
+          bareTree: anchorCount(host, "encoded-home") + anchorCount(host, "bare-tree-name"),
+        }).toEqual({
+          homeAbsolute: independent.elected.tally.homeAbsolute,
+          homeRelative: independent.elected.tally.homeRelative,
+          temp: independent.elected.tally.temp,
+          bareTree: independent.elected.tally.bareTree,
+        });
+        expect({
+          homeAbsolute: anchorCount(host, "home-absolute"),
+          homeRelative: anchorCount(host, "home-relative"),
+          temp: anchorCount(host, "temp"),
+          bareTree: anchorCount(host, "encoded-home") + anchorCount(host, "bare-tree-name"),
+        }).toEqual({ homeAbsolute: 630, homeRelative: 382, temp: 122, bareTree: 24 });
+
+        // No elected-extension blob fails strict UTF-8 at this snapshot, so only links are skipped.
+        expect(
+          A.map(
+            A.filter(report.skipped, (blob) => blob.reason === "malformed-utf8"),
+            (blob) => blob.path
+          )
+        ).toEqual([]);
+      }).pipe(Effect.scoped, provideScopedLayer(baselineLayer)),
+    BASELINE_TIMEOUT_MS
+  );
+});

--- a/packages/tooling/tool/cli/test/knowledge-refs.test.ts
+++ b/packages/tooling/tool/cli/test/knowledge-refs.test.ts
@@ -416,6 +416,26 @@ describe("knowledge refs negative controls", () => {
     })
   );
 
+  it.effect("a goal manifest tracked as a symlink is skipped, not followed, and does not resolve", () =>
+    Effect.gen(function* () {
+      const report = yield* scanFixture(
+        {
+          "docs/guide.md": "Tracks repo://goal/example-packet today.\n",
+          "goals/example-packet/ops/manifest.json": goalManifestText("example-packet"),
+        },
+        {
+          modes: { "goals/example-packet/ops/manifest.json": "120000" },
+          // The archive drops link entries, so a run that succeeds never tried to read it.
+          unreadable: ["goals/example-packet/ops/manifest.json"],
+        }
+      );
+      expect(A.map(report.skipped, (blob) => `${blob.reason} ${blob.path}`)).toEqual([
+        "symlink goals/example-packet/ops/manifest.json",
+      ]);
+      expect(verdicts(inDocument(report, "docs/guide.md"))).toEqual(["broken-target/missing"]);
+    })
+  );
+
   it.effect("a gitlink is skipped", () =>
     Effect.gen(function* () {
       const report = yield* scanFixture(

--- a/standards/schema-first.inventory.jsonc
+++ b/standards/schema-first.inventory.jsonc
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedOn": "2026-08-06",
+  "generatedOn": "2026-08-07",
   "scope": ["apps/**/*.{ts,tsx}", "packages/**/*.{ts,tsx}", "infra/**/*.ts"],
   "entries": [
     {
@@ -482,6 +482,46 @@
       "reason": "Scoped test resource intentionally couples a live StartedTestContainer with its connection metadata for use and teardown."
     },
     {
+      "file": "packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.refs.ts",
+      "symbol": "KnowledgeDocumentLine",
+      "kind": "exported-type-literal",
+      "status": "exception",
+      "owner": "@beep/repo-cli",
+      "reason": "Line-scanner intermediate pairing one raw document line with its 1-based number and ratified fence verdict; produced and consumed inside a single census pass and never decoded or persisted, while every value it flows into (KnowledgeRefObservation, KnowledgeRefsReport) is schema-backed."
+    },
+    {
+      "file": "packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.refs.ts",
+      "symbol": "KnowledgeHostAnchorMatch",
+      "kind": "exported-type-literal",
+      "status": "exception",
+      "owner": "@beep/repo-cli",
+      "reason": "Lexical host-anchor match intermediate (anchor, containing token, column) consumed in the same extraction pass that produced it; the anchor member is already schema-backed by KnowledgeHostAnchor and the observation it becomes is a schema class, so the intermediate has no decode or persistence boundary."
+    },
+    {
+      "file": "packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.refs.ts",
+      "symbol": "KnowledgeInlineSpan",
+      "kind": "exported-type-literal",
+      "status": "exception",
+      "owner": "@beep/repo-cli",
+      "reason": "Inline-code span intermediate from the shared Markdown reader (span text plus 1-based column); assembled from RegExp matches in-process and consumed by the same line pass, never decoded or persisted."
+    },
+    {
+      "file": "packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.refs.ts",
+      "symbol": "KnowledgeRefClassificationInput",
+      "kind": "exported-type-literal",
+      "status": "exception",
+      "owner": "@beep/repo-cli",
+      "reason": "Pure classifier input carrying Option-typed per-bus fields for the ordered rule table; constructed in-process from schema-backed candidates and consumed synchronously by classifyKnowledgeRef, never decoded from external data or persisted."
+    },
+    {
+      "file": "packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.refs.ts",
+      "symbol": "KnowledgeTreeOracle",
+      "kind": "exported-interface",
+      "status": "exception",
+      "owner": "@beep/repo-cli",
+      "reason": "Injected single-tree read seam, the census counterpart of KnowledgeArchiveOracle's recorded exception: readBytes is an Effectful read over an extracted Git archive, trackedEntries is already schema-backed by KnowledgeTrackedEntry, and treeish/commit are validated into the schema-backed KnowledgeRefsReport. The seam is constructed in-process by the live layer and by golden fixtures, so it has no decode or persistence boundary."
+    },
+    {
       "file": "packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.service.ts",
       "symbol": "KnowledgeArchiveOracle",
       "kind": "exported-interface",
@@ -507,16 +547,6 @@
     },
     {
       "file": "packages/tooling/tool/cli/src/commands/Quality/internal/JSDocMigrateApply.ts",
-      "symbol": "partitionMigratedOrphans",
-      "kind": "schema-policy-advisory",
-      "status": "exception",
-      "ruleId": "SFV4-fn-schema",
-      "line": 233,
-      "owner": "@beep/repo-cli",
-      "reason": "Pure partition over in-memory anchor strings and scanned-block lookups; the inline pair of anchor arrays is transient control flow for the apply re-run tolerance, never decoded or persisted."
-    },
-    {
-      "file": "packages/tooling/tool/cli/src/commands/Quality/internal/JSDocMigrateApply.ts",
       "symbol": "computeJSDocMigrateBinding",
       "kind": "schema-policy-advisory",
       "status": "exception",
@@ -524,6 +554,16 @@
       "line": 178,
       "owner": "@beep/repo-cli",
       "reason": "Pure comparison over already schema-decoded record sets; the inline input trio groups arrays of S.Class rows at the call site rather than modeling an IO boundary, and the output is the annotated JSDocMigrateBindingReport class."
+    },
+    {
+      "file": "packages/tooling/tool/cli/src/commands/Quality/internal/JSDocMigrateApply.ts",
+      "symbol": "partitionMigratedOrphans",
+      "kind": "schema-policy-advisory",
+      "status": "exception",
+      "ruleId": "SFV4-fn-schema",
+      "line": 233,
+      "owner": "@beep/repo-cli",
+      "reason": "Pure partition over in-memory anchor strings and scanned-block lookups; the inline pair of anchor arrays is transient control flow for the apply re-run tolerance, never decoded or persisted."
     },
     {
       "file": "packages/tooling/tool/cli/src/commands/Quality/internal/JSDocMigrateExtract.ts",


### PR DESCRIPTION
## What

`bun run beep knowledge refs [--tree <rev>] [--surface live|archival|all] [--json]` — the Workstream A phase-0 read-only census for `goals/knowledge-surface-automation`. One Git tree's agent-facing corpus is scanned on three buses (repository paths, machine-local host paths, `repo://goal/*` identities), resolved **against the tree's tracked entries alone** (never the working filesystem), and classified by a total twelve-class pure rule table. Observations carry versioned `knowledge-ref/v1` SHA-256 identities with length-prefixed preimages; the report is byte-stable under tracked-entry permutation.

Structure: `Knowledge.refs.ts` (ref schemas, shared Markdown scanning machinery, pure classifier, tree evaluator) + `KnowledgeServiceShape.refsTree` with the injectable `KnowledgeTreeOracle` seam + command registration beside `semantic-delta`. The shared machinery (governed path normalization, fence-aware line reader, inline-span reader, length-prefixed digests) moved out of `Knowledge.service.ts` into `Knowledge.refs.ts`, so Stage-1 enforcement and the census read documents through one grammar.

## Doctrine

Implements `research/p1-refs-tree-design.md` under the ratified T2 mini-grill decisions A1–A7 and the P2 grill's A1 (`beep:ref` same-line/heading-scope pairing) and A2 — sealed inputs, not relitigated here.

## Evidence (E4)

Committed live-run report: `goals/knowledge-surface-automation/research/p1-report-refs-tree.md` (host paths redacted to `<HOME>`; the packet's verification grep stays green). Headline: 18,433 observations at HEAD; the census at the frozen inventory SHA reproduces the published baseline **exactly** — 1,158 host occurrences / 291 files / 287 live / 871 archival, with the inventory's 1,741 / 406 / 298 / 1,443 decomposing as census population plus 583 occurrences in non-elected extensions (`.log` 484, `.inventory` 38, `.sh` 32, `.txt` 15, `.diff` 10, `.tsv` 4). The committed baseline-agreement test re-derives both sides of that reconciliation on every run.

## Tests

65 passing in the knowledge suites: the design doc's full 22-case golden fixture matrix, negative controls (byte-identical JSON under entry permutation, symlink/gitlink skip, rename lineage, encoded-home vs bare-tree-name anchors), classifier-order units (pattern-literal outranks archival), fail-closed goal-manifest decode, and the two-sided baseline-agreement test.

## Scope guard

Read-only census: exit 0 for every observation mix, no `--fix`/`--write`, no rewrite pass, no `relink`/`rename --plan`, no dual-write insertion, no lint-lane wiring. P3 mutation work stays gated on the FP eyeball (E5, per-workstream unlock).

## Deviations & notes

- `knowledgeRefsCommand` registers in `Knowledge.command.ts` beside `knowledgeSemanticDeltaCommand` instead of inside `Knowledge.refs.ts` as the design doc's placement list said: that placement is an import cycle, since `refs.ts` is the shared-parser home `service.ts` imports from. Family convention preserved.
- Five scanner-machinery types (`KnowledgeTreeOracle`, classifier/scanner intermediates) are recorded as justified schema-first inventory exceptions — they carry Effect members or are in-process intermediates; every serialized value stays schema-backed.
- Census runtime at HEAD scale is ~1m45s after replacing quadratic array accumulation with single-allocation passes (behavior byte-identical).
- Also fixes an inherited unredacted host path in `research/p1-context-pruning-analysis.md` that had the packet's own verification grep red on main (receipt in the packet ledger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788675248&installation_model_id=424656&pr_number=613&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F613&signature=975a90f0b2f1fdbc8700429fe0325dee96ece3a8033ad1aadda3f84d1a26e6e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->