### PR TITLE
chore(security): admit Effect beta.105 subtree fingerprint

### DIFF
--- a/.changeset/gitleaks-effect-beta105-fingerprint.md
+++ b/.changeset/gitleaks-effect-beta105-fingerprint.md
@@ -1,0 +1,5 @@
+---
+{}
+---
+
+chore(security): admit the Effect beta.105 subtree squash Gitleaks fingerprint

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -88,3 +88,7 @@ goals/repo-crispening-orchestration/ops/inventory/S5/beep__shared-domain.json:ge
 # 4.0.0-beta.104 refresh. Same Config.redacted JSDoc sample, now at line 1484.
 cb5d50cf0a7e6ca0cf7b31be33f2ed931b36e92e:packages/effect/src/Config.ts:generic-api-key:1484
 .repos/effect/packages/effect/src/Config.ts:generic-api-key:1484
+
+# False positive in the immutable Effect subtree squash used by the
+# 4.0.0-beta.105 refresh. Same Config.redacted JSDoc sample at line 1484.
+ceebcebce7e0ffff8dd377f524e05c9ceafde756:packages/effect/src/Config.ts:generic-api-key:1484


### PR DESCRIPTION
## Summary

- allowlist the immutable Effect beta.105 Config.ts JSDoc false positive
- keep the base-pinned secret scan effective for the dependency adoption PR

## Verification

- bun run beep yeet publish --message "chore(security): admit Effect beta.105 subtree fingerprint"

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788952498&installation_model_id=424656&pr_number=641&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F641&signature=4c2b514a318e9efb3dfad551e2b145361e37f818bb44ab76b862fc75eb6383f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->