### PR TITLE
fix(cli): delete-package scoped baselines and receipt 9-11 closeout

### DIFF
--- a/.changeset/delete-package-scoped-baselines.md
+++ b/.changeset/delete-package-scoped-baselines.md
@@ -1,0 +1,10 @@
+---
+"@beep/repo-cli": patch
+---
+
+`beep delete-package` now subtracts the deleted workspace's rows from the committed coverage
+baseline schema-first instead of re-running repo-wide coverage (receipt 9); the dependents scan
+classifies packet `history/**` and `research/**` references as historical records rather than live
+packet claims and the residue probes exclude machine-local `.beep/` state (receipt 11); and
+`beep lint reflection-artifacts` validates reflection frontmatter in every packet, not only
+completed ones (receipt 10).

--- a/goals/lab-apps-lifecycle/PLAN.md
+++ b/goals/lab-apps-lifecycle/PLAN.md
@@ -217,6 +217,16 @@ fails the delete. Deleting one leaf package is coupled to every other package's
 tests passing. The registration work had already completed correctly by then,
 so the command destroys and then reports failure.
 
+> **Correction (2026-08-17, receipt-9 fix PR):** the failure attribution in
+> the paragraph above is wrong. Run 2's coverage rebuild was green and wrote
+> the 127-package baseline; the `@beep/wink` message was a WARN from the
+> expected-failure path of a passing test, and the exit 1 came from the
+> post-apply doctor's `authored-references` residue on a machine-local
+> `.beep/yeet` artifact. The corrected record is
+> `history/p4-first-vertical-slice.md` §4c and ledger receipt 9's correction;
+> the cost and coupling *properties* stand and were fixed by replacing the
+> coverage rebuild with schema-first row subtraction.
+
 None of the drift is probe removal —
 a lab minted after `HEAD` never entered a committed baseline, so regenerating
 repo-wide to remove it is wasted work by construction, and what it actually

--- a/goals/lab-apps-lifecycle/README.md
+++ b/goals/lab-apps-lifecycle/README.md
@@ -9,12 +9,17 @@ All seven phases complete, closed out 2026-08-17. Final work shipped in
 earlier phases in #722 (P0), #723 (P1), #732 + #742 (P2), #752 (P3).
 
 Latest evidence: [`history/p4-first-vertical-slice.md`](./history/p4-first-vertical-slice.md)
-is the round-trip record, [`history/reflections/2026-08-17-claude.md`](./history/reflections/2026-08-17-claude.md)
+is the round-trip record (§4c carries the corrected failure attribution),
+[`history/reflections/2026-08-17-claude.md`](./history/reflections/2026-08-17-claude.md)
 the closeout reflection, and [`research/OPPORTUNITIES.md`](./research/OPPORTUNITIES.md)
-carries eleven friction receipts — of which **receipt 9 is a live defect in
-shipped tooling**: `beep delete-package`'s default path cannot complete on a
-tree with any failing test, because its baseline rebuild runs the repo-wide
-coverage suite, and it removes the package before discovering that.
+carries eleven friction receipts. Receipts 9, 10, and 11 were **fixed
+2026-08-17** in the receipt-9 fix PR: `beep delete-package` now subtracts the
+target's rows from the committed coverage baseline schema-first instead of
+re-running repo-wide coverage, packet `history/**`/`research/**` references
+classify as historical records rather than live claims, `.beep/` is excluded
+from residue scans, and `beep lint reflection-artifacts` validates frontmatter
+in every packet. The reported `@beep/wink` test failure never existed — see
+receipt 9's correction.
 
 Source: [`ops/manifest.json`](./ops/manifest.json)
 

--- a/goals/lab-apps-lifecycle/history/p4-first-vertical-slice.md
+++ b/goals/lab-apps-lifecycle/history/p4-first-vertical-slice.md
@@ -119,6 +119,34 @@ A third finding came from attempting the re-run at all: `delete-package` now
 refuses with `REFUSE [packet-claim/soft]` because six lines of *this file* name
 the probe. Recording the proof makes the proof unrepeatable (ledger receipt 11).
 
+### 4c. Corrected attribution (2026-08-17, receipt-9 fix PR)
+
+Conclusion 2 in §4b is wrong, and the error is worth recording precisely
+because two review rounds had already taught this file that a claim is only as
+corrected as its least-corrected copy. Re-reading run 2's own logs:
+
+- The repo-wide coverage rebuild **succeeded**: `Tasks: 17 successful, 17
+  total`, then `[coverage-ratchet] wrote
+  standards/coverage.regression-baseline.jsonc with 127 package(s)`.
+- The `@beep/wink` line was a `WARN` emitted by the expected-failure path of a
+  **passing** test — `ToolValidation.test.ts` deliberately queries a corpus
+  that must not exist and asserts the structured failure; the log shows
+  `✓ test/ToolValidation.test.ts` immediately after the WARN in both runs.
+  There was never a failing wink test, and no wink fix was needed.
+- The exit 1 came from the **post-apply doctor**: `authored-references`
+  residue on `.beep/yeet/runs/.../pr-body.md` — a machine-local yeet artifact
+  mentioning the probe, which the residue scan should never have read. That is
+  receipt 11's conflation of record with claim, reached through a sibling
+  directory.
+
+What survives from §4b: the drift determinism (conclusion 1), the ~12-minute
+coverage-rebuild cost, and the *property* that a genuinely red test anywhere
+would fail the default delete. What does not survive: the claim that such a
+test existed. The fix PR removes the property too — the delete path now
+subtracts the target's rows from the committed coverage baseline schema-first,
+classifies packet `history/**` and `research/**` as historical records, and
+excludes `.beep/` from residue scans.
+
 ## 5. Doctor
 
 ```
@@ -153,8 +181,11 @@ Read that scope precisely, because §4b narrows it:
 
 The defect the loop surfaced is **structural, not operational**. An earlier
 draft of this file called it "slower than a ten-minute ceiling"; that was
-wrong, and PR review caught it. The default `delete-package` cannot complete on
-a tree with any failing test anywhere, because its baseline step runs the
-repo-wide coverage suite — and it removes the package before discovering that.
-Tracked as ledger receipt 9, with receipts 3 (half-deleted state) and 11
-(evidence blocks re-proof) adjacent.
+wrong, and PR review caught it. A later correction (§4c) narrowed §4b in turn:
+the run-2 failure was the residue scan reading a machine-local `.beep`
+artifact, not a red test, though the repo-wide coverage rerun and its
+red-test coupling were real properties of the default path. Tracked as ledger
+receipt 9, with receipts 3 (half-deleted state) and 11 (evidence blocks
+re-proof) adjacent. Receipts 9 and 11 are closed by the receipt-9 fix PR;
+receipt 3's interrupt hazard is narrowed (the slow, fallible step is gone)
+but an interrupt mid-delete can still leave partial state.

--- a/goals/lab-apps-lifecycle/research/OPPORTUNITIES.md
+++ b/goals/lab-apps-lifecycle/research/OPPORTUNITIES.md
@@ -256,6 +256,24 @@ Numbers are STABLE IDS — never renumber to express priority.
    Until then `--skip-baselines` is not a convenience flag, it is the only path
    that can succeed on a tree with any failing test anywhere.
 
+   *Correction (2026-08-17, receipt-9 fix PR):* the coupling **instance**
+   recorded above was misattributed. Run 2's own logs show the repo-wide
+   coverage rebuild **succeeded** — `[coverage-ratchet] wrote
+   standards/coverage.regression-baseline.jsonc with 127 package(s)` — and the
+   `@beep/wink` message is a WARN emitted by the expected-failure path of a
+   test that *passes*: `ToolValidation.test.ts` deliberately queries a corpus
+   that must not exist and asserts the structured failure, and the suite shows
+   `✓` immediately after that WARN in both P4 run logs. There was never a wink
+   defect. The exit 1 came from the post-apply doctor instead:
+   `authored-references` residue on `.beep/yeet/runs/.../pr-body.md`, a
+   machine-local yeet artifact the residue scan should never have read —
+   receipt 11's class reached through a sibling directory. The structural
+   claims stand (the coverage rebuild is the bulk of the 718s, and a genuinely
+   red test anywhere would fail it), but no red test existed that day.
+   *Fixed:* the delete path now subtracts the target's rows from the committed
+   coverage baseline schema-first instead of re-running repo-wide coverage,
+   and `.beep/` is excluded from residue scans.
+
 10. **The reflection lint reports a false green on an active packet, and only
     `goals doctor` catches the invalid frontmatter.** — `unowned`
 
@@ -287,6 +305,11 @@ Numbers are STABLE IDS — never renumber to express priority.
     the validation step, so following the packet's own instructions produces
     the false green.
 
+    *Fixed (2026-08-17, receipt-9 fix PR):* `beep lint reflection-artifacts`
+    now validates frontmatter in every packet, active or completed; only the
+    closeout-presence gate remains a completed-packet contract. The two
+    validators agree again.
+
 11. **Recording the evidence of a round-trip makes that round-trip
     unrepeatable.** — `unowned`
 
@@ -313,3 +336,11 @@ Numbers are STABLE IDS — never renumber to express priority.
     having deleted* one. Any repo that asks agents to write durable evidence
     will keep hitting this, and the incentive it creates is to write less
     evidence.
+
+    *Fixed (2026-08-17, receipt-9 fix PR):* the dependents scan now classifies
+    `goals/*/history/**` and `goals/*/research/**` as `historical-doc` rather
+    than live packet claims, so recorded proofs and ledger receipts no longer
+    refuse the deletion they document; live claims in `PLAN.md`/`SPEC.md`
+    still do. `.beep/` is excluded from the authored-references residue probe
+    for the same reason — it is machine-local operator state, not a
+    registration surface.

--- a/packages/tooling/tool/cli/src/commands/DeletePackage/DeletePackage.command.ts
+++ b/packages/tooling/tool/cli/src/commands/DeletePackage/DeletePackage.command.ts
@@ -30,6 +30,7 @@ import { runToExit } from "../../internal/process/index.ts";
 import { CreatePackageIdentityRegistration } from "../CreatePackage/internal/IdentityRegistration.ts";
 import { LabIdentitySegment } from "../CreatePackage/internal/LabIdentitySegment.ts";
 import { changesetPackageReferencesFromText } from "../Quality/ChangesetGraph.ts";
+import { subtractPackageFromCoverageRegressionBaseline } from "../Quality/internal/CoverageRegression.ts";
 import { syncTsconfigAtRoot } from "../TsconfigSync/index.ts";
 import { DeletePackagePolicyEvaluation } from "./DeletePackage.policy.ts";
 import {
@@ -399,6 +400,12 @@ const runStep = Effect.fn("DeletePackage.runStep")(function* (
 // the --save-baseline write succeeded (P1 round-trip proof), so that one step
 // tolerates exit 1 iff its verified output was provably written. Exit >= 2 is
 // a real fallow fault and always fails.
+//
+// The coverage baseline is deliberately NOT in this table. Its writer re-runs
+// the repo-wide coverage suite (~12 minutes, and coupled to every test in the
+// repo passing) to compute what is, for a leaf deletion, a pure row removal —
+// so the delete path subtracts the target's rows schema-first instead
+// (receipt 9, lab-apps-lifecycle).
 const BASELINE_WRITER_STEPS: ReadonlyArray<BaselineWriterStep> = [
   BaselineWriterStep.make({ label: "fallow boundaries", args: ["run", "beep", "fallow", "boundaries", "--write"] }),
   BaselineWriterStep.make({
@@ -419,7 +426,6 @@ const BASELINE_WRITER_STEPS: ReadonlyArray<BaselineWriterStep> = [
   }),
   BaselineWriterStep.make({ label: "schema catalog", args: ["run", "beep", "lint", "schema-catalog", "--write"] }),
   BaselineWriterStep.make({ label: "Knip baseline", args: ["run", "beep", "quality", "knip", "--write-baseline"] }),
-  BaselineWriterStep.make({ label: "coverage replacement baseline", args: ["run", "coverage:baseline:write"] }),
 ];
 
 const baselineOutputWritten = (before: O.Option<BaselineOutputStamp>, after: O.Option<BaselineOutputStamp>): boolean =>
@@ -495,7 +501,17 @@ const statBaselineOutput = Effect.fn("DeletePackage.statBaselineOutput")(functio
  */
 export const DeletePackageBaselineWriters = { baselineStepOutcome, steps: BASELINE_WRITER_STEPS } as const;
 
-const runBaselineWriters = Effect.fn("DeletePackage.runBaselineWriters")(function* (repoRoot: string) {
+const runBaselineWriters = Effect.fn("DeletePackage.runBaselineWriters")(function* (
+  repoRoot: string,
+  packageName: string
+) {
+  // Coverage first, and not as a shell step: the target's rows are removed
+  // from the committed baseline in-process, which is what a repo-wide
+  // regeneration would produce for a leaf target without the coverage rerun.
+  yield* Console.log(`[delete-package] coverage baseline subtraction: ${packageName}`);
+  yield* subtractPackageFromCoverageRegressionBaseline(repoRoot, packageName).pipe(
+    Effect.mapError(DomainError.newCause("coverage baseline subtraction failed."))
+  );
   for (const step of BASELINE_WRITER_STEPS) {
     yield* Console.log(`[delete-package] ${step.label}: bun ${A.join(step.args, " ")}`);
     const before = yield* statBaselineOutput(repoRoot, step.verifiedOutput);
@@ -711,7 +727,7 @@ const handler = Effect.fn("DeletePackage.handler")(function* (options: DeletePac
       Effect.mapError(DomainError.newCause("tsconfig-sync failed after package deletion."))
     );
     if (!options.skipLockfile) yield* runStep(repoRoot, "lockfile refresh", "bun", ["install", "--lockfile-only"]);
-    if (!options.skipBaselines) yield* runBaselineWriters(repoRoot);
+    if (!options.skipBaselines) yield* runBaselineWriters(repoRoot, plan.target.packageName);
     yield* invalidateCiMirrors(repoRoot);
   });
   const geometry = yield* makeRegistrationGeometryService(repoRoot, executePlan);

--- a/packages/tooling/tool/cli/src/commands/DeletePackage/DeletePackage.command.ts
+++ b/packages/tooling/tool/cli/src/commands/DeletePackage/DeletePackage.command.ts
@@ -476,31 +476,6 @@ const statBaselineOutput = Effect.fn("DeletePackage.statBaselineOutput")(functio
   });
 });
 
-/**
- * Baseline-writer step table and the pure exit-outcome decision helper.
- *
- * **Details**
- *
- * `baselineStepOutcome` classifies one writer invocation: exit 0 is `ok`;
- * exit 1 under `tolerate-finding-exit` is `tolerated` only when the verified
- * output's `(mtime, size)` stamp changed or the file was created; everything
- * else — including every exit `>= 2` — is `failed`.
- *
- * **Example** (Classify a finding exit without a written baseline)
- *
- * ```ts
- * import { DeletePackageBaselineWriters } from "@beep/repo-cli/commands/DeletePackage"
- * import * as O from "effect/Option"
- *
- * const outcome = DeletePackageBaselineWriters.baselineStepOutcome(1, "tolerate-finding-exit", O.none(), O.none())
- * console.log(outcome) // "failed"
- * ```
- *
- * @category utilities
- * @since 0.0.0
- */
-export const DeletePackageBaselineWriters = { baselineStepOutcome, steps: BASELINE_WRITER_STEPS } as const;
-
 const runBaselineWriters = Effect.fn("DeletePackage.runBaselineWriters")(function* (
   repoRoot: string,
   packageName: string
@@ -529,6 +504,38 @@ const runBaselineWriters = Effect.fn("DeletePackage.runBaselineWriters")(functio
     });
   }
 });
+
+/**
+ * Baseline-writer step table, the pure exit-outcome decision helper, and the
+ * writer stage itself.
+ *
+ * **Details**
+ *
+ * `baselineStepOutcome` classifies one writer invocation: exit 0 is `ok`;
+ * exit 1 under `tolerate-finding-exit` is `tolerated` only when the verified
+ * output's `(mtime, size)` stamp changed or the file was created; everything
+ * else — including every exit `>= 2` — is `failed`. `run` is the full writer
+ * stage: coverage-baseline subtraction first, then the shell steps in table
+ * order.
+ *
+ * **Example** (Classify a finding exit without a written baseline)
+ *
+ * ```ts
+ * import { DeletePackageBaselineWriters } from "@beep/repo-cli/commands/DeletePackage"
+ * import * as O from "effect/Option"
+ *
+ * const outcome = DeletePackageBaselineWriters.baselineStepOutcome(1, "tolerate-finding-exit", O.none(), O.none())
+ * console.log(outcome) // "failed"
+ * ```
+ *
+ * @category utilities
+ * @since 0.0.0
+ */
+export const DeletePackageBaselineWriters = {
+  baselineStepOutcome,
+  steps: BASELINE_WRITER_STEPS,
+  run: runBaselineWriters,
+} as const;
 
 const invalidateCiMirrors = Effect.fn("DeletePackage.invalidateCiMirrors")(function* (repoRoot: string) {
   const fs = yield* FileSystem.FileSystem;

--- a/packages/tooling/tool/cli/src/commands/Lint/ReflectionArtifact.ts
+++ b/packages/tooling/tool/cli/src/commands/Lint/ReflectionArtifact.ts
@@ -1,10 +1,13 @@
 /**
  * Reflection-artifact inventory and enforcement command.
  *
- * Verifies that completed goal packets carry a schema-valid closeout reflection
- * under `goals/<slug>/history/reflections/<YYYY-MM-DD>-<agent>.md`. Packets that
- * opt in via `reflectionRequired: true` in their manifest record the intent
- * explicitly, but all completed packets are gated once they lack a valid
+ * Validates the YAML frontmatter of every reflection artifact under
+ * `goals/<slug>/history/reflections/<YYYY-MM-DD>-<agent>.md` in EVERY packet —
+ * active or completed — so this lint cannot report a false green that
+ * `goals doctor` then fails (the PR #365 YAML traps hid in a completed-only
+ * gap). Only the closeout-presence gate is a completed-packet contract:
+ * packets that opt out via `reflectionRequired: false` in their manifest get
+ * an advisory, and every other completed packet blocks when it lacks a
  * reflection artifact.
  *
  * @packageDocumentation
@@ -13,7 +16,7 @@
 
 import { $RepoCliId } from "@beep/identity/packages";
 import { decodeYamlTextAs, LiteralKit } from "@beep/schema";
-import { A } from "@beep/utils";
+import { A, thunkFalse } from "@beep/utils";
 import { Console, Effect, FileSystem, Path, pipe } from "effect";
 import * as O from "effect/Option";
 import * as P from "effect/Predicate";
@@ -184,8 +187,8 @@ const frontmatterIsValid = (raw: string): Effect.Effect<boolean> =>
  *
  * **Details**
  *
- * Shared with `beep goals doctor`, which validates reflections in every
- * packet (not only completed ones).
+ * Shared with `beep goals doctor`; both this lint and the doctor validate
+ * reflections in every packet, completed or not.
  *
  * **Example** (Check empty frontmatter validity)
  *
@@ -254,7 +257,8 @@ const REMEDIATION =
   "Write a closeout reflection at goals/<slug>/history/reflections/<YYYY-MM-DD>-<agent>.md via the /reflect skill (copy goals/_template/history/reflections/_TEMPLATE.md); its YAML frontmatter must validate against ReflectionFrontmatter.";
 
 /**
- * Verifies completed goal packets carry a schema-valid closeout reflection.
+ * Validates reflection frontmatter in every packet and closeout presence in
+ * completed ones.
  *
  * **Example** (Log lint runner name)
  *
@@ -278,6 +282,38 @@ export const runReflectionArtifactLint = Effect.fn(function* () {
     if (slug === TEMPLATE_SLUG) {
       continue;
     }
+
+    // Frontmatter must decode in ANY packet, not only completed ones — the
+    // PR #365 YAML traps hid in the completed-only gap, and goals doctor
+    // already validates every packet (Doctor.ts carries the same rule).
+    // `goals/` entries can be plain files (README.md); probing below one
+    // fails with ENOTDIR rather than returning false, so both probes degrade
+    // to "no reflections" instead of failing the whole lint.
+    const reflectionsDir = path.join(GOALS_DIR, slug, ...REFLECTIONS_SUBDIR);
+    const reflectionsDirExists = yield* fs.exists(reflectionsDir).pipe(Effect.orElseSucceed(thunkFalse));
+    const reflectionFiles = reflectionsDirExists
+      ? (yield* fs.readDirectory(reflectionsDir).pipe(Effect.orElseSucceed(A.empty<string>))).filter(
+          reflectionFileNameIsArtifact
+        )
+      : [];
+
+    for (const file of reflectionFiles) {
+      const raw = yield* fs.readFileString(path.join(reflectionsDir, file)).pipe(Effect.orElseSucceed(() => Str.empty));
+      const valid = yield* frontmatterIsValid(raw);
+      if (!valid) {
+        const finding = makeFinding(
+          slug,
+          "error",
+          `Reflection artifact has missing or invalid ReflectionFrontmatter.`,
+          REMEDIATION,
+          `${reflectionsDir}/${file}`
+        );
+        blocking.push(finding);
+      }
+    }
+
+    // The closeout-presence gate and the reflectionRequired opt-out remain
+    // completed-packet contracts.
     const manifestPath = path.join(GOALS_DIR, slug, "ops", "manifest.json");
     const manifestRead = yield* fs
       .readFileString(manifestPath)
@@ -306,12 +342,6 @@ export const runReflectionArtifactLint = Effect.fn(function* () {
       continue;
     }
 
-    const reflectionsDir = path.join(GOALS_DIR, slug, ...REFLECTIONS_SUBDIR);
-    const reflectionsDirExists = yield* fs.exists(reflectionsDir);
-    const reflectionFiles = reflectionsDirExists
-      ? (yield* fs.readDirectory(reflectionsDir)).filter((file) => REFLECTION_FILE_PATTERN.test(file))
-      : [];
-
     if (reflectionFiles.length === 0) {
       const finding = makeFinding(
         slug,
@@ -320,22 +350,6 @@ export const runReflectionArtifactLint = Effect.fn(function* () {
         REMEDIATION
       );
       blocking.push(finding);
-      continue;
-    }
-
-    for (const file of reflectionFiles) {
-      const raw = yield* fs.readFileString(path.join(reflectionsDir, file));
-      const valid = yield* frontmatterIsValid(raw);
-      if (!valid) {
-        const finding = makeFinding(
-          slug,
-          "error",
-          `Reflection artifact has missing or invalid ReflectionFrontmatter.`,
-          REMEDIATION,
-          `${reflectionsDir}/${file}`
-        );
-        blocking.push(finding);
-      }
     }
   }
 
@@ -371,5 +385,7 @@ export const runReflectionArtifactLint = Effect.fn(function* () {
  * @since 0.0.0
  */
 export const lintReflectionArtifactsCommand = Command.make("reflection-artifacts", {}, runReflectionArtifactLint).pipe(
-  Command.withDescription("Verify completed goal packets carry a schema-valid closeout reflection")
+  Command.withDescription(
+    "Validate reflection frontmatter in every goal packet and closeout presence in completed ones"
+  )
 );

--- a/packages/tooling/tool/cli/src/commands/Lint/ReflectionArtifact.ts
+++ b/packages/tooling/tool/cli/src/commands/Lint/ReflectionArtifact.ts
@@ -177,7 +177,7 @@ const frontmatterIsValid = (raw: string): Effect.Effect<boolean> =>
     onSome: (yamlText) =>
       decodeFrontmatter(yamlText).pipe(
         Effect.map(() => true),
-        Effect.orElseSucceed(() => false)
+        Effect.orElseSucceed(thunkFalse)
       ),
   });
 

--- a/packages/tooling/tool/cli/src/commands/Quality/internal/CoverageRegression.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/internal/CoverageRegression.ts
@@ -1098,6 +1098,22 @@ const formatBaseline = Effect.fn("CoverageRegression.formatBaseline")(function* 
   ].join("\n");
 });
 
+const writeBaselineDocument = Effect.fn("CoverageRegression.writeBaselineDocument")(function* (
+  repoRoot: string,
+  baseline: CoverageRegressionBaseline
+): Effect.fn.Return<void, CoverageRegressionError, FileSystem.FileSystem | Path.Path> {
+  const path = yield* Path.Path;
+  const content = yield* formatBaseline(baseline);
+  yield* writeArtifact({
+    path: path.join(repoRoot, coverageRegressionBaselinePath),
+    body: content,
+    onError: (cause) =>
+      QualityTaskConfigurationError.new(
+        `Failed to write ${coverageRegressionBaselinePath}.: ${Inspectable.toStringUnknown(cause, 0)}`
+      ),
+  });
+});
+
 const missingCoverageSnapshotPackages = (
   entries: ReadonlyArray<CoverageSnapshotEntry>,
   expectedPackageNames: ReadonlyArray<string>
@@ -1197,15 +1213,7 @@ export const writeCoverageRegressionBaseline = Effect.fn("CoverageRegression.wri
     }
 
     const baseline = yield* baselineDocumentFromSnapshot(repoRoot, entries, previous, scoped);
-    const content = yield* formatBaseline(baseline);
-    yield* writeArtifact({
-      path: path.join(repoRoot, coverageRegressionBaselinePath),
-      body: content,
-      onError: (cause) =>
-        QualityTaskConfigurationError.new(
-          `Failed to write ${coverageRegressionBaselinePath}.: ${Inspectable.toStringUnknown(cause, 0)}`
-        ),
-    });
+    yield* writeBaselineDocument(repoRoot, baseline);
     yield* Console.log(
       scoped
         ? `[coverage-ratchet] merged ${A.length(entries)} measured package(s) into ${coverageRegressionBaselinePath} (${R.size(baseline.packages)} total)`
@@ -1248,7 +1256,6 @@ export const subtractPackageFromCoverageRegressionBaseline = Effect.fn(
   repoRoot: string,
   packageName: string
 ): Effect.fn.Return<void, CoverageRegressionError, FileSystem.FileSystem | Path.Path> {
-  const path = yield* Path.Path;
   const previous = yield* readPreviousBaseline(repoRoot);
 
   if (O.isNone(previous)) {
@@ -1285,15 +1292,7 @@ export const subtractPackageFromCoverageRegressionBaseline = Effect.fn(
     follow_ups: R.remove(document.follow_ups, packageName),
     packages: R.remove(document.packages, packageName),
   });
-  const content = yield* formatBaseline(next);
-  yield* writeArtifact({
-    path: path.join(repoRoot, coverageRegressionBaselinePath),
-    body: content,
-    onError: (cause) =>
-      QualityTaskConfigurationError.new(
-        `Failed to write ${coverageRegressionBaselinePath}.: ${Inspectable.toStringUnknown(cause, 0)}`
-      ),
-  });
+  yield* writeBaselineDocument(repoRoot, next);
   yield* Console.log(
     `[coverage-ratchet] subtracted ${packageName} from ${coverageRegressionBaselinePath} (${R.size(next.packages)} package(s) remain)`
   );

--- a/packages/tooling/tool/cli/src/commands/Quality/internal/CoverageRegression.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/internal/CoverageRegression.ts
@@ -1214,6 +1214,91 @@ export const writeCoverageRegressionBaseline = Effect.fn("CoverageRegression.wri
   }
 );
 
+/**
+ * Remove one workspace's rows from the committed coverage regression baseline
+ * without re-measuring coverage.
+ *
+ * **Details**
+ *
+ * Deleting a leaf workspace cannot change any other package's coverage — the
+ * delete path only admits targets with an empty dependents cascade — so the
+ * correct baseline update is exactly the removal of that workspace's
+ * `packages`, `exemptions`, and `follow_ups` rows, which is what an unscoped
+ * regeneration would produce for those rows without the repo-wide coverage
+ * run it costs. The edit is strictly delete-only: every surviving row and the
+ * document's provenance fields (`generated_at`, `git_sha`) are carried through
+ * byte-identically, matching how scoped merges inherit provenance.
+ *
+ * **Gotchas**
+ *
+ * A missing baseline and a baseline with no rows for the package are both
+ * successful no-ops — lab workspaces never enter the baseline at all, so the
+ * lab delete path lands here by construction. A schema-version-1 document is
+ * refused the same way scoped writes refuse it: v1 must be regenerated in
+ * full before any row-level edit is meaningful.
+ *
+ * @param repoRoot - Repository root.
+ * @param packageName - Workspace package name (`@beep/...`) whose rows are removed.
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const subtractPackageFromCoverageRegressionBaseline = Effect.fn(
+  "CoverageRegression.subtractPackageFromCoverageRegressionBaseline"
+)(function* (
+  repoRoot: string,
+  packageName: string
+): Effect.fn.Return<void, CoverageRegressionError, FileSystem.FileSystem | Path.Path> {
+  const path = yield* Path.Path;
+  const previous = yield* readPreviousBaseline(repoRoot);
+
+  if (O.isNone(previous)) {
+    yield* Console.log(`[coverage-ratchet] no committed baseline exists; nothing to subtract for ${packageName}`);
+    return;
+  }
+
+  const document = previous.value;
+  if (!isCurrentCoverageRegressionBaseline(document)) {
+    return yield* QualityTaskConfigurationError.new(
+      `Refusing to edit ${coverageRegressionBaselinePath}: schema version 1 requires a full ${coverageRegressionRegenerationCommand} run before package rows can be subtracted.`
+    );
+  }
+
+  const mentioned =
+    R.has(document.packages, packageName) ||
+    R.has(document.exemptions, packageName) ||
+    R.has(document.follow_ups, packageName);
+  if (!mentioned) {
+    yield* Console.log(
+      `[coverage-ratchet] ${coverageRegressionBaselinePath} carries no rows for ${packageName}; nothing to subtract`
+    );
+    return;
+  }
+
+  const next = CoverageRegressionBaseline.make({
+    schema_version: document.schema_version,
+    generated_at: document.generated_at,
+    git_sha: document.git_sha,
+    command: document.command,
+    epsilon: document.epsilon,
+    minimum: document.minimum,
+    exemptions: R.remove(document.exemptions, packageName),
+    follow_ups: R.remove(document.follow_ups, packageName),
+    packages: R.remove(document.packages, packageName),
+  });
+  const content = yield* formatBaseline(next);
+  yield* writeArtifact({
+    path: path.join(repoRoot, coverageRegressionBaselinePath),
+    body: content,
+    onError: (cause) =>
+      QualityTaskConfigurationError.new(
+        `Failed to write ${coverageRegressionBaselinePath}.: ${Inspectable.toStringUnknown(cause, 0)}`
+      ),
+  });
+  yield* Console.log(
+    `[coverage-ratchet] subtracted ${packageName} from ${coverageRegressionBaselinePath} (${R.size(next.packages)} package(s) remain)`
+  );
+});
+
 const actualByPackageName = (actuals: ReadonlyArray<CoverageSnapshotEntry>) =>
   R.fromEntries(A.map(actuals, (entry) => [entry.packageName, entry] as const));
 

--- a/packages/tooling/tool/cli/src/commands/Quality/internal/CoverageRegression.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/internal/CoverageRegression.ts
@@ -1245,6 +1245,16 @@ export const writeCoverageRegressionBaseline = Effect.fn("CoverageRegression.wri
  * refused the same way scoped writes refuse it: v1 must be regenerated in
  * full before any row-level edit is meaningful.
  *
+ * **Example** (Subtract a deleted workspace's rows)
+ *
+ * ```ts
+ * import { subtractPackageFromCoverageRegressionBaseline } from "@beep/repo-cli/test/Quality"
+ * import { Effect } from "effect"
+ *
+ * const program = subtractPackageFromCoverageRegressionBaseline("/repo", "@beep/retired-driver")
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
  * @param repoRoot - Repository root.
  * @param packageName - Workspace package name (`@beep/...`) whose rows are removed.
  * @category use-cases

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/WatchStream.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/WatchStream.ts
@@ -591,7 +591,7 @@ export const diffYeetWatchSnapshots = (input: YeetWatchDiffInput): ReadonlyArray
           : O.some(thread.isResolved ? ("resolved" as const) : ("unresolved" as const)),
     });
     return O.match(to, {
-      onNone: () => A.empty<YeetWatchEvent>(),
+      onNone: A.empty<YeetWatchEvent>,
       onSome: (state) => [YeetThreadTransition.make({ at, headSha: next.headSha, threadId: thread.id, to: state })],
     });
   });

--- a/packages/tooling/tool/cli/src/internal/cli/RegistrationGeometry/RegistrationGeometry.probes.ts
+++ b/packages/tooling/tool/cli/src/internal/cli/RegistrationGeometry/RegistrationGeometry.probes.ts
@@ -38,7 +38,10 @@ const SCAN_ROOTS = [
   ".changeset",
   ".github",
 ];
-const EXCLUDED_DIRECTORIES = HashSet.fromIterable([".git", "node_modules", "dist", "coverage", ".turbo"]);
+// `.beep` holds machine-local operator state (yeet run artifacts, CI mirrors);
+// the runtime-artifact probe scans `.beep/ci` deliberately from inside that
+// root, so excluding the top-level entry here never reaches it.
+const EXCLUDED_DIRECTORIES = HashSet.fromIterable([".git", "node_modules", "dist", "coverage", ".turbo", ".beep"]);
 const SOURCE_SUFFIXES = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"];
 const TEXT_SUFFIXES = [
   ".ts",
@@ -375,8 +378,19 @@ const isBaselineReferenceFile = (file: string): boolean =>
   Str.startsWith(".changeset/")(file) ||
   A.some(BASELINE_REFERENCE_FILES, Str.equivalence(file));
 
+// Inside a packet, only the live planning surface (PLAN/SPEC/GOAL/README/ops)
+// carries claims a deletion must answer for. `history/**` is preserved
+// evidence and `research/**` is the packet's ledger and intel — both record
+// the past, so a deleted package named there is expected, not a stale claim.
+// Receipt 11 (lab-apps-lifecycle): recording a deletion proof in packet
+// history made the proof unrepeatable because these files classified as
+// live packet claims.
+const isPacketHistoricalRecord = (file: string): boolean =>
+  Str.startsWith("goals/")(file) && (Str.includes("/history/")(file) || Str.includes("/research/")(file));
+
 const AUTHORED_KIND_RULES: ReadonlyArray<readonly [matches: (file: string) => boolean, kind: DependentHitKind]> = [
   [isBaselineReferenceFile, "baseline"],
+  [isPacketHistoricalRecord, "historical-doc"],
   [Str.startsWith("goals/"), "packet"],
   [Str.startsWith("research/"), "historical-doc"],
   [Str.equivalence("package.json"), "script"],

--- a/packages/tooling/tool/cli/test/coverage-baseline-subtraction.test.ts
+++ b/packages/tooling/tool/cli/test/coverage-baseline-subtraction.test.ts
@@ -1,0 +1,183 @@
+import {
+  coverageRegressionBaselinePath,
+  subtractPackageFromCoverageRegressionBaseline,
+} from "@beep/repo-cli/test/Quality";
+import { Str } from "@beep/utils";
+import { NodeServices } from "@effect/platform-node";
+import { Cause, Effect, FileSystem, Layer, Path } from "effect";
+import * as Exit from "effect/Exit";
+import * as O from "effect/Option";
+import * as R from "effect/Record";
+import * as S from "effect/Schema";
+import { parse } from "jsonc-parser";
+import { describe, expect, it } from "vitest";
+
+const encodeJson = S.encodeUnknownSync(S.fromJsonString(S.Unknown));
+
+const BaselineProjection = S.Struct({
+  generated_at: S.String,
+  git_sha: S.String,
+  exemptions: S.Record(S.String, S.String),
+  follow_ups: S.Record(S.String, S.String),
+  packages: S.Record(S.String, S.Struct({ path: S.String })),
+});
+
+const provideNode = <A2, E, R2>(effect: Effect.Effect<A2, E, R2>) =>
+  Effect.scoped(
+    Layer.build(NodeServices.layer).pipe(Effect.flatMap((context) => effect.pipe(Effect.provide(context))))
+  );
+
+const withTempDirectory = <A2, E, R2>(use: (directory: string) => Effect.Effect<A2, E, R2>) =>
+  Effect.acquireUseRelease(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      return yield* fs.makeTempDirectory();
+    }),
+    use,
+    (directory) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        yield* fs.remove(directory, { recursive: true, force: true });
+      })
+  );
+
+const zeroUncovered = { branches: 0, functions: 0, lines: 0, statements: 0 };
+
+const packageRow = (packagePath: string) => ({
+  path: packagePath,
+  lines: 100,
+  statements: 100,
+  branches: 100,
+  functions: 100,
+  uncovered: zeroUncovered,
+  files: {
+    [`${packagePath}/src/index.ts`]: {
+      lines: 100,
+      statements: 100,
+      branches: 100,
+      functions: 100,
+      uncovered: zeroUncovered,
+    },
+  },
+});
+
+const baselineFixture = {
+  schema_version: 2,
+  generated_at: "2026-08-17T00:00:00.000Z",
+  git_sha: "0123456789abcdef0123456789abcdef01234567",
+  command: "bun run coverage:baseline:write",
+  epsilon: 0.001,
+  minimum: { lines: 70, statements: 70, branches: 50, functions: 60 },
+  exemptions: { "@beep/courtlistener": "Fixture exemption for the target." },
+  follow_ups: {
+    "@beep/alpha": "Fixture follow-up for the survivor.",
+    "@beep/courtlistener": "Fixture follow-up for the target.",
+  },
+  packages: {
+    "@beep/alpha": packageRow("packages/foundation/modeling/alpha"),
+    "@beep/courtlistener": packageRow("packages/drivers/courtlistener"),
+  },
+};
+
+const writeBaselineFixture = Effect.fn("writeBaselineFixture")(function* (repoRoot: string, document: unknown) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  yield* fs.makeDirectory(path.join(repoRoot, "standards"), { recursive: true });
+  yield* fs.writeFileString(path.join(repoRoot, coverageRegressionBaselinePath), `${encodeJson(document)}\n`);
+});
+
+const readBaselineText = Effect.fn("readBaselineText")(function* (repoRoot: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  return yield* fs.readFileString(path.join(repoRoot, coverageRegressionBaselinePath));
+});
+
+describe("coverage baseline subtraction", () => {
+  it("removes exactly the target's packages, exemptions, and follow_ups rows", () =>
+    Effect.runPromise(
+      provideNode(
+        withTempDirectory((repoRoot) =>
+          Effect.gen(function* () {
+            yield* writeBaselineFixture(repoRoot, baselineFixture);
+            yield* subtractPackageFromCoverageRegressionBaseline(repoRoot, "@beep/courtlistener");
+
+            const text = yield* readBaselineText(repoRoot);
+            expect(Str.startsWith("// Coverage regression baseline. Do not edit by hand.")(text)).toBe(true);
+            expect(Str.includes("@beep/courtlistener")(text)).toBe(false);
+
+            const decoded = yield* S.decodeUnknownEffect(BaselineProjection)(parse(text));
+            expect(R.keys(decoded.packages)).toStrictEqual(["@beep/alpha"]);
+            expect(R.keys(decoded.exemptions)).toStrictEqual([]);
+            expect(R.keys(decoded.follow_ups)).toStrictEqual(["@beep/alpha"]);
+            expect(R.get(decoded.packages, "@beep/alpha")).toStrictEqual(
+              O.some({ path: "packages/foundation/modeling/alpha" })
+            );
+            // Provenance is inherited, matching how scoped merges carry it through.
+            expect(decoded.generated_at).toBe(baselineFixture.generated_at);
+            expect(decoded.git_sha).toBe(baselineFixture.git_sha);
+          })
+        )
+      )
+    ));
+
+  it("leaves the document byte-identical when the target has no rows", () =>
+    Effect.runPromise(
+      provideNode(
+        withTempDirectory((repoRoot) =>
+          Effect.gen(function* () {
+            yield* writeBaselineFixture(repoRoot, baselineFixture);
+            const before = yield* readBaselineText(repoRoot);
+            yield* subtractPackageFromCoverageRegressionBaseline(repoRoot, "@beep/round-trip-probe");
+            const after = yield* readBaselineText(repoRoot);
+            expect(after).toBe(before);
+          })
+        )
+      )
+    ));
+
+  it("succeeds as a no-op when no committed baseline exists", () =>
+    Effect.runPromise(
+      provideNode(
+        withTempDirectory((repoRoot) =>
+          Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            const path = yield* Path.Path;
+            yield* subtractPackageFromCoverageRegressionBaseline(repoRoot, "@beep/courtlistener");
+            const exists = yield* fs.exists(path.join(repoRoot, coverageRegressionBaselinePath));
+            expect(exists).toBe(false);
+          })
+        )
+      )
+    ));
+
+  it("refuses a schema-v1 document without touching the file", () =>
+    Effect.runPromise(
+      provideNode(
+        withTempDirectory((repoRoot) =>
+          Effect.gen(function* () {
+            const legacy = {
+              schema_version: 1,
+              generated_at: "2026-01-01T00:00:00.000Z",
+              git_sha: "feedfacefeedfacefeedfacefeedfacefeedface",
+              command: "bun run coverage:baseline:write",
+              epsilon: 0.001,
+              packages: { "@beep/courtlistener": { path: "packages/drivers/courtlistener" } },
+            };
+            yield* writeBaselineFixture(repoRoot, legacy);
+            const before = yield* readBaselineText(repoRoot);
+
+            const exit = yield* Effect.exit(
+              subtractPackageFromCoverageRegressionBaseline(repoRoot, "@beep/courtlistener")
+            );
+            expect(Exit.isFailure(exit)).toBe(true);
+            if (Exit.isFailure(exit)) {
+              expect(Str.includes("schema version 1")(Cause.pretty(exit.cause))).toBe(true);
+            }
+
+            const after = yield* readBaselineText(repoRoot);
+            expect(after).toBe(before);
+          })
+        )
+      )
+    ));
+});

--- a/packages/tooling/tool/cli/test/delete-package.test.ts
+++ b/packages/tooling/tool/cli/test/delete-package.test.ts
@@ -17,7 +17,7 @@ import { PosixPath } from "@beep/schema/PosixPath";
 import { provideScopedLayer } from "@beep/test-utils";
 import { A, Str } from "@beep/utils";
 import { NodeServices } from "@effect/platform-node";
-import { Effect, FileSystem, Layer, Path } from "effect";
+import { Effect, FileSystem, Layer, Path, pipe } from "effect";
 import * as O from "effect/Option";
 import * as P from "effect/Predicate";
 import * as TestConsole from "effect/testing/TestConsole";
@@ -182,6 +182,77 @@ describe("delete-package registration geometry", () => {
           expect(A.some(report.hits, (hit) => hit.kind === "import-prod" && hit.owner === "@beep/consumer")).toBe(true);
         })
       ).pipe(provideScopedLayer(commandLayer))
+    ));
+
+  it("classifies packet history and ledger references as historical, not live packet claims", () =>
+    Effect.runPromise(
+      withTempDirectory((repoRoot) =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          yield* fs.writeFileString(
+            path.join(repoRoot, "package.json"),
+            '{ "name": "fixture", "private": true, "workspaces": [] }\n'
+          );
+          yield* fs.writeFileString(path.join(repoRoot, "bun.lock"), "");
+          yield* fs.makeDirectory(path.join(repoRoot, "goals", "lab-x", "history"), { recursive: true });
+          yield* fs.makeDirectory(path.join(repoRoot, "goals", "lab-x", "research"), { recursive: true });
+          yield* fs.writeFileString(
+            path.join(repoRoot, "goals", "lab-x", "PLAN.md"),
+            "# Plan\n\nShip @beep/courtlistener next.\n"
+          );
+          yield* fs.writeFileString(
+            path.join(repoRoot, "goals", "lab-x", "history", "p4-evidence.md"),
+            "# Evidence\n\nDeleted @beep/courtlistener during the slice.\n"
+          );
+          yield* fs.writeFileString(
+            path.join(repoRoot, "goals", "lab-x", "research", "OPPORTUNITIES.md"),
+            "# Ledger\n\nReceipt: @beep/courtlistener delete cost too much.\n"
+          );
+
+          const report = yield* dependentsOfAtRoot(repoRoot, target);
+          const kindOf = (file: string) =>
+            pipe(
+              A.findFirst(report.hits, (hit) => Str.equivalence(hit.file, file)),
+              O.map((hit) => hit.kind)
+            );
+          expect(kindOf("goals/lab-x/PLAN.md")).toStrictEqual(O.some("packet"));
+          expect(kindOf("goals/lab-x/history/p4-evidence.md")).toStrictEqual(O.some("historical-doc"));
+          expect(kindOf("goals/lab-x/research/OPPORTUNITIES.md")).toStrictEqual(O.some("historical-doc"));
+        })
+      ).pipe(provideScopedLayer(commandLayer))
+    ));
+
+  it("ignores machine-local .beep artifacts in the authored-reference probe", () =>
+    Effect.runPromise(
+      provideNode(
+        withTempDirectory((repoRoot) =>
+          Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            const path = yield* Path.Path;
+            yield* fs.makeDirectory(path.join(repoRoot, ".beep", "yeet", "runs", "20260817"), { recursive: true });
+            yield* fs.writeFileString(
+              path.join(repoRoot, ".beep", "yeet", "runs", "20260817", "pr-body.md"),
+              "Deletes @beep/courtlistener from the workspace.\n"
+            );
+
+            const clean = yield* inspectTargetAtRoot(repoRoot, target);
+            const authoredClean = O.getOrThrow(A.findFirst(clean, (item) => item.surfaceId === "authored-references"));
+            expect(authoredClean.status).toBe("clean");
+
+            yield* fs.makeDirectory(path.join(repoRoot, "infra"), { recursive: true });
+            yield* fs.writeFileString(
+              path.join(repoRoot, "infra", "deploy.yml"),
+              "packages:\n  - '@beep/courtlistener'\n"
+            );
+            const dirty = yield* inspectTargetAtRoot(repoRoot, target);
+            const authoredDirty = O.getOrThrow(A.findFirst(dirty, (item) => item.surfaceId === "authored-references"));
+            expect(authoredDirty.status).toBe("residue");
+            expect(authoredDirty.evidence).toContain("infra/deploy.yml");
+            expect(A.some(authoredDirty.evidence, Str.startsWith(".beep/"))).toBe(false);
+          })
+        )
+      )
     ));
 
   it("refuses deleting a live package whose README carries a promotion record", () =>
@@ -380,4 +451,32 @@ describe("delete-package hard-refuse table", () => {
       expect(cascade[1]).toContain("transitive:");
     }
   );
+});
+
+describe("delete-package packet-claim refusal", () => {
+  const claimReport = (kind: DependentHit["kind"], file: string): DependentsReport =>
+    DependentsReport.make({
+      target,
+      directWorkspaceDependents: [],
+      transitiveWorkspaceDependents: [],
+      hits: [DependentHit.make({ kind, owner: "goals", file: PosixPath.make(file), line: O.some(1), direct: false })],
+    });
+
+  it("soft-refuses a live packet claim when stale packets are not allowed", () => {
+    const refusals = DeletePackagePolicyEvaluation.refusalReasons(
+      target,
+      claimReport("packet", "goals/lab-x/PLAN.md"),
+      policy({ allowStalePackets: false })
+    );
+    expect(A.some(refusals, (refusal) => refusal.kind === "packet-claim" && refusal.severity === "soft")).toBe(true);
+  });
+
+  it("does not refuse on historical-doc hits from packet history or ledgers", () => {
+    const refusals = DeletePackagePolicyEvaluation.refusalReasons(
+      target,
+      claimReport("historical-doc", "goals/lab-x/history/p4-evidence.md"),
+      policy({ allowStalePackets: false })
+    );
+    expect(refusals).toStrictEqual([]);
+  });
 });

--- a/packages/tooling/tool/cli/test/delete-package.test.ts
+++ b/packages/tooling/tool/cli/test/delete-package.test.ts
@@ -505,8 +505,9 @@ describe("delete-package baseline writer stage", () => {
 }
 `;
 
-  it("subtracts the coverage baseline then runs every shell step in table order", () =>
-    Effect.runPromise(
+  it("subtracts the coverage baseline then runs every shell step in table order", () => {
+    const spawned: Array<string> = [];
+    return Effect.runPromise(
       withTempDirectory((repoRoot) =>
         Effect.gen(function* () {
           const fs = yield* FileSystem.FileSystem;
@@ -517,10 +518,7 @@ describe("delete-package baseline writer stage", () => {
             coverageBaselineFixture
           );
 
-          const spawned: Array<string> = [];
-          yield* DeletePackageBaselineWriters.run(repoRoot, "@beep/courtlistener").pipe(
-            Effect.provide(fakeSpawnerLayer(0, spawned))
-          );
+          yield* DeletePackageBaselineWriters.run(repoRoot, "@beep/courtlistener");
 
           const baseline = yield* fs.readFileString(
             path.join(repoRoot, "standards", "coverage.regression-baseline.jsonc")
@@ -530,27 +528,25 @@ describe("delete-package baseline writer stage", () => {
             A.map(DeletePackageBaselineWriters.steps, (step) => A.join(["bun", ...step.args], " "))
           );
         })
-      ).pipe(provideScopedLayer(commandLayer))
-    ));
+      ).pipe(provideScopedLayer(Layer.mergeAll(commandLayer, fakeSpawnerLayer(0, spawned))))
+    );
+  });
 
-  it("fails the stage on the first zero-only step that exits nonzero", () =>
-    Effect.runPromise(
+  it("fails the stage on the first zero-only step that exits nonzero", () => {
+    const spawned: Array<string> = [];
+    return Effect.runPromise(
       withTempDirectory((repoRoot) =>
         Effect.gen(function* () {
-          const spawned: Array<string> = [];
-          const exit = yield* Effect.exit(
-            DeletePackageBaselineWriters.run(repoRoot, "@beep/courtlistener").pipe(
-              Effect.provide(fakeSpawnerLayer(1, spawned))
-            )
-          );
+          const exit = yield* Effect.exit(DeletePackageBaselineWriters.run(repoRoot, "@beep/courtlistener"));
           expect(Exit.isFailure(exit)).toBe(true);
           if (Exit.isFailure(exit)) {
             expect(Str.includes("fallow boundaries failed with exit code 1")(Cause.pretty(exit.cause))).toBe(true);
           }
           expect(A.length(spawned)).toBe(1);
         })
-      ).pipe(provideScopedLayer(commandLayer))
-    ));
+      ).pipe(provideScopedLayer(Layer.mergeAll(commandLayer, fakeSpawnerLayer(1, spawned))))
+    );
+  });
 });
 
 describe("delete-package packet-claim refusal", () => {

--- a/packages/tooling/tool/cli/test/delete-package.test.ts
+++ b/packages/tooling/tool/cli/test/delete-package.test.ts
@@ -17,11 +17,13 @@ import { PosixPath } from "@beep/schema/PosixPath";
 import { provideScopedLayer } from "@beep/test-utils";
 import { A, Str } from "@beep/utils";
 import { NodeServices } from "@effect/platform-node";
-import { Effect, FileSystem, Layer, Path, pipe } from "effect";
+import { Cause, Effect, FileSystem, Layer, Path, pipe, Sink, Stream } from "effect";
+import * as Exit from "effect/Exit";
 import * as O from "effect/Option";
 import * as P from "effect/Predicate";
 import * as TestConsole from "effect/testing/TestConsole";
 import { Command } from "effect/unstable/cli";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 import { describe, expect, it } from "vitest";
 import { expectReportedExit, withTempWorkingDirectory } from "./support/CommandTest.ts";
 import type { DeletePackageRefusal } from "@beep/repo-cli/test/DeletePackage";
@@ -451,6 +453,104 @@ describe("delete-package hard-refuse table", () => {
       expect(cascade[1]).toContain("transitive:");
     }
   );
+});
+
+describe("delete-package baseline writer stage", () => {
+  const fakeSpawnerLayer = (exitCode: number, spawned: Array<string>) =>
+    Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
+      ChildProcessSpawner.make((command) =>
+        Effect.sync(() => {
+          if (command._tag === "StandardCommand") {
+            spawned.push(A.join([command.command, ...command.args], " "));
+          }
+          return ChildProcessSpawner.makeHandle({
+            pid: ChildProcessSpawner.ProcessId(1),
+            exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(exitCode)),
+            isRunning: Effect.succeed(false),
+            kill: () => Effect.void,
+            stdin: Sink.drain,
+            stdout: Stream.empty,
+            stderr: Stream.empty,
+            all: Stream.empty,
+            getInputFd: () => Sink.drain,
+            getOutputFd: () => Stream.empty,
+            unref: Effect.succeed(Effect.void),
+          });
+        })
+      )
+    );
+
+  const coverageBaselineFixture = `{
+  "schema_version": 2,
+  "generated_at": "2026-08-17T00:00:00.000Z",
+  "git_sha": "0123456789abcdef0123456789abcdef01234567",
+  "command": "bun run coverage:baseline:write",
+  "epsilon": 0.001,
+  "minimum": { "lines": 70, "statements": 70, "branches": 50, "functions": 60 },
+  "exemptions": {},
+  "follow_ups": {},
+  "packages": {
+    "@beep/courtlistener": {
+      "path": "packages/drivers/courtlistener",
+      "lines": 100, "statements": 100, "branches": 100, "functions": 100,
+      "uncovered": { "lines": 0, "statements": 0, "branches": 0, "functions": 0 },
+      "files": {
+        "packages/drivers/courtlistener/src/index.ts": {
+          "lines": 100, "statements": 100, "branches": 100, "functions": 100,
+          "uncovered": { "lines": 0, "statements": 0, "branches": 0, "functions": 0 }
+        }
+      }
+    }
+  }
+}
+`;
+
+  it("subtracts the coverage baseline then runs every shell step in table order", () =>
+    Effect.runPromise(
+      withTempDirectory((repoRoot) =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          yield* fs.makeDirectory(path.join(repoRoot, "standards"), { recursive: true });
+          yield* fs.writeFileString(
+            path.join(repoRoot, "standards", "coverage.regression-baseline.jsonc"),
+            coverageBaselineFixture
+          );
+
+          const spawned: Array<string> = [];
+          yield* DeletePackageBaselineWriters.run(repoRoot, "@beep/courtlistener").pipe(
+            Effect.provide(fakeSpawnerLayer(0, spawned))
+          );
+
+          const baseline = yield* fs.readFileString(
+            path.join(repoRoot, "standards", "coverage.regression-baseline.jsonc")
+          );
+          expect(Str.includes("@beep/courtlistener")(baseline)).toBe(false);
+          expect(spawned).toStrictEqual(
+            A.map(DeletePackageBaselineWriters.steps, (step) => A.join(["bun", ...step.args], " "))
+          );
+        })
+      ).pipe(provideScopedLayer(commandLayer))
+    ));
+
+  it("fails the stage on the first zero-only step that exits nonzero", () =>
+    Effect.runPromise(
+      withTempDirectory((repoRoot) =>
+        Effect.gen(function* () {
+          const spawned: Array<string> = [];
+          const exit = yield* Effect.exit(
+            DeletePackageBaselineWriters.run(repoRoot, "@beep/courtlistener").pipe(
+              Effect.provide(fakeSpawnerLayer(1, spawned))
+            )
+          );
+          expect(Exit.isFailure(exit)).toBe(true);
+          if (Exit.isFailure(exit)) {
+            expect(Str.includes("fallow boundaries failed with exit code 1")(Cause.pretty(exit.cause))).toBe(true);
+          }
+          expect(A.length(spawned)).toBe(1);
+        })
+      ).pipe(provideScopedLayer(commandLayer))
+    ));
 });
 
 describe("delete-package packet-claim refusal", () => {

--- a/packages/tooling/tool/cli/test/reflection-lint.test.ts
+++ b/packages/tooling/tool/cli/test/reflection-lint.test.ts
@@ -61,6 +61,19 @@ todos:
 
 const VALID_REFLECTION_CRLF = Str.replaceAll("\n", "\r\n")(VALID_REFLECTION);
 
+const writeActiveGoal = Effect.fn("writeActiveGoal")(function* (slug: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  yield* fs.makeDirectory(path.join("goals", slug, "ops"), { recursive: true });
+  yield* fs.writeFileString(
+    path.join("goals", slug, "ops", "manifest.json"),
+    `${encodeJson({
+      schemaVersion: "initiative-manifest/v1",
+      initiative: { id: slug, title: slug, status: "active" },
+    })}\n`
+  );
+});
+
 const writeReflection = Effect.fn("writeReflection")(function* (slug: string, file: string, body: string) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
@@ -181,6 +194,42 @@ describe("reflection-artifacts lint command", { concurrent: false }, () => {
           expectReflectionLintSuccess({
             reflectionRequired: false,
             reflection: { body: VALID_REFLECTION, file: "2026-06-09-claude.md" },
+          })
+        ).pipe(provideScopedLayer(testLayer))
+      ),
+    20_000
+  );
+
+  // The PR #365 YAML traps hid in a completed-only gap: an invalid reflection
+  // in an ACTIVE packet passed this lint while goals doctor failed it. The
+  // frontmatter gate now covers every packet.
+  it(
+    "blocks an active goal whose reflection frontmatter does not decode",
+    () =>
+      Effect.runPromise(
+        withTempWorkingDirectory(
+          Effect.gen(function* () {
+            yield* writeActiveGoal("in-flight");
+            yield* writeReflection("in-flight", "2026-08-17-claude.md", "# no frontmatter here\n");
+            const exit = yield* Effect.exit(runLintCommand(["reflection-artifacts"]));
+            expectReportedFailure(exit);
+          })
+        ).pipe(provideScopedLayer(testLayer))
+      ),
+    20_000
+  );
+
+  it(
+    "does not apply the closeout-presence gate to active goals",
+    () =>
+      Effect.runPromise(
+        withTempWorkingDirectory(
+          Effect.gen(function* () {
+            yield* writeActiveGoal("in-flight");
+            yield* writeReflection("in-flight", "2026-08-17-claude.md", VALID_REFLECTION);
+            yield* writeActiveGoal("no-reflections-yet");
+            const exit = yield* Effect.exit(runLintCommand(["reflection-artifacts"]));
+            expect(Exit.isSuccess(exit)).toBe(true);
           })
         ).pipe(provideScopedLayer(testLayer))
       ),

--- a/packages/tooling/tool/cli/test/reflection-lint.test.ts
+++ b/packages/tooling/tool/cli/test/reflection-lint.test.ts
@@ -204,13 +204,39 @@ describe("reflection-artifacts lint command", { concurrent: false }, () => {
   // in an ACTIVE packet passed this lint while goals doctor failed it. The
   // frontmatter gate now covers every packet.
   it(
-    "blocks an active goal whose reflection frontmatter does not decode",
+    "blocks an active goal whose reflection file has no frontmatter block",
     () =>
       Effect.runPromise(
         withTempWorkingDirectory(
           Effect.gen(function* () {
             yield* writeActiveGoal("in-flight");
             yield* writeReflection("in-flight", "2026-08-17-claude.md", "# no frontmatter here\n");
+            const exit = yield* Effect.exit(runLintCommand(["reflection-artifacts"]));
+            expectReportedFailure(exit);
+          })
+        ).pipe(provideScopedLayer(testLayer))
+      ),
+    20_000
+  );
+
+  // Present-but-invalid frontmatter is the decode-failure path — this is the
+  // literal receipt-10 trap: a colon-space inside an unquoted plain scalar
+  // turns the explanation into a YAML mapping error.
+  it(
+    "blocks an active goal whose present frontmatter does not decode",
+    () =>
+      Effect.runPromise(
+        withTempWorkingDirectory(
+          Effect.gen(function* () {
+            yield* writeActiveGoal("in-flight");
+            yield* writeReflection(
+              "in-flight",
+              "2026-08-17-claude.md",
+              Str.replace(
+                "explanation: Because of the evidence.",
+                'explanation: the template emitted "icon": [] here.'
+              )(VALID_REFLECTION)
+            );
             const exit = yield* Effect.exit(runLintCommand(["reflection-artifacts"]));
             expectReportedFailure(exit);
           })


### PR DESCRIPTION
## fix(cli): close out lab-apps-lifecycle receipts 9-11 in delete-package and lint

delete-package now subtracts the deleted workspace's rows from the committed
coverage baseline schema-first instead of re-running repo-wide coverage
(receipt 9). The dependents scan classifies packet history/** and research/**
references as historical-doc rather than live packet claims, and residue
probes exclude machine-local .beep/ state (receipt 11 — this .beep read, not
a red test, is what actually failed the P4 run; the recorded @beep/wink
failure never existed and the packet ledger now carries the correction).
beep lint reflection-artifacts validates reflection frontmatter in every
packet, not only completed ones (receipt 10).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

## style(cli): apply yeet repair terseness fixes

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

## refactor(cli): extract shared coverage-baseline write helper

The subtraction path and the full-regeneration path share one
writeBaselineDocument helper instead of duplicating the artifact write.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

## Local proof

- publish:head-install-preflight: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/fix_delete-package-scoped-baselines-45366528993b/verdict.json

---

## Provenance

- Branch: <code>fix/delete-package-scoped-baselines</code>
- Harness: `codex`

<!-- yeet-provenance
{
  "schemaVersion": 1,
  "branch": "fix/delete-package-scoped-baselines",
  "harness": "codex"
}
-->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/760"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789592332&installation_model_id=424656&pr_number=760&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F760&signature=c219a3483bd93db794a6e1695bef92fbcd4bd4ae0c4b9691d6978289be4a5fc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->