### PR TITLE
fix(repo-cli): harden the yeet monitor loop and the reply verdict

### DIFF
--- a/.changeset/yeet-monitor-hardening.md
+++ b/.changeset/yeet-monitor-hardening.md
@@ -1,0 +1,33 @@
+---
+"@beep/repo-cli": patch
+---
+
+Harden the Yeet monitor loop and the reply verdict (ship-velocity A7).
+
+`yeet reply` now exits non-zero when any drafted reply is `failed`. The batch
+still runs to completion and the report is still written, but an unwritten
+reply leaves its review thread open — a hard merge gate — so a
+`yeet reply && yeet monitor` chain no longer walks past it on a false green.
+`stale` outcomes wrote nothing because there was nothing to write and are not
+failures.
+
+Monitor comment cursors persist across runs in a schema-versioned
+`monitor-comments.json` beside the other branch-scoped Yeet artifacts. A
+session resumes from the saved position instead of its own clock, so a comment
+posted while no monitor was attached is printed by the next run rather than
+falling into the gap between two processes. Anything unusable — no artifact, a
+different pull request, an older schema version, a torn file — reads as "start
+from now".
+
+A failing comment poll can no longer cancel the check watcher it is raced
+against: the poller's error channel is `never` by construction. Each failed
+poll is reported with gh's own words and numbered against a bound, and a
+stream that exhausts the bound parks instead of completing, because completing
+the race is what would take the checks down.
+
+Post-push check watching distinguishes "no checks registered yet" from
+"terminal empty". `gh pr checks --watch` reports a head GitHub has not wired
+up yet as exit 1 with `no checks reported`, seconds after the push that
+created it; that answer is now re-attempted on a bounded backoff (six
+attempts, ~95s). An exhausted backoff is still a failure naming the condition,
+never a pass.

--- a/goals/ship-velocity/PLAN.md
+++ b/goals/ship-velocity/PLAN.md
@@ -26,8 +26,11 @@ phase flips ride the final PR of each phase.
   (`PortfolioIndexGuard.ts`; renders the projection after the staged-only stash, stages it when it
   differs, refuses a hand-staged copy that disagrees).
 - C1 local remote-cache read path + checkout env template.
-- A7 monitor hardening quick items (`yeet reply` exit code, cursor persistence, registration
-  backoff).
+- ~~A7 monitor hardening quick items (`yeet reply` exit code, cursor persistence, registration
+  backoff).~~ Done 2026-08-16 (reply exits non-zero on any `failed` outcome; comment cursors
+  persist through a versioned `monitor-comments.json`; comment-poll failures degrade without
+  cancelling the check watch; bounded post-push check-registration backoff. The lane
+  success-exit hang was already closed on main by the `run_lane` process-group reap in #718.)
 
 ## P2 — Backpressure engine
 

--- a/goals/ship-velocity/research/OPPORTUNITIES.md
+++ b/goals/ship-velocity/research/OPPORTUNITIES.md
@@ -165,3 +165,74 @@ session/machine ids.
   debug cycle on a test that reported "no lane carries the flake quarantine" when both lanes
   did. Already recorded as agent memory; worth a lint rule or a v3→v4 migration note, since the
   failure mode is a wrong answer rather than a type error.
+
+## 2026-08-16 — A7 implementation
+
+- Four new exported helpers were written, typechecked green by the package's own
+  `bunx tsgo -p tsconfig.check.json`, and only then rejected by the same command once the
+  effect language-service rules ran: `TS377101 missingPipeableSignature` on every 2+-parameter
+  export (two renderers, one combinator, one Option-returning formatter). The rule is invisible
+  while authoring — nothing in the editor loop, the law files, or the JSDoc pattern doc says
+  "a new exported function with two or more parameters needs a data-last partner or it will not
+  compile". Cost: a second authoring pass over four symbols plus their call sites and tests.
+  Prevention: state the arity rule in the code laws next to the helper-form law, with its three
+  standard remedies (make it module-private, curry it data-last, or `dual` it) — the remedy is
+  cheap once known and expensive to rediscover.
+- The test-file typecheck lane cannot be run for one package. `bunx tsgo -p test/tsconfig.json`
+  from the package fails immediately with TS6059 (`rootDir` is `src`), because the real lane
+  (`beep quality test-tsgo`) synthesises a per-package config with `rootDir: <repoRoot>` into
+  `node_modules/.tmp/`. Reproducing that by hand was the only way to typecheck three new test
+  files without running the repo-wide lane; a first attempt with the synthetic config outside
+  the repo failed differently (TS2688, `bun`/`node` type roots unresolvable). It found two real
+  classes immediately — `strictEffectProvide` (TS377032) on mid-effect `Effect.provide(layer)`
+  and a `Ref<string[]>` vs `Ref<readonly string[]>` mismatch — so the lane is worth reaching,
+  which is the argument for `beep quality test-tsgo --filter <package>` (or a documented
+  scoped recipe) rather than all-or-nothing.
+- `it.effect` runs under a TestClock, so every timed assertion silently hangs to the 30s vitest
+  timeout instead of failing: four monitor tests wedged with no diagnostic beyond "Test timed
+  out", including one whose only sleep was 30 real milliseconds. `it.live` is the fix and it is
+  in the repo already (`worktree-fleet-scan.test.ts`), but nothing connects the symptom to the
+  cause. Prevention: a testing-patterns line — "a test that sleeps, races, or polls needs
+  `it.live`; `it.effect` gives it a clock that never advances".
+- A monitor comment poll reported `Failed to poll pull request comments during yeet monitor.`
+  and dropped gh's own words on the floor, so the degraded-stream line an operator sees could
+  not distinguish a rate limit from a revoked token. Found only because a test asserted on the
+  surfaced text. Same class as the misattributed-composite-hint receipts above: a failure that
+  is *reported* to a human must carry the underlying tool's message, not just the wrapper's.
+- SPEC A7's optional fifth item (Lint Policy lane success-exit hang) was already closed on main:
+  `.github/workflows/check.yml` runs every lane through a `run_lane` wrapper (`setsid` + `wait`
+  + process-group TERM/KILL) that landed in #718, and `bin-main.ts` already exits explicitly on
+  success for all three entry paths. Re-deriving that cost a full investigation pass. Prevention:
+  when a SPEC item is closed incidentally by another PR, strike it in the SPEC in that PR — the
+  workflow comment cites "ship-velocity SPEC A7" but the SPEC bullet never learned about it.
+  Residual gap worth its own receipt: the post-lane `Append Turbo summary` steps still invoke
+  `bun run beep` directly, outside the reaping wrapper.
+- Ran `bun run beep lint schema-catalog` as a pre-flight, saw it red, and regenerated
+  `standards/schema-catalog.generated.jsonc` into a feature branch — a +170/-458 whole-file
+  diff of which three entries were mine. Wrong call, reverted: `standards/generated-artifacts.
+  policy.md` says whole-repo snapshots are refreshed only in dedicated chore PRs, that these
+  gates are delta/ratchet-based, and that staleness at HEAD is not gating; the same mistake is
+  already recorded there against PR #452. Confirmed the mechanics too — `schema-catalog`
+  appears in no `package.json` script and nowhere in `.github/workflows/check.yml`, and the
+  gating composite in `Quality/Tasks.ts:1699` carries `lint:schema-first` only. The trap is
+  that `beep lint` exposes gating and non-gating scans through one uniform surface with one
+  uniform exit code, so a manual pre-flight sweep of "the cheap lint gates" cannot tell which
+  reds a proof actually enforces. Two preventions: have `beep lint <subcommand>` state whether
+  the scan is gating (and point at the policy when it is not), and separately, the underlying
+  staleness — a package deletion left `packages/drivers/box/src/experimental` entries behind —
+  wants the standing `chore: refresh generated standards artifacts` PR from clean main, not a
+  feature branch.
+- The coverage ratchet cost two ~6.5-minute cycles for the same defect class, and neither hit
+  was where the risk was expected. Both were `Option.getOrElse` fallback thunks that no test
+  reaches: `replyOutcomeTarget`'s "neither handle" arm (unreachable through a decoded outcome,
+  because `ReplyTargetPresenceCheck` rejects an empty target) and `yeetCheckRegistration`'s
+  absent-`output` arm. Two rules made this expensive to predict: a **new** file is held to zero
+  uncovered units ("no baseline file identity"), not to the package floor, so `MonitorChecks.ts`
+  failed at 91.66% functions while the package's own floor is 63%; and a per-file floor at 100%
+  means a single new defensive thunk is a regression. Both fixes were real tests, not floor
+  moves — the first required changing `replyOutcomeTarget` to take the two handles instead of
+  the whole outcome, since the schema check makes the empty case impossible to construct and
+  therefore impossible to test. Prevention: say in the coverage lane's output that new files
+  are held to 100%, and treat "a `getOrElse`/`orElse` thunk over a field the tests always
+  populate" as the house signature of a ratchet failure — grep the diff for it before paying a
+  cycle.

--- a/goals/ship-velocity/research/OPPORTUNITIES.md
+++ b/goals/ship-velocity/research/OPPORTUNITIES.md
@@ -260,3 +260,16 @@ session/machine ids.
   in one block, with the failure line the most eye-catching part. Sixth receipt in the
   misattributed-hint family: a summary must read the verdict written by the run it is summarizing,
   or state which run it came from.
+- Seventh misattributed-hint receipt, and the clearest yet: a `full:pre-push` failure whose only
+  red lanes were `quality:check` and `quality:check:tsgo-tests` — a single `strictEffectProvide`
+  diagnostic in one test file — produced the verdict repair command *"Inspect the OSV finding and
+  rerun `bun run beep quality github-checks security`"*. The security lane had passed. Six prior
+  receipts in this ledger describe the same class from different lanes; at seven, the pattern is
+  no longer anecdotal and the fix is A-track capsule work: the hint must be derived from the
+  failing sublane, not from a fixed template.
+- The same failure is also a receipt against my own process: the synthetic `test-tsgo` replica I
+  ran to pre-check the test files was executed *before* the P1 regression test existed, and I did
+  not re-run it after adding that test — so a gate result was carried forward onto a tree it never
+  saw. `bun run beep quality test-tsgo` is in-process, takes no lock, and needs no turbo, so there
+  was no reason to skip it except forgetting that a proof binds to a tree. Prevention: re-run the
+  cheap in-process gates as the *last* step before publish, never as a step before the last edit.

--- a/goals/ship-velocity/research/OPPORTUNITIES.md
+++ b/goals/ship-velocity/research/OPPORTUNITIES.md
@@ -236,3 +236,27 @@ session/machine ids.
   are held to 100%, and treat "a `getOrElse`/`orElse` thunk over a field the tests always
   populate" as the house signature of a ratchet failure — grep the diff for it before paying a
   cycle.
+- **B5 has a costed case now.** Publishing A7 paid for two full ~17-minute proofs on byte-identical
+  content. The second was not triggered by any source change but by `git add`: `ProofState.ts`'s
+  `collectDiffFingerprint` hashes
+  `sha256(git status --short ‖ git diff HEAD ‖ git diff --cached)`, so staging invalidates the
+  proof three ways at once — status letters flip (`??`→`A `, `MM`→`M `), bytes leave the unstaged
+  diff, and the same bytes enter the cached diff — while the resulting tree is unchanged. The
+  fingerprint keys on the *staging arrangement*, not on the tree. Keying it on a tree SHA
+  (`git write-tree` over the index) would have reused the proof. That is SPEC B5, and the price
+  here was ~17 minutes of serialized slot time for a no-op, with three queued items waiting.
+  Ordering half of the same defect: `yeet publish` refuses untracked files only *after* running
+  the fallow-advisory preflight, and under `--start-pr-early` that waste sits on the critical
+  path — the intent check belongs before the preflight, and the fingerprint could be taken after
+  intent staging rather than before.
+- Never pipe a long proof through `tail`: `bun run beep yeet verify 2>&1 | tail -50` buffers
+  everything until exit, so 16 minutes of a healthy run were indistinguishable from a hang and
+  the monitor armed on the log file could not fire until completion. Confirming liveness needed
+  `ps`. Redirect to a file and tail the file. Same family as the existing piped-exit-code receipt.
+- `yeet publish`'s operator status summary quoted a *stale* verdict: after the second publish
+  attempt pushed and created PR #738, the summary printed
+  `verdict: publish failure: yeet publish refuses untracked files` — the previous attempt's
+  artifact — beside `checks: 28 total, 0 failing, 0 pending` from the current one. Two runs' state
+  in one block, with the failure line the most eye-catching part. Sixth receipt in the
+  misattributed-hint family: a summary must read the verdict written by the run it is summarizing,
+  or state which run it came from.

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts
@@ -693,14 +693,25 @@ const runMonitorCheckWatch = Effect.fn("Yeet.runMonitorCheckWatch")(function* (
   context: RepoRunContext,
   checkSteps: ReadonlyArray<RepoPlanStep>,
   recorder: Ref.Ref<ReadonlyArray<YeetExecutedStep>>,
-  failureMessage: string
+  failureMessage: string,
+  delays: ReadonlyArray<Duration.Duration> = YEET_CHECK_REGISTRATION_BACKOFF
 ): Effect.fn.Return<
   void,
   YeetCommandError,
   FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
 > {
-  const results = yield* runPhase(context, checkSteps, recorder).pipe(
-    awaitYeetCheckRegistration(YEET_CHECK_REGISTRATION_BACKOFF)
+  // `runPhase` appends to the recorder, and the recorder is what the verdict,
+  // the PR body, and `yeet status` all read. A retried attempt must therefore
+  // REPLACE the previous attempt's record rather than add to it: otherwise one
+  // step id carries both a failed entry (no checks registered yet) and a passed
+  // one, and every downstream surface reports the same lane as both — the
+  // misattributed-hint class this packet already has receipts for. Rewinding to
+  // the pre-attempt snapshot before each try makes the last attempt the only
+  // one that survives.
+  const beforeAttempts = yield* Ref.get(recorder);
+  const results = yield* Ref.set(recorder, beforeAttempts).pipe(
+    Effect.andThen(runPhase(context, checkSteps, recorder)),
+    awaitYeetCheckRegistration(delays)
   );
   if (A.every(results, (result) => result.exitCode === 0)) {
     return;
@@ -710,10 +721,18 @@ const runMonitorCheckWatch = Effect.fn("Yeet.runMonitorCheckWatch")(function* (
     checkSteps,
     results,
     isAwaitingYeetCheckRegistration(results)
-      ? `${failureMessage} ${renderYeetCheckRegistrationExhausted(YEET_CHECK_REGISTRATION_BACKOFF)}`
+      ? `${failureMessage} ${renderYeetCheckRegistrationExhausted(delays)}`
       : failureMessage
   );
 });
+
+/**
+ * Run the monitor check watch in isolation, with an injectable backoff.
+ *
+ * @category testing
+ * @since 0.0.0
+ */
+export const runMonitorCheckWatchForTesting = runMonitorCheckWatch;
 
 const runMonitorPhase = Effect.fn("Yeet.runMonitorPhase")(function* (
   context: RepoRunContext,

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts
@@ -60,6 +60,12 @@ import {
   writeTextFile,
 } from "./IssueArtifacts.ts";
 import { installYeetMergePreview, withYeetMergePreview, yeetMergedPreviewContext } from "./MergedPreview.ts";
+import {
+  awaitYeetCheckRegistration,
+  isAwaitingYeetCheckRegistration,
+  renderYeetCheckRegistrationExhausted,
+  YEET_CHECK_REGISTRATION_BACKOFF,
+} from "./MonitorChecks.ts";
 import { runYeetPullRequestCommentMonitor } from "./MonitorComments.ts";
 import {
   buildYeetRunPlanWithMode,
@@ -679,6 +685,36 @@ const assertNoUnresolvedReviewThreads = Effect.fn("Yeet.assertNoUnresolvedReview
   });
 });
 
+// A pushed head whose checks have not registered yet is not a head with
+// nothing to watch. The watch re-attempts on a bounded backoff, and only an
+// exhausted backoff lets the empty answer stand — as a failure naming that
+// condition, never as a pass.
+const runMonitorCheckWatch = Effect.fn("Yeet.runMonitorCheckWatch")(function* (
+  context: RepoRunContext,
+  checkSteps: ReadonlyArray<RepoPlanStep>,
+  recorder: Ref.Ref<ReadonlyArray<YeetExecutedStep>>,
+  failureMessage: string
+): Effect.fn.Return<
+  void,
+  YeetCommandError,
+  FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+> {
+  const results = yield* runPhase(context, checkSteps, recorder).pipe(
+    awaitYeetCheckRegistration(YEET_CHECK_REGISTRATION_BACKOFF)
+  );
+  if (A.every(results, (result) => result.exitCode === 0)) {
+    return;
+  }
+  return yield* failWithIssueArtifacts(
+    context,
+    checkSteps,
+    results,
+    isAwaitingYeetCheckRegistration(results)
+      ? `${failureMessage} ${renderYeetCheckRegistrationExhausted(YEET_CHECK_REGISTRATION_BACKOFF)}`
+      : failureMessage
+  );
+});
+
 const runMonitorPhase = Effect.fn("Yeet.runMonitorPhase")(function* (
   context: RepoRunContext,
   monitorSteps: ReadonlyArray<RepoPlanStep>,
@@ -714,7 +750,7 @@ const runMonitorPhase = Effect.fn("Yeet.runMonitorPhase")(function* (
     Effect.mapError(YeetCommandError.new("Failed to decode pull request number for yeet monitor."))
   );
   yield* Effect.raceFirst(
-    runRequiredPhase(context, checkSteps, recorder, failureMessage),
+    runMonitorCheckWatch(context, checkSteps, recorder, failureMessage),
     runYeetPullRequestCommentMonitor(context, pullRequestNumber)
   );
 });

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/MonitorChecks.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/MonitorChecks.ts
@@ -1,0 +1,243 @@
+/**
+ * Post-push check registration for Yeet monitor sessions.
+ *
+ * **Details**
+ *
+ * `gh pr checks` answers "this head has no check runs" and "this head's checks
+ * are done" through two different surfaces, and only one of them is terminal.
+ * A head GitHub has not finished wiring up yet reports *no checks at all* — an
+ * error, exit 1, `no checks reported on the '<branch>' branch` — which arrives
+ * in the same shape as a genuine failure and within a second or two of the push
+ * that created the head. Treating that as the watch's answer ends the monitor
+ * before the pipeline it was asked to watch has begun.
+ *
+ * This module is the distinction: {@link yeetCheckRegistration} classifies one
+ * watch attempt, and {@link awaitYeetCheckRegistration} re-attempts an
+ * unregistered head on a bounded backoff before letting the result stand.
+ *
+ * **Gotchas**
+ *
+ * Exhausting the backoff is not a green. The results are handed back exactly as
+ * observed — still non-zero, still `awaiting-registration` — so the caller
+ * fails the phase. A head that never registers a check is a real condition
+ * (a workflow whose path filters excluded every file, a disabled Actions
+ * setting) and the operator has to be told about it, not have it rounded down
+ * to "nothing to watch, carry on".
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { LiteralKit } from "@beep/schema";
+import { Console, Duration, Effect, pipe } from "effect";
+import * as A from "effect/Array";
+import * as O from "effect/Option";
+import * as Str from "effect/String";
+import type { RepoStepRunResult } from "../../../internal/repo-run/index.ts";
+
+const $I = $RepoCliId.create("commands/Yeet/internal/MonitorChecks");
+
+// `gh pr checks` prints "no checks reported on the '<branch>' branch", and
+// "no required checks reported on ..." under `--required`. Both mean the same
+// thing to a freshly pushed head: nothing has registered yet.
+const NO_CHECKS_REPORTED = /no (?:required )?checks reported/iu;
+
+/**
+ * Whether a check watch found checks to watch.
+ *
+ * **Details**
+ *
+ * `awaiting-registration` is deliberately narrow: it means the watch found
+ * *zero* checks, which is the only state a later attempt can change on its own.
+ * A watch that saw checks and reported a red is `registered` — that answer is
+ * about the code, and no amount of waiting improves it.
+ *
+ * **Example** (Name the states)
+ *
+ * ```ts
+ * import { YeetCheckRegistration } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(YeetCheckRegistration.is["awaiting-registration"]("awaiting-registration")) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const YeetCheckRegistration = LiteralKit(["registered", "awaiting-registration"]).pipe(
+  $I.annoteSchema("YeetCheckRegistration", {
+    title: "Yeet Check Registration",
+    description: "Whether a pull request head had any check runs registered when the watch ran.",
+  })
+);
+
+/**
+ * Whether a check watch found checks to watch.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type YeetCheckRegistration = typeof YeetCheckRegistration.Type;
+
+/**
+ * Classify one `gh pr checks --watch` result.
+ *
+ * **Details**
+ *
+ * Both conditions are required. A zero exit means the watch ran to a verdict,
+ * so it is `registered` whatever it printed; a non-zero exit whose output does
+ * not name the empty-check condition is an ordinary failure — a denied token,
+ * no pull request, a network error — and re-attempting it would just spend the
+ * backoff on a failure that is already the answer.
+ *
+ * **Example** (Classify an unregistered head)
+ *
+ * ```ts
+ * import { RepoStepRunResult } from "@beep/repo-cli/internal/repo-run"
+ * import { yeetCheckRegistration } from "@beep/repo-cli/test/Yeet"
+ *
+ * const result = RepoStepRunResult.make({
+ *   stepId: "monitor:02-pr-checks-watch",
+ *   commandText: "gh pr checks --watch",
+ *   exitCode: 1,
+ *   output: "no checks reported on the 'feat/x' branch",
+ * })
+ * console.log(yeetCheckRegistration(result)) // awaiting-registration
+ * ```
+ *
+ * @param result - One executed check-watch step result.
+ * @returns `awaiting-registration` when the head carried no checks, else `registered`.
+ * @category predicates
+ * @since 0.0.0
+ */
+export const yeetCheckRegistration = (result: RepoStepRunResult): YeetCheckRegistration =>
+  result.exitCode !== 0 && NO_CHECKS_REPORTED.test(O.getOrElse(O.fromUndefinedOr(result.output), () => Str.empty))
+    ? YeetCheckRegistration.Enum["awaiting-registration"]
+    : YeetCheckRegistration.Enum.registered;
+
+/**
+ * Whether any step in a watch attempt found no checks registered.
+ *
+ * **Example** (An empty attempt is not awaiting anything)
+ *
+ * ```ts
+ * import { isAwaitingYeetCheckRegistration } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(isAwaitingYeetCheckRegistration([])) // false
+ * ```
+ *
+ * @param results - The results of one check-watch attempt.
+ * @returns True when at least one result reported zero registered checks.
+ * @category predicates
+ * @since 0.0.0
+ */
+export const isAwaitingYeetCheckRegistration = (results: ReadonlyArray<RepoStepRunResult>): boolean =>
+  A.some(results, (result) => YeetCheckRegistration.is["awaiting-registration"](yeetCheckRegistration(result)));
+
+/**
+ * The waits between check-registration attempts, in order.
+ *
+ * **Details**
+ *
+ * Registration normally lands within a few seconds of the push, so the first
+ * wait is short and the tail widens to cover a slow control plane without
+ * hammering it. Its length is the bound: five entries, six attempts,
+ * ~95 seconds of patience, after which the empty result is the answer. The
+ * bound is what keeps this a fix and not a new way for a monitor to hang.
+ *
+ * **Example** (Read the bound)
+ *
+ * ```ts
+ * import { YEET_CHECK_REGISTRATION_BACKOFF } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(YEET_CHECK_REGISTRATION_BACKOFF.length) // 5
+ * ```
+ *
+ * @category constants
+ * @since 0.0.0
+ */
+export const YEET_CHECK_REGISTRATION_BACKOFF: ReadonlyArray<Duration.Duration> = [
+  Duration.seconds(5),
+  Duration.seconds(10),
+  Duration.seconds(20),
+  Duration.seconds(30),
+  Duration.seconds(30),
+];
+
+// Printed by the loop below rather than exported: the line's content is proven
+// where it is emitted, and a three-parameter renderer has no meaningful
+// data-last partner to satisfy the pipeable-signature rule with.
+const renderRegistrationWait = (attempt: number, attempts: number, delay: Duration.Duration): string =>
+  `[yeet] no checks registered for this head yet; retrying in ${Duration.format(delay)} (${attempt}/${attempts})`;
+
+/**
+ * Report that no check ever registered for the pushed head.
+ *
+ * **Example** (Render the exhausted verdict)
+ *
+ * ```ts
+ * import { renderYeetCheckRegistrationExhausted, YEET_CHECK_REGISTRATION_BACKOFF } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(renderYeetCheckRegistrationExhausted(YEET_CHECK_REGISTRATION_BACKOFF))
+ * ```
+ *
+ * @param delays - The backoff that was exhausted.
+ * @returns The operator line naming the condition and what to check.
+ * @category formatting
+ * @since 0.0.0
+ */
+export const renderYeetCheckRegistrationExhausted = (delays: ReadonlyArray<Duration.Duration>): string =>
+  `No checks registered for the pushed head after ${A.length(delays) + 1} attempts over ${Duration.format(
+    A.reduce(delays, Duration.zero, (total, delay) => Duration.sum(total, delay))
+  )}; GitHub never reported a check run for it. Confirm the workflows' path filters cover this diff and that Actions is enabled for the repository.`;
+
+/**
+ * Re-run a check watch while the pushed head has no checks registered.
+ *
+ * **Details**
+ *
+ * The attempt is passed as an effect and re-executed, rather than a result
+ * being inspected once, because "watch the checks" and "wait for the checks to
+ * exist" are the same command — the second attempt is just the first one run
+ * again after the control plane has had time to catch up. The bound comes from
+ * `delays`, which the caller supplies so tests can exercise the loop without
+ * waiting for real seconds.
+ *
+ * The bound is a required argument rather than a default, so every call site
+ * states how much patience it is buying and a test can buy none.
+ *
+ * **Example** (Wrap a check watch)
+ *
+ * ```ts
+ * import { awaitYeetCheckRegistration, YEET_CHECK_REGISTRATION_BACKOFF } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const watched = Effect.succeed([]).pipe(awaitYeetCheckRegistration(YEET_CHECK_REGISTRATION_BACKOFF))
+ * console.log(Effect.isEffect(watched)) // true
+ * ```
+ *
+ * @param delays - Waits between attempts, in order; its length is the bound.
+ * @returns A combinator over one check-watch attempt, yielding the results of
+ * the first attempt that found checks, or of the last attempt made.
+ * @category execution
+ * @since 0.0.0
+ */
+export const awaitYeetCheckRegistration =
+  (delays: ReadonlyArray<Duration.Duration>) =>
+  <Failure, Requirements>(
+    attempt: Effect.Effect<ReadonlyArray<RepoStepRunResult>, Failure, Requirements>
+  ): Effect.Effect<ReadonlyArray<RepoStepRunResult>, Failure, Requirements> =>
+    Effect.flatMap(attempt, (first) =>
+      Effect.reduce(
+        delays,
+        () => first,
+        (results, delay, index) =>
+          isAwaitingYeetCheckRegistration(results)
+            ? pipe(
+                Console.log(renderRegistrationWait(index + 1, A.length(delays), delay)),
+                Effect.andThen(Effect.sleep(delay)),
+                Effect.andThen(attempt)
+              )
+            : Effect.succeed(results)
+      )
+    );

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/MonitorComments.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/MonitorComments.ts
@@ -1,12 +1,23 @@
 /**
  * Pull request comment streaming for Yeet monitor sessions.
  *
+ * **Details**
+ *
+ * The stream is durable across runs and independent of the check watcher it is
+ * raced against. Durable: the per-collection watermarks are persisted to a
+ * branch-scoped artifact after every poll that advances them, so a comment
+ * posted while no monitor was attached is printed by the next run instead of
+ * falling into the gap between a process exit and the next process start.
+ * Independent: a poll that fails degrades this stream alone — the surrounding
+ * race can never be decided by a GitHub read error, because the poller's error
+ * channel is `never` by construction.
+ *
  * @packageDocumentation
  * @since 0.0.0
  */
 
 import { $RepoCliId } from "@beep/identity/packages";
-import { Console, DateTime, Duration, Effect, Match, Order, pipe, Ref } from "effect";
+import { Console, DateTime, Duration, Effect, FileSystem, Match, Order, pipe, Ref, Result } from "effect";
 import * as A from "effect/Array";
 import { dual, flow } from "effect/Function";
 import * as O from "effect/Option";
@@ -14,7 +25,11 @@ import * as S from "effect/Schema";
 import * as Str from "effect/String";
 import { GhActor } from "../../../internal/github/index.ts";
 import { runRepoCommandCapture } from "../../../internal/repo-run/index.ts";
+import { JsonStringCodec } from "../../../internal/schema/JsonCodec.ts";
 import { YeetCommandError } from "../Yeet.errors.ts";
+import { runArtifactPathForContext } from "./ArtifactPaths.ts";
+import { writeTextFile } from "./IssueArtifacts.ts";
+import type { Path } from "effect";
 import type { ChildProcessSpawner } from "effect/unstable/process";
 import type { RepoRunContext } from "../../../internal/repo-run/index.ts";
 
@@ -201,15 +216,142 @@ export class GhRestIssueComment extends S.Class<GhRestIssueComment>($I`GhRestIss
   })
 ) {}
 
-class YeetMonitorCommentWatermark extends S.Class<YeetMonitorCommentWatermark>($I`YeetMonitorCommentWatermark`)(
+/**
+ * The pair of cursors one monitor session advances.
+ *
+ * **Details**
+ *
+ * GitHub exposes inline review comments and conversation comments as two
+ * collections with independent id spaces and independent `since` filters, so
+ * one shared cursor would let a busy collection drag the quiet one forward and
+ * silently skip its comments. They are carried together because they are
+ * advanced and persisted together — one poll, one write.
+ *
+ * **Example** (Start both cursors at the same instant)
+ *
+ * ```ts
+ * import { YeetMonitorCommentCursor, YeetMonitorCommentWatermark } from "@beep/repo-cli/test/Yeet"
+ *
+ * const cursor = YeetMonitorCommentCursor.make({ createdAt: "2026-08-16T12:00:00.000Z", id: 0 })
+ * const watermark = YeetMonitorCommentWatermark.make({ issue: cursor, review: cursor })
+ * console.log(watermark.review.id) // 0
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetMonitorCommentWatermark extends S.Class<YeetMonitorCommentWatermark>($I`YeetMonitorCommentWatermark`)(
   {
     issue: YeetMonitorCommentCursor,
     review: YeetMonitorCommentCursor,
   },
   $I.annote("YeetMonitorCommentWatermark", {
-    description: "In-memory per-collection comment cursors for one pull request monitor session.",
+    description: "Per-collection comment cursors for one pull request monitor session.",
   })
 ) {}
+
+/**
+ * The persisted comment watermark for one branch's pull request.
+ *
+ * **Details**
+ *
+ * Written next to the other branch-scoped Yeet run artifacts and versioned like
+ * them, so a future shape change is a decode miss — which restarts the stream
+ * from now — rather than a crash inside a monitor session. `prNumber` is part
+ * of the record because the file is keyed by branch: a branch whose pull
+ * request was closed and reopened as a new number must not inherit the old
+ * one's cursors, and comparing the recorded number is what detects that.
+ *
+ * **Example** (Describe a resumable stream position)
+ *
+ * ```ts
+ * import { YeetMonitorCommentCursor, YeetMonitorCommentState, YeetMonitorCommentWatermark } from "@beep/repo-cli/test/Yeet"
+ *
+ * const cursor = YeetMonitorCommentCursor.make({ createdAt: "2026-08-16T12:00:00.000Z", id: 44 })
+ * const state = YeetMonitorCommentState.make({
+ *   schemaVersion: "yeet-monitor-comments/v1",
+ *   prNumber: 558,
+ *   updatedAt: "2026-08-16T12:00:05.000Z",
+ *   watermark: YeetMonitorCommentWatermark.make({ issue: cursor, review: cursor }),
+ * })
+ * console.log(state.prNumber) // 558
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class YeetMonitorCommentState extends S.Class<YeetMonitorCommentState>($I`YeetMonitorCommentState`)(
+  {
+    schemaVersion: S.Literal("yeet-monitor-comments/v1"),
+    prNumber: S.Int.check(S.isGreaterThan(0)),
+    updatedAt: S.String,
+    watermark: YeetMonitorCommentWatermark,
+  },
+  $I.annote("YeetMonitorCommentState", {
+    description: "Branch-scoped comment stream position carried between Yeet monitor runs.",
+  })
+) {}
+
+/**
+ * JSON-string codec for the persisted comment stream position.
+ *
+ * **Example** (Encode a stream position)
+ *
+ * ```ts
+ * import { YeetMonitorCommentCursor, YeetMonitorCommentState, YeetMonitorCommentStateJson, YeetMonitorCommentWatermark } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const cursor = YeetMonitorCommentCursor.make({ createdAt: "2026-08-16T12:00:00.000Z", id: 44 })
+ * const state = YeetMonitorCommentState.make({
+ *   schemaVersion: "yeet-monitor-comments/v1",
+ *   prNumber: 558,
+ *   updatedAt: "2026-08-16T12:00:05.000Z",
+ *   watermark: YeetMonitorCommentWatermark.make({ issue: cursor, review: cursor }),
+ * })
+ * console.log(Effect.runSync(YeetMonitorCommentStateJson.encode(state)).includes("yeet-monitor-comments/v1"))
+ * ```
+ *
+ * @category codecs
+ * @since 0.0.0
+ */
+export const YeetMonitorCommentStateJson = JsonStringCodec(YeetMonitorCommentState);
+
+/**
+ * File name of the persisted comment stream position inside a Yeet run
+ * directory.
+ *
+ * **Example** (Name the artifact)
+ *
+ * ```ts
+ * import { YEET_MONITOR_COMMENT_STATE_FILE_NAME } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(YEET_MONITOR_COMMENT_STATE_FILE_NAME)
+ * ```
+ *
+ * @category constants
+ * @since 0.0.0
+ */
+export const YEET_MONITOR_COMMENT_STATE_FILE_NAME = "monitor-comments.json";
+
+/**
+ * Resolve the branch-scoped comment stream position artifact path.
+ *
+ * **Example** (Resolve the artifact path)
+ *
+ * ```ts
+ * import { yeetMonitorCommentStatePath } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * console.log(Effect.isEffect(Effect.succeed(yeetMonitorCommentStatePath))) // true
+ * ```
+ *
+ * @param context - Repo run context carrying the artifact directory and branch.
+ * @returns Absolute path to the branch-scoped `monitor-comments.json`.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const yeetMonitorCommentStatePath = (context: RepoRunContext): Effect.Effect<string, never, Path.Path> =>
+  runArtifactPathForContext(context, YEET_MONITOR_COMMENT_STATE_FILE_NAME);
 
 const commentCursorOrder: Order.Order<YeetMonitorCommentCursor> = Order.combine(
   Order.mapInput(Order.String, (cursor: YeetMonitorCommentCursor) => cursor.createdAt),
@@ -402,7 +544,10 @@ const fetchComments = Effect.fn("YeetMonitor.fetchComments")(function* <Comment>
     return yield* YeetCommandError.make({
       command: `gh api --method GET ${endpoint}`,
       exitCode: result.exitCode === 0 ? 1 : result.exitCode,
-      message: "Failed to poll pull request comments during yeet monitor.",
+      // The reason travels with the failure: a degraded poll is reported to the
+      // operator by message alone, and "the poll failed" without gh's own words
+      // cannot distinguish a rate limit from a revoked token.
+      message: `Failed to poll pull request comments during yeet monitor: ${excerpt(result.output)}`,
     });
   }
   return yield* decode(result.output).pipe(
@@ -417,11 +562,104 @@ const nextCursor = (cursor: YeetMonitorCommentCursor, comments: ReadonlyArray<Ye
       : latest
   );
 
+const writeCommentState = Effect.fn("YeetMonitor.writeCommentState")(function* (
+  context: RepoRunContext,
+  pullRequestNumber: number,
+  watermark: YeetMonitorCommentWatermark
+): Effect.fn.Return<void, YeetCommandError, FileSystem.FileSystem | Path.Path> {
+  const statePath = yield* yeetMonitorCommentStatePath(context);
+  const updatedAt = yield* DateTime.now.pipe(Effect.map(DateTime.formatIso));
+  const json = yield* YeetMonitorCommentStateJson.encode(
+    YeetMonitorCommentState.make({
+      schemaVersion: "yeet-monitor-comments/v1",
+      prNumber: pullRequestNumber,
+      updatedAt,
+      watermark,
+    })
+  ).pipe(Effect.mapError(YeetCommandError.new("Failed to encode the yeet monitor comment cursor artifact.")));
+  yield* writeTextFile(statePath, `${json}\n`);
+});
+
+/**
+ * Warn that the comment cursor could not be persisted, naming the consequence.
+ *
+ * **Example** (Render the warning)
+ *
+ * ```ts
+ * import { renderYeetMonitorCommentStateWarning } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(renderYeetMonitorCommentStateWarning("disk is full"))
+ * ```
+ *
+ * @param reason - Why the write failed.
+ * @returns The operator warning line.
+ * @category formatting
+ * @since 0.0.0
+ */
+export const renderYeetMonitorCommentStateWarning = (reason: string): string =>
+  `[yeet] could not persist the PR comment cursor (${reason}); this session still streams, but the next monitor run will start from its own clock and may miss comments posted before it.`;
+
+// Persisting is best effort by design: the position is an optimisation over
+// "start from now", and losing it costs one run's worth of resumption, while
+// failing the poll over it would cost the whole comment stream.
+const persistCommentState = (
+  context: RepoRunContext,
+  pullRequestNumber: number,
+  watermark: YeetMonitorCommentWatermark
+): Effect.Effect<void, never, FileSystem.FileSystem | Path.Path> =>
+  writeCommentState(context, pullRequestNumber, watermark).pipe(
+    Effect.catch((error) => Console.warn(renderYeetMonitorCommentStateWarning(error.message)))
+  );
+
+/**
+ * Read the persisted comment stream position for one pull request.
+ *
+ * **Details**
+ *
+ * Every way the read can go wrong — no artifact yet, an unreadable file, a
+ * shape from an older schema version, a position recorded against a different
+ * pull request — yields `None`, which the caller reads as "start from now".
+ * A monitor session must not be blocked by its own resumption optimisation.
+ *
+ * **Example** (Build the read effect)
+ *
+ * ```ts
+ * import { loadYeetMonitorCommentWatermark } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * console.log(Effect.isEffect(Effect.succeed(loadYeetMonitorCommentWatermark))) // true
+ * ```
+ *
+ * @param context - Repo run context carrying the artifact directory and branch.
+ * @param pullRequestNumber - The pull request the position must belong to.
+ * @returns The persisted watermark, or `None` when there is no usable one.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const loadYeetMonitorCommentWatermark = Effect.fn("YeetMonitor.loadCommentWatermark")(function* (
+  context: RepoRunContext,
+  pullRequestNumber: number
+): Effect.fn.Return<O.Option<YeetMonitorCommentWatermark>, never, FileSystem.FileSystem | Path.Path> {
+  const fs = yield* FileSystem.FileSystem;
+  const statePath = yield* yeetMonitorCommentStatePath(context);
+  const text = yield* Effect.option(fs.readFileString(statePath));
+  return pipe(
+    text,
+    O.flatMap(YeetMonitorCommentStateJson.decodeOption),
+    O.filter((state) => state.prNumber === pullRequestNumber),
+    O.map((state) => state.watermark)
+  );
+});
+
 const pollComments = Effect.fn("YeetMonitor.pollComments")(function* (
   context: RepoRunContext,
   pullRequestNumber: number,
   watermarkRef: Ref.Ref<YeetMonitorCommentWatermark>
-): Effect.fn.Return<void, YeetCommandError, ChildProcessSpawner.ChildProcessSpawner> {
+): Effect.fn.Return<
+  void,
+  YeetCommandError,
+  ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
+> {
   const watermark = yield* Ref.get(watermarkRef);
   const [reviewPayload, issuePayload] = yield* Effect.all(
     [
@@ -446,14 +684,115 @@ const pollComments = Effect.fn("YeetMonitor.pollComments")(function* (
   const newIssueComments = A.filter(issueComments, (comment) => isYeetMonitorCommentAfter(watermark.issue, comment));
   const newComments = A.sort([...newReviewComments, ...newIssueComments], commentOrder);
   yield* Effect.forEach(newComments, (comment) => Console.log(renderYeetMonitorComment(comment)), { concurrency: 1 });
-  yield* Ref.set(
-    watermarkRef,
-    YeetMonitorCommentWatermark.make({
-      issue: nextCursor(watermark.issue, newIssueComments),
-      review: nextCursor(watermark.review, newReviewComments),
+  if (A.isReadonlyArrayEmpty(newComments)) {
+    return;
+  }
+  const advanced = YeetMonitorCommentWatermark.make({
+    issue: nextCursor(watermark.issue, newIssueComments),
+    review: nextCursor(watermark.review, newReviewComments),
+  });
+  yield* Ref.set(watermarkRef, advanced);
+  yield* persistCommentState(context, pullRequestNumber, advanced);
+});
+
+/**
+ * How many consecutive failed polls end the comment stream.
+ *
+ * **Details**
+ *
+ * A bound, not a retry budget: each failure is reported as it happens and the
+ * next poll still runs, so a rate limit or a dropped connection costs one tick.
+ * The bound exists for the failure that is not transient — a revoked token, a
+ * deleted pull request — where continuing to print the same error every ten
+ * seconds for the length of a CI run is noise, not signal.
+ *
+ * **Example** (Read the bound)
+ *
+ * ```ts
+ * import { YEET_MONITOR_COMMENT_FAILURE_BUDGET } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(YEET_MONITOR_COMMENT_FAILURE_BUDGET)
+ * ```
+ *
+ * @category constants
+ * @since 0.0.0
+ */
+export const YEET_MONITOR_COMMENT_FAILURE_BUDGET = 5;
+
+// Printed by the tick below rather than exported: the line is proven where it
+// is emitted, and a three-parameter renderer has no meaningful data-last
+// partner to satisfy the pipeable-signature rule with.
+const renderCommentPollFailure = (reason: string, failures: number, budget: number): string =>
+  `[yeet] PR comment poll failed (${failures}/${budget}): ${reason} Check watching is unaffected.`;
+
+/**
+ * Report that comment streaming stopped while the session continues.
+ *
+ * **Example** (Render the degraded notice)
+ *
+ * ```ts
+ * import { renderYeetMonitorCommentStreamStopped } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(renderYeetMonitorCommentStreamStopped(5))
+ * ```
+ *
+ * @param budget - The consecutive-failure bound that was reached.
+ * @returns The operator line naming the degradation and how to see comments.
+ * @category formatting
+ * @since 0.0.0
+ */
+export const renderYeetMonitorCommentStreamStopped = (budget: number): string =>
+  `[yeet] PR comment streaming stopped after ${budget} consecutive failed polls; this session keeps watching checks. Read comments with \`bun run beep yeet status --remote\` or on the pull request.`;
+
+const pollTick = Effect.fn("YeetMonitor.pollTick")(function* (
+  context: RepoRunContext,
+  pullRequestNumber: number,
+  watermarkRef: Ref.Ref<YeetMonitorCommentWatermark>,
+  failuresRef: Ref.Ref<number>,
+  budget: number
+): Effect.fn.Return<void, never, ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path> {
+  const polled = yield* Effect.result(pollComments(context, pullRequestNumber, watermarkRef));
+  if (Result.isSuccess(polled)) {
+    return yield* Ref.set(failuresRef, 0);
+  }
+  const failures = yield* Ref.updateAndGet(failuresRef, (count) => count + 1);
+  yield* Console.error(renderCommentPollFailure(polled.failure.message, failures, budget));
+  if (failures < budget) {
+    return;
+  }
+  yield* Console.error(renderYeetMonitorCommentStreamStopped(budget));
+  // Parking instead of returning is the whole point: this poller is raced
+  // against the check watcher, so *completing* here — success or failure —
+  // would cancel the checks. A stream that has given up must become a fiber
+  // that never decides the race.
+  return yield* Effect.never;
+});
+
+/**
+ * Report where this session's comment stream starts.
+ *
+ * **Example** (Render a resumed start)
+ *
+ * ```ts
+ * import { renderYeetMonitorCommentStreamStart } from "@beep/repo-cli/test/Yeet"
+ * import * as O from "effect/Option"
+ *
+ * console.log(renderYeetMonitorCommentStreamStart(O.some("2026-08-16T12:00:00.000Z")))
+ * ```
+ *
+ * @param resumedFrom - The persisted position's timestamp, when one was found.
+ * @returns The operator line naming the stream's starting position.
+ * @category formatting
+ * @since 0.0.0
+ */
+export const renderYeetMonitorCommentStreamStart = (resumedFrom: O.Option<string>): string =>
+  pipe(
+    resumedFrom,
+    O.match({
+      onNone: () => "[yeet] streaming new PR comments from now (no saved position for this branch)",
+      onSome: (createdAt) => `[yeet] resuming the PR comment stream from ${createdAt}`,
     })
   );
-});
 
 /**
  * Poll and stream pull request comments until the surrounding monitor interrupts it.
@@ -462,6 +801,21 @@ const pollComments = Effect.fn("YeetMonitor.pollComments")(function* (
  *
  * Use with the existing hosted-check watcher so comments and pipeline state are
  * visible during the same Yeet monitor session.
+ *
+ * **Details**
+ *
+ * The session resumes from the branch-scoped position written by the previous
+ * run, so a comment posted between two monitor runs is printed by the second
+ * one. With no usable saved position the stream starts from now — the old
+ * behaviour and the only safe fallback — and writes that starting position
+ * straight away, so even a session that prints nothing leaves the next one a
+ * position to resume from.
+ *
+ * **Gotchas**
+ *
+ * This effect cannot fail. That is a contract, not an accident: it is raced
+ * against the check watcher, and an error channel here would let one failed
+ * GitHub read cancel the checks the operator is actually waiting on.
  *
  * **Example** (Create the long-lived monitor effect)
  *
@@ -482,19 +836,45 @@ const pollComments = Effect.fn("YeetMonitor.pollComments")(function* (
  * console.log(Effect.isEffect(runYeetPullRequestCommentMonitor(context, 42))) // true
  * ```
  *
+ * @param context - Repo run context carrying the repo root and artifact directory.
+ * @param pullRequestNumber - The pull request whose comments are streamed.
+ * @param budget - Consecutive failed polls that stop the stream; tests pass a
+ * small one to reach the degraded state without waiting.
+ * @returns A fiber that streams until interrupted and never completes.
  * @category streams
  * @since 0.0.0
  */
 export const runYeetPullRequestCommentMonitor = Effect.fn("Yeet.runPullRequestCommentMonitor")(function* (
   context: RepoRunContext,
-  pullRequestNumber: number
-): Effect.fn.Return<never, YeetCommandError, ChildProcessSpawner.ChildProcessSpawner> {
+  pullRequestNumber: number,
+  budget: number = YEET_MONITOR_COMMENT_FAILURE_BUDGET
+): Effect.fn.Return<never, never, ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path> {
   const startedAt = yield* DateTime.now.pipe(Effect.map(DateTime.formatIso));
   const initialCursor = YeetMonitorCommentCursor.make({ createdAt: startedAt, id: 0 });
-  const watermarkRef = yield* Ref.make(
+  const persisted = yield* loadYeetMonitorCommentWatermark(context, pullRequestNumber);
+  // The earlier of the two cursors is where the stream genuinely resumes: the
+  // collections advance independently, so quoting one of them would understate
+  // how far back the other still reaches.
+  yield* Console.log(
+    renderYeetMonitorCommentStreamStart(
+      O.map(persisted, (watermark) => Order.min(commentCursorOrder)(watermark.issue, watermark.review).createdAt)
+    )
+  );
+  const watermark = O.getOrElse(persisted, () =>
     YeetMonitorCommentWatermark.make({ issue: initialCursor, review: initialCursor })
   );
+  const watermarkRef = yield* Ref.make(watermark);
+  // A first session on this branch writes its starting position immediately
+  // rather than only when it prints something. Otherwise a quiet session leaves
+  // no position at all, and the next run starts from *its* own clock — which is
+  // precisely the gap a comment posted between the two runs falls into.
+  if (O.isNone(persisted)) {
+    yield* persistCommentState(context, pullRequestNumber, watermark);
+  }
+  const failuresRef = yield* Ref.make(0);
   return yield* Effect.forever(
-    pollComments(context, pullRequestNumber, watermarkRef).pipe(Effect.andThen(Effect.sleep(monitorPollInterval)))
+    pollTick(context, pullRequestNumber, watermarkRef, failuresRef, budget).pipe(
+      Effect.andThen(Effect.sleep(monitorPollInterval))
+    )
   );
 });

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Porcelain.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Porcelain.ts
@@ -24,17 +24,21 @@
 
 import { Console, Effect } from "effect";
 import * as A from "effect/Array";
+import * as O from "effect/Option";
 import * as Str from "effect/String";
+import { failWithReportedExit } from "../../../internal/cli/ExitCodeError.ts";
 import { YeetCommandError } from "../Yeet.errors.ts";
 import { hydrateYeetReadOnlyContext } from "./Handler.ts";
 import { mergePr } from "./Merge.ts";
 import { runYeetMonitorUntilMerged } from "./MonitorLoop.ts";
-import { runYeetReply } from "./Reply.ts";
+import { renderYeetReplyFailureVerdict, replyReportPathForContext, runYeetReply } from "./Reply.ts";
 import { SweepPlanJson, SweepReportJson } from "./Sweep.schemas.ts";
 import { executeSweep, overrideSweepBranch, planSweep, renderSweepReport } from "./Sweep.ts";
 import type { FileSystem, Path } from "effect";
 import type { ChildProcessSpawner } from "effect/unstable/process";
+import type { CliReportedExit } from "../../../internal/cli/ExitCodeError.ts";
 import type { YeetMonitorTerminalState } from "./MonitorLoop.ts";
+import type { ReplyReport } from "./Reply.schemas.ts";
 import type { SweepPlan, SweepPlanStep, SweepReport } from "./Sweep.schemas.ts";
 
 /**
@@ -166,6 +170,18 @@ export const runYeetMerge = Effect.fn("Yeet.runMergeCommand")(function* (
  * from any worktree. Every draft gets its turn: a denied scope or a deleted
  * thread becomes that draft's outcome, never an aborted pass.
  *
+ * **Gotchas**
+ *
+ * The batch running to completion is not the same as the batch succeeding, and
+ * this seam is where the two part company. Any `failed` outcome exits non-zero
+ * through {@link CliReportedExit}, because an unwritten reply leaves its review
+ * thread open — an unresolved thread is a hard merge gate, so an exit-0 pass
+ * would hand `yeet reply && bun run beep yeet monitor` a green it has not
+ * earned. `stale` is not a failure: the thread was already resolved upstream,
+ * so there was nothing to write. The exit is silent by construction — the pass
+ * already printed every outcome and the report path, so the sentinel adds the
+ * code and the verdict line, not a second rendering of the same failure.
+ *
  * **Example** (Build the reply runner effect)
  *
  * ```ts
@@ -177,7 +193,7 @@ export const runYeetMerge = Effect.fn("Yeet.runMergeCommand")(function* (
  * ```
  *
  * @param options - Parsed `yeet reply` flag values.
- * @returns Void once every draft outcome has been recorded and reported.
+ * @returns Void once every draft was written; a non-zero exit when any failed.
  * @category commands
  * @since 0.0.0
  */
@@ -185,10 +201,58 @@ export const runYeetReplyPass = Effect.fn("Yeet.runReplyCommand")(function* (
   options: YeetPorcelainOptions
 ): Effect.fn.Return<
   void,
-  YeetCommandError,
+  YeetCommandError | CliReportedExit,
   FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
 > {
-  yield* runYeetReply(yield* hydrateYeetReadOnlyContext(options));
+  const context = yield* hydrateYeetReadOnlyContext(options);
+  const report = yield* runYeetReply(context);
+  yield* failYeetReplyOnFailedOutcomes(report, yield* replyReportPathForContext(context));
+});
+
+/**
+ * Exit non-zero when a reply pass left any drafted reply unwritten.
+ *
+ * **Details**
+ *
+ * The report is the accounting and this is the verdict read off it. It is a
+ * separate function because the decision is the interesting part: which
+ * outcomes count as failure (`failed` only — `stale` wrote nothing because
+ * there was nothing to write) and what the operator is told. The exit is
+ * silent, since the pass already printed every outcome; this adds the verdict
+ * line and the code.
+ *
+ * **Example** (A clean report exits normally)
+ *
+ * ```ts
+ * import { failYeetReplyOnFailedOutcomes, ReplyReport } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const report = ReplyReport.make({
+ *   schemaVersion: "yeet-reply-report/v1",
+ *   prNumber: 558,
+ *   createdAt: "2026-08-16T00:00:00.000Z",
+ *   outcomes: [],
+ * })
+ * const verdict = failYeetReplyOnFailedOutcomes(report, "reply-report.json").pipe(Effect.as("clean"))
+ * console.log(Effect.runSync(verdict))
+ * ```
+ *
+ * @param report - The report written by one reply pass.
+ * @param reportPath - Where that report was written, quoted in the verdict.
+ * @returns Void when every draft was written; a reported non-zero exit otherwise.
+ * @category commands
+ * @since 0.0.0
+ */
+export const failYeetReplyOnFailedOutcomes = Effect.fn("Yeet.failReplyOnFailedOutcomes")(function* (
+  report: ReplyReport,
+  reportPath: string
+): Effect.fn.Return<void, CliReportedExit> {
+  const verdict = renderYeetReplyFailureVerdict(report, reportPath);
+  if (O.isNone(verdict)) {
+    return;
+  }
+  yield* Console.error(verdict.value);
+  return yield* failWithReportedExit(verdict.value);
 });
 
 /**

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Reply.schemas.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Reply.schemas.ts
@@ -28,6 +28,8 @@
 import { $RepoCliId } from "@beep/identity/packages";
 import { LiteralKit, SchemaUtils } from "@beep/schema";
 import { Effect } from "effect";
+import * as A from "effect/Array";
+import { dual } from "effect/Function";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
 import { JsonStringCodec } from "../../../internal/schema/JsonCodec.ts";
@@ -321,6 +323,110 @@ export class ReplyReport extends S.Class<ReplyReport>($I`ReplyReport`)(
     description: "Result document for one reply run: every drafted reply paired with its outcome.",
   })
 ) {}
+
+/**
+ * Name one reply outcome by the handle its draft used.
+ *
+ * **Details**
+ *
+ * A draft targets a thread either way GitHub exposes one, so the operator-facing
+ * handle has to follow the draft rather than pick a canonical id: printing a
+ * thread id for a draft written against a comment id names something the author
+ * never typed. Shared by the per-draft log line and the run's failure verdict so
+ * both name the same thing.
+ *
+ * **Gotchas**
+ *
+ * It takes the two handles rather than a whole {@link ReplyDraftOutcome} on
+ * purpose. `ReplyTargetPresenceCheck` makes a decoded outcome carrying neither
+ * handle impossible to construct, which would leave the "neither" arm here
+ * unreachable and untestable; accepting the handles alone lets that arm be
+ * exercised directly, and the function never needed the status or detail.
+ *
+ * **Example** (Name a comment-id target)
+ *
+ * ```ts
+ * import { ReplyDraftOutcome, replyOutcomeTarget } from "@beep/repo-cli/test/Yeet"
+ * import * as O from "effect/Option"
+ *
+ * const outcome = ReplyDraftOutcome.make({
+ *   commentId: O.some(2284119001),
+ *   status: "failed",
+ *   detail: "the reply mutation was denied",
+ * })
+ * console.log(replyOutcomeTarget(outcome))
+ * ```
+ *
+ * @param target - The thread id and comment id a draft named, either optional.
+ * @returns The thread id when the draft carried one, else its comment handle.
+ * @category formatting
+ * @since 0.0.0
+ */
+export const replyOutcomeTarget = (target: Pick<ReplyDraftOutcome, "commentId" | "threadId">): string =>
+  O.getOrElse(target.threadId, () => `comment ${O.getOrElse(O.map(target.commentId, String), () => "?")}`);
+
+/**
+ * Select the outcomes a reply run recorded with one status.
+ *
+ * **Example** (Count the stale outcomes)
+ *
+ * ```ts
+ * import { ReplyDraftOutcome, replyOutcomesWithStatus } from "@beep/repo-cli/test/Yeet"
+ * import * as O from "effect/Option"
+ *
+ * const outcomes = [
+ *   ReplyDraftOutcome.make({ threadId: O.some("PRRT_a"), status: "stale", detail: "already resolved" }),
+ * ]
+ * console.log(replyOutcomesWithStatus(outcomes, "stale").length)
+ * ```
+ *
+ * @param outcomes - Every outcome one reply run recorded.
+ * @param status - The status to select.
+ * @returns The outcomes carrying that status, in run order.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const replyOutcomesWithStatus: {
+  (status: ReplyOutcomeStatus): (outcomes: ReadonlyArray<ReplyDraftOutcome>) => ReadonlyArray<ReplyDraftOutcome>;
+  (outcomes: ReadonlyArray<ReplyDraftOutcome>, status: ReplyOutcomeStatus): ReadonlyArray<ReplyDraftOutcome>;
+} = dual(
+  2,
+  (outcomes: ReadonlyArray<ReplyDraftOutcome>, status: ReplyOutcomeStatus): ReadonlyArray<ReplyDraftOutcome> =>
+    A.filter(outcomes, (outcome) => outcome.status === status)
+);
+
+/**
+ * The drafts a reply run could not write.
+ *
+ * **Details**
+ *
+ * This is the run's verdict surface: a `failed` outcome means a reply the
+ * operator asked for is not on the pull request, which leaves the thread open
+ * and the merge criterion unmet. `stale` is deliberately not a failure — the
+ * thread was already resolved upstream, so there was nothing to write and
+ * nothing to retry.
+ *
+ * **Example** (Read a report's failures)
+ *
+ * ```ts
+ * import { failedReplyOutcomes, ReplyReport } from "@beep/repo-cli/test/Yeet"
+ *
+ * const report = ReplyReport.make({
+ *   schemaVersion: "yeet-reply-report/v1",
+ *   prNumber: 558,
+ *   createdAt: "2026-08-16T00:00:00.000Z",
+ *   outcomes: [],
+ * })
+ * console.log(failedReplyOutcomes(report).length)
+ * ```
+ *
+ * @param report - The written report for one reply run.
+ * @returns Every outcome the run recorded as `failed`.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const failedReplyOutcomes = (report: ReplyReport): ReadonlyArray<ReplyDraftOutcome> =>
+  replyOutcomesWithStatus(report.outcomes, ReplyOutcomeStatus.Enum.failed);
 
 /**
  * JSON-string codec for the reply drafts artifact.

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Reply.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Reply.ts
@@ -58,7 +58,16 @@ import { artifactDirForContext } from "./ArtifactPaths.ts";
 import { decodeGhRepoView } from "./closeout/Gh.schemas.ts";
 import { REPLY_THREAD_MUTATION, RESOLVE_THREAD_MUTATION } from "./closeout/WritePlan.ts";
 import { writeTextFile } from "./IssueArtifacts.ts";
-import { ReplyDraft, ReplyDraftOutcome, ReplyDraftsJson, ReplyReport, ReplyReportJson } from "./Reply.schemas.ts";
+import {
+  failedReplyOutcomes,
+  ReplyDraft,
+  ReplyDraftOutcome,
+  ReplyDraftsJson,
+  ReplyReport,
+  ReplyReportJson,
+  replyOutcomesWithStatus,
+  replyOutcomeTarget,
+} from "./Reply.schemas.ts";
 import type { ChildProcessSpawner } from "effect/unstable/process";
 import type { GhCommandFailure } from "../../../internal/github/index.ts";
 import type { RepoRunContext } from "../../../internal/repo-run/index.ts";
@@ -872,7 +881,7 @@ const executeReplyAction = (
   );
 
 const countStatus = (outcomes: ReadonlyArray<ReplyDraftOutcome>, status: ReplyOutcomeStatus): number =>
-  A.length(A.filter(outcomes, (outcome) => outcome.status === status));
+  A.length(replyOutcomesWithStatus(outcomes, status));
 
 const replyPreflight = Effect.fn("Yeet.replyPreflight")(function* (
   context: RepoRunContext,
@@ -931,10 +940,15 @@ const preflightFailureOutcomes = (drafts: ReplyDrafts, failure: YeetCommandError
  *
  * **Gotchas**
  *
- * Per-draft failures exit 0 — the batch ran and the report is authoritative.
- * Only the preflight (nothing attempted) fails the run, and with no drafts
- * loaded it fails without a report: there is no outcome to attach the failure
- * to, so an exit-0 empty report would be a silent green.
+ * This engine returns the report for every pass that attempted work; the
+ * *command* turns a report carrying `failed` outcomes into a non-zero exit
+ * (`failedReplyOutcomes` at the `yeet reply` seam). Splitting it that way
+ * keeps the batch semantics — every remaining draft still gets its turn — while
+ * denying a `yeet reply && ...` chain the false green it used to get from a
+ * pass whose replies were all rejected. Only the preflight (nothing attempted)
+ * fails here, and with no drafts loaded it fails without a report: there is no
+ * outcome to attach the failure to, so an exit-0 empty report would be a silent
+ * green.
  *
  * **Example** (Build the reply run effect)
  *
@@ -981,10 +995,7 @@ export const runYeetReply = Effect.fn("Yeet.runReply")(function* (
     : preflightFailureOutcomes(drafts, preflight.failure);
   yield* Effect.forEach(
     outcomes,
-    (outcome) =>
-      Console.log(
-        `[yeet] reply ${outcome.status} ${O.getOrElse(outcome.threadId, () => `comment ${O.getOrElse(O.map(outcome.commentId, String), () => "?")}`)}: ${outcome.detail}`
-      ),
+    (outcome) => Console.log(`[yeet] reply ${outcome.status} ${replyOutcomeTarget(outcome)}: ${outcome.detail}`),
     { concurrency: 1 }
   );
 
@@ -1014,3 +1025,54 @@ export const runYeetReply = Effect.fn("Yeet.runReply")(function* (
 
   return report;
 });
+
+/**
+ * The operator verdict for a reply pass that could not write every draft.
+ *
+ * **Details**
+ *
+ * `None` is the whole contract for a clean pass: nothing failed, so there is
+ * nothing to say and nothing to exit non-zero over. `Some` names how many
+ * drafts failed out of how many ran and which handles they were, then points at
+ * the report — deliberately *not* at a retry command. Failures do not share one
+ * retry: a draft whose post was rejected is retried by re-running the pass,
+ * while a draft that posted and only failed to resolve must never be re-run
+ * that way or the body posts twice. Each outcome's own `detail` already carries
+ * the correct instruction, so the verdict routes the operator to them instead
+ * of overwriting them with a wrong one.
+ *
+ * **Example** (A clean pass has no verdict)
+ *
+ * ```ts
+ * import { renderYeetReplyFailureVerdict, ReplyReport } from "@beep/repo-cli/test/Yeet"
+ *
+ * const report = ReplyReport.make({
+ *   schemaVersion: "yeet-reply-report/v1",
+ *   prNumber: 558,
+ *   createdAt: "2026-08-16T00:00:00.000Z",
+ *   outcomes: [],
+ * })
+ * console.log(renderYeetReplyFailureVerdict(report, ".beep/yeet/reply-report.json"))
+ * ```
+ *
+ * @param report - The report written by one reply pass.
+ * @param reportPath - Where that report was written, quoted in the verdict.
+ * @returns The verdict line when any draft failed, else `None`.
+ * @category formatting
+ * @since 0.0.0
+ */
+export const renderYeetReplyFailureVerdict: {
+  (reportPath: string): (report: ReplyReport) => O.Option<string>;
+  (report: ReplyReport, reportPath: string): O.Option<string>;
+} = dual(
+  2,
+  (report: ReplyReport, reportPath: string): O.Option<string> =>
+    pipe(
+      failedReplyOutcomes(report),
+      O.liftPredicate(A.isReadonlyArrayNonEmpty),
+      O.map(
+        (failed) =>
+          `[yeet] reply failed for ${A.length(failed)} of ${A.length(report.outcomes)} drafts (${A.join(A.map(failed, replyOutcomeTarget), ", ")}); those review threads are still open. Each failed outcome in ${reportPath} carries its own retry.`
+      )
+    )
+);

--- a/packages/tooling/tool/cli/src/test/Yeet.test-kit.ts
+++ b/packages/tooling/tool/cli/src/test/Yeet.test-kit.ts
@@ -36,6 +36,7 @@ export * from "../commands/Yeet/internal/IssueClassification.ts";
 export * from "../commands/Yeet/internal/IssueParser.ts";
 export * from "../commands/Yeet/internal/Merge.ts";
 export * from "../commands/Yeet/internal/MergedPreview.ts";
+export * from "../commands/Yeet/internal/MonitorChecks.ts";
 export * from "../commands/Yeet/internal/MonitorComments.ts";
 export * from "../commands/Yeet/internal/MonitorLoop.ts";
 export * from "../commands/Yeet/internal/Planner.ts";

--- a/packages/tooling/tool/cli/test/yeet-monitor-check-registration.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-monitor-check-registration.test.ts
@@ -5,8 +5,10 @@ import {
   RepoRunContext,
   RepoStepRunResult,
   renderYeetCheckRegistrationExhausted,
+  runMonitorCheckWatchForTesting,
   runMonitorPhaseForTesting,
   YEET_CHECK_REGISTRATION_BACKOFF,
+  YeetExecutedStep,
   yeetCheckRegistration,
 } from "@beep/repo-cli/test/Yeet";
 import { provideScopedLayer } from "@beep/test-utils";
@@ -18,7 +20,6 @@ import * as A from "effect/Array";
 import * as Str from "effect/String";
 import * as TestConsole from "effect/testing/TestConsole";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
-import type { YeetExecutedStep } from "@beep/repo-cli/test/Yeet";
 
 // A7 (ship-velocity): `gh pr checks --watch` reports a head with no check runs
 // as an error — exit 1, "no checks reported on the '<branch>' branch" — and
@@ -307,5 +308,64 @@ describe("the monitor phase check watch", () => {
         )
       )
     )
+  );
+});
+
+// Greptile P1 on #738: the registration retry re-runs a recorder-mutating
+// phase, so a first attempt that found no checks and a later attempt that
+// passed both landed in the recorder. The verdict, the PR body, and
+// `yeet status` all read that recorder, so one step id reported as failed AND
+// passed — and status would print a repair command for a lane that passed.
+const registrationThenSuccessSpawnerLayer = (callsRef: Ref.Ref<number>) =>
+  Layer.effect(
+    ChildProcessSpawner.ChildProcessSpawner,
+    Effect.succeed(
+      ChildProcessSpawner.make((command) => {
+        if (!ChildProcess.isStandardCommand(command)) {
+          return Effect.die("the check watch never spawns a piped command");
+        }
+        return Effect.map(
+          Ref.updateAndGet(callsRef, (count) => count + 1),
+          (call) =>
+            call === 1
+              ? stubHandle(1, "no checks reported on the 'feat/yeet-monitor-hardening' branch")
+              : stubHandle(0, "All checks were successful")
+        );
+      })
+    )
+  );
+
+describe("the monitor check watch recorder", () => {
+  it.effect("records only the final attempt, never the attempt it retried", () =>
+    withTempDirectory((root) =>
+      Effect.gen(function* () {
+        const context = monitorPhaseContext(root);
+        const callsRef = yield* Ref.make(0);
+        const priorStep = YeetExecutedStep.make({
+          durationMs: 1,
+          result: RepoStepRunResult.make({
+            stepId: "monitor:01-pr-context",
+            commandText: "gh pr view",
+            exitCode: 0,
+          }),
+          step: A.headNonEmpty(monitorSteps(root) as A.NonEmptyReadonlyArray<RepoPlanStep>),
+        });
+        const recorder = yield* Ref.make<ReadonlyArray<YeetExecutedStep>>([priorStep]);
+        const checkSteps = A.filter(monitorSteps(root), (step) => step.id === "monitor:02-pr-checks-watch");
+
+        yield* runMonitorCheckWatchForTesting(context, checkSteps, recorder, "yeet monitor failed.", [
+          Duration.zero,
+        ]).pipe(Effect.provide(registrationThenSuccessSpawnerLayer(callsRef)));
+
+        const recorded = yield* Ref.get(recorder);
+        const watchEntries = A.filter(recorded, (entry) => entry.step.id === "monitor:02-pr-checks-watch");
+        expect(yield* Ref.get(callsRef)).toBe(2);
+        // Exactly one entry for the retried step, carrying the attempt that won.
+        expect(A.length(watchEntries)).toBe(1);
+        expect(A.map(watchEntries, (entry) => entry.result.exitCode)).toEqual([0]);
+        // The rewind must not eat entries recorded before the watch began.
+        expect(A.length(A.filter(recorded, (entry) => entry.step.id === "monitor:01-pr-context"))).toBe(1);
+      })
+    ).pipe(provideScopedLayer(PlatformLayer))
   );
 });

--- a/packages/tooling/tool/cli/test/yeet-monitor-check-registration.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-monitor-check-registration.test.ts
@@ -1,0 +1,311 @@
+import {
+  awaitYeetCheckRegistration,
+  isAwaitingYeetCheckRegistration,
+  RepoPlanStep,
+  RepoRunContext,
+  RepoStepRunResult,
+  renderYeetCheckRegistrationExhausted,
+  runMonitorPhaseForTesting,
+  YEET_CHECK_REGISTRATION_BACKOFF,
+  yeetCheckRegistration,
+} from "@beep/repo-cli/test/Yeet";
+import { provideScopedLayer } from "@beep/test-utils";
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import * as NodePath from "@effect/platform-node/NodePath";
+import { describe, expect, it } from "@effect/vitest";
+import { Duration, Effect, FileSystem, Layer, Ref, Sink, Stream } from "effect";
+import * as A from "effect/Array";
+import * as Str from "effect/String";
+import * as TestConsole from "effect/testing/TestConsole";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import type { YeetExecutedStep } from "@beep/repo-cli/test/Yeet";
+
+// A7 (ship-velocity): `gh pr checks --watch` reports a head with no check runs
+// as an error — exit 1, "no checks reported on the '<branch>' branch" — and
+// GitHub needs a moment after a push to register them. Reading that as the
+// watch's answer ended the monitor before the pipeline started.
+const watchResult = (exitCode: number, output: string): RepoStepRunResult =>
+  RepoStepRunResult.make({
+    stepId: "monitor:02-pr-checks-watch",
+    commandText: "gh pr checks --watch",
+    exitCode,
+    output,
+  });
+
+const unregistered = watchResult(1, "no checks reported on the 'feat/yeet-monitor-hardening' branch");
+const green = watchResult(0, "All checks were successful\n0 failing, 16 successful");
+const red = watchResult(1, "Some checks were not successful\n1 failing, 15 successful");
+
+describe("yeetCheckRegistration", () => {
+  it("reads the empty-check error as awaiting registration", () => {
+    expect(yeetCheckRegistration(unregistered)).toBe("awaiting-registration");
+  });
+
+  it("reads the --required variant of the same message the same way", () => {
+    expect(yeetCheckRegistration(watchResult(1, "no required checks reported on the 'feat/x' branch"))).toBe(
+      "awaiting-registration"
+    );
+  });
+
+  it("reads a red watch as registered — waiting cannot improve a real failure", () => {
+    expect(yeetCheckRegistration(red)).toBe("registered");
+  });
+
+  it("reads any other failure as registered, so the backoff is not spent on it", () => {
+    expect(yeetCheckRegistration(watchResult(4, "gh: authentication required"))).toBe("registered");
+  });
+
+  it("reads a successful watch as registered", () => {
+    expect(yeetCheckRegistration(green)).toBe("registered");
+  });
+
+  // `output` is optional on a step result: a capture that was skipped or lost
+  // leaves none. Absent output cannot claim "no checks reported", so it must
+  // not buy the backoff.
+  it("reads a failure with no captured output as registered", () => {
+    expect(
+      yeetCheckRegistration(
+        RepoStepRunResult.make({
+          stepId: "monitor:02-pr-checks-watch",
+          commandText: "gh pr checks --watch",
+          exitCode: 1,
+        })
+      )
+    ).toBe("registered");
+  });
+
+  it("treats an attempt that ran no steps as nothing to wait for", () => {
+    expect(isAwaitingYeetCheckRegistration(A.empty())).toBe(false);
+  });
+});
+
+describe("awaitYeetCheckRegistration", () => {
+  const noDelays = [Duration.zero, Duration.zero];
+
+  it.effect("re-attempts an unregistered head until checks appear", () =>
+    Effect.gen(function* () {
+      const callsRef = yield* Ref.make(0);
+      const attempt = Effect.gen(function* () {
+        const call = yield* Ref.getAndUpdate(callsRef, (count) => count + 1);
+        return call < 2 ? [unregistered] : [green];
+      });
+
+      const results = yield* attempt.pipe(awaitYeetCheckRegistration(noDelays));
+
+      expect(yield* Ref.get(callsRef)).toBe(3);
+      expect(A.map(results, (result) => result.exitCode)).toEqual([0]);
+    })
+  );
+
+  it.effect("stops re-attempting the moment checks are registered", () =>
+    Effect.gen(function* () {
+      const callsRef = yield* Ref.make(0);
+      const attempt = Ref.updateAndGet(callsRef, (count) => count + 1).pipe(Effect.as([green]));
+
+      yield* attempt.pipe(awaitYeetCheckRegistration(noDelays));
+
+      expect(yield* Ref.get(callsRef)).toBe(1);
+    })
+  );
+
+  it.effect("never re-attempts a watch that failed for any other reason", () =>
+    Effect.gen(function* () {
+      const callsRef = yield* Ref.make(0);
+      const attempt = Ref.updateAndGet(callsRef, (count) => count + 1).pipe(Effect.as([red]));
+
+      yield* attempt.pipe(awaitYeetCheckRegistration(noDelays));
+
+      expect(yield* Ref.get(callsRef)).toBe(1);
+    })
+  );
+
+  it.effect("is bounded, and hands the empty answer back unchanged rather than green", () =>
+    Effect.gen(function* () {
+      const callsRef = yield* Ref.make(0);
+      const attempt = Ref.updateAndGet(callsRef, (count) => count + 1).pipe(Effect.as([unregistered]));
+
+      const results = yield* attempt.pipe(awaitYeetCheckRegistration(noDelays));
+
+      expect(yield* Ref.get(callsRef)).toBe(A.length(noDelays) + 1);
+      // Exhaustion must not launder "no checks" into a pass: the caller sees the
+      // non-zero result and the awaiting classification, and fails the phase.
+      expect(A.map(results, (result) => result.exitCode)).toEqual([1]);
+      expect(isAwaitingYeetCheckRegistration(results)).toBe(true);
+    })
+  );
+
+  it.effect("tells the operator why it is pausing, and where in the bound it is", () =>
+    Effect.gen(function* () {
+      const attempt = Effect.succeed([unregistered]);
+
+      yield* attempt.pipe(awaitYeetCheckRegistration([Duration.zero, Duration.zero]));
+
+      const logs = A.map(yield* TestConsole.logLines, String);
+      expect(A.some(logs, Str.includes("no checks registered for this head yet"))).toBe(true);
+      expect(A.some(logs, Str.includes("(1/2)"))).toBe(true);
+      expect(A.some(logs, Str.includes("(2/2)"))).toBe(true);
+    }).pipe(provideScopedLayer(TestConsole.layer))
+  );
+
+  it.effect("propagates a failing attempt instead of retrying it", () =>
+    Effect.gen(function* () {
+      const failure = yield* Effect.flip(Effect.fail("spawn failed").pipe(awaitYeetCheckRegistration(noDelays)));
+
+      expect(failure).toBe("spawn failed");
+    })
+  );
+});
+
+describe("the shipped check-registration backoff", () => {
+  it("is bounded and short enough to stay a monitor, not a hang", () => {
+    const total = A.reduce(YEET_CHECK_REGISTRATION_BACKOFF, Duration.zero, (sum, delay) => Duration.sum(sum, delay));
+    expect(A.length(YEET_CHECK_REGISTRATION_BACKOFF)).toBe(5);
+    expect(Duration.toMillis(total)).toBeLessThanOrEqual(Duration.toMillis(Duration.minutes(2)));
+  });
+
+  it("explains the exhausted case in terms of attempts, wait, and what to check", () => {
+    const message = renderYeetCheckRegistrationExhausted(YEET_CHECK_REGISTRATION_BACKOFF);
+    expect(message).toContain("6 attempts");
+    expect(message).toContain("path filters");
+  });
+});
+
+// The wiring, not just the combinator: the monitor phase must route its check
+// steps through the registration wrapper and keep the comment stream racing
+// alongside. Driving `runMonitorPhaseForTesting` is what proves the seam in
+// Handler.ts, which the combinator's own tests cannot reach.
+const encoder = new TextEncoder();
+
+const stubHandle = (exitCode: number, output: string) =>
+  ChildProcessSpawner.makeHandle({
+    all: Stream.make(encoder.encode(output)),
+    exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(exitCode)),
+    getInputFd: () => Sink.drain,
+    getOutputFd: () => Stream.empty,
+    isRunning: Effect.succeed(false),
+    kill: () => Effect.void,
+    pid: ChildProcessSpawner.ProcessId(1),
+    stderr: Stream.empty,
+    stdin: Sink.drain,
+    stdout: Stream.make(encoder.encode(output)),
+    unref: Effect.succeed(Effect.void),
+  });
+
+const PR_VIEW_JSON = `{"number":558,"headRefName":"feat/yeet-monitor-hardening","state":"OPEN"}`;
+
+/** Answers `gh pr view` and `gh api`; the check watch answers from `watch`. */
+const monitorSpawnerLayer = (watch: { readonly exitCode: number; readonly output: string }) =>
+  Layer.effect(
+    ChildProcessSpawner.ChildProcessSpawner,
+    Effect.succeed(
+      ChildProcessSpawner.make((command) => {
+        if (!ChildProcess.isStandardCommand(command)) {
+          return Effect.die("the monitor phase never spawns a piped command");
+        }
+        const line = A.join([command.command, ...command.args], " ");
+        if (Str.includes("pr view")(line)) {
+          return Effect.succeed(stubHandle(0, PR_VIEW_JSON));
+        }
+        if (Str.includes("pr checks")(line)) {
+          return Effect.succeed(stubHandle(watch.exitCode, watch.output));
+        }
+        return Effect.succeed(stubHandle(0, "[]"));
+      })
+    )
+  );
+
+const monitorSteps = (cwd: string): ReadonlyArray<RepoPlanStep> => [
+  RepoPlanStep.make({
+    id: "monitor:01-pr-context",
+    label: "monitor:pr-context",
+    phase: "monitor",
+    command: "gh",
+    args: ["pr", "view", "--json", "number,headRefName,state"],
+    cwd,
+    scope: "repo",
+    mutability: "readonly",
+    resume: "never",
+  }),
+  RepoPlanStep.make({
+    id: "monitor:02-pr-checks-watch",
+    label: "monitor:pr-checks:watch",
+    phase: "monitor",
+    command: "gh",
+    args: ["pr", "checks", "--watch"],
+    cwd,
+    scope: "repo",
+    mutability: "readonly",
+    resume: "never",
+  }),
+];
+
+const monitorPhaseContext = (root: string): RepoRunContext =>
+  RepoRunContext.make({
+    base: "origin/main",
+    branch: "feat/yeet-monitor-hardening",
+    cwd: root,
+    head: "HEAD",
+    originalArgv: [],
+    packetDir: root,
+    repoRoot: root,
+    turbo: { graphHealthStatus: "ok", graphHealthWarnings: [], tasks: [] },
+  });
+
+const withTempDirectory = Effect.fn("withTempDirectory")(function* <Value, Failure, Requirements>(
+  use: (root: string) => Effect.Effect<Value, Failure, Requirements>
+) {
+  const fs = yield* FileSystem.FileSystem;
+  return yield* Effect.acquireUseRelease(fs.makeTempDirectory(), use, (root) =>
+    Effect.ignore(fs.remove(root, { recursive: true }))
+  );
+});
+
+const PlatformLayer = Layer.mergeAll(NodeFileSystem.layer, NodePath.layer);
+
+describe("the monitor phase check watch", () => {
+  it.live("completes when the watch finds registered checks and they pass", () =>
+    withTempDirectory((root) =>
+      Effect.gen(function* () {
+        const context = monitorPhaseContext(root);
+        const recorder = yield* Ref.make<ReadonlyArray<YeetExecutedStep>>(A.empty());
+
+        yield* runMonitorPhaseForTesting(context, monitorSteps(root), recorder, "yeet monitor failed.");
+
+        // Both planned steps ran, and the comment stream did not decide the race.
+        expect(A.map(yield* Ref.get(recorder), (executed) => executed.step.id)).toEqual([
+          "monitor:01-pr-context",
+          "monitor:02-pr-checks-watch",
+        ]);
+      })
+    ).pipe(
+      provideScopedLayer(
+        Layer.mergeAll(PlatformLayer, monitorSpawnerLayer({ exitCode: 0, output: "All checks were successful" }))
+      )
+    )
+  );
+
+  it.live("fails a red watch immediately, without spending the registration backoff", () =>
+    withTempDirectory((root) =>
+      Effect.gen(function* () {
+        const context = monitorPhaseContext(root);
+        const recorder = yield* Ref.make<ReadonlyArray<YeetExecutedStep>>(A.empty());
+
+        const error = yield* Effect.flip(
+          runMonitorPhaseForTesting(context, monitorSteps(root), recorder, "yeet monitor failed.")
+        );
+
+        expect(error.message).toContain("yeet monitor failed.");
+        // A red is about the code, so the registration story must stay out of it.
+        expect(error.message).not.toContain("No checks registered");
+        expect(error.exitCode).toBe(1);
+      })
+    ).pipe(
+      provideScopedLayer(
+        Layer.mergeAll(
+          PlatformLayer,
+          monitorSpawnerLayer({ exitCode: 1, output: "Some checks were not successful\n1 failing, 15 successful" })
+        )
+      )
+    )
+  );
+});

--- a/packages/tooling/tool/cli/test/yeet-monitor-check-registration.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-monitor-check-registration.test.ts
@@ -355,7 +355,7 @@ describe("the monitor check watch recorder", () => {
 
         yield* runMonitorCheckWatchForTesting(context, checkSteps, recorder, "yeet monitor failed.", [
           Duration.zero,
-        ]).pipe(Effect.provide(registrationThenSuccessSpawnerLayer(callsRef)));
+        ]).pipe(provideScopedLayer(registrationThenSuccessSpawnerLayer(callsRef)));
 
         const recorded = yield* Ref.get(recorder);
         const watchEntries = A.filter(recorded, (entry) => entry.step.id === "monitor:02-pr-checks-watch");

--- a/packages/tooling/tool/cli/test/yeet-monitor-comment-stream.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-monitor-comment-stream.test.ts
@@ -1,0 +1,309 @@
+import {
+  loadYeetMonitorCommentWatermark,
+  RepoRunContext,
+  renderYeetMonitorCommentStreamStopped,
+  runYeetPullRequestCommentMonitor,
+  YeetMonitorCommentCursor,
+  YeetMonitorCommentState,
+  YeetMonitorCommentStateJson,
+  YeetMonitorCommentWatermark,
+  yeetMonitorCommentStatePath,
+} from "@beep/repo-cli/test/Yeet";
+import { provideScopedLayer } from "@beep/test-utils";
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import * as NodePath from "@effect/platform-node/NodePath";
+import { describe, expect, it } from "@effect/vitest";
+import { Duration, Effect, FileSystem, Layer, Path, Ref, Schedule, Sink, Stream } from "effect";
+import * as A from "effect/Array";
+import * as O from "effect/Option";
+import * as Str from "effect/String";
+import * as TestConsole from "effect/testing/TestConsole";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+
+const PR_NUMBER = 558;
+const EARLIER_COMMENT_AT = "2026-08-16T12:00:00.000Z";
+// A session with no saved position starts its cursors at wall-clock now, so a
+// comment the stub means to be "new" has to be dated after the test runs.
+const LATER_COMMENT_AT = "2099-01-01T00:00:00.000Z";
+const encoder = new TextEncoder();
+
+type CommandStub = {
+  readonly exitCode: number;
+  readonly output: string;
+};
+
+const stubHandle = (stub: CommandStub) =>
+  ChildProcessSpawner.makeHandle({
+    all: Stream.make(encoder.encode(stub.output)),
+    exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(stub.exitCode)),
+    getInputFd: () => Sink.drain,
+    getOutputFd: () => Stream.empty,
+    isRunning: Effect.succeed(false),
+    kill: () => Effect.void,
+    pid: ChildProcessSpawner.ProcessId(1),
+    stderr: Stream.empty,
+    stdin: Sink.drain,
+    stdout: Stream.make(encoder.encode(stub.output)),
+    unref: Effect.succeed(Effect.void),
+  });
+
+/** A spawner that records every command line and answers from one function. */
+const recordingSpawnerLayer = (
+  commandsRef: Ref.Ref<ReadonlyArray<string>>,
+  respond: (commandLine: string) => CommandStub
+) =>
+  Layer.effect(
+    ChildProcessSpawner.ChildProcessSpawner,
+    Effect.succeed(
+      ChildProcessSpawner.make((command) =>
+        ChildProcess.isStandardCommand(command)
+          ? Effect.map(
+              Ref.updateAndGet(commandsRef, A.append(A.join([command.command, ...command.args], " "))),
+              (commands) => stubHandle(respond(O.getOrElse(A.last(commands), () => Str.empty)))
+            )
+          : Effect.die("the comment monitor never spawns a piped command")
+      )
+    )
+  );
+
+const issueCommentJson = (id: number, createdAt: string): string =>
+  JSON.stringify([
+    {
+      body: "The hosted checks are green.",
+      created_at: createdAt,
+      html_url: `https://github.com/o/r/pull/${PR_NUMBER}#issuecomment-${id}`,
+      id,
+      user: { login: "octocat" },
+    },
+  ]);
+
+const commentEndpointStub = (commandLine: string): CommandStub =>
+  Str.includes("/issues/")(commandLine)
+    ? { exitCode: 0, output: issueCommentJson(44, LATER_COMMENT_AT) }
+    : { exitCode: 0, output: "[]" };
+
+const deniedStub = (): CommandStub => ({ exitCode: 1, output: "gh: API rate limit exceeded" });
+
+const monitorContext = (root: string): RepoRunContext =>
+  RepoRunContext.make({
+    base: "origin/main",
+    branch: "feat/yeet-monitor-hardening",
+    cwd: root,
+    head: "HEAD",
+    originalArgv: [],
+    packetDir: root,
+    repoRoot: root,
+    turbo: { graphHealthStatus: "ok", graphHealthWarnings: [], tasks: [] },
+  });
+
+const withTempDirectory = Effect.fn("withTempDirectory")(function* <Value, Failure, Requirements>(
+  use: (root: string) => Effect.Effect<Value, Failure, Requirements>
+) {
+  const fs = yield* FileSystem.FileSystem;
+  return yield* Effect.acquireUseRelease(fs.makeTempDirectory(), use, (root) =>
+    Effect.ignore(fs.remove(root, { recursive: true }))
+  );
+});
+
+/**
+ * Poll a condition until it holds, so a tick is awaited rather than timed.
+ * Bounded so a broken expectation fails the test instead of hanging it.
+ */
+const until = <Failure, Requirements>(probe: Effect.Effect<boolean, Failure, Requirements>) =>
+  Effect.repeat(probe, { until: (ready: boolean) => ready, schedule: Schedule.spaced(Duration.millis(5)) }).pipe(
+    Effect.timeout(Duration.seconds(5))
+  );
+
+const writeStateText = Effect.fnUntraced(function* (context: RepoRunContext, text: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const statePath = yield* yeetMonitorCommentStatePath(context);
+  yield* fs.makeDirectory(path.dirname(statePath), { recursive: true });
+  yield* fs.writeFileString(statePath, text);
+});
+
+const writeState = Effect.fnUntraced(function* (context: RepoRunContext, state: YeetMonitorCommentState) {
+  yield* writeStateText(context, yield* YeetMonitorCommentStateJson.encode(state));
+});
+
+const stateAt = (prNumber: number, createdAt: string, id: number): YeetMonitorCommentState => {
+  const cursor = YeetMonitorCommentCursor.make({ createdAt, id });
+  return YeetMonitorCommentState.make({
+    schemaVersion: "yeet-monitor-comments/v1",
+    prNumber,
+    updatedAt: createdAt,
+    watermark: YeetMonitorCommentWatermark.make({ issue: cursor, review: cursor }),
+  });
+};
+
+const PlatformLayer = Layer.mergeAll(NodeFileSystem.layer, NodePath.layer);
+
+// A7 (ship-velocity): the comment stream used to start both cursors at process
+// start, so a comment posted while no monitor was attached was never printed by
+// any run, and a single failed poll cancelled the check watcher it was raced
+// against.
+describe("yeet monitor comment cursor persistence", () => {
+  it.effect("has no position before a session has run", () =>
+    withTempDirectory((root) =>
+      Effect.gen(function* () {
+        expect(yield* loadYeetMonitorCommentWatermark(monitorContext(root), PR_NUMBER)).toEqual(O.none());
+      })
+    ).pipe(provideScopedLayer(PlatformLayer))
+  );
+
+  it.effect("reads back a position written for the same pull request", () =>
+    withTempDirectory((root) =>
+      Effect.gen(function* () {
+        const context = monitorContext(root);
+        yield* writeState(context, stateAt(PR_NUMBER, EARLIER_COMMENT_AT, 44));
+
+        const watermark = yield* loadYeetMonitorCommentWatermark(context, PR_NUMBER);
+
+        expect(O.map(watermark, (mark) => mark.issue.createdAt)).toEqual(O.some(EARLIER_COMMENT_AT));
+        expect(O.map(watermark, (mark) => mark.review.id)).toEqual(O.some(44));
+      })
+    ).pipe(provideScopedLayer(PlatformLayer))
+  );
+
+  it.effect("refuses a position recorded against a different pull request", () =>
+    withTempDirectory((root) =>
+      Effect.gen(function* () {
+        const context = monitorContext(root);
+        yield* writeState(context, stateAt(PR_NUMBER + 1, EARLIER_COMMENT_AT, 44));
+
+        expect(yield* loadYeetMonitorCommentWatermark(context, PR_NUMBER)).toEqual(O.none());
+      })
+    ).pipe(provideScopedLayer(PlatformLayer))
+  );
+
+  it.effect("treats an unreadable position as no position rather than failing", () =>
+    withTempDirectory((root) =>
+      Effect.gen(function* () {
+        const context = monitorContext(root);
+        yield* writeStateText(context, "{ this is not the artifact }");
+
+        expect(yield* loadYeetMonitorCommentWatermark(context, PR_NUMBER)).toEqual(O.none());
+      })
+    ).pipe(provideScopedLayer(PlatformLayer))
+  );
+
+  it.live("writes its starting position even when the pull request is quiet", () => {
+    const commandsRef = Ref.makeUnsafe<ReadonlyArray<string>>(A.empty());
+    return withTempDirectory((root) =>
+      Effect.gen(function* () {
+        const context = monitorContext(root);
+        const fs = yield* FileSystem.FileSystem;
+        const statePath = yield* yeetMonitorCommentStatePath(context);
+
+        yield* Effect.raceFirst(until(fs.exists(statePath)), runYeetPullRequestCommentMonitor(context, PR_NUMBER));
+
+        // Nothing was streamed, so the position is this session's own start —
+        // and it exists, which is the point: a quiet run that left no position
+        // would send the next run back to its own clock, straight past any
+        // comment posted in between.
+        const persisted = yield* loadYeetMonitorCommentWatermark(context, PR_NUMBER);
+        expect(O.map(persisted, (mark) => mark.issue.id)).toEqual(O.some(0));
+        expect(O.isSome(persisted)).toBe(true);
+      })
+    ).pipe(
+      provideScopedLayer(
+        Layer.mergeAll(
+          PlatformLayer,
+          recordingSpawnerLayer(commandsRef, () => ({ exitCode: 0, output: "[]" }))
+        )
+      )
+    );
+  });
+
+  it.live("persists the cursor of a streamed comment, and resumes from it next run", () => {
+    // Both runs share one recorder because one spawner is provided once, at the
+    // test's edge; the second run's commands are the ones recorded after the
+    // first run ended.
+    const commandsRef = Ref.makeUnsafe<ReadonlyArray<string>>(A.empty());
+    return withTempDirectory((root) =>
+      Effect.gen(function* () {
+        const context = monitorContext(root);
+        // The session seeds its starting position immediately, so waiting for
+        // the file to exist would race the comment; wait for the cursor to
+        // reach the streamed comment instead.
+        const streamed = Effect.map(loadYeetMonitorCommentWatermark(context, PR_NUMBER), (persisted) =>
+          O.exists(persisted, (mark) => mark.issue.id === 44)
+        );
+
+        yield* Effect.raceFirst(until(streamed), runYeetPullRequestCommentMonitor(context, PR_NUMBER));
+
+        const persisted = yield* loadYeetMonitorCommentWatermark(context, PR_NUMBER);
+        expect(O.map(persisted, (mark) => mark.issue.id)).toEqual(O.some(44));
+        expect(O.map(persisted, (mark) => mark.issue.createdAt)).toEqual(O.some(LATER_COMMENT_AT));
+
+        // The second run must ask GitHub for everything since the saved
+        // position — not since its own start — or a comment posted between the
+        // two runs is invisible to both.
+        const firstRunCommandCount = A.length(yield* Ref.get(commandsRef));
+        yield* Effect.raceFirst(
+          until(Effect.map(Ref.get(commandsRef), (commands) => A.length(commands) >= firstRunCommandCount + 2)),
+          runYeetPullRequestCommentMonitor(context, PR_NUMBER)
+        );
+
+        const secondRunCommands = A.drop(yield* Ref.get(commandsRef), firstRunCommandCount);
+        const issuePoll = A.findFirst(secondRunCommands, Str.includes("/issues/"));
+        expect(O.map(issuePoll, Str.includes(`since=${LATER_COMMENT_AT}`))).toEqual(O.some(true));
+      })
+    ).pipe(provideScopedLayer(Layer.mergeAll(PlatformLayer, recordingSpawnerLayer(commandsRef, commentEndpointStub))));
+  });
+});
+
+describe("yeet monitor comment poll failures", () => {
+  it("names where comments can still be read once the stream gives up", () => {
+    expect(renderYeetMonitorCommentStreamStopped(5)).toContain("yeet status --remote");
+  });
+
+  it.live("never cancels the check watcher it is raced against", () => {
+    const commandsRef = Ref.makeUnsafe<ReadonlyArray<string>>(A.empty());
+    return withTempDirectory((root) =>
+      Effect.gen(function* () {
+        // Stands in for `gh pr checks --watch`: the effect the operator is
+        // actually waiting on. Before this fix, the failing comment poll won
+        // the race with an error and took this fiber down with it.
+        const checkWatch = Effect.as(Effect.sleep(Duration.millis(30)), "checks finished");
+
+        const winner = yield* Effect.raceFirst(
+          checkWatch,
+          runYeetPullRequestCommentMonitor(monitorContext(root), PR_NUMBER, 1)
+        );
+
+        expect(winner).toBe("checks finished");
+        // It really did try, and really did fail: the race was survived, not skipped.
+        expect(A.length(yield* Ref.get(commandsRef))).toBeGreaterThan(0);
+      })
+    ).pipe(provideScopedLayer(Layer.mergeAll(PlatformLayer, recordingSpawnerLayer(commandsRef, deniedStub))));
+  });
+
+  it.live("surfaces every failed poll and says so when it stops streaming", () => {
+    const commandsRef = Ref.makeUnsafe<ReadonlyArray<string>>(A.empty());
+    return withTempDirectory((root) =>
+      Effect.gen(function* () {
+        yield* Effect.raceFirst(
+          until(
+            Effect.map(TestConsole.errorLines, (lines) =>
+              A.some(lines, (line) => Str.includes("stopped after")(String(line)))
+            )
+          ),
+          runYeetPullRequestCommentMonitor(monitorContext(root), PR_NUMBER, 1)
+        );
+
+        const errors = A.map(yield* TestConsole.errorLines, String);
+        // Each failed tick is reported with gh's own words, numbered against
+        // the bound, and says the checks are still being watched.
+        expect(A.some(errors, Str.includes("API rate limit exceeded"))).toBe(true);
+        expect(A.some(errors, Str.includes("PR comment poll failed (1/1)"))).toBe(true);
+        expect(A.some(errors, Str.includes("Check watching is unaffected"))).toBe(true);
+        expect(A.some(errors, Str.includes("PR comment streaming stopped"))).toBe(true);
+      })
+    ).pipe(
+      provideScopedLayer(
+        Layer.mergeAll(PlatformLayer, TestConsole.layer, recordingSpawnerLayer(commandsRef, deniedStub))
+      )
+    );
+  });
+});

--- a/packages/tooling/tool/cli/test/yeet-reply-engine.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-reply-engine.test.ts
@@ -1,10 +1,13 @@
 import {
+  failedReplyOutcomes,
+  failYeetReplyOnFailedOutcomes,
   findReplyThread,
   planReplyActions,
   REPLY_DRAFTS_FILE_NAME,
   REPLY_REPORT_FILE_NAME,
   REPLY_RERUN_COMMAND,
   ReplyDraft,
+  ReplyDraftOutcome,
   ReplyDrafts,
   ReplyDraftsJson,
   ReplyLiveThread,
@@ -13,7 +16,9 @@ import {
   ReplyThreadComment,
   ReplyThreadCommentConnection,
   RepoRunContext,
+  renderYeetReplyFailureVerdict,
   replyDraftsPathForContext,
+  replyOutcomeTarget,
   replyReportPathForContext,
   replyResolveRetryCommand,
   replyReviewThreadsPageQuery,
@@ -28,7 +33,8 @@ import * as A from "effect/Array";
 import * as O from "effect/Option";
 import * as Str from "effect/String";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
-import type { ReplyAction, ReplyDraftOutcome } from "@beep/repo-cli/test/Yeet";
+import { expectReportedExit } from "./support/CommandTest.ts";
+import type { ReplyAction } from "@beep/repo-cli/test/Yeet";
 
 const OPEN_COMMENT_ID = 2_284_119_001;
 const RESOLVED_COMMENT_ID = 2_284_119_002;
@@ -422,4 +428,132 @@ describe("reply operator surfaces", () => {
     expect(REPLY_REPORT_FILE_NAME).toBe("reply-report.json");
     expect(REPLY_RERUN_COMMAND).toBe("bun run beep yeet reply");
   });
+});
+
+// A7 (ship-velocity): a pass whose replies were rejected used to exit 0, so
+// `yeet reply && bun run beep yeet monitor` walked straight past threads that
+// are still open — and an unresolved thread is a hard merge gate. The batch
+// still runs to completion; the exit code is what changed.
+const deniedReplyMutationStubs: ReadonlyArray<readonly [string, CommandStub]> = [
+  ["gh repo view", ok(repoViewJson)],
+  ["YeetReplyReviewThreads", ok(reviewThreadsJson)],
+  ["addPullRequestReviewThreadReply", { exitCode: 1, output: "gh: Resource not accessible by integration" }],
+];
+
+const reportOf = (outcomes: ReadonlyArray<ReplyDraftOutcome>): ReplyReport =>
+  ReplyReport.make({
+    schemaVersion: "yeet-reply-report/v1",
+    prNumber: 558,
+    createdAt: "2026-08-16T00:00:00.000Z",
+    outcomes,
+  });
+
+describe("replyOutcomeTarget", () => {
+  it("prefers the thread id the draft named", () => {
+    expect(replyOutcomeTarget({ threadId: O.some("PRRT_open"), commentId: O.some(OPEN_COMMENT_ID) })).toBe("PRRT_open");
+  });
+
+  it("falls back to the comment handle when only a comment id was named", () => {
+    expect(replyOutcomeTarget({ threadId: O.none(), commentId: O.some(OPEN_COMMENT_ID) })).toBe(
+      `comment ${OPEN_COMMENT_ID}`
+    );
+  });
+
+  // Unreachable through a decoded outcome — ReplyTargetPresenceCheck rejects an
+  // empty target — but reachable here, which is why the function takes the
+  // handles instead of the outcome.
+  it("renders an unknown handle rather than throwing on an empty target", () => {
+    expect(replyOutcomeTarget({ threadId: O.none(), commentId: O.none() })).toBe("comment ?");
+  });
+});
+
+describe("reply run verdict", () => {
+  it("counts only failed outcomes, never stale ones", () => {
+    const report = reportOf([
+      ReplyDraftOutcome.make({ threadId: O.some("PRRT_stale"), status: "stale", detail: "already resolved upstream" }),
+      ReplyDraftOutcome.make({ threadId: O.some("PRRT_posted"), status: "posted", detail: "reply posted" }),
+      ReplyDraftOutcome.make({ threadId: O.some("PRRT_open"), status: "failed", detail: "denied" }),
+    ]);
+    expect(A.map(failedReplyOutcomes(report), (outcome) => outcome.threadId)).toEqual([O.some("PRRT_open")]);
+  });
+
+  it("names every failed handle, the report, and the still-open threads", () => {
+    const verdict = renderYeetReplyFailureVerdict(
+      reportOf([
+        ReplyDraftOutcome.make({ threadId: O.some("PRRT_open"), status: "failed", detail: "denied" }),
+        ReplyDraftOutcome.make({ commentId: O.some(OPEN_COMMENT_ID), status: "failed", detail: "denied" }),
+      ]),
+      "/repo/.beep/yeet/reply-report.json"
+    );
+    expect(O.isSome(verdict)).toBe(true);
+    const text = O.getOrElse(verdict, () => "");
+    expect(text).toContain("2 of 2 drafts");
+    expect(text).toContain("PRRT_open");
+    expect(text).toContain(`comment ${OPEN_COMMENT_ID}`);
+    expect(text).toContain("/repo/.beep/yeet/reply-report.json");
+    expect(text).toContain("still open");
+    // The retry is per outcome: a draft that posted and only failed to resolve
+    // must never be told to re-run the pass, which would post the body twice.
+    expect(text).not.toContain(REPLY_RERUN_COMMAND);
+  });
+
+  it("has no verdict for a pass where nothing failed", () => {
+    expect(
+      renderYeetReplyFailureVerdict(
+        reportOf([
+          ReplyDraftOutcome.make({ threadId: O.some("PRRT_a"), status: "resolved", detail: "reply posted" }),
+          ReplyDraftOutcome.make({ threadId: O.some("PRRT_b"), status: "stale", detail: "already resolved upstream" }),
+        ]),
+        "reply-report.json"
+      )
+    ).toEqual(O.none());
+  });
+
+  it.effect("exits zero when every outcome is posted, resolved, or stale", () =>
+    failYeetReplyOnFailedOutcomes(
+      reportOf([
+        ReplyDraftOutcome.make({ threadId: O.some("PRRT_a"), status: "resolved", detail: "reply posted" }),
+        ReplyDraftOutcome.make({ threadId: O.some("PRRT_b"), status: "stale", detail: "already resolved upstream" }),
+      ]),
+      "reply-report.json"
+    )
+  );
+
+  it.effect("exits non-zero, and silently, when any outcome failed", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        failYeetReplyOnFailedOutcomes(
+          reportOf([ReplyDraftOutcome.make({ threadId: O.some("PRRT_open"), status: "failed", detail: "denied" })]),
+          "reply-report.json"
+        )
+      );
+
+      // Exit code 1, and reported=false: the pass already printed every
+      // outcome, so the sentinel adds the code, not a second rendering.
+      expectReportedExit(exit);
+    })
+  );
+
+  it.effect("fails the whole reply run when a live draft's reply is rejected", () =>
+    withTempDirectory((root) =>
+      Effect.gen(function* () {
+        const context = replyContext(root);
+        yield* writeDrafts(
+          context,
+          draftsOf([
+            ReplyDraft.make({ threadId: O.some("PRRT_open"), body: "Fixed in 0123456." }),
+            ReplyDraft.make({ commentId: O.some(RESOLVED_COMMENT_ID), body: "Already handled." }),
+          ])
+        );
+
+        const report = yield* runYeetReply(context);
+        // The batch still ran: the stale draft was still classified.
+        expect(A.map(report.outcomes, (outcome) => outcome.status)).toEqual(["failed", "stale"]);
+
+        expectReportedExit(
+          yield* Effect.exit(failYeetReplyOnFailedOutcomes(report, yield* replyReportPathForContext(context)))
+        );
+      })
+    ).pipe(provideScopedLayer(replyTestLayer(deniedReplyMutationStubs)))
+  );
 });


### PR DESCRIPTION
## fix(repo-cli): harden the yeet monitor loop and the reply verdict

ship-velocity A7: four monitor defects, each with tests.

`yeet reply` exits non-zero when any drafted reply is `failed`. The batch still runs to
completion and the report is still written, but an unwritten reply leaves its review thread
open — a hard merge gate — so `yeet reply && yeet monitor` no longer walks past it on a false
green. `stale` wrote nothing because there was nothing to write, and is not a failure. The
verdict deliberately does not quote the rerun command: a draft that posted and only failed to
resolve must never re-run the pass, and each outcome's own detail already carries the right
retry.

Monitor comment cursors persist across runs in a schema-versioned `monitor-comments.json`
beside the other branch-scoped artifacts. A session resumes from the saved position instead of
its own clock, and writes that position at startup too, so even a run that streams nothing
leaves the next one somewhere to resume from. Anything unusable — no artifact, another pull
request, an older schema version, a torn file — reads as "start from now".

A failing comment poll can no longer cancel the check watcher it is raced against: the
poller's error channel is `never` by construction. Each failed poll is reported with gh's own
message text, numbered against a bound, and a stream that exhausts the bound parks rather than
completing, because completing the race is what would take the checks down.

Post-push check watching distinguishes "no checks registered yet" from "terminal empty". gh
reports a head GitHub has not wired up yet as exit 1 with "no checks reported", seconds after
the push that created it; that answer is now retried on a bounded backoff of six attempts over
~95s. An exhausted backoff stays a failure naming the condition, never a pass.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01D8gFezKrRXYMs8ZiFxpu7v

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/feat_yeet-monitor-hardening-43f60e7f8ff7/verdict.json

---

## Provenance

- Branch: <code>feat/yeet-monitor-hardening</code>
- Harness: `codex`

<!-- yeet-provenance
{
  "schemaVersion": 1,
  "branch": "feat/yeet-monitor-hardening",
  "harness": "codex"
}
-->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/738"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789542333&installation_model_id=424656&pr_number=738&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F738&signature=15f85e1a4a51cd400bdcc2a28e3b415b8a4b318c7195a110c9eb3698ec6614fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->