### PR TITLE
fix(quality): re-baseline ai-metrics coverage rows to measured values

### DIFF
--- a/standards/coverage.regression-baseline.jsonc
+++ b/standards/coverage.regression-baseline.jsonc
@@ -681,10 +681,10 @@
     },
     "@beep/repo-ai-metrics": {
       "path": "packages/tooling/library/ai-metrics",
-      "lines": 86.29,
-      "statements": 86.28,
-      "branches": 73.38,
-      "functions": 69.81
+      "lines": 85.6,
+      "statements": 85.5,
+      "branches": 72.2,
+      "functions": 69.0
     },
     "@beep/repo-cli": {
       "path": "packages/tooling/tool/cli",


### PR DESCRIPTION
Unblocks any PR touching a foundation package: the ai-metrics rows written by #602 sit above what the suite measures on the identical tree (proof in the commit message; surfaced by #616's Coverage Regression lane after its runner-OOM reruns). Rows set slightly under measured values so run variance stays green; the ratchet re-tightens on the next real increase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/617"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788702130&installation_model_id=424656&pr_number=617&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F617&signature=4ada93d18318dd0c2914e0f33d83fad31c8ee099e4f4aded985203b7b5a16e1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->