### PR TITLE
feat(repo-cli): fail knowledge archives closed on non-empty clone-local info/attributes

### DIFF
--- a/.changeset/knowledge-info-attributes-guard.md
+++ b/.changeset/knowledge-info-attributes-guard.md
@@ -1,0 +1,13 @@
+---
+"@beep/repo-cli": patch
+---
+
+Guard hermetic knowledge archives against clone-local `.git/info/attributes` (ratified decision,
+goals/knowledge-surface-automation research/p3-hermetic-lane-decisions.md "Measured residual"). The
+file outranks every attribute layer the canonical archive contract pins and no git invocation can
+disable it, so `beep knowledge semantic-delta` and `beep knowledge refs` now stat the path from
+`git rev-parse --git-path info/attributes` before writing any archive and fail closed with the new
+typed `KnowledgeCloneAttributesError` naming the resolved path when the file exists non-empty. An
+absent or empty file passes, so the guard is vacuously green in CI and fresh clones; worktrees
+resolve to the shared common-dir file. The reusable primitive is
+`guardCloneLocalGitAttributes` in the repo-run GitExec internals.

--- a/goals/knowledge-surface-automation/research/OPPORTUNITIES.md
+++ b/goals/knowledge-surface-automation/research/OPPORTUNITIES.md
@@ -301,3 +301,22 @@ measurement first). Reviewed at each grill.
 - **Prevention:** when rewriting a scanner against an all-green corpus, diff the parsed
   inventory (reference list / observation set), not just the emitted findings — or plant a
   canary (temporarily dead target) per structural link shape present in the live corpus.
+
+## 2026-08-17 — guard wiring in never-covered live functions reddens the coverage ratchet
+
+- **What happened:** the info/attributes guard PR (#757) wired three lines into
+  `Knowledge.service.ts` (`semanticDeltaLive`, `makeKnowledgeTreeOracle`, and one shared
+  helper). Those live entry points have never been unit-covered — the suite exercises
+  injected oracles via `makeKnowledgeArchiveOracle` instead — so the new lines landed at 0%
+  and diluted the file below its per-file ratchet floor (`lines: 86.8 < 86.89`,
+  `statements: 87.31 < 87.4`), failing the hosted Coverage Regression lane even though the
+  underlying primitive is fully tested in `step-git-exec.test.ts`.
+- **Evidence:** Coverage Regression job 95460770069 on PR #757; local
+  `vitest --coverage` confirms `semanticDeltaLive` (lines ~1397-1470) uncovered before and
+  after the change.
+- **Prevention:** local verify runs `test`, never `coverage`, so this class is only visible
+  hosted (already a recorded gap). When touching a file with a ratchet floor, check whether
+  the touched region is covered at all (`vitest run --coverage` scoped to the package,
+  then read the file's uncovered ranges) before pushing; wiring lines into an uncovered
+  function need either a directly testable seam (export the helper and pin it) or a
+  deliberate floor adjustment, decided before the hosted lane spends 13 minutes finding it.

--- a/goals/knowledge-surface-automation/research/p3-hermetic-lane-decisions.md
+++ b/goals/knowledge-surface-automation/research/p3-hermetic-lane-decisions.md
@@ -61,12 +61,22 @@ segments), so location-depth behavior is exercised in the live spawn path rather
 assumed. It is hygiene, not a security boundary, and stays out of the archive-contract
 changes to keep each PR single-subject.
 
-## Measured residual, recorded not fixed
+## Measured residual, guarded fail-closed
 
 Clone-local `.git/info/attributes` outranks every attribute layer and **no git
 invocation can disable it** — measured against git 2.55.0: `core.attributesFile=/dev/null`,
 `--attr-source=HEAD`, `GIT_ATTR_SOURCE`, `-c attr.tree=HEAD`, and `GIT_ATTR_NOSYSTEM`
 all fail to suppress it (full matrix in the design report's addendum). It is absent
-from fresh clones and CI. If it must be guarded, the shape is: stat
-`git rev-parse --git-path info/attributes` before archiving and fail with a remediation
-naming the file. Whether to add that guard is an open decision, not ratified here.
+from fresh clones and CI.
+
+**Ratified 2026-08-17 (follow-up grill, same session as H1–H3):** the guard ships,
+fail-closed on a non-empty file. Every tree-materializing knowledge operation stats
+the path from `git rev-parse --git-path info/attributes` (so worktrees reach the
+shared common-dir file) before writing a hermetic archive and fails with the typed
+`KnowledgeCloneAttributesError`, naming the resolved path and carrying the
+move-or-delete remediation inline. An empty file passes; an absent file passes, so
+the guard is vacuously green in CI. A stat failure other than not-found also fails
+closed as operational — a file that cannot be verified cannot be proven inert. The
+standing proof is the fixture-clone test alongside the hostile-profile differentials
+(`test/step-git-exec.test.ts`): absent passes, empty passes, non-empty raises the
+typed failure, and a worktree resolves to — and fails on — the main clone's file.

--- a/packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.errors.ts
+++ b/packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.errors.ts
@@ -256,3 +256,74 @@ export class KnowledgeHostPathDebtError extends S.TaggedError<KnowledgeHostPathD
     description: "The checked census carries live host-path observations in the gated classes.",
   })
 ) {}
+
+/**
+ * The guard failure raised when a non-empty clone-local git attributes file is present.
+ *
+ * **Details**
+ *
+ * The clone-local attributes file (`git rev-parse --git-path info/attributes`) outranks every
+ * attribute layer the canonical archive contract pins, and no git invocation can disable it
+ * (measured against git 2.55.0 — `goals/knowledge-surface-automation/research/p3-hermetic-lane-decisions.md`).
+ * A non-empty file would silently rewrite the hermetic archive bytes both knowledge commands
+ * compare, so tree materialization refuses to archive while one is present. The file is absent
+ * from fresh clones and CI, where this guard is vacuously green; an empty file also passes.
+ *
+ * **Example** (Fail closed on a non-empty clone-local attributes file)
+ *
+ * ```ts
+ * import { KnowledgeCloneAttributesError } from "@beep/repo-cli/commands/Knowledge/Knowledge.errors"
+ *
+ * const error = KnowledgeCloneAttributesError.at("/repo/.git/info/attributes")
+ *
+ * console.log(error.attributesPath) // "/repo/.git/info/attributes"
+ * ```
+ *
+ * @category errors
+ * @since 0.0.0
+ */
+export class KnowledgeCloneAttributesError extends S.TaggedError<KnowledgeCloneAttributesError>(
+  $I`KnowledgeCloneAttributesError`
+)(
+  "KnowledgeCloneAttributesError",
+  {
+    message: S.String,
+    attributesPath: S.String,
+  },
+  $I.annote("KnowledgeCloneAttributesError", {
+    description: "A non-empty clone-local git attributes file would silently rewrite hermetic archive bytes.",
+  })
+) {
+  /**
+   * Constructs the guard failure for one resolved clone-local attributes path.
+   *
+   * **Details**
+   *
+   * The message carries the remediation inline: the file must be moved or deleted, because no git
+   * invocation can suppress it and any attribute rules it holds belong in the repository's tracked
+   * `.gitattributes` instead.
+   *
+   * **Example** (Name the offending file)
+   *
+   * ```ts
+   * import { KnowledgeCloneAttributesError } from "@beep/repo-cli/commands/Knowledge/Knowledge.errors"
+   *
+   * const error = KnowledgeCloneAttributesError.at("/repo/.git/info/attributes")
+   *
+   * console.log(error.message.includes("/repo/.git/info/attributes")) // true
+   * ```
+   *
+   * @param attributesPath - Resolved path of the offending clone-local attributes file.
+   * @returns The typed guard failure carrying the path and the inline remediation.
+   * @category constructors
+   * @since 0.0.0
+   */
+  static readonly at = (attributesPath: string): KnowledgeCloneAttributesError =>
+    KnowledgeCloneAttributesError.make({
+      attributesPath,
+      message:
+        `Clone-local git attributes file "${attributesPath}" is non-empty. ` +
+        "It silently rewrites `git archive` bytes and no git invocation can disable it. " +
+        "Move or delete the file; attribute rules belong in the repository's tracked .gitattributes.",
+    });
+}

--- a/packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.service.ts
+++ b/packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.service.ts
@@ -894,10 +894,40 @@ const gitAdapter: GitCommandErrorAdapter<KnowledgeOperationalError> = {
   onTruncated: O.none(),
 };
 
-// A clone-local info/attributes file outranks every attribute layer the canonical archive contract
-// pins and no git invocation can disable it (research/p3-hermetic-lane-decisions.md, "Measured
-// residual"), so both tree-materializing entry points refuse to archive while a non-empty one exists.
-const guardKnowledgeCloneAttributes = (repoRoot: string) =>
+/**
+ * Refuses to materialize archives while a non-empty clone-local git attributes file exists.
+ *
+ * **Details**
+ *
+ * A clone-local `info/attributes` file outranks every attribute layer the canonical archive
+ * contract pins and no git invocation can disable it
+ * (`goals/knowledge-surface-automation/research/p3-hermetic-lane-decisions.md`, "Measured
+ * residual"), so both tree-materializing entry points run this guard before writing any archive.
+ * An absent or empty file passes; a non-empty file fails with
+ * {@link KnowledgeCloneAttributesError}; a stat failure other than not-found fails closed as
+ * {@link KnowledgeOperationalError}.
+ *
+ * **Example** (Guard a repository root before archiving)
+ *
+ * ```ts
+ * import { guardKnowledgeCloneAttributes } from "@beep/repo-cli/commands/Knowledge/Knowledge.service"
+ * import { Effect } from "effect"
+ *
+ * console.log(Effect.isEffect(guardKnowledgeCloneAttributes("/repo"))) // true
+ * ```
+ *
+ * @param repoRoot - Repository root whose clone-local attributes file is checked.
+ * @returns Void when archiving may proceed; a typed failure otherwise.
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const guardKnowledgeCloneAttributes = (
+  repoRoot: string
+): Effect.Effect<
+  void,
+  KnowledgeOperationalError | KnowledgeCloneAttributesError,
+  ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
+> =>
   guardCloneLocalGitAttributes(repoRoot, gitAdapter, KnowledgeCloneAttributesError.at, (attributesPath) =>
     KnowledgeOperationalError.new(`Failed to stat clone-local git attributes "${attributesPath}".`)
   );
@@ -1400,11 +1430,11 @@ const semanticDeltaLive = Effect.fn("Knowledge.semanticDelta")(function* (baseRe
   const repoRoot = yield* findRepoRoot().pipe(
     KnowledgeOperationalError.mapError("Failed to locate the repository root for semantic-delta.")
   );
+  yield* guardKnowledgeCloneAttributes(repoRoot);
   const historyAdapter = historyGitAdapter(baseRef);
   const headCommit = yield* resolveGitCommit(repoRoot, "HEAD", historyAdapter);
   const baseCommit = yield* resolveGitMergeBase(repoRoot, baseRef, headCommit, historyAdapter);
   const probePolicy = yield* resolveKnowledgeProbePolicy(process.env);
-  yield* guardKnowledgeCloneAttributes(repoRoot);
 
   return yield* Effect.scoped(
     Effect.gen(function* () {
@@ -1507,8 +1537,8 @@ export const makeKnowledgeTreeOracle = Effect.fn("Knowledge.makeTreeOracle")(fun
   const repoRoot = yield* findRepoRoot().pipe(
     KnowledgeOperationalError.mapError("Failed to locate the repository root for the reference census.")
   );
-  const commit = yield* resolveGitCommit(repoRoot, treeish, treeGitAdapter(treeish));
   yield* guardKnowledgeCloneAttributes(repoRoot);
+  const commit = yield* resolveGitCommit(repoRoot, treeish, treeGitAdapter(treeish));
   const tempRoot = yield* fs
     .makeTempDirectoryScoped({ prefix: "beep-knowledge-refs-" })
     .pipe(KnowledgeOperationalError.mapError("Failed to create a reference-census temporary root."));

--- a/packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.service.ts
+++ b/packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.service.ts
@@ -20,6 +20,7 @@ import { extract as extractTar } from "tar";
 import { OutputBound, runCapturedStreams } from "../../internal/process/StepExec.ts";
 import {
   gitArchiveEnv,
+  guardCloneLocalGitAttributes,
   readGitRenames,
   readGitTree,
   resolveGitCommit,
@@ -29,6 +30,7 @@ import {
 import { KnowledgeCommandSurface } from "./Knowledge.command-surface.ts";
 import {
   KNOWLEDGE_HISTORY_REMEDIATION,
+  KnowledgeCloneAttributesError,
   KnowledgeOperationalError,
   KnowledgeProbeBootError,
 } from "./Knowledge.errors.ts";
@@ -217,18 +219,24 @@ export interface KnowledgePairedOracleInput {
  * `scanPair` takes an already-materialized comparison boundary and stays pure; `semanticDelta` builds
  * that boundary from local Git history for a base ref and then delegates to it. `refsTree` is the
  * single-tree read-only census: it shares the archive plumbing but compares nothing, so it gates
- * nothing either.
+ * nothing either. Both tree-materializing operations refuse to archive while a non-empty
+ * clone-local git attributes file is present, failing with {@link KnowledgeCloneAttributesError}
+ * before any bytes are compared.
  *
  * @see {@link KnowledgeService} for the service tag that carries this shape.
  * @category services
  * @since 0.0.0
  */
 export interface KnowledgeServiceShape {
-  readonly refsTree: (treeish: string) => Effect.Effect<KnowledgeRefsReport, KnowledgeOperationalError>;
+  readonly refsTree: (
+    treeish: string
+  ) => Effect.Effect<KnowledgeRefsReport, KnowledgeOperationalError | KnowledgeCloneAttributesError>;
   readonly scanPair: (
     input: KnowledgePairedOracleInput
   ) => Effect.Effect<KnowledgeSemanticDeltaReport, KnowledgeOperationalError>;
-  readonly semanticDelta: (baseRef: string) => Effect.Effect<KnowledgeSemanticDeltaReport, KnowledgeOperationalError>;
+  readonly semanticDelta: (
+    baseRef: string
+  ) => Effect.Effect<KnowledgeSemanticDeltaReport, KnowledgeOperationalError | KnowledgeCloneAttributesError>;
 }
 
 /**
@@ -886,6 +894,14 @@ const gitAdapter: GitCommandErrorAdapter<KnowledgeOperationalError> = {
   onTruncated: O.none(),
 };
 
+// A clone-local info/attributes file outranks every attribute layer the canonical archive contract
+// pins and no git invocation can disable it (research/p3-hermetic-lane-decisions.md, "Measured
+// residual"), so both tree-materializing entry points refuse to archive while a non-empty one exists.
+const guardKnowledgeCloneAttributes = (repoRoot: string) =>
+  guardCloneLocalGitAttributes(repoRoot, gitAdapter, KnowledgeCloneAttributesError.at, (attributesPath) =>
+    KnowledgeOperationalError.new(`Failed to stat clone-local git attributes "${attributesPath}".`)
+  );
+
 const ROOT_COMMAND_MODULE = "packages/tooling/tool/cli/src/commands/Root.ts";
 const PORTFOLIO_INDEX_MODULE = "packages/tooling/tool/cli/src/commands/Goals/PortfolioIndex.ts";
 
@@ -1388,6 +1404,7 @@ const semanticDeltaLive = Effect.fn("Knowledge.semanticDelta")(function* (baseRe
   const headCommit = yield* resolveGitCommit(repoRoot, "HEAD", historyAdapter);
   const baseCommit = yield* resolveGitMergeBase(repoRoot, baseRef, headCommit, historyAdapter);
   const probePolicy = yield* resolveKnowledgeProbePolicy(process.env);
+  yield* guardKnowledgeCloneAttributes(repoRoot);
 
   return yield* Effect.scoped(
     Effect.gen(function* () {
@@ -1491,6 +1508,7 @@ export const makeKnowledgeTreeOracle = Effect.fn("Knowledge.makeTreeOracle")(fun
     KnowledgeOperationalError.mapError("Failed to locate the repository root for the reference census.")
   );
   const commit = yield* resolveGitCommit(repoRoot, treeish, treeGitAdapter(treeish));
+  yield* guardKnowledgeCloneAttributes(repoRoot);
   const tempRoot = yield* fs
     .makeTempDirectoryScoped({ prefix: "beep-knowledge-refs-" })
     .pipe(KnowledgeOperationalError.mapError("Failed to create a reference-census temporary root."));

--- a/packages/tooling/tool/cli/src/commands/Knowledge/index.ts
+++ b/packages/tooling/tool/cli/src/commands/Knowledge/index.ts
@@ -47,6 +47,7 @@ export * from "./Knowledge.schemas.ts";
  * @since 0.0.0
  */
 export {
+  guardKnowledgeCloneAttributes,
   KnowledgeService,
   KnowledgeServiceLive,
   makeKnowledgeFindingId,

--- a/packages/tooling/tool/cli/src/internal/repo-run/GitExec.ts
+++ b/packages/tooling/tool/cli/src/internal/repo-run/GitExec.ts
@@ -19,7 +19,7 @@
 import { $RepoCliId } from "@beep/identity/packages";
 import { isOptionLike } from "@beep/repo-utils";
 import { NonNegativeInt } from "@beep/schema";
-import { Effect, flow, Number as N, Order, pipe } from "effect";
+import { Effect, FileSystem, flow, Number as N, Order, Path, pipe } from "effect";
 import * as A from "effect/Array";
 import { dual } from "effect/Function";
 import * as O from "effect/Option";
@@ -27,6 +27,7 @@ import * as P from "effect/Predicate";
 import * as S from "effect/Schema";
 import * as Str from "effect/String";
 import { formatCommandLine, repoRunOutputBound, runCaptured, runCapturedStreams } from "../process/StepExec.ts";
+import type * as PlatformError from "effect/PlatformError";
 import type { ChildProcessSpawner } from "effect/unstable/process";
 import type { RunCapturedOptions, RunCapturedStreamsOptions } from "../process/StepExec.ts";
 
@@ -636,6 +637,49 @@ export const writeGitArchive = Effect.fn("GitExec.writeGitArchive")(function* <E
     env: gitArchiveEnv,
     extendEnv: true,
   });
+});
+
+/**
+ * Fails closed when a non-empty clone-local `info/attributes` file would poison archive bytes.
+ *
+ * **Details**
+ *
+ * The clone-local attributes file outranks every attribute layer {@link gitArchiveArgs} and
+ * {@link gitArchiveEnv} pin, and no git invocation can disable it (measured against git 2.55.0).
+ * The path is resolved through `git rev-parse --git-path info/attributes` so worktrees reach the
+ * shared common-dir file, then stat'd: an absent or empty file passes — fresh clones and CI never
+ * carry one, so the guard is vacuously green there — while a non-empty file fails with the resolved
+ * path. A stat failure other than not-found also fails closed via `onStatFailure`: a file that
+ * cannot be verified cannot be proven inert.
+ *
+ * @category execution
+ * @since 0.0.0
+ */
+export const guardCloneLocalGitAttributes = Effect.fn("GitExec.guardCloneLocalGitAttributes")(function* <E, EDirty>(
+  cwd: string,
+  adapter: GitCommandErrorAdapter<E>,
+  onCloneLocalAttributes: (attributesPath: string) => EDirty,
+  onStatFailure: (attributesPath: string) => (cause: PlatformError.PlatformError) => E
+): Effect.fn.Return<void, E | EDirty, ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path> {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const gitPath = yield* runGitStructured(
+    ["rev-parse", "--git-path", "info/attributes"],
+    adapter,
+    structuredCapture(cwd)
+  );
+  const attributesPath = path.isAbsolute(gitPath) ? gitPath : path.join(cwd, gitPath);
+  const nonEmpty = yield* fs.stat(attributesPath).pipe(
+    Effect.map((info) => info.size > 0n),
+    Effect.catchIf(
+      (error) => error.reason._tag === "NotFound",
+      () => Effect.succeed(false)
+    ),
+    Effect.mapError(onStatFailure(attributesPath))
+  );
+  if (nonEmpty) {
+    return yield* Effect.fail(onCloneLocalAttributes(attributesPath));
+  }
 });
 
 /** Read and strictly parse one recursive full Git tree. @category execution @since 0.0.0 */

--- a/packages/tooling/tool/cli/test/knowledge-semantic-delta.test.ts
+++ b/packages/tooling/tool/cli/test/knowledge-semantic-delta.test.ts
@@ -1,6 +1,7 @@
 import {
   decodeKnowledgeUtf8,
   encodeKnowledgeSemanticDeltaReportJson,
+  guardKnowledgeCloneAttributes,
   KNOWLEDGE_PROBE_DEPENDENT_KINDS,
   KnowledgeCommandResolved,
   KnowledgeCommandUnknown,
@@ -1594,5 +1595,59 @@ describe("knowledge semantic-delta base probe boot failure", () => {
       assert.notInclude(human, "\u202E");
       assert.include(human, "<absolute-path>");
     })
+  );
+});
+
+// The clone-local info/attributes file is the one attribute layer no git invocation can disable
+// (research/p3-hermetic-lane-decisions.md "Measured residual"). The GitExec primitive's states are
+// pinned in step-git-exec.test.ts; this block pins the service wiring — the typed errors both
+// tree-materializing entry points surface through guardKnowledgeCloneAttributes.
+describe("knowledge clone-local attributes guard", () => {
+  const runGit = (cwd: string, args: ReadonlyArray<string>, env: Record<string, string>): void => {
+    const result = Bun.spawnSync(["git", ...args], { cwd, env, stderr: "pipe", stdout: "pipe" });
+    if (result.exitCode !== 0) {
+      throw new Error(`git ${A.join(args, " ")} failed: ${result.stderr.toString()}`);
+    }
+  };
+
+  it.effect("passes while the clone-local attributes file is absent or empty and fails closed once non-empty", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempRoot = yield* fs.makeTempDirectoryScoped({ prefix: "knowledge-clone-attributes-" });
+      const repoDir = path.join(tempRoot, "repo");
+      const home = path.join(tempRoot, "home");
+      yield* fs.makeDirectory(repoDir, { recursive: true });
+      yield* fs.makeDirectory(home, { recursive: true });
+      const env = {
+        PATH: Bun.env.PATH ?? "",
+        HOME: home,
+        GIT_CONFIG_GLOBAL: "/dev/null",
+        GIT_CONFIG_NOSYSTEM: "1",
+      };
+      yield* Effect.sync(() => runGit(repoDir, ["init", "-b", "main"], env));
+
+      yield* guardKnowledgeCloneAttributes(repoDir);
+      const attributesPath = path.join(repoDir, ".git", "info", "attributes");
+      yield* fs.writeFileString(attributesPath, "");
+      yield* guardKnowledgeCloneAttributes(repoDir);
+
+      yield* fs.writeFileString(attributesPath, "*.md eol=crlf\n");
+      const failure = yield* Effect.flip(guardKnowledgeCloneAttributes(repoDir));
+      assert.strictEqual(failure._tag, "KnowledgeCloneAttributesError");
+      if (failure._tag === "KnowledgeCloneAttributesError") {
+        assert.strictEqual(failure.attributesPath, attributesPath);
+        assert.include(failure.message, attributesPath);
+      }
+    }).pipe(provideScopedLayer(testLayer))
+  );
+
+  it.effect("runs the guard on the live semantic-delta path before failing typed on an unresolvable base ref", () =>
+    Effect.gen(function* () {
+      const knowledge = yield* KnowledgeService;
+      const failure = yield* Effect.flip(knowledge.semanticDelta("refs/beep/definitely-missing-base"));
+      assert.strictEqual(failure._tag, "KnowledgeOperationalError");
+      assert.include(failure.message, "fetch-depth: 0");
+    }).pipe(provideScopedLayer(testLayer))
   );
 });

--- a/packages/tooling/tool/cli/test/step-git-exec.test.ts
+++ b/packages/tooling/tool/cli/test/step-git-exec.test.ts
@@ -1,3 +1,4 @@
+import { KnowledgeCloneAttributesError, KnowledgeOperationalError } from "@beep/repo-cli/commands/Knowledge";
 import {
   BoundedOutput,
   boundedChunkReducer,
@@ -14,6 +15,7 @@ import {
   gitArchiveEnv,
   gitLinesFromOutput,
   gitPathListFromNulOutput,
+  guardCloneLocalGitAttributes,
   isSafeOriginBranch,
   originBranchFromBase,
   safeOriginBranchFromBase,
@@ -28,6 +30,7 @@ import { Effect, FileSystem, Layer, Path, Ref, Sink, Stream } from "effect";
 import * as A from "effect/Array";
 import * as O from "effect/Option";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import type { GitCommandErrorAdapter } from "@beep/repo-cli/test/RepoRun";
 
 const encode = (value: string): Uint8Array => new TextEncoder().encode(value);
 
@@ -334,6 +337,92 @@ layer(NodeServices.layer)("GitExec archive hostile-profile canonicality", (it) =
         const umaskWitness = yield* archiveBytes("umask-witness.tar", unpinnedArgs, envWith(umaskEnv));
         expect(umaskPinned).toStrictEqual(canonical);
         expect(umaskWitness).not.toStrictEqual(canonical);
+      });
+
+      yield* body.pipe(Effect.ensuring(fs.remove(tmpDir, { recursive: true }).pipe(Effect.ignore)));
+    })
+  );
+});
+
+// The clone-local info/attributes file is the one attribute layer no git invocation can disable
+// (research/p3-hermetic-lane-decisions.md "Measured residual"): the guard must pass while the file
+// is absent or empty, fail closed with the resolved path once it is non-empty, and resolve through
+// `rev-parse --git-path` so a worktree reaches the shared common-dir file.
+layer(NodeServices.layer)("GitExec clone-local attributes guard", (it) => {
+  const runGit = (cwd: string, args: ReadonlyArray<string>, env: Record<string, string>): void => {
+    const result = Bun.spawnSync(["git", ...args], { cwd, env, stderr: "pipe", stdout: "pipe" });
+    if (result.exitCode !== 0) {
+      throw new Error(`git ${A.join(args, " ")} failed: ${result.stderr.toString()}`);
+    }
+  };
+
+  it.effect(
+    "passes on absent and empty info/attributes, fails closed on non-empty, and follows worktrees to the common dir",
+    Effect.fnUntraced(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      // realPath keeps the joined expectation byte-identical to what git records for the common
+      // dir even when the temp root contains symlinked segments.
+      const tmpDir = yield* fs.realPath(yield* fs.makeTempDirectory());
+
+      const body = Effect.gen(function* () {
+        const repoDir = path.join(tmpDir, "repo");
+        const home = path.join(tmpDir, "home");
+        yield* fs.makeDirectory(repoDir, { recursive: true });
+        yield* fs.makeDirectory(home, { recursive: true });
+        const env = {
+          PATH: Bun.env.PATH ?? "",
+          HOME: home,
+          GIT_CONFIG_GLOBAL: "/dev/null",
+          GIT_CONFIG_NOSYSTEM: "1",
+        };
+        yield* Effect.sync(() => {
+          runGit(repoDir, ["init", "-b", "main"], env);
+          runGit(repoDir, ["config", "user.email", "guard@example.test"], env);
+          runGit(repoDir, ["config", "user.name", "Guard Test"], env);
+        });
+
+        const adapter: GitCommandErrorAdapter<KnowledgeOperationalError> = {
+          onSpawnFailure: (commandLine) => (cause) =>
+            KnowledgeOperationalError.make({ message: `spawn ${commandLine}`, cause }),
+          onNonZeroExit: ({ commandLine, exitCode }) =>
+            KnowledgeOperationalError.make({ message: `${commandLine} exit ${exitCode}` }),
+          onTruncated: O.none(),
+        };
+        const guardAt = (cwd: string) =>
+          guardCloneLocalGitAttributes(cwd, adapter, KnowledgeCloneAttributesError.at, (attributesPath) =>
+            KnowledgeOperationalError.new(`stat failed for "${attributesPath}".`)
+          );
+        const attributesPath = path.join(repoDir, ".git", "info", "attributes");
+
+        yield* guardAt(repoDir);
+        yield* fs.writeFileString(attributesPath, "");
+        yield* guardAt(repoDir);
+
+        yield* fs.writeFileString(attributesPath, "*.md eol=crlf\n");
+        const failure = yield* Effect.flip(guardAt(repoDir));
+        if (failure._tag !== "KnowledgeCloneAttributesError") {
+          throw new Error(`expected KnowledgeCloneAttributesError, got ${failure._tag}`);
+        }
+        expect(failure.attributesPath).toBe(attributesPath);
+        expect(failure.message).toContain(attributesPath);
+
+        const worktreeDir = path.join(tmpDir, "wt");
+        yield* fs.writeFileString(path.join(repoDir, "seed.txt"), "seed\n");
+        yield* Effect.sync(() => {
+          runGit(repoDir, ["add", "."], env);
+          runGit(repoDir, ["commit", "-m", "seed"], env);
+          runGit(repoDir, ["worktree", "add", worktreeDir], env);
+        });
+        const worktreeFailure = yield* Effect.flip(guardAt(worktreeDir));
+        if (worktreeFailure._tag !== "KnowledgeCloneAttributesError") {
+          throw new Error(`expected KnowledgeCloneAttributesError, got ${worktreeFailure._tag}`);
+        }
+        expect(worktreeFailure.attributesPath).toBe(attributesPath);
+
+        yield* fs.remove(attributesPath);
+        yield* guardAt(worktreeDir);
+        yield* guardAt(repoDir);
       });
 
       yield* body.pipe(Effect.ensuring(fs.remove(tmpDir, { recursive: true }).pipe(Effect.ignore)));


### PR DESCRIPTION
Ships the ratified info/attributes guard (goals/knowledge-surface-automation,
`research/p3-hermetic-lane-decisions.md` "Measured residual"): the clone-local attributes file
outranks every layer the canonical archive contract pins and no git invocation can disable it, so
`beep knowledge semantic-delta` and `beep knowledge refs` now stat `git rev-parse --git-path
info/attributes` before writing any hermetic archive and fail closed with the new typed
`KnowledgeCloneAttributesError` naming the resolved path when the file exists non-empty.

- Absent and empty files pass, so the guard is vacuously green in CI and fresh clones.
- Worktrees resolve through `--git-path` to the shared common-dir file.
- A stat failure other than not-found also fails closed as operational — an unverifiable file
  cannot be proven inert.
- Fixture-clone tests in `test/step-git-exec.test.ts` pin all four ratified behaviors (absent
  passes, empty passes, non-empty raises the typed failure, worktree fails on the main clone's
  file) alongside the existing hostile-profile differentials.
- The decisions doc's "open decision, not ratified here" paragraph flips to the 2026-08-17
  ratification record in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUaZTN6dN4yoA8j5tSVExt

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/757"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789582725&installation_model_id=424656&pr_number=757&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F757&signature=f68c4949c32c1c4223cc11bbe1d1727c7b1c873dcf3a1c0e035459e0576c44c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->