### PR TITLE
fix(repo-cli): address the PR 628 post-merge review round

### DIFF
--- a/.changeset/widgets-628-review.md
+++ b/.changeset/widgets-628-review.md
@@ -1,0 +1,10 @@
+---
+{}
+---
+
+No release: address the PR #628 post-merge review round — nine fixes
+(unproven-gate rendering, explicit --runs contract, all-attempt job
+collection, even-median math, typed gh-api failures, pid-namespaced merge
+previews, remediation-command corrections, lead-paragraph module docs, strict
+run_attempt decode) and one recorded decline (proof-provenance staleness
+waits on the ProofState.laneProofs contract).

--- a/packages/tooling/tool/cli/src/commands/Ci/LaneTimings.ts
+++ b/packages/tooling/tool/cli/src/commands/Ci/LaneTimings.ts
@@ -1,5 +1,7 @@
 /**
- * Hosted CI lane timings, collected per job with attempt-aware provenance.
+ * Hosted CI lane timings collected per job with attempt-aware provenance.
+ *
+ * **Details**
  *
  * The lane-timings numbers this repo reasons about used to be gathered ad hoc
  * from `gh run`, and one of those numbers was an artifact. Run-level
@@ -10,8 +12,6 @@
  * not runner wait. Actual pickup, measured at job level in the same window, was
  * 19–67 seconds — and "PRs are blocked because no runners are available" was
  * falsified as a justification for an entire project.
- *
- * **Details**
  *
  * The correction is structural, not procedural: the attempt filter lives in the
  * collector, so a reader cannot forget it. {@link ciLaneTimingRow} returns
@@ -48,6 +48,7 @@ import * as S from "effect/Schema";
 import { Command, Flag } from "effect/unstable/cli";
 import { detectGithubJobShapeClass, GithubJobRecord, GithubJobStepRecord } from "../../internal/github/index.ts";
 import { runRepoCommandCapture } from "../../internal/repo-run/index.ts";
+import { CiCommandError } from "./Ci.errors.ts";
 import type { ChildProcessSpawner } from "effect/unstable/process";
 
 const $I = $RepoCliId.create("commands/Ci/LaneTimings");
@@ -128,7 +129,7 @@ export class CiWorkflowJob extends S.Class<CiWorkflowJob>($I`CiWorkflowJob`)(
     id: S.Finite,
     labels: S.Array(S.String).pipe(SchemaUtils.withKeyDefaults([])),
     name: S.String,
-    run_attempt: S.Finite.pipe(SchemaUtils.withKeyDefaults(1)),
+    run_attempt: S.Finite,
     run_id: S.Finite,
     runner_name: S.NullOr(S.String).pipe(SchemaUtils.withKeyDefaults(null)),
     started_at: S.NullOr(S.String),
@@ -484,9 +485,20 @@ export const withCiLanePeakRss = (
 const numberOrder = Order.Number;
 
 const medianOf = (values: ReadonlyArray<number>): O.Option<number> =>
-  pipe(A.sort(values, numberOrder), (sorted) =>
-    A.isReadonlyArrayEmpty(sorted) ? O.none() : O.fromNullishOr(sorted[Math.floor(A.length(sorted) / 2)])
-  );
+  pipe(A.sort(values, numberOrder), (sorted) => {
+    const length = A.length(sorted);
+    if (length === 0) {
+      return O.none();
+    }
+    const middle = Math.floor(length / 2);
+    return length % 2 === 0
+      ? O.zipWith(
+          O.fromNullishOr(sorted[middle - 1]),
+          O.fromNullishOr(sorted[middle]),
+          (left, right) => (left + right) / 2
+        )
+      : O.fromNullishOr(sorted[middle]);
+  });
 
 /**
  * Aggregate collected rows into the report operators read.
@@ -663,11 +675,18 @@ const decodeCiWorkflowRunsPage = S.decodeUnknownEffect(S.fromJsonString(CiWorkfl
 const ghApiJson = Effect.fn("Ci.laneTimingsGhApi")(function* (
   repoRoot: string,
   endpoint: string
-): Effect.fn.Return<O.Option<string>, never, ChildProcessSpawner.ChildProcessSpawner> {
+): Effect.fn.Return<string, CiCommandError, ChildProcessSpawner.ChildProcessSpawner> {
   const result = yield* runRepoCommandCapture("gh", ["api", endpoint], repoRoot).pipe(
-    Effect.orElseSucceed(() => ({ exitCode: 1, output: Str.empty, truncated: false }))
+    CiCommandError.mapError(`Failed to run gh api ${endpoint}.`)
   );
-  return result.exitCode === 0 && !result.truncated ? O.some(result.output) : O.none();
+  if (result.exitCode !== 0 || result.truncated) {
+    return yield* CiCommandError.make({
+      message: result.truncated
+        ? `gh api ${endpoint} returned a truncated response.`
+        : `gh api ${endpoint} exited ${result.exitCode}: ${result.output}`,
+    });
+  }
+  return result.output;
 });
 
 /**
@@ -685,9 +704,9 @@ const ghApiJson = Effect.fn("Ci.laneTimingsGhApi")(function* (
  * GitHub rewrites on re-dispatch; the job record carries `run_attempt`, which
  * is what makes the filter possible at all.
  *
- * A run whose jobs cannot be fetched is skipped rather than failing the sweep,
- * because a partial corpus is more useful than none — and the row count is
- * reported so a reader can see how partial it is.
+ * API failures, truncated captures, and invalid payloads fail the collection.
+ * Returning an empty or partial corpus would make unavailable evidence look
+ * like a successful observation of zero runs or jobs.
  *
  * **Example** (Collect timings through the test seam)
  *
@@ -708,31 +727,24 @@ const ghApiJson = Effect.fn("Ci.laneTimingsGhApi")(function* (
 export const collectCiLaneTimings = Effect.fn("Ci.collectCiLaneTimings")(function* (
   repoRoot: string,
   runLimit: number
-): Effect.fn.Return<CiLaneTimingsReport, never, ChildProcessSpawner.ChildProcessSpawner> {
-  const runsJson = yield* ghApiJson(
-    repoRoot,
-    `repos/{owner}/{repo}/actions/runs?per_page=${Math.max(1, Math.min(runLimit, 100))}`
+): Effect.fn.Return<CiLaneTimingsReport, CiCommandError, ChildProcessSpawner.ChildProcessSpawner> {
+  if (runLimit < 1 || runLimit > 100) {
+    return yield* CiCommandError.make({ message: `--runs must be between 1 and 100; received ${runLimit}.` });
+  }
+  const runsJson = yield* ghApiJson(repoRoot, `repos/{owner}/{repo}/actions/runs?per_page=${runLimit}`);
+  const runs = yield* decodeCiWorkflowRunsPage(runsJson).pipe(
+    Effect.map((page) => page.workflow_runs),
+    CiCommandError.mapError("Failed to decode the workflow-runs response.")
   );
-  const runs = yield* O.match(runsJson, {
-    onNone: () => Effect.succeed(A.empty<CiWorkflowRun>()),
-    onSome: (json) =>
-      decodeCiWorkflowRunsPage(json).pipe(
-        Effect.map((page) => page.workflow_runs),
-        Effect.orElseSucceed(A.empty<CiWorkflowRun>)
-      ),
-  });
   const jobPages = yield* Effect.forEach(
     runs,
     Effect.fnUntraced(function* (run: CiWorkflowRun) {
-      const json = yield* ghApiJson(repoRoot, `repos/{owner}/{repo}/actions/runs/${run.id}/jobs?per_page=100`);
-      return yield* O.match(json, {
-        onNone: () => Effect.succeed(A.empty<CiWorkflowJob>()),
-        onSome: (payload) =>
-          decodeCiWorkflowJobsPage(payload).pipe(
-            Effect.map((page) => page.jobs),
-            Effect.orElseSucceed(A.empty<CiWorkflowJob>)
-          ),
-      });
+      const endpoint = `repos/{owner}/{repo}/actions/runs/${run.id}/jobs?filter=all&per_page=100`;
+      const json = yield* ghApiJson(repoRoot, endpoint);
+      return yield* decodeCiWorkflowJobsPage(json).pipe(
+        Effect.map((page) => page.jobs),
+        CiCommandError.mapError(`Failed to decode the jobs response for run ${run.id}.`)
+      );
     }),
     { concurrency: 4 }
   );
@@ -740,7 +752,7 @@ export const collectCiLaneTimings = Effect.fn("Ci.collectCiLaneTimings")(functio
 });
 
 const runLimitFlag = Flag.integer("runs").pipe(
-  Flag.withDescription("How many recent workflow runs to read jobs for"),
+  Flag.withDescription("How many recent workflow runs to read jobs for (1-100)"),
   Flag.withDefault(20)
 );
 

--- a/packages/tooling/tool/cli/src/commands/Ci/LaneTimings.ts
+++ b/packages/tooling/tool/cli/src/commands/Ci/LaneTimings.ts
@@ -689,6 +689,30 @@ const ghApiJson = Effect.fn("Ci.laneTimingsGhApi")(function* (
   return result.output;
 });
 
+const collectCiWorkflowJobPages = Effect.fn("Ci.collectCiWorkflowJobPages")(function* (
+  repoRoot: string,
+  runId: number,
+  pageNumber: number,
+  collected: ReadonlyArray<CiWorkflowJob>
+): Effect.fn.Return<ReadonlyArray<CiWorkflowJob>, CiCommandError, ChildProcessSpawner.ChildProcessSpawner> {
+  const endpoint = `repos/{owner}/{repo}/actions/runs/${runId}/jobs?filter=all&per_page=100&page=${pageNumber}`;
+  const json = yield* ghApiJson(repoRoot, endpoint);
+  const page = yield* decodeCiWorkflowJobsPage(json).pipe(
+    CiCommandError.mapError(`Failed to decode jobs page ${pageNumber} for run ${runId}.`)
+  );
+  const jobs = A.appendAll(collected, page.jobs);
+  if (A.length(jobs) >= page.total_count) {
+    return jobs;
+  }
+  return yield* A.match(page.jobs, {
+    onEmpty: () =>
+      CiCommandError.make({
+        message: `Jobs pagination for run ${runId} ended after ${A.length(jobs)} of ${page.total_count} jobs.`,
+      }),
+    onNonEmpty: () => collectCiWorkflowJobPages(repoRoot, runId, pageNumber + 1, jobs),
+  });
+});
+
 /**
  * Collect lane timings for the most recent workflow runs.
  *
@@ -736,18 +760,9 @@ export const collectCiLaneTimings = Effect.fn("Ci.collectCiLaneTimings")(functio
     Effect.map((page) => page.workflow_runs),
     CiCommandError.mapError("Failed to decode the workflow-runs response.")
   );
-  const jobPages = yield* Effect.forEach(
-    runs,
-    Effect.fnUntraced(function* (run: CiWorkflowRun) {
-      const endpoint = `repos/{owner}/{repo}/actions/runs/${run.id}/jobs?filter=all&per_page=100`;
-      const json = yield* ghApiJson(repoRoot, endpoint);
-      return yield* decodeCiWorkflowJobsPage(json).pipe(
-        Effect.map((page) => page.jobs),
-        CiCommandError.mapError(`Failed to decode the jobs response for run ${run.id}.`)
-      );
-    }),
-    { concurrency: 4 }
-  );
+  const jobPages = yield* Effect.forEach(runs, (run) => collectCiWorkflowJobPages(repoRoot, run.id, 1, A.empty()), {
+    concurrency: 4,
+  });
   return ciLaneTimingsReport(A.map(A.flatten(jobPages), ciLaneTimingRow));
 });
 

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/GateStaleness.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/GateStaleness.ts
@@ -44,7 +44,11 @@ import {
   coverageRegressionBaselinePath,
   coverageRegressionRegenerationCommand,
 } from "../../Quality/internal/CoverageRegression.ts";
-import { defaultJSDocTotalsBaselinePath, jsdocTotalsSnapshotCommand } from "../../Quality/internal/JSDocRatchet.ts";
+import {
+  defaultJSDocTotalsBaselinePath,
+  jsdocInventoryRegenerationCommand,
+  jsdocTotalsSnapshotCommand,
+} from "../../Quality/internal/JSDocRatchet.ts";
 import {
   collectStagedPublishPaths,
   collectUnstagedTrackedPaths,
@@ -279,7 +283,7 @@ export const YEET_GATE_ARTIFACT_DESCRIPTORS: ReadonlyArray<GateArtifactDescripto
     artifactPath: defaultJSDocTotalsBaselinePath,
     gateId: "jsdoc-totals-ratchet",
     kind: "baseline",
-    regenerateCommand: jsdocTotalsSnapshotCommand,
+    regenerateCommand: `${jsdocInventoryRegenerationCommand} && ${jsdocTotalsSnapshotCommand}`,
   }),
   GateArtifactDescriptor.make({
     artifactPath: "standards/knip.regression-baseline.jsonc",

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/GateStaleness.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/GateStaleness.ts
@@ -40,8 +40,11 @@ import * as O from "effect/Option";
 import * as S from "effect/Schema";
 import { sortedUniquePaths } from "../../../internal/repo-run/index.ts";
 import { GOALS_DOCTOR_BASELINE_PATH } from "../../Goals/Doctor.ts";
-import { coverageRegressionBaselinePath } from "../../Quality/internal/CoverageRegression.ts";
-import { defaultJSDocTotalsBaselinePath } from "../../Quality/internal/JSDocRatchet.ts";
+import {
+  coverageRegressionBaselinePath,
+  coverageRegressionRegenerationCommand,
+} from "../../Quality/internal/CoverageRegression.ts";
+import { defaultJSDocTotalsBaselinePath, jsdocTotalsSnapshotCommand } from "../../Quality/internal/JSDocRatchet.ts";
 import {
   collectStagedPublishPaths,
   collectUnstagedTrackedPaths,
@@ -242,6 +245,7 @@ export const GateStalenessVerdict = S.Union([GateFresh, GateStale, GateUnproven]
 export type GateStalenessVerdict = typeof GateStalenessVerdict.Type;
 
 const isGateStale = S.is(GateStale);
+const isGateUnproven = S.is(GateUnproven);
 
 /**
  * The cached gate artifacts yeet knows how to judge for staleness.
@@ -269,25 +273,25 @@ export const YEET_GATE_ARTIFACT_DESCRIPTORS: ReadonlyArray<GateArtifactDescripto
     artifactPath: coverageRegressionBaselinePath,
     gateId: "coverage-regression",
     kind: "baseline",
-    regenerateCommand: "bun run beep quality coverage",
+    regenerateCommand: coverageRegressionRegenerationCommand,
   }),
   GateArtifactDescriptor.make({
     artifactPath: defaultJSDocTotalsBaselinePath,
     gateId: "jsdoc-totals-ratchet",
     kind: "baseline",
-    regenerateCommand: "bun run beep quality jsdoc-ratchet",
+    regenerateCommand: jsdocTotalsSnapshotCommand,
   }),
   GateArtifactDescriptor.make({
     artifactPath: "standards/knip.regression-baseline.jsonc",
     gateId: "knip-ratchet",
     kind: "baseline",
-    regenerateCommand: "bun run beep quality knip-ratchet",
+    regenerateCommand: "bun run beep quality knip --write-baseline",
   }),
   GateArtifactDescriptor.make({
     artifactPath: "standards/test-typecheck.blindspot-baseline.jsonc",
     gateId: "test-typecheck-blindspot",
     kind: "baseline",
-    regenerateCommand: "bun run beep lint package-test-typecheck",
+    regenerateCommand: "bun run beep lint package-test-typecheck --write-baseline",
   }),
   GateArtifactDescriptor.make({
     artifactPath: GOALS_DOCTOR_BASELINE_PATH,
@@ -385,6 +389,25 @@ export const staleGateVerdicts = (verdicts: ReadonlyArray<GateStalenessVerdict>)
   A.filter(verdicts, isGateStale);
 
 /**
+ * Keep only verdicts whose proof artifact or comparison input is absent.
+ *
+ * **Example** (Filter an unproven verdict)
+ *
+ * ```ts
+ * import { GateUnproven, unprovenGateVerdicts } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(unprovenGateVerdicts([GateUnproven.make({ gateId: "coverage-regression", detail: "artifact not found" })]).length)
+ * ```
+ *
+ * @param verdicts - Every verdict produced by one staleness pass.
+ * @returns Only unproven verdicts, in the order they were produced.
+ * @category detection
+ * @since 0.0.0
+ */
+export const unprovenGateVerdicts = (verdicts: ReadonlyArray<GateStalenessVerdict>): ReadonlyArray<GateUnproven> =>
+  A.filter(verdicts, isGateUnproven);
+
+/**
  * Render the gate-staleness line of a yeet status summary.
  *
  * **Details**
@@ -402,21 +425,26 @@ export const staleGateVerdicts = (verdicts: ReadonlyArray<GateStalenessVerdict>)
  * ```
  *
  * @param stale - Stale verdicts from one staleness pass.
+ * @param unproven - Verdicts whose proof artifact or comparison input is absent.
  * @returns The `gate staleness:` line plus one indented line per stale gate.
  * @category formatting
  * @since 0.0.0
  */
-export const renderYeetGateStalenessBlock = (stale: ReadonlyArray<GateStale>): string =>
-  A.isReadonlyArrayEmpty(stale)
+export const renderYeetGateStalenessBlock = (
+  stale: ReadonlyArray<GateStale>,
+  unproven: ReadonlyArray<GateUnproven> = []
+): string =>
+  A.isReadonlyArrayEmpty(stale) && A.isReadonlyArrayEmpty(unproven)
     ? "gate staleness: none"
     : A.join(
         [
-          `gate staleness: ${A.length(stale)} artifact(s) predate this branch's newest change`,
+          `gate staleness: ${A.length(stale)} stale, ${A.length(unproven)} unproven`,
           ...A.map(
             stale,
             (verdict) =>
               `  - ${verdict.gateId} (${verdict.kind}): ${verdict.artifactPath} is older than ${verdict.newestInputPath}; regenerate with \`${verdict.regenerateCommand}\``
           ),
+          ...A.map(unproven, (verdict) => `  - ${verdict.gateId} (unproven): ${verdict.detail}`),
         ],
         "\n"
       );

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/MergedPreview.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/MergedPreview.ts
@@ -70,7 +70,7 @@ const $I = $RepoCliId.create("commands/Yeet/internal/MergedPreview");
  * @category configuration
  * @since 0.0.0
  */
-export const YEET_MERGED_PREVIEW_DIR_NAME = "merged-preview";
+export const YEET_MERGED_PREVIEW_DIR_NAME = `merged-preview-${process.pid}`;
 
 /**
  * A merge preview whose tree merged cleanly.

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Status.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Status.ts
@@ -21,8 +21,10 @@ import { PrCloseoutReport } from "./Closeout.ts";
 import {
   collectYeetGateStaleness,
   GateStale,
+  GateUnproven,
   renderYeetGateStalenessBlock,
   staleGateVerdicts,
+  unprovenGateVerdicts,
 } from "./GateStaleness.ts";
 import { yeetCommentExcerpt } from "./MonitorComments.ts";
 import { YeetMergeReady, YeetMergeReadyCriteria, YeetMergeReadyCriterion, YeetVerdict } from "./Verdict.ts";
@@ -256,6 +258,7 @@ export class YeetStatusSnapshot extends S.Class<YeetStatusSnapshot>($I`YeetStatu
     worktree: YeetStatusWorktree,
     mergeReady: YeetMergeReady.pipe(S.OptionFromOptionalKey, SchemaUtils.withNoneDefault),
     staleGates: S.Array(GateStale).pipe(SchemaUtils.withKeyDefaults([])),
+    unprovenGates: S.Array(GateUnproven).pipe(SchemaUtils.withKeyDefaults([])),
   },
   $I.annote("YeetStatusSnapshot", {
     description: "Machine-readable status snapshot emitted by yeet status.",
@@ -1066,6 +1069,7 @@ export const collectYeetStatus = Effect.fn("YeetStatus.collectYeetStatus")(funct
     worktree,
     mergeReady: deriveYeetMergeReady(closeout, remoteStatus),
     staleGates: staleGateVerdicts(gateVerdicts),
+    unprovenGates: unprovenGateVerdicts(gateVerdicts),
   });
 });
 
@@ -1197,7 +1201,7 @@ export const renderYeetStatusSummary = (snapshot: YeetStatusSnapshot): string =>
       `- ${renderCheckLine(snapshot.remote)}`,
       `- ${renderYeetReviewThreadBlock(snapshot.remote)}`,
       `- ${renderMergeReadyLine(snapshot)}`,
-      `- ${renderYeetGateStalenessBlock(snapshot.staleGates)}`,
+      `- ${renderYeetGateStalenessBlock(snapshot.staleGates, snapshot.unprovenGates)}`,
       `- rerun-failed: ${snapshot.remote.rerunFailedDecision ?? "not checked"}`,
       `- status artifact: ${snapshot.statusPath}`,
       `- next: ${snapshot.nextCommand}`,

--- a/packages/tooling/tool/cli/test/ci-lane-timings.test.ts
+++ b/packages/tooling/tool/cli/test/ci-lane-timings.test.ts
@@ -5,15 +5,18 @@ import {
   ciLaneTimingsReport,
   ciRunnerClassForLabels,
   ciTimestampSpanSeconds,
+  collectCiLaneTimings,
   decodeCiWorkflowJobsPage,
   renderCiLaneTimingsSummary,
   renderCiLaneTimingsTsv,
   withCiLanePeakRss,
 } from "@beep/repo-cli/commands/Ci";
-import { A } from "@beep/utils";
+import { provideScopedLayer } from "@beep/test-utils";
+import { A, Str } from "@beep/utils";
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, Exit } from "effect";
+import { Effect, Exit, Layer, Sink, Stream } from "effect";
 import * as O from "effect/Option";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 // The Actions jobs endpoint returns snake_case wire fields; these fixtures keep
 // them so the derivations are exercised on the shape they actually receive.
@@ -47,7 +50,51 @@ const job = (overrides: Partial<CiWorkflowJob> = {}) =>
     ...overrides,
   });
 
+const encoder = new TextEncoder();
+
+const stubHandle = (output: string) =>
+  ChildProcessSpawner.makeHandle({
+    all: Stream.make(encoder.encode(output)),
+    exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(0)),
+    getInputFd: () => Sink.drain,
+    getOutputFd: () => Stream.empty,
+    isRunning: Effect.succeed(false),
+    kill: () => Effect.void,
+    pid: ChildProcessSpawner.ProcessId(1),
+    stderr: Stream.empty,
+    stdin: Sink.drain,
+    stdout: Stream.make(encoder.encode(output)),
+    unref: Effect.succeed(Effect.void),
+  });
+
+const laneTimingsSpawnerLayer = Layer.effect(
+  ChildProcessSpawner.ChildProcessSpawner,
+  Effect.succeed(
+    ChildProcessSpawner.make((command) => {
+      if (!ChildProcess.isStandardCommand(command)) {
+        return Effect.die("lane timings never spawns a piped command");
+      }
+      const rendered = A.join([command.command, ...command.args], " ");
+      const output = Str.includes("actions/runs?per_page=1")(rendered)
+        ? '{"workflow_runs":[{"id":42}]}'
+        : Str.includes("per_page=100&page=1")(rendered)
+          ? '{"jobs":[{"completed_at":"2026-08-06T12:10:00Z","conclusion":"success","created_at":"2026-08-06T12:00:00Z","id":991,"labels":["self-hosted"],"name":"Test Unit","run_attempt":1,"run_id":42,"runner_name":"runner-1","started_at":"2026-08-06T12:00:30Z","status":"completed","steps":[]}],"total_count":2}'
+          : '{"jobs":[{"completed_at":"2026-08-06T12:11:00Z","conclusion":"success","created_at":"2026-08-06T12:01:00Z","id":992,"labels":["self-hosted"],"name":"Test Unit 2","run_attempt":1,"run_id":42,"runner_name":"runner-1","started_at":"2026-08-06T12:01:30Z","status":"completed","steps":[]}],"total_count":2}';
+      return Effect.succeed(stubHandle(output));
+    })
+  )
+);
+
 describe("ci lane timings attempt filter", () => {
+  it.effect("collects every page of all-attempt jobs", () =>
+    Effect.gen(function* () {
+      const report = yield* collectCiLaneTimings(".", 1);
+
+      expect(report.jobCount).toBe(2);
+      expect(A.map(report.rows, (row) => row.jobId)).toStrictEqual([991, 992]);
+    }).pipe(provideScopedLayer(laneTimingsSpawnerLayer))
+  );
+
   it("reports job-level pickup latency on the first attempt", () => {
     expect(attemptOnePickupSeconds(job())).toStrictEqual(O.some(30));
   });

--- a/packages/tooling/tool/cli/test/ci-lane-timings.test.ts
+++ b/packages/tooling/tool/cli/test/ci-lane-timings.test.ts
@@ -5,12 +5,14 @@ import {
   ciLaneTimingsReport,
   ciRunnerClassForLabels,
   ciTimestampSpanSeconds,
+  decodeCiWorkflowJobsPage,
   renderCiLaneTimingsSummary,
   renderCiLaneTimingsTsv,
   withCiLanePeakRss,
 } from "@beep/repo-cli/commands/Ci";
 import { A } from "@beep/utils";
 import { describe, expect, it } from "@effect/vitest";
+import { Effect, Exit } from "effect";
 import * as O from "effect/Option";
 
 // The Actions jobs endpoint returns snake_case wire fields; these fixtures keep
@@ -72,6 +74,27 @@ describe("ci lane timings attempt filter", () => {
     expect(report.attemptOneJobCount).toBe(1);
     expect(report.medianAttemptOnePickupSeconds).toStrictEqual(O.some(30));
   });
+
+  it("computes the midpoint for an even number of pickup samples", () => {
+    const report = ciLaneTimingsReport([
+      ciLaneTimingRow(job({ id: 991, started_at: "2026-08-06T12:00:01Z" })),
+      ciLaneTimingRow(job({ id: 992, started_at: "2026-08-06T12:01:39Z" })),
+    ]);
+
+    expect(report.medianAttemptOnePickupSeconds).toStrictEqual(O.some(50));
+  });
+
+  it.effect("rejects a jobs payload that omits run_attempt", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        decodeCiWorkflowJobsPage(
+          '{"jobs":[{"completed_at":null,"conclusion":null,"created_at":"2026-08-06T12:00:00Z","id":991,"name":"Test Unit","run_id":42,"started_at":null,"status":"queued"}]}'
+        )
+      );
+
+      expect(Exit.isFailure(exit)).toBe(true);
+    })
+  );
 
   it("renders an absent pickup as an empty TSV cell, never as zero", () => {
     // A zero would drag a spreadsheet average toward zero; an empty cell is

--- a/packages/tooling/tool/cli/test/yeet-gate-staleness.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-gate-staleness.test.ts
@@ -4,8 +4,10 @@ import {
   GateFileWitness,
   GateFresh,
   GateStale,
+  GateUnproven,
   renderYeetGateStalenessBlock,
   staleGateVerdicts,
+  unprovenGateVerdicts,
   YEET_GATE_ARTIFACT_DESCRIPTORS,
 } from "@beep/repo-cli/test/Yeet";
 import { A } from "@beep/utils";
@@ -86,6 +88,16 @@ describe("gate staleness reporting", () => {
     expect(renderYeetGateStalenessBlock([])).toBe("gate staleness: none");
   });
 
+  it("preserves an absent artifact as unproven in operator output", () => {
+    const verdict = GateUnproven.make({
+      gateId: "jsdoc-documentation-inventory",
+      detail: ".beep/ci/jsdoc-documentation.inventory.jsonc does not exist",
+    });
+
+    expect(unprovenGateVerdicts([verdict])).toStrictEqual([verdict]);
+    expect(renderYeetGateStalenessBlock([], [verdict])).toContain("jsdoc-documentation-inventory (unproven)");
+  });
+
   it("names the artifact, the newer input, and the regenerate command", () => {
     const rendered = renderYeetGateStalenessBlock([
       GateStale.make({
@@ -110,5 +122,13 @@ describe("gate staleness reporting", () => {
     expect(A.length(YEET_GATE_ARTIFACT_DESCRIPTORS)).toBeGreaterThan(0);
     expect(A.length(A.dedupe(gateIds))).toBe(A.length(gateIds));
     expect(A.every(YEET_GATE_ARTIFACT_DESCRIPTORS, (entry) => entry.regenerateCommand.length > 0)).toBe(true);
+    expect(A.map(YEET_GATE_ARTIFACT_DESCRIPTORS, (entry) => entry.regenerateCommand)).toStrictEqual([
+      "bun run coverage:baseline:write",
+      "bun run beep quality jsdoc-ratchet --write-baseline",
+      "bun run beep quality knip --write-baseline",
+      "bun run beep lint package-test-typecheck --write-baseline",
+      "bun run beep goals doctor --write-baseline",
+      "bun run beep ci lane jsdoc-inventory",
+    ]);
   });
 });

--- a/packages/tooling/tool/cli/test/yeet-gate-staleness.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-gate-staleness.test.ts
@@ -124,7 +124,7 @@ describe("gate staleness reporting", () => {
     expect(A.every(YEET_GATE_ARTIFACT_DESCRIPTORS, (entry) => entry.regenerateCommand.length > 0)).toBe(true);
     expect(A.map(YEET_GATE_ARTIFACT_DESCRIPTORS, (entry) => entry.regenerateCommand)).toStrictEqual([
       "bun run coverage:baseline:write",
-      "bun run beep quality jsdoc-ratchet --write-baseline",
+      "bun run beep quality jsdoc-inventory && bun run beep quality jsdoc-ratchet --write-baseline",
       "bun run beep quality knip --write-baseline",
       "bun run beep lint package-test-typecheck --write-baseline",
       "bun run beep goals doctor --write-baseline",

--- a/packages/tooling/tool/cli/test/yeet-merged-preview.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-merged-preview.test.ts
@@ -5,6 +5,7 @@ import {
   RepoRunContext,
   renderYeetMergePreviewConflict,
   validateMonitorGuards,
+  YEET_MERGED_PREVIEW_DIR_NAME,
   YeetMergePreview,
   YeetMergeTreeConflicted,
   yeetMergedPreviewContext,
@@ -125,6 +126,10 @@ describe("yeet merge-tree parsing", () => {
 });
 
 describe("yeet merged preview context", () => {
+  it("isolates the preview directory by process", () => {
+    expect(YEET_MERGED_PREVIEW_DIR_NAME).toBe(`merged-preview-${process.pid}`);
+  });
+
   it("moves the tree the proof runs on without moving the run identity", () => {
     const derived = yeetMergedPreviewContext(context, preview, "/repo/.beep/yeet");
 

--- a/packages/tooling/tool/cli/test/yeet-status-triage.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-status-triage.test.ts
@@ -1,5 +1,6 @@
 import {
   deriveYeetMergeReady,
+  GateUnproven,
   renderYeetReviewThreadBlock,
   renderYeetStatusSummary,
   YeetStatusArtifact,
@@ -241,6 +242,18 @@ describe("yeet status snapshot rendering and encoding", () => {
     expect(summary).toContain("- merge-ready: no, blocked on threads-resolved (greptile 5/5)");
   });
 
+  it("renders missing gate artifacts as unproven rather than clean", () => {
+    const summary = renderYeetStatusSummary(
+      YeetStatusSnapshot.make({
+        ...snapshot,
+        unprovenGates: [GateUnproven.make({ gateId: "jsdoc-inventory", detail: "artifact does not exist" })],
+      })
+    );
+
+    expect(summary).toContain("gate staleness: 0 stale, 1 unproven");
+    expect(summary).not.toContain("gate staleness: none");
+  });
+
   it.effect("round-trips through the status JSON codec instead of leaking Option runtime objects", () =>
     Effect.gen(function* () {
       const json = yield* YeetStatusSnapshotJson.encode(snapshot);
@@ -272,6 +285,7 @@ describe("yeet status snapshot rendering and encoding", () => {
       expect(decoded.mergeReady).toStrictEqual(O.none());
       expect(decoded.remote.unresolvedThreads).toStrictEqual(O.none());
       expect(decoded.remote.headSha).toStrictEqual(O.none());
+      expect(decoded.unprovenGates).toStrictEqual([]);
     })
   );
 });

--- a/standards/jsdoc-documentation.inventory.jsonc
+++ b/standards/jsdoc-documentation.inventory.jsonc
@@ -1,7 +1,7 @@
 {
   "standard": "jsdoc-documentation",
   "version": 1,
-  "generatedAt": "2026-08-08T18:09:07.891Z",
+  "generatedAt": "2026-08-08T19:51:02.055Z",
   "source": {
     "packageUniverseCommand": "bun run topo-sort",
     "generator": "bun run beep quality jsdoc-inventory",
@@ -40725,8 +40725,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Ci/LaneTimings.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Ci/LaneTimings.ts",
-          "line": 727,
-          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-727-collectcilanetimings",
+          "line": 751,
+          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-751-collectcilanetimings",
           "currentTags": [
             "@param",
             "@returns",
@@ -40749,8 +40749,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Ci/LaneTimings.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Ci/LaneTimings.ts",
-          "line": 777,
-          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-777-cilanetimingscommand",
+          "line": 792,
+          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-792-cilanetimingscommand",
           "currentTags": [
             "@category",
             "@since"

--- a/standards/jsdoc-documentation.inventory.jsonc
+++ b/standards/jsdoc-documentation.inventory.jsonc
@@ -1,7 +1,7 @@
 {
   "standard": "jsdoc-documentation",
   "version": 1,
-  "generatedAt": "2026-08-08T16:32:19.323Z",
+  "generatedAt": "2026-08-08T18:09:07.891Z",
   "source": {
     "packageUniverseCommand": "bun run topo-sort",
     "generator": "bun run beep quality jsdoc-inventory",
@@ -67,7 +67,7 @@
     "packagesNeedingRemediation": 63,
     "publicModules": 2419,
     "publicExports": 16006,
-    "openModules": 407,
+    "openModules": 406,
     "openExports": 157,
     "missingExportExamples": 0,
     "missingExportCategories": 0,
@@ -78,7 +78,7 @@
     "unsafeExampleFindings": 0,
     "schemaAnnotationFindings": 0,
     "undescribed-see": 12,
-    "multiple-description-paragraphs": 548,
+    "multiple-description-paragraphs": 547,
     "leading-blank": 0,
     "trailing-blank": 1,
     "invalid-heading": 1,
@@ -34068,7 +34068,7 @@
         "enforceVersion": true
       },
       "counts": {
-        "openModules": 47,
+        "openModules": 46,
         "openExports": 10,
         "missingExportExamples": 0,
         "missingExportCategories": 0,
@@ -34081,7 +34081,7 @@
         "schemaAnnotationFindings": 0,
         "documentationRuleFindings": {
           "undescribed-see": 0,
-          "multiple-description-paragraphs": 57,
+          "multiple-description-paragraphs": 56,
           "leading-blank": 0,
           "trailing-blank": 0,
           "invalid-heading": 1,
@@ -34543,13 +34543,9 @@
           "unsafeExampleViolations": [],
           "schemaAnnotationGaps": [],
           "categoryViolations": [],
-          "documentationShapeViolations": [
-            {
-              "rule": "multiple-description-paragraphs"
-            }
-          ],
+          "documentationShapeViolations": [],
           "exportCount": 17,
-          "remediationStatus": "open"
+          "remediationStatus": "resolved"
         },
         {
           "docKind": "packageDocumentation",
@@ -40383,8 +40379,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Ci/LaneTimings.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Ci/LaneTimings.ts",
-          "line": 78,
-          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-78-cirunnerclass",
+          "line": 79,
+          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-79-cirunnerclass",
           "currentTags": [
             "@category",
             "@since"
@@ -40405,8 +40401,8 @@
           "exportKind": "type",
           "filePath": "src/commands/Ci/LaneTimings.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Ci/LaneTimings.ts",
-          "line": 91,
-          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-91-cirunnerclass",
+          "line": 92,
+          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-92-cirunnerclass",
           "currentTags": [
             "@category",
             "@since"
@@ -40427,8 +40423,8 @@
           "exportKind": "class",
           "filePath": "src/commands/Ci/LaneTimings.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Ci/LaneTimings.ts",
-          "line": 123,
-          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-123-ciworkflowjob",
+          "line": 124,
+          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-124-ciworkflowjob",
           "currentTags": [
             "@category",
             "@since"
@@ -40449,8 +40445,8 @@
           "exportKind": "class",
           "filePath": "src/commands/Ci/LaneTimings.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Ci/LaneTimings.ts",
-          "line": 164,
-          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-164-ciworkflowjobspage",
+          "line": 165,
+          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-165-ciworkflowjobspage",
           "currentTags": [
             "@category",
             "@since"
@@ -40471,8 +40467,8 @@
           "exportKind": "class",
           "filePath": "src/commands/Ci/LaneTimings.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Ci/LaneTimings.ts",
-          "line": 205,
-          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-205-cilanetimingrow",
+          "line": 206,
+          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-206-cilanetimingrow",
           "currentTags": [
             "@category",
             "@since"
@@ -40493,8 +40489,8 @@
           "exportKind": "class",
           "filePath": "src/commands/Ci/LaneTimings.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Ci/LaneTimings.ts",
-          "line": 247,
-          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-247-cilanetimingsreport",
+          "line": 248,
+          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-248-cilanetimingsreport",
           "currentTags": [
             "@category",
             "@since"
@@ -40515,8 +40511,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Ci/LaneTimings.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Ci/LaneTimings.ts",
-          "line": 294,
-          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-294-citimestampspanseconds",
+          "line": 295,
+          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-295-citimestampspanseconds",
           "currentTags": [
             "@param",
             "@returns",
@@ -40539,8 +40535,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Ci/LaneTimings.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Ci/LaneTimings.ts",
-          "line": 338,
-          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-338-attemptonepickupseconds",
+          "line": 339,
+          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-339-attemptonepickupseconds",
           "currentTags": [
             "@param",
             "@returns",
@@ -40563,8 +40559,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Ci/LaneTimings.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Ci/LaneTimings.ts",
-          "line": 373,
-          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-373-cirunnerclassforlabels",
+          "line": 374,
+          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-374-cirunnerclassforlabels",
           "currentTags": [
             "@param",
             "@returns",
@@ -40587,8 +40583,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Ci/LaneTimings.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Ci/LaneTimings.ts",
-          "line": 427,
-          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-427-cilanetimingrow",
+          "line": 428,
+          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-428-cilanetimingrow",
           "currentTags": [
             "@param",
             "@returns",
@@ -40611,8 +40607,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Ci/LaneTimings.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Ci/LaneTimings.ts",
-          "line": 478,
-          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-478-withcilanepeakrss",
+          "line": 479,
+          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-479-withcilanepeakrss",
           "currentTags": [
             "@param",
             "@returns",
@@ -40635,8 +40631,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Ci/LaneTimings.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Ci/LaneTimings.ts",
-          "line": 516,
-          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-516-cilanetimingsreport",
+          "line": 528,
+          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-528-cilanetimingsreport",
           "currentTags": [
             "@param",
             "@returns",
@@ -40659,8 +40655,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Ci/LaneTimings.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Ci/LaneTimings.ts",
-          "line": 573,
-          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-573-rendercilanetimingstsv",
+          "line": 585,
+          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-585-rendercilanetimingstsv",
           "currentTags": [
             "@param",
             "@returns",
@@ -40683,8 +40679,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Ci/LaneTimings.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Ci/LaneTimings.ts",
-          "line": 616,
-          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-616-rendercilanetimingssummary",
+          "line": 628,
+          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-628-rendercilanetimingssummary",
           "currentTags": [
             "@param",
             "@returns",
@@ -40707,8 +40703,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Ci/LaneTimings.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Ci/LaneTimings.ts",
-          "line": 649,
-          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-649-decodeciworkflowjobspage",
+          "line": 661,
+          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-661-decodeciworkflowjobspage",
           "currentTags": [
             "@category",
             "@since"
@@ -40729,8 +40725,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Ci/LaneTimings.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Ci/LaneTimings.ts",
-          "line": 708,
-          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-708-collectcilanetimings",
+          "line": 727,
+          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-727-collectcilanetimings",
           "currentTags": [
             "@param",
             "@returns",
@@ -40753,8 +40749,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Ci/LaneTimings.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Ci/LaneTimings.ts",
-          "line": 765,
-          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-765-cilanetimingscommand",
+          "line": 777,
+          "anchor": "packages-tooling-tool-cli-src-commands-ci-lanetimings-ts-777-cilanetimingscommand",
           "currentTags": [
             "@category",
             "@since"

--- a/standards/jsdoc-documentation.inventory.md
+++ b/standards/jsdoc-documentation.inventory.md
@@ -1,6 +1,6 @@
 # JSDoc Documentation Compliance Inventory
 
-Generated: 2026-08-08T18:09:07.891Z
+Generated: 2026-08-08T19:51:02.055Z
 
 ## Scope
 

--- a/standards/jsdoc-documentation.inventory.md
+++ b/standards/jsdoc-documentation.inventory.md
@@ -1,6 +1,6 @@
 # JSDoc Documentation Compliance Inventory
 
-Generated: 2026-08-08T16:32:19.323Z
+Generated: 2026-08-08T18:09:07.891Z
 
 ## Scope
 
@@ -16,7 +16,7 @@ The package universe is the current `bun run topo-sort` output. This inventory c
 | packagesNeedingRemediation | 63 |
 | publicModules | 2419 |
 | publicExports | 16006 |
-| openModules | 407 |
+| openModules | 406 |
 | openExports | 157 |
 | missingExportExamples | 0 |
 | missingExportCategories | 0 |
@@ -27,7 +27,7 @@ The package universe is the current `bun run topo-sort` output. This inventory c
 | unsafeExampleFindings | 0 |
 | schemaAnnotationFindings | 0 |
 | undescribed-see | 12 |
-| multiple-description-paragraphs | 548 |
+| multiple-description-paragraphs | 547 |
 | leading-blank | 0 |
 | trailing-blank | 1 |
 | invalid-heading | 1 |
@@ -75,7 +75,7 @@ The package universe is the current `bun run topo-sort` output. This inventory c
 | 18 | `@beep/ontology-use-cases` | `packages/ontology/use-cases` | needs-remediation | 23 | 214 | 1 | 3 |
 | 19 | `@beep/architecture-lab-client` | `packages/architecture-lab/client` | clean | 3 | 7 | 0 | 0 |
 | 20 | `@beep/dock` | `packages/foundation/ui-system/dock` | clean | 20 | 212 | 0 | 0 |
-| 21 | `@beep/repo-cli` | `packages/tooling/tool/cli` | needs-remediation | 176 | 1335 | 47 | 10 |
+| 21 | `@beep/repo-cli` | `packages/tooling/tool/cli` | needs-remediation | 176 | 1335 | 46 | 10 |
 | 22 | `@beep/pglite` | `packages/drivers/pglite` | needs-remediation | 4 | 11 | 3 | 0 |
 | 23 | `@beep/ai-sync` | `packages/tooling/library/ai-sync` | clean | 10 | 83 | 0 | 0 |
 | 24 | `@beep/agents-server` | `packages/agents/server` | needs-remediation | 11 | 39 | 2 | 0 |
@@ -306,7 +306,6 @@ Path: `packages/tooling/tool/cli`
 
 Module findings:
 - `src/commands/Ci/CiLane.ts:1` (packageDocumentation) - 1 documentation section/link violation(s)
-- `src/commands/Ci/LaneTimings.ts:1` (packageDocumentation) - 1 documentation section/link violation(s)
 - `src/commands/Codegen/Codegen.command.ts:1` (packageDocumentation) - 1 documentation section/link violation(s)
 - `src/commands/Codex/Findings.capture.schemas.ts:1` (packageDocumentation) - 1 documentation section/link violation(s)
 - `src/commands/Codex/Findings.command.ts:1` (packageDocumentation) - 1 documentation section/link violation(s)

--- a/standards/jsdoc-totals.regression-baseline.jsonc
+++ b/standards/jsdoc-totals.regression-baseline.jsonc
@@ -8,7 +8,7 @@
   "regeneration_command": "bun run beep quality jsdoc-inventory",
   "snapshot_command": "bun run beep quality jsdoc-ratchet --write-baseline",
   "comparison": "fail-on-growth: generated inventory totals must not exceed this committed baseline",
-  "generated_at": "2026-08-08T18:13:55.273Z",
+  "generated_at": "2026-08-08T19:55:11.369Z",
   "tracked_totals": {
     "packagesNeedingRemediation": 63,
     "missingExportExamples": 0,

--- a/standards/jsdoc-totals.regression-baseline.jsonc
+++ b/standards/jsdoc-totals.regression-baseline.jsonc
@@ -8,7 +8,7 @@
   "regeneration_command": "bun run beep quality jsdoc-inventory",
   "snapshot_command": "bun run beep quality jsdoc-ratchet --write-baseline",
   "comparison": "fail-on-growth: generated inventory totals must not exceed this committed baseline",
-  "generated_at": "2026-08-08T16:37:03.713Z",
+  "generated_at": "2026-08-08T18:13:55.273Z",
   "tracked_totals": {
     "packagesNeedingRemediation": 63,
     "missingExportExamples": 0,
@@ -17,7 +17,7 @@
     "unsafeExampleFindings": 0,
     "schemaAnnotationFindings": 0,
     "undescribed-see": 12,
-    "multiple-description-paragraphs": 548,
+    "multiple-description-paragraphs": 547,
     "leading-blank": 0,
     "trailing-blank": 1,
     "invalid-heading": 1,


### PR DESCRIPTION
## fix(repo-cli): address the PR 628 post-merge review round

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- full:pre-push: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/fix_widgets-628-review-efdca765dc44/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/630"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788807812&installation_model_id=424656&pr_number=630&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F630&signature=98b6d1a8b5700cd53458c0a7b20cddbcc1a74f197cee14c6af66003969f78707"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->