### PR TITLE
ci(runners): move heavy lanes onto the owned beep-ec2-heavy fleet

### DIFF
--- a/.changeset/heavy-lanes-to-ec2.md
+++ b/.changeset/heavy-lanes-to-ec2.md
@@ -1,0 +1,8 @@
+---
+{}
+---
+
+No release: move the four memory-heavy CI lanes (Check, Test Integration,
+Coverage Regression, Docgen) and the push-only Build job onto the owned
+`beep-ec2-heavy` EC2 spot runners; duplicate the image-size advisory triage so
+this branch's proof is self-sufficient.

--- a/.github/actions/setup-monorepo-ci/action.yml
+++ b/.github/actions/setup-monorepo-ci/action.yml
@@ -27,6 +27,12 @@ runs:
       uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       with:
         bun-version-file: .bun-version
+        # The fleet is heterogeneous (GitHub-hosted + owned beep-ec2 workers):
+        # setup-bun's cross-job cache stores absolute paths from the SAVING
+        # runner's home, which poisons restores on runners with a different
+        # layout (fleet run 31245263696: "Cache restored successfully" followed
+        # by bun missing at $HOME/.bun). A fresh ~2s download is deterministic.
+        no-cache: "true"
 
     - name: Setup Node.js
       if: ${{ inputs.use-node == 'true' }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -74,7 +74,7 @@ jobs:
             install_typos: "false"
           - id: check
             name: Check
-            runner: ubuntu-24.04
+            runner: beep-ec2-heavy
             timeout_minutes: 120
             uses_turbo: "true"
             install_typos: "false"
@@ -86,19 +86,19 @@ jobs:
             install_typos: "false"
           - id: test-integration
             name: Test Integration
-            runner: ubuntu-24.04
+            runner: beep-ec2-heavy
             timeout_minutes: 40
             uses_turbo: "true"
             install_typos: "false"
           - id: coverage
             name: Coverage Regression
-            runner: ubuntu-24.04
+            runner: beep-ec2-heavy
             timeout_minutes: 80
             uses_turbo: "true"
             install_typos: "false"
           - id: docgen
             name: Docgen
-            runner: ubuntu-24.04
+            runner: beep-ec2-heavy
             timeout_minutes: 60
             uses_turbo: "false"
             install_typos: "false"
@@ -554,7 +554,7 @@ jobs:
   build:
     name: Build
     if: github.event_name == 'push'
-    runs-on: ubuntu-24.04
+    runs-on: beep-ec2-heavy
     timeout-minutes: 40
     permissions:
       contents: read

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -28,6 +28,16 @@ id = "GHSA-xcpc-8h2w-3j85"
 ignoreUntil = 2026-09-15T00:00:00Z
 reason = "adm-zip advisory affecting <0.6.0 (0.5.18 present in the tree); fixed in 0.6.0. adm-zip is a transitive dependency of onnxruntime-node@1.27.0 (via @beep/face-detection), whose range ^0.5.16 cannot resolve to 0.6.0 — no lockfile bump fixes this without a root override against onnxruntime-node's declared range. Newly published advisory, not introduced by the current PR (identical version present on main); tracked for removal when onnxruntime-node widens its adm-zip range. Revisit on the next onnxruntime-node release."
 
+[[IgnoredVulns]]
+id = "GHSA-w3rx-r6r6-pgpr"
+ignoreUntil = 2026-09-15T00:00:00Z
+reason = "image-size ICNS-parser infinite-loop DoS affecting <=2.0.2; 2.0.2 IS the npm latest, so no fixed release exists to bump to (verified against the registry 2026-08-08). image-size is a direct dependency of @beep/repo-cli used only by the operator-invoked media tooling (Files/internal/Media*) over locally produced QA artifacts; the DoS requires attacker-supplied ICNS input and no CI lane feeds untrusted files to it, so worst case is an infinite loop inside a timeboxed job. Newly published advisory, not introduced by the current PR (identical version on main; main's Security lane is red on the same finding). Revisit when image-size publishes a release above 2.0.2."
+
+[[IgnoredVulns]]
+id = "GHSA-5p2g-fcmc-qvqq"
+ignoreUntil = 2026-09-15T00:00:00Z
+reason = "image-size JXL/HEIF-parser infinite-loop DoS affecting <=2.0.2; same package, same exposure, and same no-fixed-release status as GHSA-w3rx-r6r6-pgpr above. Revisit when image-size publishes a release above 2.0.2."
+
 [[PackageOverrides]]
 name = "effect"
 version = "https://pkg.pr.new/Effect-TS/effect-smol/effect@51f6d19"


### PR DESCRIPTION
## ci(runners): move heavy lanes onto the owned beep-ec2-heavy fleet

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- full:pre-push: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/ci_heavy-lanes-to-ec2-d195bb0cf9c2/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/620"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788764533&installation_model_id=424656&pr_number=620&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F620&signature=2a08b1f52ad434d80cf66a7d8906553569db79629a90240eaf9afa6476b5a5ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->