### PR TITLE
feat(repo-cli): goals bootstrap and adopt pure-plan commands (Workstream E phase 0)

### DIFF
--- a/.changeset/goals-bootstrap-adopt-plan.md
+++ b/.changeset/goals-bootstrap-adopt-plan.md
@@ -1,0 +1,15 @@
+---
+"@beep/repo-cli": minor
+---
+
+Workstream E phase 0 of goals/knowledge-surface-automation: `beep goals bootstrap --plan` and
+`beep goals adopt <slug> --plan`, the read-only materialization-plan slice. A pure
+`compileMaterializationPlan` maps a decoded `BootstrapInput` through phase-archetype constructors
+(`standard-delivery`, `report-first`) to a content-addressed `MaterializationPlan` carrying every
+path, ownership boundary, payload byte, digest, and validation requirement; adoption splits into a
+read-only `readPacketSnapshot` and a pure `compileAdoptionPlan` that retains authored files,
+preserves the manifest byte-for-byte while enumerating its unmodeled top-level keys, reports absent
+authored artifacts instead of inventing them, and records the archetype plus `goals/_template`
+snapshot hash it measured against. No writer exists in this slice: `--plan` is the only mode, plans
+are golden-tested and hash-pinned (`goal-plan/v1:<sha256>`), and the self-hosting pilot adoption of
+the knowledge-surface-automation packet compiles with zero authored-file creations.

--- a/goals/knowledge-surface-automation/ops/manifest.json
+++ b/goals/knowledge-surface-automation/ops/manifest.json
@@ -58,7 +58,8 @@
     "research/p3-report-refs-rewrite.md",
     "research/p3-hermetic-lane-design.md",
     "research/p3-hermetic-lane-decisions.md",
-    "research/p3-report-roadmap-refs-fold-in.md"
+    "research/p3-report-roadmap-refs-fold-in.md",
+    "research/p1-report-bootstrap-adopt-plan.md"
   ],
   "agentLaunchers": [
     {

--- a/goals/knowledge-surface-automation/research/OPPORTUNITIES.md
+++ b/goals/knowledge-surface-automation/research/OPPORTUNITIES.md
@@ -320,3 +320,21 @@ measurement first). Reviewed at each grill.
   then read the file's uncovered ranges) before pushing; wiring lines into an uncovered
   function need either a directly testable seam (export the helper and pin it) or a
   deliberate floor adjustment, decided before the hosted lane spends 13 minutes finding it.
+
+## 2026-08-17 — scoped baseline writes capture environment-dependent coverage
+
+- **What happened:** clearing the new-file Coverage Regression identity for PR #762 with
+  `TURBO_SCM_BASE=origin/main bun run coverage -- --affected --write-baseline` also
+  tightened every other `@beep/repo-cli` per-file floor to the dev machine's achieved
+  values. `internal/cli/EnvConfig.ts` covers environment-dependent branches, so the local
+  run reaches 74.66/75/77.77 (lines/statements/functions) while the hosted runner reaches
+  exactly the old committed floors (73.33/73.68/74.07) — the write minted floors the
+  hosted lane can never satisfy, and the next hosted run went red on a file the PR never
+  touched.
+- **Evidence:** Coverage Regression run 32079431847 on PR #762; `git show HEAD~1` of
+  `standards/coverage.regression-baseline.jsonc` matches the hosted numbers digit-for-digit.
+- **Prevention:** after a scoped `--write-baseline`, diff the baseline for tightened
+  entries on files the PR did not touch and restore them to their committed values —
+  only the new-file identities and floors for deliberately covered files belong in the
+  commit. A writer flag that only ADDS missing file identities without tightening
+  existing entries would remove the hazard class.

--- a/goals/knowledge-surface-automation/research/p1-report-bootstrap-adopt-plan.md
+++ b/goals/knowledge-surface-automation/research/p1-report-bootstrap-adopt-plan.md
@@ -1,0 +1,151 @@
+# P1 report — `goals bootstrap|adopt --plan` pure-plan evidence (Workstream E phase 0)
+
+Commands run 2026-08-17 against the live checkout (no fixture copies):
+
+```text
+bun run beep goals bootstrap --slug example-goal --title "Example Goal" \
+  --mission "Prove the plan compiler." --today 2026-08-17 --plan --json
+bun run beep goals adopt knowledge-surface-automation --plan --json
+```
+
+Both commands are plan-only: no `--write`, no `--apply`, no `--force` exists, and no function
+in the slice calls a mutating `FileSystem` member. The suite proves this empirically two
+ways: a porcelain-equality test asserts `git status --porcelain` is byte-identical around
+compilation and snapshotting, and the evergreen pilot test re-snapshots the packet and
+compares per-file digest sets before and after compilation (the same evidence a doctor
+before/after parity run would consume — doctor reads exactly those files).
+
+## Bootstrap plan headline
+
+`planId: goal-plan/v1:76621ab1a39245c998729b55c1dcae53d0be0fc3e753917f806d09250cd6376d`
+
+| Action / ownership | Count | Paths |
+| --- | --- | --- |
+| create / generated | 4 | `ops/manifest.json`, three `.gitkeep` markers |
+| create / generated-seed | 5 | `README.md`, `GOAL.md`, `SPEC.md`, `PLAN.md`, `research/SOURCES.md` |
+| report / generated | 1 | `goals/INDEX.md` (producer://goals/index, `bun run beep goals index --write`) |
+
+Validations: `manifest-decodes`, `doctor-clean`, `index-regenerates`,
+`readme-lifecycle-line`, `goal-md-within-budget`. Conflicts: none. Every `create` entry
+carries its complete payload bytes plus a SHA-256 digest; the generated manifest mints the
+E4 PacketId beacon (`initiative.packetId = goal-packet/v1:<sha256(slug\ntoday)>`), which the
+lenient decoder accepts and ignores today and the schema models in the executor era.
+
+Excerpt (`entries[0]`, payload elided):
+
+```json
+{
+  "action": "create",
+  "ownership": "generated",
+  "path": "goals/example-goal/ops/manifest.json",
+  "payloadDigest": "…64 hex…",
+  "reason": "Every byte derives from the input and the archetype."
+}
+```
+
+## Pilot adoption headline (self-hosting test case #1)
+
+`towardArchetype: report-first` (inferred from the packet's phase names)
+`templateSnapshotHash: 4f608b5d317256669749fcca4684749d3988d749e9ba26535129c2d28440736e`
+
+The pilot planId is deliberately **not** quoted as a reproducible constant: this report file
+lives inside the packet it snapshots, so any edit to the report shifts the packet tree and
+with it the content-addressed planId (self-inclusion). The tree-stable evidence below —
+per-action counts, the manifest pre-image digest, and the template snapshot hash — is
+captured against the exact tree this report ships in, and re-running the printed command on
+that tree reproduces it.
+
+| Action / ownership | Count | Meaning |
+| --- | --- | --- |
+| retain / authored | 29 | every tracked prose/research file (this report included), untouched |
+| retain / generated | 2 | `history/.gitkeep`, `history/reflections/.gitkeep` |
+| preserve / preserved | 1 | `ops/manifest.json`, byte-preserving obligation |
+| report / authored | 1 | `history/reflections/_TEMPLATE.md` absent — a human resolves it |
+| create / generated | 1 | `research/.gitkeep` directory marker (machine-derivable) |
+
+**Authored-file creations: zero**, as the design requires — if this table ever shows one,
+the ownership rules are wrong and the eyeball has done its job before a writer existed.
+
+The preservation row enumerates exactly the five unmodeled top-level manifest keys the
+design predicted, with the pre-image digest binding a future adoption patch to the exact
+bytes reviewed:
+
+```json
+{
+  "path": "goals/knowledge-surface-automation/ops/manifest.json",
+  "preImageDigest": "346db1b7c05b18662231786df82f294257c3f49fa9eff4b6d1cf248b26d742b9",
+  "reason": "The canonical decoder strips these top-level keys from decoded output.",
+  "unmodeledKeys": [
+    "agentLaunchers",
+    "currentSourceOfTruth",
+    "researchReports",
+    "stopConditions",
+    "verificationCommands"
+  ]
+}
+```
+
+The preservation counterfactual test proves the naive path destroys data: round-tripping
+the pilot manifest through `decodeGoalManifest` then `S.encodeUnknownEffect(GoalManifest)`
+loses all five keys.
+
+## Deviations from the illustrative sketch (recorded, not doctrine changes)
+
+- `PlanConflictReason` ships as `slug-exists | packet-not-found | manifest-unparseable`.
+  The sketch's `template-slug` is unreachable by construction — the `GoalSlug` grammar
+  rejects `_template` at decode, as the design's D1 reuse intends — and
+  `standard-artifact-absent` contradicts the adopt semantics section itself, which routes
+  absent standard artifacts to `report` entries rather than conflicts. Dead domain values
+  were dropped instead of shipped.
+- Snapshot digests are computed over exact file **bytes** (`sha256HexBytes`), not decoded
+  text: several hand-rolled packets carry binary evidence (PNG/JPG under `history/`), and a
+  lossy UTF-8 decode would emit digests external `sha256sum` tooling cannot verify —
+  breaking the bind-to-exact-bytes contract for any non-pilot packet. Caught by the
+  adversarial review pass before publish; the pilot is all-text either way.
+- `MODELED_GOAL_MANIFEST_KEYS` is derived from `GoalManifest.fields` rather than
+  hand-listed, so the unmodeled-key enumeration cannot drift from the schema.
+- The bootstrap handler refuses a `--provides`/`--requires` self-cycle before compiling:
+  the `GoalManifest` schema rejects self-cycles, so a plan carrying one could never satisfy
+  its own `manifest-decodes` validation.
+
+## Test evidence
+
+`packages/tooling/tool/cli/test/goals-bootstrap-plan.test.ts`, 20 tests green, covering the
+design's eleven classes: three committed golden plans (regenerate with `REGEN_GOLDENS=1`),
+determinism under repetition and permuted input field order, slug-grammar rejection
+(uppercase, separators, traversal, whitespace, `_template`), slug-exists fail-closed,
+evergreen live pilot adoption, digest-set zero-write/doctor-input parity, idempotence and
+the simulated-overlay fixed point (zero creates), the preservation counterfactual, the
+manifest-less synthetic packet (one generated manifest, README never written), the
+missing-packet and corrupt-manifest conflicts, index parity, the exhaustive
+doctor-finding → validation-requirement mapping (a compile-time-exhaustive record; new
+doctor kinds fail the build until mapped), the command-surface gate (missing `--plan`,
+self-cycle refusal, happy-path JSON), and the porcelain-equality zero-write proof.
+
+## Annotated false-positive review
+
+A false positive here means one of exactly three things: (1) a `create` entry that would
+overwrite authored prose, (2) a `preserve` entry missing an unmodeled key, or (3) a
+`report` entry for an artifact the standard does not actually require. Against the pilot:
+
+- **(1) none observed** — the only `create` is `research/.gitkeep`, a byte-exact copy of
+  the template's marker in a directory that already carries authored files. Borderline
+  cosmetic rather than wrong: the standard ships the marker, the pilot dropped it once
+  real research files existed. If the eyeball prefers, "marker beside real files" could
+  downgrade to `report`; recorded as the one candidate judgement call.
+- **(2) none observed** — the five enumerated keys match a hand diff of the manifest
+  against the `GoalManifest` struct fields; `provenance` does not appear because the pilot
+  manifest does not carry it (the `_template` does, which the manifest-less synthetic test
+  covers).
+- **(3) one candidate** — `history/reflections/_TEMPLATE.md` is reported absent. The
+  `_template` tree ships it as authoring convenience; whether a conforming packet must
+  carry a copy is a standards question, not a compiler question. If Benjamin rules it
+  optional, the fix is a documented-convention exclusion in the adoption classifier, not a
+  marker syntax.
+
+## Eyeball ask
+
+Confirm the ownership rule table (generated / generated-seed / authored / preserved as
+compiled above), confirm the pilot's preservation set is complete, rule on the two
+annotated judgement calls, and confirm nothing else blocks the P4 unlock for Workstream E.
+Per PLAN P4 and execution decision E5, this gate is E's alone and blocks nothing else.

--- a/packages/tooling/tool/cli/src/commands/Goals/Adopt.ts
+++ b/packages/tooling/tool/cli/src/commands/Goals/Adopt.ts
@@ -56,48 +56,66 @@ const REFLECTION_TEMPLATE_BASENAME = "_TEMPLATE.md";
 
 const isGitkeepPath = (relativePath: string): boolean => Str.endsWith(".gitkeep")(relativePath);
 
-const walkDirectory = Effect.fn("Goals.walkPacketDirectory")(function* (root: string) {
+const readSnapshotFile = Effect.fn("Goals.readSnapshotFile")(function* (root: string, entryRelative: string) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
-  let files = A.empty<PacketSnapshotFile>();
-  let pending: ReadonlyArray<string> = [""];
-  while (A.isReadonlyArrayNonEmpty(pending)) {
-    const relative = A.headNonEmpty(pending);
-    pending = A.tailNonEmpty(pending);
-    const absolute = relative === "" ? root : path.join(root, relative);
-    const entries = yield* fs
-      .readDirectory(absolute)
-      .pipe(Effect.mapError(GoalPlanOperationalError.new(`Failed to read directory "${absolute}".`)));
-    for (const entry of A.sort(entries, Order.String)) {
-      const entryRelative = relative === "" ? entry : `${relative}/${entry}`;
-      const entryAbsolute = path.join(root, entryRelative);
-      const info = yield* fs
-        .stat(entryAbsolute)
-        .pipe(Effect.mapError(GoalPlanOperationalError.new(`Failed to stat "${entryAbsolute}".`)));
-      if (info.type === "Directory") {
-        pending = A.append(pending, entryRelative);
-      } else if (info.type === "File") {
-        // Digest the raw bytes: decoding first is lossy for non-UTF-8 content
-        // (binary evidence under history/), which would break hash-pinning.
-        const bytes = yield* fs
-          .readFile(entryAbsolute)
-          .pipe(Effect.mapError(GoalPlanOperationalError.new(`Failed to read "${entryAbsolute}".`)));
-        files = A.append(
-          files,
-          PacketSnapshotFile.make({
-            path: entryRelative,
-            text: new TextDecoder().decode(bytes),
-            digest: sha256HexBytes(bytes),
-          })
-        );
-      }
-    }
-  }
-  return A.sort(
-    files,
-    Order.mapInput(Order.String, (file: PacketSnapshotFile) => file.path)
-  );
+  const entryAbsolute = path.join(root, entryRelative);
+  // Digest the raw bytes: decoding first is lossy for non-UTF-8 content
+  // (binary evidence under history/), which would break hash-pinning.
+  const bytes = yield* fs
+    .readFile(entryAbsolute)
+    .pipe(Effect.mapError(GoalPlanOperationalError.new(`Failed to read "${entryAbsolute}".`)));
+  return PacketSnapshotFile.make({
+    path: entryRelative,
+    text: new TextDecoder().decode(bytes),
+    digest: sha256HexBytes(bytes),
+  });
 });
+
+const walkEntry: (
+  root: string,
+  entryRelative: string
+) => Effect.Effect<ReadonlyArray<PacketSnapshotFile>, GoalPlanOperationalError, FileSystem.FileSystem | Path.Path> =
+  Effect.fn("Goals.walkPacketEntry")(function* (root: string, entryRelative: string) {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const entryAbsolute = path.join(root, entryRelative);
+    const info = yield* fs
+      .stat(entryAbsolute)
+      .pipe(Effect.mapError(GoalPlanOperationalError.new(`Failed to stat "${entryAbsolute}".`)));
+    if (info.type === "Directory") {
+      return yield* walkEntries(root, entryRelative);
+    }
+    if (info.type === "File") {
+      return [yield* readSnapshotFile(root, entryRelative)];
+    }
+    return A.empty<PacketSnapshotFile>();
+  });
+
+const walkEntries = Effect.fn("Goals.walkPacketEntries")(function* (root: string, relative: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const absolute = relative === "" ? root : path.join(root, relative);
+  const entries = yield* fs
+    .readDirectory(absolute)
+    .pipe(Effect.mapError(GoalPlanOperationalError.new(`Failed to read directory "${absolute}".`)));
+  let files = A.empty<PacketSnapshotFile>();
+  for (const entry of A.sort(entries, Order.String)) {
+    const entryRelative = relative === "" ? entry : `${relative}/${entry}`;
+    files = A.appendAll(files, yield* walkEntry(root, entryRelative));
+  }
+  return files;
+});
+
+const walkDirectory = (
+  root: string
+): Effect.Effect<ReadonlyArray<PacketSnapshotFile>, GoalPlanOperationalError, FileSystem.FileSystem | Path.Path> =>
+  Effect.map(walkEntries(root, ""), (files) =>
+    A.sort(
+      files,
+      Order.mapInput(Order.String, (file: PacketSnapshotFile) => file.path)
+    )
+  );
 
 const directoryExists = Effect.fn("Goals.packetDirectoryExists")(function* (target: string) {
   const fs = yield* FileSystem.FileSystem;
@@ -277,134 +295,25 @@ export const compileAdoptionPlan: {
   };
 
   if (!snapshot.exists) {
-    return sealMaterializationPlan({
-      ...base,
-      entries: [],
-      preservations: [],
-      validations: [],
-      conflicts: [
-        {
-          reason: "packet-not-found",
-          message: `No goal packet directory "${snapshot.packetPath}".`,
-        },
-      ],
-    });
+    return conflictedAdoptionPlan(base, "packet-not-found", `No goal packet directory "${snapshot.packetPath}".`);
   }
 
   const manifestFile = A.findFirst(snapshot.files, (file) => file.path === MANIFEST_RELATIVE_PATH);
   const parsedManifest = O.flatMap(manifestFile, (file) => parseGoalManifestText(file.text));
   if (O.isSome(manifestFile) && O.isNone(parsedManifest)) {
-    return sealMaterializationPlan({
-      ...base,
-      entries: [],
-      preservations: [],
-      validations: [],
-      conflicts: [
-        {
-          reason: "manifest-unparseable",
-          message: `"${snapshot.packetPath}/${MANIFEST_RELATIVE_PATH}" does not parse as JSON; adoption cannot classify it.`,
-        },
-      ],
-    });
+    return conflictedAdoptionPlan(
+      base,
+      "manifest-unparseable",
+      `"${snapshot.packetPath}/${MANIFEST_RELATIVE_PATH}" does not parse as JSON; adoption cannot classify it.`
+    );
   }
 
-  let entries = A.empty<PlanRow>();
-  let preservations = A.empty<PreservationRow>();
-  const conflicts = A.empty<ConflictRow>();
-
-  for (const file of snapshot.files) {
-    const fullPath = `${snapshot.packetPath}/${file.path}`;
-    if (file.path === MANIFEST_RELATIVE_PATH) {
-      const unmodeledKeys = pipe(
-        parsedManifest,
-        O.filter(isJsonRecord),
-        O.map((record) => A.sort(A.difference(R.keys(record), MODELED_GOAL_MANIFEST_KEYS), Str.Order)),
-        O.getOrElse(A.empty<string>)
-      );
-      entries = A.append(entries, {
-        path: fullPath,
-        action: "preserve",
-        ownership: "preserved",
-        reason: "Manifest bytes survive only through byte-preserving JSONC edits; re-encoding strips unmodeled keys.",
-        existingDigest: file.digest,
-      });
-      preservations = A.append(preservations, {
-        path: fullPath,
-        unmodeledKeys,
-        preImageDigest: file.digest,
-        reason: "The canonical decoder strips these top-level keys from decoded output.",
-      });
-    } else if (isGitkeepPath(file.path)) {
-      entries = A.append(entries, {
-        path: fullPath,
-        action: "retain",
-        ownership: "generated",
-        reason: "Machine-derivable directory marker already present.",
-        existingDigest: file.digest,
-      });
-    } else {
-      entries = A.append(entries, {
-        path: fullPath,
-        action: "retain",
-        ownership: "authored",
-        reason: "Tracked packet file conforms to the standard and stays human-owned.",
-        existingDigest: file.digest,
-      });
-    }
-  }
-
+  const present = A.map(snapshot.files, (file) => presentFileRow(snapshot.packetPath, file, parsedManifest));
   const packetPaths = A.map(snapshot.files, (file) => file.path);
-  for (const templateFile of snapshot.templateFiles) {
-    if (A.contains(packetPaths, templateFile.path)) {
-      continue;
-    }
-    const fullPath = `${snapshot.packetPath}/${templateFile.path}`;
-    if (templateFile.path === MANIFEST_RELATIVE_PATH) {
-      const readme = A.findFirst(snapshot.files, (file) => file.path === README_RELATIVE_PATH);
-      const readmeText = O.map(readme, (file) => file.text);
-      const status = pipe(
-        readmeText,
-        O.flatMap(readmeLifecycleToken),
-        O.filter(isGoalStatus),
-        O.getOrElse((): GoalStatus => "active")
-      );
-      const payload = seededManifestPayload({
-        slug: snapshot.slug,
-        title: pipe(
-          readmeText,
-          O.flatMap(readmeTitle),
-          O.getOrElse(() => snapshot.slug)
-        ),
-        status,
-        mission: O.flatMap(readmeText, readmeMissionLine),
-        archetype,
-      });
-      entries = A.append(entries, {
-        path: fullPath,
-        action: "create",
-        ownership: "generated",
-        reason: "Manifest-less packet: seed a manifest from README-extractable fields.",
-        payload,
-        payloadDigest: sha256Hex(payload),
-      });
-    } else if (isGitkeepPath(templateFile.path)) {
-      entries = A.append(entries, {
-        path: fullPath,
-        action: "create",
-        ownership: "generated",
-        reason: "Machine-derivable directory marker the standard ships.",
-        payload: templateFile.text,
-        payloadDigest: templateFile.digest,
-      });
-    } else {
-      entries = A.append(entries, {
-        path: fullPath,
-        action: "report",
-        ownership: "authored",
-        reason: "Standard artifact absent; a human authors it — diagnosis never invents prose.",
-      });
-    }
-  }
+  const missing = A.map(
+    A.filter(snapshot.templateFiles, (templateFile) => !A.contains(packetPaths, templateFile.path)),
+    (templateFile) => missingTemplateRow(snapshot, archetype, templateFile)
+  );
 
   const validations: ReadonlyArray<ValidationRequirement> = A.some(snapshot.files, (file) =>
     isReflectionArtifact(file.path)
@@ -414,12 +323,157 @@ export const compileAdoptionPlan: {
 
   return sealMaterializationPlan({
     ...base,
-    entries,
-    preservations,
+    entries: A.map([...present, ...missing], (classified) => classified.entry),
+    preservations: A.getSomes(A.map(present, (classified) => classified.preservation)),
     validations,
-    conflicts,
+    conflicts: [],
   });
 });
+
+type AdoptionPlanBase = {
+  readonly mode: PlanMode;
+  readonly slug: string;
+  readonly packetPath: string;
+  readonly towardArchetype: PhaseArchetype;
+  readonly templateSnapshotHash: string;
+};
+
+type ClassifiedRow = {
+  readonly entry: PlanRow;
+  readonly preservation: O.Option<PreservationRow>;
+};
+
+const conflictedAdoptionPlan = (
+  base: AdoptionPlanBase,
+  reason: ConflictRow["reason"],
+  message: string
+): MaterializationPlan =>
+  sealMaterializationPlan({
+    ...base,
+    entries: [],
+    preservations: [],
+    validations: [],
+    conflicts: [{ reason, message }],
+  });
+
+// Present manifest → preserve + preservation row; present .gitkeep → generated retain;
+// anything else present → authored retain.
+const presentFileRow = (
+  packetPath: string,
+  file: PacketSnapshotFile,
+  parsedManifest: O.Option<unknown>
+): ClassifiedRow => {
+  const fullPath = `${packetPath}/${file.path}`;
+  if (file.path === MANIFEST_RELATIVE_PATH) {
+    const unmodeledKeys = pipe(
+      parsedManifest,
+      O.filter(isJsonRecord),
+      O.map((record) => A.sort(A.difference(R.keys(record), MODELED_GOAL_MANIFEST_KEYS), Str.Order)),
+      O.getOrElse(A.empty<string>)
+    );
+    return {
+      entry: {
+        path: fullPath,
+        action: "preserve",
+        ownership: "preserved",
+        reason: "Manifest bytes survive only through byte-preserving JSONC edits; re-encoding strips unmodeled keys.",
+        existingDigest: file.digest,
+      },
+      preservation: O.some({
+        path: fullPath,
+        unmodeledKeys,
+        preImageDigest: file.digest,
+        reason: "The canonical decoder strips these top-level keys from decoded output.",
+      }),
+    };
+  }
+  if (isGitkeepPath(file.path)) {
+    return {
+      entry: {
+        path: fullPath,
+        action: "retain",
+        ownership: "generated",
+        reason: "Machine-derivable directory marker already present.",
+        existingDigest: file.digest,
+      },
+      preservation: O.none(),
+    };
+  }
+  return {
+    entry: {
+      path: fullPath,
+      action: "retain",
+      ownership: "authored",
+      reason: "Tracked packet file conforms to the standard and stays human-owned.",
+      existingDigest: file.digest,
+    },
+    preservation: O.none(),
+  };
+};
+
+const seededManifestRow = (snapshot: PacketSnapshot, archetype: PhaseArchetype, fullPath: string): PlanRow => {
+  const readme = A.findFirst(snapshot.files, (file) => file.path === README_RELATIVE_PATH);
+  const readmeText = O.map(readme, (file) => file.text);
+  const payload = seededManifestPayload({
+    slug: snapshot.slug,
+    title: pipe(
+      readmeText,
+      O.flatMap(readmeTitle),
+      O.getOrElse(() => snapshot.slug)
+    ),
+    status: pipe(
+      readmeText,
+      O.flatMap(readmeLifecycleToken),
+      O.filter(isGoalStatus),
+      O.getOrElse((): GoalStatus => "active")
+    ),
+    mission: O.flatMap(readmeText, readmeMissionLine),
+    archetype,
+  });
+  return {
+    path: fullPath,
+    action: "create",
+    ownership: "generated",
+    reason: "Manifest-less packet: seed a manifest from README-extractable fields.",
+    payload,
+    payloadDigest: sha256Hex(payload),
+  };
+};
+
+// Template artifact absent from the packet: manifest → generated seed; .gitkeep →
+// generated marker copy; prose → report row (diagnosis never invents prose).
+const missingTemplateRow = (
+  snapshot: PacketSnapshot,
+  archetype: PhaseArchetype,
+  templateFile: PacketSnapshotFile
+): ClassifiedRow => {
+  const fullPath = `${snapshot.packetPath}/${templateFile.path}`;
+  if (templateFile.path === MANIFEST_RELATIVE_PATH) {
+    return { entry: seededManifestRow(snapshot, archetype, fullPath), preservation: O.none() };
+  }
+  if (isGitkeepPath(templateFile.path)) {
+    return {
+      entry: {
+        path: fullPath,
+        action: "create",
+        ownership: "generated",
+        reason: "Machine-derivable directory marker the standard ships.",
+        payload: templateFile.text,
+        payloadDigest: templateFile.digest,
+      },
+      preservation: O.none(),
+    };
+  }
+  return {
+    entry: {
+      path: fullPath,
+      action: "report",
+      ownership: "authored",
+      reason: "Standard artifact absent; a human authors it — diagnosis never invents prose.",
+    },
+    preservation: O.none(),
+  };
+};
 
 const slugArgument = Argument.string("slug").pipe(Argument.withDescription("Goal packet slug under goals/"));
 const towardFlag = Flag.choice("toward", PhaseArchetype.Options).pipe(

--- a/packages/tooling/tool/cli/src/commands/Goals/Adopt.ts
+++ b/packages/tooling/tool/cli/src/commands/Goals/Adopt.ts
@@ -117,9 +117,19 @@ const walkDirectory = (
     )
   );
 
+// Only a provable NotFound reads as absence: any other stat failure (for example
+// PermissionDenied) leaves existence unverifiable, and an adoption plan compiled over
+// unverifiable state could misreport a real packet as packet-not-found.
 const directoryExists = Effect.fn("Goals.packetDirectoryExists")(function* (target: string) {
   const fs = yield* FileSystem.FileSystem;
-  const info = yield* fs.stat(target).pipe(Effect.map(O.some), Effect.orElseSucceed(O.none));
+  const info = yield* fs.stat(target).pipe(
+    Effect.map(O.some),
+    Effect.catchIf(
+      (error) => error.reason._tag === "NotFound",
+      () => Effect.succeedNone
+    ),
+    Effect.mapError(GoalPlanOperationalError.new(`Failed to stat "${target}".`))
+  );
   return O.exists(info, (value) => value.type === "Directory");
 });
 

--- a/packages/tooling/tool/cli/src/commands/Goals/Adopt.ts
+++ b/packages/tooling/tool/cli/src/commands/Goals/Adopt.ts
@@ -1,0 +1,484 @@
+/**
+ * Read-only packet snapshot, pure adoption compiler, and `beep goals adopt --plan`.
+ *
+ * **Details**
+ *
+ * Adoption is split in two by a value boundary: an effectful
+ * `readPacketSnapshot` whose entire `FileSystem` surface is read members, and
+ * a pure `compileAdoptionPlan` over the resulting `PacketSnapshot` value with
+ * requirements `never`. The first adoption target is the hand-rolled
+ * knowledge-surface-automation packet itself — the self-hosting pilot whose
+ * expected plan contains zero authored-file creations.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { Console, Effect, FileSystem, Order, Path, pipe } from "effect";
+import * as A from "effect/Array";
+import { dual } from "effect/Function";
+import * as O from "effect/Option";
+import * as P from "effect/Predicate";
+import * as R from "effect/Record";
+import * as S from "effect/Schema";
+import * as Str from "effect/String";
+import { Argument, Command, Flag } from "effect/unstable/cli";
+import { failWithReportedExit } from "../../internal/cli/ExitCodeError.ts";
+import { optionalProp } from "../../internal/cli/OptionRecord.ts";
+import {
+  GoalSlug,
+  MODELED_GOAL_MANIFEST_KEYS,
+  PacketSnapshot,
+  PacketSnapshotFile,
+  PhaseArchetype,
+  PlanMode,
+} from "./Bootstrap.schemas.ts";
+import { archetypePhases, reportMaterializationPlan, sealMaterializationPlan } from "./Bootstrap.ts";
+import { GoalPlanInputError, GoalPlanOperationalError } from "./Goals.errors.ts";
+import { isGoalStatus } from "./Goals.schemas.ts";
+import {
+  GOALS_DIR,
+  isJsonRecord,
+  parseGoalManifestText,
+  readmeLifecycleToken,
+  readmeMissionLine,
+  readmeTitle,
+  TEMPLATE_SLUG,
+} from "./Inventory.ts";
+import { canonicalJsonText, sha256Hex, sha256HexBytes } from "./PacketCore/PacketDigest.ts";
+import type { MaterializationPlan, ValidationRequirement } from "./Bootstrap.schemas.ts";
+import type { ConflictRow, PlanRow, PreservationRow } from "./Bootstrap.ts";
+import type { GoalStatus } from "./Goals.schemas.ts";
+
+const MANIFEST_RELATIVE_PATH = "ops/manifest.json";
+const README_RELATIVE_PATH = "README.md";
+const REFLECTION_TEMPLATE_BASENAME = "_TEMPLATE.md";
+
+const isGitkeepPath = (relativePath: string): boolean => Str.endsWith(".gitkeep")(relativePath);
+
+const walkDirectory = Effect.fn("Goals.walkPacketDirectory")(function* (root: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  let files = A.empty<PacketSnapshotFile>();
+  let pending: ReadonlyArray<string> = [""];
+  while (A.isReadonlyArrayNonEmpty(pending)) {
+    const relative = A.headNonEmpty(pending);
+    pending = A.tailNonEmpty(pending);
+    const absolute = relative === "" ? root : path.join(root, relative);
+    const entries = yield* fs
+      .readDirectory(absolute)
+      .pipe(Effect.mapError(GoalPlanOperationalError.new(`Failed to read directory "${absolute}".`)));
+    for (const entry of A.sort(entries, Order.String)) {
+      const entryRelative = relative === "" ? entry : `${relative}/${entry}`;
+      const entryAbsolute = path.join(root, entryRelative);
+      const info = yield* fs
+        .stat(entryAbsolute)
+        .pipe(Effect.mapError(GoalPlanOperationalError.new(`Failed to stat "${entryAbsolute}".`)));
+      if (info.type === "Directory") {
+        pending = A.append(pending, entryRelative);
+      } else if (info.type === "File") {
+        // Digest the raw bytes: decoding first is lossy for non-UTF-8 content
+        // (binary evidence under history/), which would break hash-pinning.
+        const bytes = yield* fs
+          .readFile(entryAbsolute)
+          .pipe(Effect.mapError(GoalPlanOperationalError.new(`Failed to read "${entryAbsolute}".`)));
+        files = A.append(
+          files,
+          PacketSnapshotFile.make({
+            path: entryRelative,
+            text: new TextDecoder().decode(bytes),
+            digest: sha256HexBytes(bytes),
+          })
+        );
+      }
+    }
+  }
+  return A.sort(
+    files,
+    Order.mapInput(Order.String, (file: PacketSnapshotFile) => file.path)
+  );
+});
+
+const directoryExists = Effect.fn("Goals.packetDirectoryExists")(function* (target: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const info = yield* fs.stat(target).pipe(Effect.map(O.some), Effect.orElseSucceed(O.none));
+  return O.exists(info, (value) => value.type === "Directory");
+});
+
+/**
+ * Captures one packet and the `goals/_template` standard as a decoded value.
+ *
+ * **Details**
+ *
+ * The entire `FileSystem` surface used here is `readDirectory`, `stat`, and
+ * `readFileString` — there is no writer to disable. A missing packet is not an
+ * error: the snapshot records `exists: false` and the pure compiler emits a
+ * `packet-not-found` conflict, keeping environment facts inside the plan. A
+ * missing or unreadable template tree is an operational failure: adoption
+ * cannot measure against a standard it cannot read.
+ *
+ * **Example** (Build the snapshot effect)
+ *
+ * ```ts
+ * import { readPacketSnapshot } from "@beep/repo-cli/commands/Goals/Adopt"
+ * import { Effect } from "effect"
+ *
+ * console.log(Effect.isEffect(readPacketSnapshot("knowledge-surface-automation"))) // true
+ * ```
+ *
+ * @param slug - The packet slug under `goals/` to capture.
+ * @param repoRoot - Repository root the `goals/` tree is resolved against.
+ * @returns The decoded snapshot the pure adoption compiler consumes.
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const readPacketSnapshot = Effect.fn("Goals.readPacketSnapshot")(function* (slug: string, repoRoot = ".") {
+  const path = yield* Path.Path;
+  const packetPath = path.join(repoRoot, GOALS_DIR, slug);
+  const templatePath = path.join(repoRoot, GOALS_DIR, TEMPLATE_SLUG);
+  const templateFiles = yield* walkDirectory(templatePath);
+  const templateSnapshotHash = sha256Hex(
+    canonicalJsonText(A.map(templateFiles, (file) => ({ path: file.path, digest: file.digest })))
+  );
+  const exists = yield* directoryExists(packetPath);
+  const files = exists ? yield* walkDirectory(packetPath) : A.empty<PacketSnapshotFile>();
+  return PacketSnapshot.make({
+    slug,
+    packetPath: `${GOALS_DIR}/${slug}`,
+    exists,
+    files,
+    templateFiles,
+    templateSnapshotHash,
+  });
+});
+
+const seededManifestPayload = (input: {
+  readonly slug: string;
+  readonly title: string;
+  readonly status: GoalStatus;
+  readonly mission: O.Option<string>;
+  readonly archetype: PhaseArchetype;
+}): string => {
+  const packetPath = `goals/${input.slug}`;
+  const document = {
+    schemaVersion: "initiative-manifest/v2",
+    initiative: {
+      id: input.slug,
+      title: input.title,
+      status: input.status,
+      packetAnchorDocument: "SPEC.md",
+    },
+    packetPath,
+    lifecycle: input.status,
+    ...optionalProp("mission", input.mission),
+    completionGate: {
+      operator: "yeet",
+      requiresPullRequest: true,
+      requiresMergeable: true,
+      statement:
+        "Not achieved until this goal's work ships as a PR driven to mergeable via /yeet (bun run beep yeet: repair -> verify -> publish --pr -> monitor).",
+      grandfathered: false,
+    },
+    phases: A.map(archetypePhases(input.archetype), (phase) => ({
+      id: phase.id,
+      name: phase.name,
+      status: "pending",
+    })),
+  };
+  return `${JSON.stringify(document, null, 2)}\n`;
+};
+
+const inferArchetype = (files: ReadonlyArray<PacketSnapshotFile>): PhaseArchetype => {
+  const manifest = A.findFirst(files, (file) => file.path === MANIFEST_RELATIVE_PATH);
+  const phaseNames = pipe(
+    manifest,
+    O.flatMap((file) => parseGoalManifestText(file.text)),
+    O.filter(isJsonRecord),
+    O.flatMap((record) => R.get(record, "phases")),
+    O.map((phases) => {
+      const entries = A.isArray(phases) ? phases : isJsonRecord(phases) ? R.values(phases) : A.empty<unknown>();
+      return A.getSomes(
+        A.map(entries, (entry) =>
+          isJsonRecord(entry) ? pipe(R.get(entry, "name"), O.filter(P.isString)) : O.none<string>()
+        )
+      );
+    }),
+    O.getOrElse(A.empty<string>)
+  );
+  return A.some(phaseNames, (name) => Str.includes("report")(Str.toLowerCase(name)))
+    ? PhaseArchetype.Enum["report-first"]
+    : PhaseArchetype.Enum["standard-delivery"];
+};
+
+const ADOPT_BASE_VALIDATIONS: ReadonlyArray<ValidationRequirement> = [
+  "manifest-decodes",
+  "doctor-clean",
+  "index-regenerates",
+  "readme-lifecycle-line",
+  "goal-md-within-budget",
+];
+
+const isReflectionArtifact = (relativePath: string): boolean =>
+  Str.startsWith("history/reflections/")(relativePath) &&
+  Str.endsWith(".md")(relativePath) &&
+  !Str.endsWith(REFLECTION_TEMPLATE_BASENAME)(relativePath);
+
+/**
+ * Compiles an adoption plan from a decoded packet snapshot.
+ *
+ * **Details**
+ *
+ * A pure function of the snapshot value: requirements `never`, no clock, no
+ * filesystem. Every present packet file is retained (`preserved` for the
+ * manifest, whose unmodeled top-level keys are enumerated with a pre-image
+ * digest); a standard artifact the packet lacks becomes a `report` entry a
+ * human resolves; only machine-derivable artifacts (directory markers, and a
+ * seeded manifest for a manifest-less packet) are planned as `create`.
+ * Diagnosis never mutates, and it never invents prose.
+ *
+ * **Example** (Compile against an empty snapshot)
+ *
+ * ```ts
+ * import { compileAdoptionPlan } from "@beep/repo-cli/commands/Goals/Adopt"
+ * import { PacketSnapshot } from "@beep/repo-cli/commands/Goals/Bootstrap.schemas"
+ * import * as O from "effect/Option"
+ *
+ * const plan = compileAdoptionPlan(
+ *   PacketSnapshot.make({
+ *     slug: "missing-goal",
+ *     packetPath: "goals/missing-goal",
+ *     exists: false,
+ *     files: [],
+ *     templateFiles: [],
+ *     templateSnapshotHash: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+ *   }),
+ *   O.none()
+ * )
+ * console.log(plan.conflicts[0]?.reason) // "packet-not-found"
+ * ```
+ *
+ * @param snapshot - The read-only packet and template capture.
+ * @param toward - Optional explicit archetype; defaults to inference from the packet's phase shape.
+ * @returns The sealed adoption plan.
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const compileAdoptionPlan: {
+  (snapshot: PacketSnapshot, toward: O.Option<PhaseArchetype>): MaterializationPlan;
+  (toward: O.Option<PhaseArchetype>): (snapshot: PacketSnapshot) => MaterializationPlan;
+} = dual(2, (snapshot: PacketSnapshot, toward: O.Option<PhaseArchetype>): MaterializationPlan => {
+  const archetype = O.getOrElse(toward, () => inferArchetype(snapshot.files));
+  const base = {
+    mode: PlanMode.Enum.adopt,
+    slug: snapshot.slug,
+    packetPath: snapshot.packetPath,
+    towardArchetype: archetype,
+    templateSnapshotHash: snapshot.templateSnapshotHash,
+  };
+
+  if (!snapshot.exists) {
+    return sealMaterializationPlan({
+      ...base,
+      entries: [],
+      preservations: [],
+      validations: [],
+      conflicts: [
+        {
+          reason: "packet-not-found",
+          message: `No goal packet directory "${snapshot.packetPath}".`,
+        },
+      ],
+    });
+  }
+
+  const manifestFile = A.findFirst(snapshot.files, (file) => file.path === MANIFEST_RELATIVE_PATH);
+  const parsedManifest = O.flatMap(manifestFile, (file) => parseGoalManifestText(file.text));
+  if (O.isSome(manifestFile) && O.isNone(parsedManifest)) {
+    return sealMaterializationPlan({
+      ...base,
+      entries: [],
+      preservations: [],
+      validations: [],
+      conflicts: [
+        {
+          reason: "manifest-unparseable",
+          message: `"${snapshot.packetPath}/${MANIFEST_RELATIVE_PATH}" does not parse as JSON; adoption cannot classify it.`,
+        },
+      ],
+    });
+  }
+
+  let entries = A.empty<PlanRow>();
+  let preservations = A.empty<PreservationRow>();
+  const conflicts = A.empty<ConflictRow>();
+
+  for (const file of snapshot.files) {
+    const fullPath = `${snapshot.packetPath}/${file.path}`;
+    if (file.path === MANIFEST_RELATIVE_PATH) {
+      const unmodeledKeys = pipe(
+        parsedManifest,
+        O.filter(isJsonRecord),
+        O.map((record) => A.sort(A.difference(R.keys(record), MODELED_GOAL_MANIFEST_KEYS), Str.Order)),
+        O.getOrElse(A.empty<string>)
+      );
+      entries = A.append(entries, {
+        path: fullPath,
+        action: "preserve",
+        ownership: "preserved",
+        reason: "Manifest bytes survive only through byte-preserving JSONC edits; re-encoding strips unmodeled keys.",
+        existingDigest: file.digest,
+      });
+      preservations = A.append(preservations, {
+        path: fullPath,
+        unmodeledKeys,
+        preImageDigest: file.digest,
+        reason: "The canonical decoder strips these top-level keys from decoded output.",
+      });
+    } else if (isGitkeepPath(file.path)) {
+      entries = A.append(entries, {
+        path: fullPath,
+        action: "retain",
+        ownership: "generated",
+        reason: "Machine-derivable directory marker already present.",
+        existingDigest: file.digest,
+      });
+    } else {
+      entries = A.append(entries, {
+        path: fullPath,
+        action: "retain",
+        ownership: "authored",
+        reason: "Tracked packet file conforms to the standard and stays human-owned.",
+        existingDigest: file.digest,
+      });
+    }
+  }
+
+  const packetPaths = A.map(snapshot.files, (file) => file.path);
+  for (const templateFile of snapshot.templateFiles) {
+    if (A.contains(packetPaths, templateFile.path)) {
+      continue;
+    }
+    const fullPath = `${snapshot.packetPath}/${templateFile.path}`;
+    if (templateFile.path === MANIFEST_RELATIVE_PATH) {
+      const readme = A.findFirst(snapshot.files, (file) => file.path === README_RELATIVE_PATH);
+      const readmeText = O.map(readme, (file) => file.text);
+      const status = pipe(
+        readmeText,
+        O.flatMap(readmeLifecycleToken),
+        O.filter(isGoalStatus),
+        O.getOrElse((): GoalStatus => "active")
+      );
+      const payload = seededManifestPayload({
+        slug: snapshot.slug,
+        title: pipe(
+          readmeText,
+          O.flatMap(readmeTitle),
+          O.getOrElse(() => snapshot.slug)
+        ),
+        status,
+        mission: O.flatMap(readmeText, readmeMissionLine),
+        archetype,
+      });
+      entries = A.append(entries, {
+        path: fullPath,
+        action: "create",
+        ownership: "generated",
+        reason: "Manifest-less packet: seed a manifest from README-extractable fields.",
+        payload,
+        payloadDigest: sha256Hex(payload),
+      });
+    } else if (isGitkeepPath(templateFile.path)) {
+      entries = A.append(entries, {
+        path: fullPath,
+        action: "create",
+        ownership: "generated",
+        reason: "Machine-derivable directory marker the standard ships.",
+        payload: templateFile.text,
+        payloadDigest: templateFile.digest,
+      });
+    } else {
+      entries = A.append(entries, {
+        path: fullPath,
+        action: "report",
+        ownership: "authored",
+        reason: "Standard artifact absent; a human authors it — diagnosis never invents prose.",
+      });
+    }
+  }
+
+  const validations: ReadonlyArray<ValidationRequirement> = A.some(snapshot.files, (file) =>
+    isReflectionArtifact(file.path)
+  )
+    ? A.append(ADOPT_BASE_VALIDATIONS, "reflection-frontmatter-valid")
+    : ADOPT_BASE_VALIDATIONS;
+
+  return sealMaterializationPlan({
+    ...base,
+    entries,
+    preservations,
+    validations,
+    conflicts,
+  });
+});
+
+const slugArgument = Argument.string("slug").pipe(Argument.withDescription("Goal packet slug under goals/"));
+const towardFlag = Flag.choice("toward", PhaseArchetype.Options).pipe(
+  Flag.optional,
+  Flag.withDescription("Archetype to measure against; defaults to inference from the packet's phase shape")
+);
+const planFlag = Flag.boolean("plan").pipe(
+  Flag.withDescription("Compile and print the adoption plan (the only mode this slice ships)")
+);
+const jsonFlag = Flag.boolean("json").pipe(Flag.withDescription("Print the plan as canonical JSON"));
+
+const runAdoptPlan = Effect.fn("Goals.runAdoptPlan")(function* (options: {
+  readonly slug: string;
+  readonly toward: O.Option<PhaseArchetype>;
+  readonly plan: boolean;
+  readonly json: boolean;
+}) {
+  if (!options.plan) {
+    return yield* GoalPlanInputError.new(
+      "Phase 0 ships plan-only commands; pass --plan (no writer exists to omit it for)."
+    );
+  }
+  const slug = yield* S.decodeEffect(GoalSlug)(options.slug).pipe(
+    Effect.mapError((issue) => GoalPlanInputError.new(`slug "${options.slug}" is invalid: ${issue.message}`))
+  );
+  const snapshot = yield* readPacketSnapshot(slug);
+  const plan = compileAdoptionPlan(snapshot, options.toward);
+  yield* reportMaterializationPlan(plan, options.json);
+});
+
+/**
+ * `bun run beep goals adopt` — compile and print a packet adoption plan.
+ *
+ * **Example** (Log command name)
+ *
+ * ```ts
+ * import { goalsAdoptCommand } from "@beep/repo-cli/commands/Goals/Adopt"
+ *
+ * console.log(goalsAdoptCommand.name)
+ * ```
+ *
+ * @category commands
+ * @since 0.0.0
+ */
+export const goalsAdoptCommand = Command.make(
+  "adopt",
+  { slug: slugArgument, toward: towardFlag, plan: planFlag, json: jsonFlag },
+  Effect.fn(function* (options) {
+    return yield* runAdoptPlan(options).pipe(
+      Effect.catchTags({
+        GoalPlanInputError: Effect.fn(function* (error) {
+          yield* Console.error(`[goals:adopt] ${error.message}`);
+          return yield* failWithReportedExit(`goals adopt: ${error.message}`);
+        }),
+        GoalPlanOperationalError: Effect.fn(function* (error) {
+          yield* Console.error(`[goals:adopt] ${error.message}`);
+          return yield* failWithReportedExit(`goals adopt: ${error.message}`);
+        }),
+      })
+    );
+  })
+).pipe(Command.withDescription("Compile the read-only packet adoption plan (--plan --json); no writer exists"));

--- a/packages/tooling/tool/cli/src/commands/Goals/Bootstrap.schemas.ts
+++ b/packages/tooling/tool/cli/src/commands/Goals/Bootstrap.schemas.ts
@@ -1,0 +1,786 @@
+/**
+ * Materialization-plan schemas for `beep goals bootstrap|adopt --plan`.
+ *
+ * **Details**
+ *
+ * Workstream E phase 0 of the knowledge-surface-automation initiative ships
+ * plan-only commands: a pure compiler maps a decoded {@link BootstrapInput}
+ * (or a read-only {@link PacketSnapshot}) to a content-addressed
+ * {@link MaterializationPlan} that fully describes the intended change —
+ * payload bytes included — without any writer existing. These schemas are the
+ * shared dry-run contract for bootstrap, graduation, adoption, and future
+ * editor tooling.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { LiteralKit } from "@beep/schema";
+import { Effect } from "effect";
+import * as A from "effect/Array";
+import * as R from "effect/Record";
+import * as S from "effect/Schema";
+import { CapabilitySlug, GoalManifest, GoalStatus } from "./Goals.schemas.ts";
+import type { GoalDoctorFindingKind } from "./Doctor.ts";
+
+const $I = $RepoCliId.create("commands/Goals/Bootstrap.schemas");
+
+/**
+ * Constrained goal-packet slug grammar.
+ *
+ * **Details**
+ *
+ * Reuses the lowercase-segment grammar ratified for capability-slug segments
+ * (decision D1) with the packet-slug length budget: lowercase ASCII segments
+ * joined by single hyphens, at most 64 characters. Path separators, traversal
+ * (`..`), uppercase, whitespace, and the reserved `_template` slug are all
+ * rejected at decode rather than by a downstream guard.
+ *
+ * **Example** (Accept a packet slug and reject traversal)
+ *
+ * ```ts
+ * import { GoalSlug } from "@beep/repo-cli/commands/Goals/Bootstrap.schemas"
+ * import * as S from "effect/Schema"
+ *
+ * console.log(S.is(GoalSlug)("knowledge-surface-automation")) // true
+ * console.log(S.is(GoalSlug)("../escape")) // false
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const GoalSlug = S.String.check(
+  S.isPattern(/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/, {
+    identifier: $I`GoalSlugPatternCheck`,
+    title: "Goal Slug Pattern",
+    description: "Lowercase ASCII slug segments joined by single hyphens.",
+    message: "Expected a lowercase goal slug with internal single hyphens only",
+  }),
+  S.isMaxLength(64, {
+    identifier: $I`GoalSlugLengthCheck`,
+    title: "Goal Slug Length",
+    description: "A goal slug is at most 64 characters.",
+    message: "Expected a goal slug with at most 64 characters",
+  })
+).pipe(
+  $I.annoteSchema("GoalSlug", {
+    description: "Constrained lowercase goal-packet slug; traversal and the template slug fail the grammar.",
+  })
+);
+
+/**
+ * Constrained goal-packet slug.
+ *
+ * **Example** (Annotate a slug value)
+ *
+ * ```ts
+ * import type { GoalSlug } from "@beep/repo-cli/commands/Goals/Bootstrap.schemas"
+ *
+ * const slug: GoalSlug = "goals-graph"
+ * console.log(slug)
+ * ```
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type GoalSlug = typeof GoalSlug.Type;
+
+/**
+ * Which compiler produced a plan.
+ *
+ * **Example** (Narrow a plan mode)
+ *
+ * ```ts
+ * import { PlanMode } from "@beep/repo-cli/commands/Goals/Bootstrap.schemas"
+ *
+ * console.log(PlanMode.is.bootstrap("bootstrap")) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const PlanMode = LiteralKit(["bootstrap", "adopt"]).pipe(
+  $I.annoteSchema("PlanMode", { description: "Which compiler produced this plan." })
+);
+
+/**
+ * Which compiler produced a plan.
+ *
+ * **Example** (Annotate a mode value)
+ *
+ * ```ts
+ * import type { PlanMode } from "@beep/repo-cli/commands/Goals/Bootstrap.schemas"
+ *
+ * const mode: PlanMode = "adopt"
+ * console.log(mode)
+ * ```
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type PlanMode = typeof PlanMode.Type;
+
+/**
+ * Who owns a path's bytes after materialization.
+ *
+ * **Details**
+ *
+ * `generated` bytes derive entirely from machine inputs and may be
+ * rematerialized; `generated-seed` bytes are written once and human-owned
+ * immediately after; `authored` bytes are human-owned from the start;
+ * `preserved` bytes must survive byte-for-byte (the manifest byte-preserving
+ * rule).
+ *
+ * **Example** (Narrow an ownership value)
+ *
+ * ```ts
+ * import { PlanOwnership } from "@beep/repo-cli/commands/Goals/Bootstrap.schemas"
+ *
+ * console.log(PlanOwnership.is["generated-seed"]("generated-seed")) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const PlanOwnership = LiteralKit(["generated", "generated-seed", "authored", "preserved"]).pipe(
+  $I.annoteSchema("PlanOwnership", { description: "Who owns a path's bytes after materialization." })
+);
+
+/**
+ * Who owns a path's bytes after materialization.
+ *
+ * **Example** (Annotate an ownership value)
+ *
+ * ```ts
+ * import type { PlanOwnership } from "@beep/repo-cli/commands/Goals/Bootstrap.schemas"
+ *
+ * const ownership: PlanOwnership = "authored"
+ * console.log(ownership)
+ * ```
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type PlanOwnership = typeof PlanOwnership.Type;
+
+/**
+ * What a later executor would do to one path.
+ *
+ * **Details**
+ *
+ * `create` writes new bytes; `retain` leaves a conforming file untouched;
+ * `preserve` keeps existing bytes byte-for-byte while enumerating what must
+ * not be lost; `report` names a gap a human resolves — diagnosis never
+ * mutates, and it never invents prose.
+ *
+ * **Example** (Narrow an action value)
+ *
+ * ```ts
+ * import { PlanAction } from "@beep/repo-cli/commands/Goals/Bootstrap.schemas"
+ *
+ * console.log(PlanAction.is.report("report")) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const PlanAction = LiteralKit(["create", "retain", "preserve", "report"]).pipe(
+  $I.annoteSchema("PlanAction", { description: "What the executor would do to one path." })
+);
+
+/**
+ * What a later executor would do to one path.
+ *
+ * **Example** (Annotate an action value)
+ *
+ * ```ts
+ * import type { PlanAction } from "@beep/repo-cli/commands/Goals/Bootstrap.schemas"
+ *
+ * const action: PlanAction = "retain"
+ * console.log(action)
+ * ```
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type PlanAction = typeof PlanAction.Type;
+
+/**
+ * A check the executor must pass against the prospective overlay before publish.
+ *
+ * **Example** (Narrow a validation requirement)
+ *
+ * ```ts
+ * import { ValidationRequirement } from "@beep/repo-cli/commands/Goals/Bootstrap.schemas"
+ *
+ * console.log(ValidationRequirement.is["manifest-decodes"]("manifest-decodes")) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const ValidationRequirement = LiteralKit([
+  "manifest-decodes",
+  "doctor-clean",
+  "index-regenerates",
+  "links-resolve",
+  "reflection-frontmatter-valid",
+  "goal-md-within-budget",
+  "readme-lifecycle-line",
+]).pipe(
+  $I.annoteSchema("ValidationRequirement", {
+    description: "A check the executor must pass against the prospective overlay before publish.",
+  })
+);
+
+/**
+ * A check the executor must pass before publish.
+ *
+ * **Example** (Annotate a validation value)
+ *
+ * ```ts
+ * import type { ValidationRequirement } from "@beep/repo-cli/commands/Goals/Bootstrap.schemas"
+ *
+ * const validation: ValidationRequirement = "doctor-clean"
+ * console.log(validation)
+ * ```
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type ValidationRequirement = typeof ValidationRequirement.Type;
+
+/**
+ * Why plan compilation failed closed.
+ *
+ * **Example** (Narrow a conflict reason)
+ *
+ * ```ts
+ * import { PlanConflictReason } from "@beep/repo-cli/commands/Goals/Bootstrap.schemas"
+ *
+ * console.log(PlanConflictReason.is["slug-exists"]("slug-exists")) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const PlanConflictReason = LiteralKit(["slug-exists", "packet-not-found", "manifest-unparseable"]).pipe(
+  $I.annoteSchema("PlanConflictReason", {
+    description: "Why plan compilation failed closed instead of emitting entries.",
+  })
+);
+
+/**
+ * Why plan compilation failed closed.
+ *
+ * **Example** (Annotate a conflict reason)
+ *
+ * ```ts
+ * import type { PlanConflictReason } from "@beep/repo-cli/commands/Goals/Bootstrap.schemas"
+ *
+ * const reason: PlanConflictReason = "slug-exists"
+ * console.log(reason)
+ * ```
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type PlanConflictReason = typeof PlanConflictReason.Type;
+
+/**
+ * Ordered goal-phase archetypes the bootstrap compiler expands.
+ *
+ * **Details**
+ *
+ * `standard-delivery` expands to the five `goals/_template` phases (Research,
+ * Implement, Verify, Yeet, Close); `report-first` expands to the phase-0
+ * report shape the knowledge-surface-automation packet itself uses (read-only
+ * report, FP eyeball, gated mutation, Yeet, Close). Archetypes are defaults,
+ * not a closed set — explicit phase lists stay expressible in later slices.
+ *
+ * **Example** (Narrow an archetype)
+ *
+ * ```ts
+ * import { PhaseArchetype } from "@beep/repo-cli/commands/Goals/Bootstrap.schemas"
+ *
+ * console.log(PhaseArchetype.is["standard-delivery"]("standard-delivery")) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const PhaseArchetype = LiteralKit(["standard-delivery", "report-first"]).pipe(
+  $I.annoteSchema("PhaseArchetype", {
+    description: "Named ordered phase shape a bootstrap plan expands into stable-ID phases.",
+  })
+);
+
+/**
+ * Ordered goal-phase archetype.
+ *
+ * **Example** (Annotate an archetype value)
+ *
+ * ```ts
+ * import type { PhaseArchetype } from "@beep/repo-cli/commands/Goals/Bootstrap.schemas"
+ *
+ * const archetype: PhaseArchetype = "report-first"
+ * console.log(archetype)
+ * ```
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type PhaseArchetype = typeof PhaseArchetype.Type;
+
+/**
+ * Lowercase SHA-256 hex digest carried by plan rows and snapshots.
+ *
+ * **Example** (Validate a digest string)
+ *
+ * ```ts
+ * import { PlanDigest } from "@beep/repo-cli/commands/Goals/Bootstrap.schemas"
+ * import * as S from "effect/Schema"
+ *
+ * console.log(S.is(PlanDigest)("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const PlanDigest = S.String.check(
+  S.isPattern(/^[0-9a-f]{64}$/, {
+    identifier: $I`PlanDigestPatternCheck`,
+    title: "Plan Digest Pattern",
+    description: "A lowercase 64-character SHA-256 hex digest.",
+    message: "Expected a lowercase 64-character SHA-256 hex digest",
+  })
+).pipe(
+  $I.annoteSchema("PlanDigest", {
+    description: "Lowercase SHA-256 hex digest of exact file bytes.",
+  })
+);
+
+/**
+ * Lowercase SHA-256 hex digest.
+ *
+ * **Example** (Annotate a digest value)
+ *
+ * ```ts
+ * import type { PlanDigest } from "@beep/repo-cli/commands/Goals/Bootstrap.schemas"
+ *
+ * const digest: PlanDigest = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+ * console.log(digest.length)
+ * ```
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type PlanDigest = typeof PlanDigest.Type;
+
+/**
+ * Content address of one compiled plan.
+ *
+ * **Details**
+ *
+ * The digest half is the SHA-256 of the compact canonical JSON encoding of
+ * every plan field except `planId` itself, so an adoption patch is hash-pinned
+ * and a later executor refuses to apply a plan whose tree moved.
+ *
+ * **Example** (Validate a plan id)
+ *
+ * ```ts
+ * import { MaterializationPlanId } from "@beep/repo-cli/commands/Goals/Bootstrap.schemas"
+ * import * as S from "effect/Schema"
+ *
+ * console.log(
+ *   S.is(MaterializationPlanId)(
+ *     "goal-plan/v1:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+ *   )
+ * ) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const MaterializationPlanId = S.String.check(
+  S.isPattern(/^goal-plan\/v1:[0-9a-f]{64}$/, {
+    identifier: $I`MaterializationPlanIdPatternCheck`,
+    title: "Materialization Plan Id Pattern",
+    description: "goal-plan/v1: followed by a lowercase SHA-256 hex digest.",
+    message: "Expected goal-plan/v1: followed by a lowercase SHA-256 hex digest",
+  })
+).pipe(
+  $I.annoteSchema("MaterializationPlanId", {
+    description: "Content address of one compiled plan.",
+  })
+);
+
+/**
+ * Content address of one compiled plan.
+ *
+ * **Example** (Annotate a plan id value)
+ *
+ * ```ts
+ * import type { MaterializationPlanId } from "@beep/repo-cli/commands/Goals/Bootstrap.schemas"
+ *
+ * const planId: MaterializationPlanId =
+ *   "goal-plan/v1:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+ * console.log(planId.length)
+ * ```
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type MaterializationPlanId = typeof MaterializationPlanId.Type;
+
+/**
+ * One reason plan compilation failed closed.
+ *
+ * **Example** (Construct a slug-exists conflict)
+ *
+ * ```ts
+ * import { PlanConflict } from "@beep/repo-cli/commands/Goals/Bootstrap.schemas"
+ *
+ * const conflict = PlanConflict.make({
+ *   reason: "slug-exists",
+ *   message: 'Packet "goals/x" already exists.',
+ * })
+ * console.log(conflict.reason)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class PlanConflict extends S.Class<PlanConflict>($I`PlanConflict`)(
+  {
+    reason: PlanConflictReason,
+    message: S.String,
+  },
+  $I.annote("PlanConflict", {
+    description: "One reason plan compilation failed closed; a conflicted plan emits no entries.",
+  })
+) {}
+
+/**
+ * One path the plan would create, retain, preserve, or report.
+ *
+ * **Details**
+ *
+ * `payload` carries the complete bytes a `create` entry would write, which is
+ * what makes plans golden-testable and lets a later executor replay a
+ * reviewed, hash-pinned artifact. `existingDigest` pins the current bytes of
+ * `retain`/`preserve` entries so a stale plan refuses rather than clobbering.
+ *
+ * **Example** (Construct a retain entry)
+ *
+ * ```ts
+ * import { PlanEntry } from "@beep/repo-cli/commands/Goals/Bootstrap.schemas"
+ *
+ * const entry = PlanEntry.make({
+ *   path: "goals/x/SPEC.md",
+ *   action: "retain",
+ *   ownership: "authored",
+ *   reason: "Tracked packet file conforms to the standard.",
+ * })
+ * console.log(entry.action)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class PlanEntry extends S.Class<PlanEntry>($I`PlanEntry`)(
+  {
+    path: S.String,
+    action: PlanAction,
+    ownership: PlanOwnership,
+    reason: S.String,
+    payload: S.optionalKey(S.String),
+    payloadDigest: S.optionalKey(PlanDigest),
+    existingDigest: S.optionalKey(PlanDigest),
+  },
+  $I.annote("PlanEntry", { description: "One path the plan would create, retain, preserve, or report." })
+) {}
+
+/**
+ * Bytes and unmodeled keys adoption must not lose.
+ *
+ * **Details**
+ *
+ * The canonical manifest decoder accepts unknown top-level keys and strips
+ * them from decoded output; re-encoding a decoded manifest would silently
+ * delete them. A preservation row enumerates every unmodeled key with a digest
+ * of the pre-image so a later hash-pinned adoption patch binds to the exact
+ * bytes reviewed.
+ *
+ * **Example** (Construct a preservation row)
+ *
+ * ```ts
+ * import { PlanPreservation } from "@beep/repo-cli/commands/Goals/Bootstrap.schemas"
+ *
+ * const preservation = PlanPreservation.make({
+ *   path: "goals/x/ops/manifest.json",
+ *   unmodeledKeys: ["researchReports"],
+ *   preImageDigest: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+ *   reason: "Unmodeled manifest keys survive only through byte-preserving JSONC edits.",
+ * })
+ * console.log(preservation.unmodeledKeys.length)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class PlanPreservation extends S.Class<PlanPreservation>($I`PlanPreservation`)(
+  {
+    path: S.String,
+    unmodeledKeys: S.Array(S.String),
+    preImageDigest: PlanDigest,
+    reason: S.String,
+  },
+  $I.annote("PlanPreservation", { description: "Bytes and unmodeled keys adoption must not lose." })
+) {}
+
+/**
+ * Deterministic, content-addressed materialization intent.
+ *
+ * **Details**
+ *
+ * The plan is the complete description of the intended change: every path with
+ * its action, ownership, and payload bytes; every preservation obligation; the
+ * validation set a later executor must satisfy; and any conflicts that made
+ * compilation fail closed (a conflicted plan carries no entries). Adoption
+ * plans additionally record the archetype they measured against and the
+ * `goals/_template` snapshot hash, making the measurement basis explicit under
+ * template drift.
+ *
+ * **Example** (Inspect the schema identifier)
+ *
+ * ```ts
+ * import { MaterializationPlan } from "@beep/repo-cli/commands/Goals/Bootstrap.schemas"
+ *
+ * console.log(typeof MaterializationPlan.make) // "function"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class MaterializationPlan extends S.Class<MaterializationPlan>($I`MaterializationPlan`)(
+  {
+    schemaVersion: S.tag("goal-materialization-plan/v1"),
+    compilerVersion: S.tag("goal-materialization-compiler/v1"),
+    planId: MaterializationPlanId,
+    mode: PlanMode,
+    slug: S.String,
+    packetPath: S.String,
+    entries: S.Array(PlanEntry),
+    preservations: S.Array(PlanPreservation),
+    validations: S.Array(ValidationRequirement),
+    conflicts: S.Array(PlanConflict),
+    towardArchetype: S.optionalKey(PhaseArchetype),
+    templateSnapshotHash: S.optionalKey(PlanDigest),
+  },
+  $I.annote("MaterializationPlan", { description: "Deterministic, content-addressed materialization intent." })
+) {}
+
+/**
+ * Everything the pure bootstrap compiler needs; no ambient state.
+ *
+ * **Details**
+ *
+ * `today` is an explicit input, not a clock read — a compiler that reads the
+ * clock is not a pure function and its golden fixtures rot daily. Defaults
+ * mirror the packet standard: `active` status, the `standard-delivery`
+ * archetype, execution-capable, reflection-required, and empty capability
+ * edges.
+ *
+ * **Example** (Construct a minimal input)
+ *
+ * ```ts
+ * import { BootstrapInput } from "@beep/repo-cli/commands/Goals/Bootstrap.schemas"
+ *
+ * const input = BootstrapInput.make({
+ *   slug: "example-goal",
+ *   title: "Example Goal",
+ *   mission: "Prove the plan compiler.",
+ *   today: "2026-08-17",
+ * })
+ * console.log(input.archetype) // "standard-delivery"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class BootstrapInput extends S.Class<BootstrapInput>($I`BootstrapInput`)(
+  {
+    slug: GoalSlug,
+    title: S.String,
+    mission: S.String,
+    status: GoalStatus.pipe(S.withConstructorDefault(Effect.succeed(GoalStatus.Enum.active))),
+    archetype: PhaseArchetype.pipe(S.withConstructorDefault(Effect.succeed(PhaseArchetype.Enum["standard-delivery"]))),
+    executionCapable: S.Boolean.pipe(S.withConstructorDefault(Effect.succeed(true))),
+    reflectionRequired: S.Boolean.pipe(S.withConstructorDefault(Effect.succeed(true))),
+    provides: S.Array(CapabilitySlug).pipe(S.withConstructorDefault(Effect.succeed(A.empty<CapabilitySlug>()))),
+    requires: S.Array(CapabilitySlug).pipe(S.withConstructorDefault(Effect.succeed(A.empty<CapabilitySlug>()))),
+    provenanceExploration: S.optionalKey(S.String),
+    today: S.String.check(
+      S.isPattern(/^\d{4}-\d{2}-\d{2}$/, {
+        identifier: $I`BootstrapTodayPatternCheck`,
+        title: "Bootstrap Today Pattern",
+        description: "An explicit ISO date (YYYY-MM-DD) input.",
+        message: "Expected an explicit ISO date (YYYY-MM-DD)",
+      })
+    ),
+  },
+  $I.annote("BootstrapInput", { description: "Everything the pure bootstrap compiler needs; no ambient state." })
+) {}
+
+/**
+ * One file captured by a read-only packet snapshot.
+ *
+ * **Example** (Construct a snapshot file)
+ *
+ * ```ts
+ * import { PacketSnapshotFile } from "@beep/repo-cli/commands/Goals/Bootstrap.schemas"
+ *
+ * const file = PacketSnapshotFile.make({
+ *   path: "README.md",
+ *   text: "# Example\n",
+ *   digest: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+ * })
+ * console.log(file.path)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class PacketSnapshotFile extends S.Class<PacketSnapshotFile>($I`PacketSnapshotFile`)(
+  {
+    path: S.String,
+    text: S.String,
+    digest: PlanDigest,
+  },
+  $I.annote("PacketSnapshotFile", {
+    description: "One packet-relative file with its exact text and SHA-256 digest.",
+  })
+) {}
+
+/**
+ * Decoded value boundary between packet reads and pure adoption compilation.
+ *
+ * **Details**
+ *
+ * `readPacketSnapshot` only ever calls read members of `FileSystem`; once this
+ * value exists, adoption is a pure function of it, which is what makes the
+ * adoption plan golden-testable. `templateFiles` carries the current
+ * `goals/_template` tree (the standard the packet is measured against) and
+ * `templateSnapshotHash` pins that measurement basis under template drift.
+ *
+ * **Example** (Construct an empty snapshot)
+ *
+ * ```ts
+ * import { PacketSnapshot } from "@beep/repo-cli/commands/Goals/Bootstrap.schemas"
+ *
+ * const snapshot = PacketSnapshot.make({
+ *   slug: "example-goal",
+ *   packetPath: "goals/example-goal",
+ *   exists: false,
+ *   files: [],
+ *   templateFiles: [],
+ *   templateSnapshotHash: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+ * })
+ * console.log(snapshot.exists)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class PacketSnapshot extends S.Class<PacketSnapshot>($I`PacketSnapshot`)(
+  {
+    slug: S.String,
+    packetPath: S.String,
+    exists: S.Boolean,
+    files: S.Array(PacketSnapshotFile),
+    templateFiles: S.Array(PacketSnapshotFile),
+    templateSnapshotHash: PlanDigest,
+  },
+  $I.annote("PacketSnapshot", {
+    description: "Read-only packet and template capture that pure adoption compilation consumes.",
+  })
+) {}
+
+/**
+ * Top-level manifest keys the `GoalManifest` schema models.
+ *
+ * **Details**
+ *
+ * The canonical decoder strips every other top-level key from decoded output,
+ * so adoption enumerates `unmodeledKeys` as the set difference against this
+ * list. The list is derived from the `GoalManifest` class fields, so it cannot
+ * drift from the schema; the preservation counterfactual test proves the naive
+ * decode-encode round trip loses exactly the keys outside it.
+ *
+ * **Example** (Check a modeled key)
+ *
+ * ```ts
+ * import { MODELED_GOAL_MANIFEST_KEYS } from "@beep/repo-cli/commands/Goals/Bootstrap.schemas"
+ * import * as A from "effect/Array"
+ *
+ * console.log(A.contains(MODELED_GOAL_MANIFEST_KEYS, "initiative")) // true
+ * console.log(A.contains(MODELED_GOAL_MANIFEST_KEYS, "researchReports")) // false
+ * ```
+ *
+ * @category constants
+ * @since 0.0.0
+ */
+export const MODELED_GOAL_MANIFEST_KEYS: ReadonlyArray<string> = R.keys(GoalManifest.fields);
+
+const VALIDATION_REQUIREMENTS_BY_FINDING_KIND: Readonly<
+  Record<GoalDoctorFindingKind, ReadonlyArray<ValidationRequirement>>
+> = {
+  "manifest-missing": ["manifest-decodes"],
+  "manifest-invalid": ["manifest-decodes"],
+  "lifecycle-mismatch": ["readme-lifecycle-line", "doctor-clean"],
+  "readme-status-line": ["readme-lifecycle-line", "doctor-clean"],
+  "goal-md-oversize": ["goal-md-within-budget"],
+  "phases-terminal-but-active": ["doctor-clean"],
+  "reflection-frontmatter-invalid": ["reflection-frontmatter-valid"],
+  "stale-active": [],
+  "active-missing-goal-md": [],
+  "schema-version-upgrade": [],
+  "completion-gate-unsatisfied": [],
+  "superseded-without-pointer": [],
+  "exploration-backlink-missing": [],
+  "packet-stream-fork": [],
+  "packet-stream-integrity": [],
+  "packet-trace-stale": [],
+  "packet-trace-missing": [],
+};
+
+/**
+ * Maps one goals-doctor finding kind onto executor validation requirements.
+ *
+ * **Details**
+ *
+ * Doctor stays the diagnostic; adoption is the remediation plan. Every
+ * blocking finding kind maps to at least one {@link ValidationRequirement}
+ * the executor must satisfy against the prospective overlay; advisory kinds
+ * map to none. The backing record is exhaustive over
+ * `GoalDoctorFindingKind`, so a new doctor finding fails compilation here
+ * until it is mapped.
+ *
+ * **Example** (Map a blocking finding)
+ *
+ * ```ts
+ * import { validationRequirementsForGoalDoctorFinding } from "@beep/repo-cli/commands/Goals/Bootstrap.schemas"
+ *
+ * console.log(validationRequirementsForGoalDoctorFinding("goal-md-oversize")) // ["goal-md-within-budget"]
+ * ```
+ *
+ * @param kind - The goals-doctor finding kind to map.
+ * @returns The validation requirements the executor must satisfy.
+ * @category mapping
+ * @since 0.0.0
+ */
+export const validationRequirementsForGoalDoctorFinding = (
+  kind: GoalDoctorFindingKind
+): ReadonlyArray<ValidationRequirement> => VALIDATION_REQUIREMENTS_BY_FINDING_KIND[kind];

--- a/packages/tooling/tool/cli/src/commands/Goals/Bootstrap.ts
+++ b/packages/tooling/tool/cli/src/commands/Goals/Bootstrap.ts
@@ -1,0 +1,959 @@
+/**
+ * Pure bootstrap plan compiler and the `beep goals bootstrap --plan` command.
+ *
+ * **Details**
+ *
+ * Workstream E phase 0: `--plan` is not a flag on a mutating command — it is
+ * the only mode this command has. No function in this module calls a mutating
+ * `FileSystem` member; the compiler is a pure total function from a decoded
+ * `BootstrapInput` and the observed slug set to a content-addressed
+ * `MaterializationPlan`, golden-tested before any writer exists.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { Console, DateTime, Effect } from "effect";
+import * as A from "effect/Array";
+import { dual } from "effect/Function";
+import * as O from "effect/Option";
+import * as S from "effect/Schema";
+import * as Str from "effect/String";
+import { Command, Flag } from "effect/unstable/cli";
+import { failWithReportedExit } from "../../internal/cli/ExitCodeError.ts";
+import {
+  BootstrapInput,
+  GoalSlug,
+  MaterializationPlan,
+  PhaseArchetype,
+  PlanConflict,
+  PlanEntry,
+  PlanPreservation,
+} from "./Bootstrap.schemas.ts";
+import { GoalPlanInputError } from "./Goals.errors.ts";
+import { isCapabilitySlug } from "./Goals.schemas.ts";
+import { listGoalPackets } from "./Inventory.ts";
+import { canonicalJsonText, canonicalJsonTextPretty, sha256Hex } from "./PacketCore/PacketDigest.ts";
+import type {
+  PlanAction,
+  PlanConflictReason,
+  PlanMode,
+  PlanOwnership,
+  ValidationRequirement,
+} from "./Bootstrap.schemas.ts";
+import type { CapabilitySlug } from "./Goals.schemas.ts";
+
+const COMPLETION_GATE_STATEMENT =
+  "Not achieved until this goal's work ships as a PR driven to mergeable via /yeet (bun run beep yeet: repair -> verify -> publish --pr -> monitor).";
+
+const STOP_CONDITIONS: ReadonlyArray<string> = [
+  "Required source files are missing or materially contradictory.",
+  "The implementation would exceed named scope.",
+  "Verification requires unnamed credentials, cost, destructive side effects, or policy approval.",
+  "The same blocker repeats after reasonable investigation.",
+];
+
+type ArchetypePhase = {
+  readonly id: string;
+  readonly name: string;
+  readonly planGoal: string;
+  readonly planExit: string;
+};
+
+const YEET_PHASE: Omit<ArchetypePhase, "id"> = {
+  name: "Yeet: PR to mergeable",
+  planGoal:
+    "Publish through yeet and drive the PR to mergeable: required checks green, review comments answered and resolved.",
+  planExit: "`mergeStateStatus` is `CLEAN`; zero unresolved review threads.",
+};
+
+const CLOSE_PHASE: Omit<ArchetypePhase, "id"> = {
+  name: "Close",
+  planGoal: "Write the closeout reflection and flip packet state.",
+  planExit: "Packet status and evidence are updated; a closeout reflection exists.",
+};
+
+const STANDARD_DELIVERY_PHASES: ReadonlyArray<ArchetypePhase> = [
+  {
+    id: "P0",
+    name: "Research",
+    planGoal: "Inspect source hierarchy and confirm scope.",
+    planExit: "Required facts and blockers are recorded.",
+  },
+  {
+    id: "P1",
+    name: "Implement",
+    planGoal: "Make the smallest changes that satisfy `SPEC.md`.",
+    planExit: "Acceptance criteria are met.",
+  },
+  {
+    id: "P2",
+    name: "Verify",
+    planGoal: "Run required checks and capture evidence.",
+    planExit: "Verification is green or blockers are documented.",
+  },
+  { id: "P3", ...YEET_PHASE },
+  { id: "P4", ...CLOSE_PHASE },
+];
+
+const REPORT_FIRST_PHASES: ReadonlyArray<ArchetypePhase> = [
+  {
+    id: "P0",
+    name: "Read-only report",
+    planGoal: "Ship the phase-0 read-only report command.",
+    planExit: "The report and a false-positive sample land for eyeball review.",
+  },
+  {
+    id: "P1",
+    name: "FP eyeball",
+    planGoal: "Review the report's false-positive rate before any writer exists.",
+    planExit: "The eyeball verdict is recorded and the mutation gate is decided.",
+  },
+  {
+    id: "P2",
+    name: "Gated mutation",
+    planGoal: "Implement the mutation pass behind the reviewed gate.",
+    planExit: "Acceptance criteria are met.",
+  },
+  { id: "P3", ...YEET_PHASE },
+  { id: "P4", ...CLOSE_PHASE },
+];
+
+/**
+ * Expands one phase archetype into its ordered stable-ID phases.
+ *
+ * **Example** (Expand the standard archetype)
+ *
+ * ```ts
+ * import { archetypePhases } from "@beep/repo-cli/commands/Goals/Bootstrap"
+ *
+ * console.log(archetypePhases("standard-delivery").length) // 5
+ * ```
+ *
+ * @param archetype - The archetype to expand.
+ * @returns Ordered phase descriptors with stable `P0..Pn` ids.
+ * @category mapping
+ * @since 0.0.0
+ */
+export const archetypePhases = (archetype: PhaseArchetype): ReadonlyArray<ArchetypePhase> =>
+  PhaseArchetype.is["standard-delivery"](archetype) ? STANDARD_DELIVERY_PHASES : REPORT_FIRST_PHASES;
+
+const manifestPayload = (input: BootstrapInput): string => {
+  const packetPath = `goals/${input.slug}`;
+  const phases = A.map(archetypePhases(input.archetype), (phase) => ({
+    id: phase.id,
+    name: phase.name,
+    status: "pending",
+  }));
+  const document = {
+    schemaVersion: "initiative-manifest/v2",
+    initiative: {
+      id: input.slug,
+      packetId: `goal-packet/v1:${sha256Hex(`${input.slug}\n${input.today}`)}`,
+      title: input.title,
+      status: input.status,
+      created: input.today,
+      updated: input.today,
+      packetAnchorDocument: "SPEC.md",
+    },
+    packetPath,
+    lifecycle: input.status,
+    mission: input.mission,
+    executionCapable: input.executionCapable,
+    reflectionRequired: input.reflectionRequired,
+    ...(input.provenanceExploration === undefined
+      ? {}
+      : {
+          provenance: {
+            exploration: `explorations/${input.provenanceExploration}`,
+            graduated: input.today,
+          },
+        }),
+    completionGate: {
+      operator: "yeet",
+      requiresPullRequest: true,
+      requiresMergeable: true,
+      statement: COMPLETION_GATE_STATEMENT,
+      grandfathered: false,
+    },
+    currentSourceOfTruth: [
+      "AGENTS.md",
+      "CLAUDE.md",
+      `${packetPath}/README.md`,
+      `${packetPath}/SPEC.md`,
+      `${packetPath}/PLAN.md`,
+      `${packetPath}/GOAL.md`,
+      `${packetPath}/research/SOURCES.md`,
+    ],
+    researchReports: ["research/SOURCES.md"],
+    agentLaunchers: [
+      {
+        kind: "codex-goal",
+        path: "GOAL.md",
+        targetChars: 3500,
+        maxChars: 4000,
+        command: `/goal follow the instructions in ${packetPath}/GOAL.md`,
+      },
+    ],
+    provides: input.provides,
+    requires: input.requires,
+    phases,
+    verificationCommands: [
+      `test "$(wc -m < ${packetPath}/GOAL.md)" -le 4000`,
+      `jq . ${packetPath}/ops/manifest.json`,
+      `rg -n "${input.slug}|GOAL.md|agentLaunchers|packetAnchorDocument" ${packetPath}`,
+      `git diff --check -- ${packetPath}`,
+      "bun run beep lint reflection-artifacts",
+    ],
+    stopConditions: STOP_CONDITIONS,
+  };
+  return `${JSON.stringify(document, null, 2)}\n`;
+};
+
+const readmePayload = (input: BootstrapInput): string => {
+  const firstPhase = A.head(archetypePhases(input.archetype));
+  const currentPhase = O.match(firstPhase, {
+    onNone: () => "Not started.",
+    onSome: (phase) => `${phase.id} ${phase.name} — not started.`,
+  });
+  return `# ${input.title}
+
+## Status
+
+Lifecycle: \`${input.status}\`
+
+Source: [\`ops/manifest.json\`](./ops/manifest.json)
+
+## Mission
+
+${input.mission}
+
+## Launch
+
+Use this command for execution-capable sessions:
+
+\`\`\`text
+/goal follow the instructions in goals/${input.slug}/GOAL.md
+\`\`\`
+
+\`GOAL.md\` is the compact launcher. \`SPEC.md\` remains the normative contract.
+
+## Read This First
+
+1. [\`GOAL.md\`](./GOAL.md) - compact \`/goal\` launcher.
+2. [\`SPEC.md\`](./SPEC.md) - normative source of truth.
+3. [\`PLAN.md\`](./PLAN.md) - active execution plan.
+4. [\`ops/manifest.json\`](./ops/manifest.json) - machine-readable routing.
+5. [\`research/\`](./research/) - supporting research, if present.
+6. [\`history/\`](./history/) - evidence and closeouts, if present.
+
+## Current Phase
+
+${currentPhase}
+
+## Latest Evidence
+
+Not started.
+
+## Notes
+
+<Record high-signal constraints or resume notes that do not belong in the
+normative spec.>
+`;
+};
+
+const goalMdPayload = (input: BootstrapInput): string => `# GOAL: ${input.title}
+
+Repo root: the current working directory — the \`beep-effect\` checkout you are
+running in. Do not assume an absolute path; several checkouts exist. All paths
+below are repo-relative.
+
+Outcome: ${input.mission}
+
+This is a compact \`/goal\` launcher. Treat the packet files as the detailed
+contract:
+
+- \`goals/${input.slug}/README.md\`
+- \`goals/${input.slug}/SPEC.md\`
+- \`goals/${input.slug}/PLAN.md\`
+- \`goals/${input.slug}/ops/manifest.json\`
+
+Read those first, then read \`AGENTS.md\`, \`CLAUDE.md\`, and any governing
+standards named by \`SPEC.md\`. Higher-priority repo standards outrank packet
+prose when they conflict.
+
+Scope:
+
+- In: <paths, packages, docs, workflows, or artifacts this goal may change>.
+- Out: <non-goals and areas not to touch>.
+
+Workflow:
+
+1. Inspect referenced files and current repo state.
+2. Make the smallest change that satisfies \`SPEC.md\`.
+3. Preserve unrelated user/worktree changes.
+4. Keep decisions tied to evidence from files, tests, docs, or command output.
+5. Update packet evidence/status if the implementation changes readiness.
+6. At the Close phase, write a closeout reflection to
+   \`history/reflections/<YYYY-MM-DD>-<agent>.md\` via the \`/reflect\` skill;
+   \`bun run beep lint reflection-artifacts\` must pass.
+
+Acceptance:
+
+- [ ] \`SPEC.md\` acceptance criteria are satisfied.
+- [ ] Required verification commands pass, or unrelated failures are reproduced
+      and recorded separately.
+- [ ] No unrelated refactors or formatting churn.
+
+Verification:
+
+\`\`\`sh
+test "$(wc -m < goals/${input.slug}/GOAL.md)" -le 4000
+jq . goals/${input.slug}/ops/manifest.json
+git diff --check -- goals/${input.slug}
+\`\`\`
+
+Stop and report before changing public API, schema, data migration, auth, infra,
+security behavior, dependencies, lockfiles, generated files, or destructive
+state unless \`SPEC.md\` explicitly requires it.
+
+Done only when acceptance passes and verification is complete, or when a blocker
+is reported with file/command evidence.
+`;
+
+const specPayload = (input: BootstrapInput): string => `# ${input.title} Spec
+
+## Objective
+
+${input.mission}
+
+## Non-Goals
+
+- <Out-of-scope behavior, package, workflow, migration, or policy.>
+
+## Source Hierarchy
+
+1. User objective or issue that created this packet.
+2. \`AGENTS.md\`, \`CLAUDE.md\`, and required skills.
+3. Governing architecture/package standards.
+4. This \`SPEC.md\`.
+5. \`PLAN.md\`.
+6. \`GOAL.md\`.
+7. Supporting \`research/\`, \`ops/\`, and \`history/\` files.
+
+Higher sources outrank lower sources when they conflict.
+
+## Target Surfaces
+
+- <Package, app, docs, workflow, or artifact this goal may change.>
+
+## Constraints
+
+- <Hard requirement, boundary rule, compatibility concern, or quality bar.>
+
+## Acceptance Criteria
+
+- [ ] <Observable result that proves the goal is complete.>
+- [ ] No unrelated refactors or formatting churn.
+
+## Verification Matrix
+
+| Check | Command or evidence | Required result |
+| --- | --- | --- |
+| Packet launcher size | \`test "$(wc -m < goals/${input.slug}/GOAL.md)" -le 4000\` | Passes |
+| Manifest JSON | \`jq . goals/${input.slug}/ops/manifest.json\` | Passes |
+| Whitespace | \`git diff --check -- goals/${input.slug}\` | Passes |
+
+## Stop Conditions
+
+- Required source files are missing or materially contradictory.
+- The implementation would exceed named scope.
+- Verification requires credentials, cost, destructive side effects, or policy
+  approval not named in this spec.
+- The same blocker repeats after reasonable investigation.
+
+## Exception Ledger
+
+| Exception | Scope | Owner | Rationale | Removal condition |
+| --- | --- | --- | --- | --- |
+| None | N/A | N/A | N/A | N/A |
+`;
+
+const planPayload = (input: BootstrapInput): string => {
+  const rows = A.map(
+    archetypePhases(input.archetype),
+    (phase) => `| ${phase.id} ${phase.name} | pending | ${phase.planGoal} | ${phase.planExit} |`
+  );
+  return `# ${input.title} Plan
+
+## Status
+
+Status: \`pending\`
+
+## Phases
+
+| Phase | Status | Goal | Exit criteria |
+| --- | --- | --- | --- |
+${A.join(rows, "\n")}
+
+## Closeout Checklist
+
+Before marking the packet closed:
+
+1. Write a closeout reflection via the \`/reflect\` skill to
+   \`history/reflections/<YYYY-MM-DD>-<agent>.md\`. Its YAML frontmatter must
+   validate against \`ReflectionFrontmatter\`.
+2. Run \`bun run beep lint reflection-artifacts\`.
+3. Update \`README.md\` (status, latest evidence) and \`ops/manifest.json\` phase
+   statuses + \`initiative.status\`.
+
+## Execution Notes
+
+- Preserve unrelated worktree changes.
+- Keep \`SPEC.md\` normative and update it only when the contract changes.
+- Keep this plan current; archive old run outputs under \`history/\`.
+
+## Verification Commands
+
+\`\`\`sh
+test "$(wc -m < goals/${input.slug}/GOAL.md)" -le 4000
+jq . goals/${input.slug}/ops/manifest.json
+rg -n "${input.slug}|GOAL.md|agentLaunchers|packetAnchorDocument" goals/${input.slug}
+git diff --check -- goals/${input.slug}
+\`\`\`
+`;
+};
+
+const sourcesPayload = (input: BootstrapInput): string => {
+  const provenanceLines =
+    input.provenanceExploration === undefined
+      ? `- **Source exploration:** none — this goal was authored directly; build the
+  corpus during the first research phase.`
+      : `- **Source exploration:** \`explorations/${input.provenanceExploration}\` — primary ledger:
+  \`explorations/${input.provenanceExploration}/research/SOURCES.md\`.`;
+  return `# ${input.title} — Sources & Provenance
+
+${provenanceLines}
+
+## 1. Mined source corpus
+
+| Source | Title | Upstream (repo) | Location (\`file:line\`) | Theme | Disposition |
+|--------|-------|-----------------|------------------------|-------|-------------|
+
+## 2. Upstream repositories & licenses
+
+| Repo | License | Port discipline | What we take |
+|------|---------|-----------------|--------------|
+
+## 3. External research sources
+
+## 4. In-repo capability references
+
+## 5. Cross-links & provenance
+`;
+};
+
+/**
+ * One plain plan row assembled before schema-class wrapping.
+ *
+ * **Details**
+ *
+ * The compilers hash the plain-value projection of a plan (the rows below)
+ * before wrapping rows in schema classes, so the content address never
+ * depends on class construction details.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export type PlanRow = {
+  readonly path: string;
+  readonly action: PlanAction;
+  readonly ownership: PlanOwnership;
+  readonly reason: string;
+  readonly payload?: string;
+  readonly payloadDigest?: string;
+  readonly existingDigest?: string;
+};
+
+const createRow = (path: string, ownership: PlanOwnership, reason: string, payload: string): PlanRow => ({
+  path,
+  action: "create",
+  ownership,
+  reason,
+  payload,
+  payloadDigest: sha256Hex(payload),
+});
+
+const BOOTSTRAP_VALIDATIONS: ReadonlyArray<ValidationRequirement> = [
+  "manifest-decodes",
+  "doctor-clean",
+  "index-regenerates",
+  "readme-lifecycle-line",
+  "goal-md-within-budget",
+];
+
+/**
+ * Plain preservation row assembled before schema-class wrapping.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export type PreservationRow = {
+  readonly path: string;
+  readonly unmodeledKeys: ReadonlyArray<string>;
+  readonly preImageDigest: string;
+  readonly reason: string;
+};
+
+/**
+ * Plain conflict row assembled before schema-class wrapping.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export type ConflictRow = {
+  readonly reason: PlanConflictReason;
+  readonly message: string;
+};
+
+/**
+ * Seals plain plan fields into a content-addressed {@link MaterializationPlan}.
+ *
+ * **Details**
+ *
+ * The plan id is the SHA-256 of the compact canonical JSON of every field
+ * except the id itself, computed over the plain-value projection the compilers
+ * assemble before wrapping rows in schema classes. Both compilers share this
+ * one sealing path so bootstrap and adoption plans are addressed identically.
+ *
+ * **Example** (Seal an empty conflicted plan)
+ *
+ * ```ts
+ * import { sealMaterializationPlan } from "@beep/repo-cli/commands/Goals/Bootstrap"
+ *
+ * const plan = sealMaterializationPlan({
+ *   mode: "bootstrap",
+ *   slug: "x-goal",
+ *   packetPath: "goals/x-goal",
+ *   entries: [],
+ *   preservations: [],
+ *   validations: [],
+ *   conflicts: [{ reason: "slug-exists", message: "exists" }],
+ * })
+ * console.log(plan.planId.startsWith("goal-plan/v1:")) // true
+ * ```
+ *
+ * @param fields - The plain plan fields, without a plan id.
+ * @returns The sealed plan carrying its content address.
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const sealMaterializationPlan = (fields: {
+  readonly mode: PlanMode;
+  readonly slug: string;
+  readonly packetPath: string;
+  readonly entries: ReadonlyArray<PlanRow>;
+  readonly preservations: ReadonlyArray<PreservationRow>;
+  readonly validations: ReadonlyArray<ValidationRequirement>;
+  readonly conflicts: ReadonlyArray<ConflictRow>;
+  readonly towardArchetype?: PhaseArchetype;
+  readonly templateSnapshotHash?: string;
+}): MaterializationPlan => {
+  const preimage = canonicalJsonText({
+    schemaVersion: "goal-materialization-plan/v1",
+    compilerVersion: "goal-materialization-compiler/v1",
+    ...fields,
+  });
+  return MaterializationPlan.make({
+    planId: `goal-plan/v1:${sha256Hex(preimage)}`,
+    mode: fields.mode,
+    slug: fields.slug,
+    packetPath: fields.packetPath,
+    entries: A.map(fields.entries, (row) => PlanEntry.make(row)),
+    preservations: A.map(fields.preservations, (row) => PlanPreservation.make(row)),
+    validations: fields.validations,
+    conflicts: A.map(fields.conflicts, (row) => PlanConflict.make(row)),
+    ...(fields.towardArchetype === undefined ? {} : { towardArchetype: fields.towardArchetype }),
+    ...(fields.templateSnapshotHash === undefined ? {} : { templateSnapshotHash: fields.templateSnapshotHash }),
+  });
+};
+
+/**
+ * Compiles a bootstrap input into a content-addressed materialization plan.
+ *
+ * **Details**
+ *
+ * A pure total function: no `Effect`, no `FileSystem`, no requirements
+ * channel. The observed slug set is an explicit argument the command handler
+ * reads, so a `slug-exists` conflict is data the compiler emits — a conflicted
+ * plan carries no entries. Every `create` entry carries its complete payload
+ * bytes and digest, matching the ratified contract that the plan is the
+ * complete deterministic description of the intended change.
+ *
+ * **Example** (Compile a minimal plan)
+ *
+ * ```ts
+ * import { compileMaterializationPlan } from "@beep/repo-cli/commands/Goals/Bootstrap"
+ * import { BootstrapInput } from "@beep/repo-cli/commands/Goals/Bootstrap.schemas"
+ *
+ * const plan = compileMaterializationPlan(
+ *   BootstrapInput.make({
+ *     slug: "example-goal",
+ *     title: "Example Goal",
+ *     mission: "Prove the plan compiler.",
+ *     today: "2026-08-17",
+ *   }),
+ *   []
+ * )
+ * console.log(plan.conflicts.length) // 0
+ * ```
+ *
+ * @param input - The decoded bootstrap input; `today` is explicit, never a clock read.
+ * @param existingSlugs - Every packet slug currently under `goals/`.
+ * @returns The sealed plan; conflicted plans carry no entries.
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const compileMaterializationPlan: {
+  (input: BootstrapInput, existingSlugs: ReadonlyArray<string>): MaterializationPlan;
+  (existingSlugs: ReadonlyArray<string>): (input: BootstrapInput) => MaterializationPlan;
+} = dual(2, (input: BootstrapInput, existingSlugs: ReadonlyArray<string>): MaterializationPlan => {
+  const packetPath = `goals/${input.slug}`;
+  if (A.contains(existingSlugs, input.slug)) {
+    return sealMaterializationPlan({
+      mode: "bootstrap",
+      slug: input.slug,
+      packetPath,
+      entries: [],
+      preservations: [],
+      validations: [],
+      conflicts: [
+        {
+          reason: "slug-exists",
+          message: `Packet "${packetPath}" already exists; adopt it instead of bootstrapping over it.`,
+        },
+      ],
+    });
+  }
+
+  const entries: ReadonlyArray<PlanRow> = [
+    createRow(
+      `${packetPath}/ops/manifest.json`,
+      "generated",
+      "Every byte derives from the input and the archetype.",
+      manifestPayload(input)
+    ),
+    createRow(
+      `${packetPath}/README.md`,
+      "generated-seed",
+      "Written once from input; human-owned immediately after.",
+      readmePayload(input)
+    ),
+    createRow(
+      `${packetPath}/GOAL.md`,
+      "generated-seed",
+      "Written once from mission and scope inputs; human-owned immediately after.",
+      goalMdPayload(input)
+    ),
+    createRow(
+      `${packetPath}/SPEC.md`,
+      "generated-seed",
+      "Written once from input; human-owned immediately after.",
+      specPayload(input)
+    ),
+    createRow(
+      `${packetPath}/PLAN.md`,
+      "generated-seed",
+      "Written once from the archetype phase table; human-owned immediately after.",
+      planPayload(input)
+    ),
+    createRow(
+      `${packetPath}/research/SOURCES.md`,
+      "generated-seed",
+      "Written once from provenance inputs; human-owned immediately after.",
+      sourcesPayload(input)
+    ),
+    createRow(`${packetPath}/research/.gitkeep`, "generated", "Directory marker.", "\n"),
+    createRow(`${packetPath}/history/.gitkeep`, "generated", "Directory marker.", "\n"),
+    createRow(`${packetPath}/history/reflections/.gitkeep`, "generated", "Directory marker.", ""),
+    {
+      path: "goals/INDEX.md",
+      action: "report",
+      ownership: "generated",
+      reason:
+        "Disposable projection owned by producer://goals/index; regenerate with `bun run beep goals index --write` after publish.",
+    },
+  ];
+
+  return sealMaterializationPlan({
+    mode: "bootstrap",
+    slug: input.slug,
+    packetPath,
+    entries,
+    preservations: [],
+    validations: BOOTSTRAP_VALIDATIONS,
+    conflicts: [],
+  });
+});
+
+/**
+ * Renders a materialization plan as canonical pretty JSON.
+ *
+ * **Example** (Render a compiled plan)
+ *
+ * ```ts
+ * import { compileMaterializationPlan, renderMaterializationPlanJson } from "@beep/repo-cli/commands/Goals/Bootstrap"
+ * import { BootstrapInput } from "@beep/repo-cli/commands/Goals/Bootstrap.schemas"
+ * import { Effect } from "effect"
+ *
+ * const plan = compileMaterializationPlan(
+ *   BootstrapInput.make({ slug: "x-goal", title: "X", mission: "Y.", today: "2026-08-17" }),
+ *   []
+ * )
+ * console.log(Effect.isEffect(renderMaterializationPlanJson(plan))) // true
+ * ```
+ *
+ * @param plan - The sealed plan to render.
+ * @returns The canonical pretty JSON text with a trailing newline.
+ * @category formatting
+ * @since 0.0.0
+ */
+export const renderMaterializationPlanJson: (plan: MaterializationPlan) => Effect.Effect<string, S.SchemaError> =
+  Effect.fnUntraced(function* (plan: MaterializationPlan) {
+    const encoded = yield* S.encodeUnknownEffect(MaterializationPlan)(plan);
+    return canonicalJsonTextPretty(encoded);
+  });
+
+/**
+ * Renders a materialization plan for local human inspection.
+ *
+ * **Example** (Render headline counts)
+ *
+ * ```ts
+ * import { compileMaterializationPlan, renderMaterializationPlanHuman } from "@beep/repo-cli/commands/Goals/Bootstrap"
+ * import { BootstrapInput } from "@beep/repo-cli/commands/Goals/Bootstrap.schemas"
+ *
+ * const plan = compileMaterializationPlan(
+ *   BootstrapInput.make({ slug: "x-goal", title: "X", mission: "Y.", today: "2026-08-17" }),
+ *   []
+ * )
+ * console.log(renderMaterializationPlanHuman(plan).includes("plan-id:")) // true
+ * ```
+ *
+ * @param plan - The sealed plan to render.
+ * @returns One line per entry plus headline counts, conflicts, and validations.
+ * @category formatting
+ * @since 0.0.0
+ */
+export const renderMaterializationPlanHuman = (plan: MaterializationPlan): string => {
+  const entryLines = A.map(
+    plan.entries,
+    (entry) => `  ${entry.action} [${entry.ownership}] ${entry.path}: ${entry.reason}`
+  );
+  const preservationLines = A.map(
+    plan.preservations,
+    (preservation) =>
+      `  preserve-keys ${preservation.path}: ${A.join(preservation.unmodeledKeys, ", ")} (pre-image ${preservation.preImageDigest})`
+  );
+  const conflictLines = A.map(plan.conflicts, (conflict) => `  ${conflict.reason}: ${conflict.message}`);
+  return A.join(
+    [
+      `plan-id: ${plan.planId}`,
+      `mode: ${plan.mode} slug: ${plan.slug} packet: ${plan.packetPath}`,
+      `entries (${A.length(plan.entries)})`,
+      ...entryLines,
+      `preservations (${A.length(plan.preservations)})`,
+      ...preservationLines,
+      `validations: ${A.join(plan.validations, ", ")}`,
+      `conflicts (${A.length(plan.conflicts)})`,
+      ...conflictLines,
+    ],
+    "\n"
+  );
+};
+
+const slugFlag = Flag.string("slug").pipe(Flag.withDescription("New packet slug under goals/ (lowercase, hyphenated)"));
+const titleFlag = Flag.string("title").pipe(Flag.withDescription("Human title for the packet"));
+const missionFlag = Flag.string("mission").pipe(
+  Flag.withDescription("One-line mission shown in the generated goals/INDEX.md")
+);
+const archetypeFlag = Flag.choice("archetype", PhaseArchetype.Options).pipe(
+  Flag.withDefault(PhaseArchetype.Enum["standard-delivery"]),
+  Flag.withDescription("Ordered phase shape: standard-delivery (template phases) or report-first")
+);
+const providesFlag = Flag.string("provides").pipe(
+  Flag.optional,
+  Flag.withDescription("Comma-separated capability slugs this packet provides (namespace/name)")
+);
+const requiresFlag = Flag.string("requires").pipe(
+  Flag.optional,
+  Flag.withDescription("Comma-separated capability slugs this packet requires (namespace/name)")
+);
+const fromExplorationFlag = Flag.string("from-exploration").pipe(
+  Flag.optional,
+  Flag.withDescription("Source exploration slug recorded as provenance")
+);
+const todayFlag = Flag.string("today").pipe(
+  Flag.optional,
+  Flag.withDescription("Explicit ISO date (YYYY-MM-DD) for deterministic plans; defaults to the current date")
+);
+const planFlag = Flag.boolean("plan").pipe(
+  Flag.withDescription("Compile and print the materialization plan (the only mode this slice ships)")
+);
+const jsonFlag = Flag.boolean("json").pipe(Flag.withDescription("Print the plan as canonical JSON"));
+
+const parseCapabilityList = (label: string, raw: O.Option<string>) =>
+  Effect.forEach(
+    O.match(raw, {
+      onNone: A.empty<string>,
+      onSome: (text) => A.filter(A.map(Str.split(",")(text), Str.trim), Str.isNonEmpty),
+    }),
+    (candidate) =>
+      isCapabilitySlug(candidate)
+        ? Effect.succeed<CapabilitySlug>(candidate)
+        : Effect.fail(
+            GoalPlanInputError.new(`--${label} entry "${candidate}" is not a namespace/name capability slug.`)
+          )
+  );
+
+const resolveToday = (raw: O.Option<string>) =>
+  O.match(raw, {
+    onNone: () => Effect.map(DateTime.now, DateTime.formatIsoDate),
+    onSome: (text) =>
+      /^\d{4}-\d{2}-\d{2}$/.test(text)
+        ? Effect.succeed(text)
+        : Effect.fail(GoalPlanInputError.new(`--today "${text}" is not an ISO date (YYYY-MM-DD).`)),
+  });
+
+const decodeSlug = (raw: string) =>
+  S.decodeEffect(GoalSlug)(raw).pipe(
+    Effect.mapError((issue) => GoalPlanInputError.new(`--slug "${raw}" is invalid: ${issue.message}`))
+  );
+
+/**
+ * Prints a compiled plan and fails closed when it carries conflicts.
+ *
+ * **Details**
+ *
+ * The plan is always printed before any failure is raised, so the operator
+ * sees the conflicts alongside the non-zero exit — the same report-then-gate
+ * shape the knowledge semantic-delta command uses.
+ *
+ * **Example** (Reference the reporter)
+ *
+ * ```ts
+ * import { reportMaterializationPlan } from "@beep/repo-cli/commands/Goals/Bootstrap"
+ *
+ * console.log(typeof reportMaterializationPlan) // "function"
+ * ```
+ *
+ * @param plan - The sealed plan to print.
+ * @param json - Print canonical JSON instead of the human rendering.
+ * @returns Void on a conflict-free plan; a reported non-zero exit otherwise.
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const reportMaterializationPlan = Effect.fn("Goals.reportMaterializationPlan")(function* (
+  plan: MaterializationPlan,
+  json: boolean
+) {
+  if (json) {
+    const rendered = yield* renderMaterializationPlanJson(plan).pipe(
+      Effect.mapError((issue) => GoalPlanInputError.new(`Failed to encode the plan: ${issue.message}`))
+    );
+    yield* Console.log(rendered);
+  } else {
+    yield* Console.log(renderMaterializationPlanHuman(plan));
+  }
+  if (A.isReadonlyArrayNonEmpty(plan.conflicts)) {
+    return yield* failWithReportedExit(`goals ${plan.mode}: ${A.length(plan.conflicts)} conflict(s).`);
+  }
+});
+
+const runBootstrapPlan = Effect.fn("Goals.runBootstrapPlan")(function* (options: {
+  readonly slug: string;
+  readonly title: string;
+  readonly mission: string;
+  readonly archetype: PhaseArchetype;
+  readonly provides: O.Option<string>;
+  readonly requires: O.Option<string>;
+  readonly fromExploration: O.Option<string>;
+  readonly today: O.Option<string>;
+  readonly plan: boolean;
+  readonly json: boolean;
+}) {
+  if (!options.plan) {
+    return yield* GoalPlanInputError.new(
+      "Phase 0 ships plan-only commands; pass --plan (no writer exists to omit it for)."
+    );
+  }
+  const slug = yield* decodeSlug(options.slug);
+  const provides = yield* parseCapabilityList("provides", options.provides);
+  const requires = yield* parseCapabilityList("requires", options.requires);
+  // The GoalManifest schema rejects self-cycles; refusing here keeps the plan's
+  // own manifest-decodes validation satisfiable by construction.
+  const selfCycles = A.intersection(provides, requires);
+  if (A.isReadonlyArrayNonEmpty(selfCycles)) {
+    return yield* GoalPlanInputError.new(
+      `--provides and --requires share ${A.join(selfCycles, ", ")}; a manifest cannot self-cycle a capability.`
+    );
+  }
+  const today = yield* resolveToday(options.today);
+  const input = BootstrapInput.make({
+    slug,
+    title: options.title,
+    mission: options.mission,
+    archetype: options.archetype,
+    provides,
+    requires,
+    ...(O.isSome(options.fromExploration) ? { provenanceExploration: options.fromExploration.value } : {}),
+    today,
+  });
+  const records = yield* listGoalPackets();
+  const plan = compileMaterializationPlan(
+    input,
+    A.map(records, (record) => record.slug)
+  );
+  yield* reportMaterializationPlan(plan, options.json);
+});
+
+/**
+ * `bun run beep goals bootstrap` — compile and print a packet materialization plan.
+ *
+ * **Example** (Log command name)
+ *
+ * ```ts
+ * import { goalsBootstrapCommand } from "@beep/repo-cli/commands/Goals/Bootstrap"
+ *
+ * console.log(goalsBootstrapCommand.name)
+ * ```
+ *
+ * @category commands
+ * @since 0.0.0
+ */
+export const goalsBootstrapCommand = Command.make(
+  "bootstrap",
+  {
+    slug: slugFlag,
+    title: titleFlag,
+    mission: missionFlag,
+    archetype: archetypeFlag,
+    provides: providesFlag,
+    requires: requiresFlag,
+    fromExploration: fromExplorationFlag,
+    today: todayFlag,
+    plan: planFlag,
+    json: jsonFlag,
+  },
+  Effect.fn(function* (options) {
+    return yield* runBootstrapPlan(options).pipe(
+      Effect.catchTag(
+        "GoalPlanInputError",
+        Effect.fn(function* (error) {
+          yield* Console.error(`[goals:bootstrap] ${error.message}`);
+          return yield* failWithReportedExit(`goals bootstrap: ${error.message}`);
+        })
+      )
+    );
+  })
+).pipe(Command.withDescription("Compile the read-only packet materialization plan (--plan --json); no writer exists"));

--- a/packages/tooling/tool/cli/src/commands/Goals/Bootstrap.ts
+++ b/packages/tooling/tool/cli/src/commands/Goals/Bootstrap.ts
@@ -34,13 +34,7 @@ import { GoalPlanInputError } from "./Goals.errors.ts";
 import { isCapabilitySlug } from "./Goals.schemas.ts";
 import { listGoalPackets } from "./Inventory.ts";
 import { canonicalJsonText, canonicalJsonTextPretty, sha256Hex } from "./PacketCore/PacketDigest.ts";
-import type {
-  PlanAction,
-  PlanConflictReason,
-  PlanMode,
-  PlanOwnership,
-  ValidationRequirement,
-} from "./Bootstrap.schemas.ts";
+import type { PlanMode, PlanOwnership, ValidationRequirement } from "./Bootstrap.schemas.ts";
 import type { CapabilitySlug } from "./Goals.schemas.ts";
 
 const COMPLETION_GATE_STATEMENT =
@@ -458,22 +452,15 @@ ${provenanceLines}
  *
  * **Details**
  *
- * The compilers hash the plain-value projection of a plan (the rows below)
- * before wrapping rows in schema classes, so the content address never
- * depends on class construction details.
+ * The compilers hash the plain-value projection of a plan (the encoded row
+ * shape) before wrapping rows in schema classes, so the content address never
+ * depends on class construction details. The alias is derived from
+ * {@link PlanEntry}'s encoded side, so it cannot drift from the schema.
  *
  * @category models
  * @since 0.0.0
  */
-export type PlanRow = {
-  readonly path: string;
-  readonly action: PlanAction;
-  readonly ownership: PlanOwnership;
-  readonly reason: string;
-  readonly payload?: string;
-  readonly payloadDigest?: string;
-  readonly existingDigest?: string;
-};
+export type PlanRow = typeof PlanEntry.Encoded;
 
 const createRow = (path: string, ownership: PlanOwnership, reason: string, payload: string): PlanRow => ({
   path,
@@ -495,26 +482,28 @@ const BOOTSTRAP_VALIDATIONS: ReadonlyArray<ValidationRequirement> = [
 /**
  * Plain preservation row assembled before schema-class wrapping.
  *
- * @category models
- * @since 0.0.0
- */
-export type PreservationRow = {
-  readonly path: string;
-  readonly unmodeledKeys: ReadonlyArray<string>;
-  readonly preImageDigest: string;
-  readonly reason: string;
-};
-
-/**
- * Plain conflict row assembled before schema-class wrapping.
+ * **Details**
+ *
+ * Derived from {@link PlanPreservation}'s encoded side, so it cannot drift
+ * from the schema.
  *
  * @category models
  * @since 0.0.0
  */
-export type ConflictRow = {
-  readonly reason: PlanConflictReason;
-  readonly message: string;
-};
+export type PreservationRow = typeof PlanPreservation.Encoded;
+
+/**
+ * Plain conflict row assembled before schema-class wrapping.
+ *
+ * **Details**
+ *
+ * Derived from {@link PlanConflict}'s encoded side, so it cannot drift from
+ * the schema.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export type ConflictRow = typeof PlanConflict.Encoded;
 
 /**
  * Seals plain plan fields into a content-addressed {@link MaterializationPlan}.

--- a/packages/tooling/tool/cli/src/commands/Goals/Goals.command.ts
+++ b/packages/tooling/tool/cli/src/commands/Goals/Goals.command.ts
@@ -11,6 +11,8 @@
 
 import { Command } from "effect/unstable/cli";
 import { printLines } from "../../internal/cli/Printer.ts";
+import { goalsAdoptCommand } from "./Adopt.ts";
+import { goalsBootstrapCommand } from "./Bootstrap.ts";
 import { goalsDoctorCommand } from "./Doctor.ts";
 import { goalsIndexCommand } from "./PortfolioIndex.ts";
 import { goalsSetStatusCommand } from "./SetStatus.ts";
@@ -36,8 +38,16 @@ export const goalsCommand = Command.make("goals", {}, () =>
     "- bun run beep goals index [--write | --check]",
     "- bun run beep goals set-status <slug> <status>",
     "- bun run beep goals set-status --migrate [--write]",
+    "- bun run beep goals bootstrap --slug <slug> --title <t> --mission <m> --plan [--json]",
+    "- bun run beep goals adopt <slug> --plan [--json] [--toward <archetype>]",
   ])
 ).pipe(
-  Command.withDescription("Goal-packet lifecycle tooling (doctor, index, set-status)"),
-  Command.withSubcommands([goalsDoctorCommand, goalsIndexCommand, goalsSetStatusCommand])
+  Command.withDescription("Goal-packet lifecycle tooling (doctor, index, set-status, bootstrap, adopt)"),
+  Command.withSubcommands([
+    goalsDoctorCommand,
+    goalsIndexCommand,
+    goalsSetStatusCommand,
+    goalsBootstrapCommand,
+    goalsAdoptCommand,
+  ])
 );

--- a/packages/tooling/tool/cli/src/commands/Goals/Goals.errors.ts
+++ b/packages/tooling/tool/cli/src/commands/Goals/Goals.errors.ts
@@ -184,3 +184,77 @@ export class GoalStatusInputError extends S.TaggedError<GoalStatusInputError>($I
 ) {
   static readonly new = (message: string): GoalStatusInputError => GoalStatusInputError.make({ message });
 }
+
+/**
+ * Failure raised when `beep goals bootstrap` or `beep goals adopt` receives
+ * input outside the plan-input domain.
+ *
+ * **Details**
+ *
+ * Covers a missing `--plan` flag (phase 0 ships plan-only commands), a slug
+ * outside the `GoalSlug` grammar, a malformed `--today` date, and a capability
+ * list entry outside the capability-slug grammar. Environment facts about the packet tree (an existing slug, a
+ * missing packet) are `PlanConflict` rows inside the compiled plan, never this
+ * error.
+ *
+ * **Example** (Create plan-input error)
+ *
+ * ```ts
+ * import { GoalPlanInputError } from "@beep/repo-cli/commands/Goals/Goals.errors"
+ *
+ * const error = GoalPlanInputError.new('Unknown archetype "waterfall".')
+ * console.log(error.message)
+ * ```
+ *
+ * @category errors
+ * @since 0.0.0
+ */
+export class GoalPlanInputError extends S.TaggedError<GoalPlanInputError>($I`GoalPlanInputError`)(
+  "GoalPlanInputError",
+  {
+    message: S.String,
+  },
+  $I.annote("GoalPlanInputError", {
+    description: "Invalid input for beep goals bootstrap/adopt plan compilation.",
+  })
+) {
+  static readonly new = (message: string): GoalPlanInputError => GoalPlanInputError.make({ message });
+}
+
+/**
+ * Failure raised when a packet snapshot read cannot be completed.
+ *
+ * **Details**
+ *
+ * `readPacketSnapshot` only ever reads, but a directory entry that vanishes or
+ * a file that cannot be read leaves the snapshot unverifiable; adoption plans
+ * over unverifiable state could misclassify authored files as absent, so the
+ * read fails closed with this error instead of degrading.
+ *
+ * **Example** (Create plan-operational error)
+ *
+ * ```ts
+ * import { GoalPlanOperationalError } from "@beep/repo-cli/commands/Goals/Goals.errors"
+ *
+ * const error = GoalPlanOperationalError.new('Failed to read "goals/x/SPEC.md".')(new Error("EACCES"))
+ * console.log(error.message)
+ * ```
+ *
+ * @category errors
+ * @since 0.0.0
+ */
+export class GoalPlanOperationalError extends S.TaggedError<GoalPlanOperationalError>($I`GoalPlanOperationalError`)(
+  "GoalPlanOperationalError",
+  {
+    message: S.String,
+    cause: S.optionalKey(S.Defect({ includeStack: true })),
+  },
+  $I.annote("GoalPlanOperationalError", {
+    description: "A packet-snapshot read failure that must fail plan compilation closed.",
+  })
+) {
+  static readonly new =
+    (message: string): ((cause: unknown) => GoalPlanOperationalError) =>
+    (cause: unknown) =>
+      GoalPlanOperationalError.make({ message, cause });
+}

--- a/packages/tooling/tool/cli/src/commands/Goals/PacketCore/PacketDigest.ts
+++ b/packages/tooling/tool/cli/src/commands/Goals/PacketCore/PacketDigest.ts
@@ -172,6 +172,30 @@ export const canonicalJsonTextPretty = (value: unknown): string => `${canonicalA
  */
 export const sha256Hex = (text: string): string => createHash("sha256").update(text).digest("hex");
 
+/**
+ * Compute the lowercase sha-256 hex digest of exact bytes.
+ *
+ * **Details**
+ *
+ * Digesting decoded text is lossy for non-UTF-8 content (invalid sequences
+ * collapse to U+FFFD), so hash-pinning file contents must digest the raw bytes
+ * — this variant matches what external `sha256sum` tooling reports.
+ *
+ * **Example** (Digest empty bytes)
+ *
+ * ```ts
+ * import { sha256HexBytes } from "@beep/repo-cli/test/Goals"
+ *
+ * console.log(sha256HexBytes(new Uint8Array()).length) // 64
+ * ```
+ *
+ * @param bytes - Exact bytes to digest.
+ * @returns Lowercase 64-character hex digest.
+ * @category encoding
+ * @since 0.0.0
+ */
+export const sha256HexBytes = (bytes: Uint8Array): string => createHash("sha256").update(bytes).digest("hex");
+
 const encodePacketEvent = S.encodeUnknownEffect(PacketEvent);
 
 /**

--- a/packages/tooling/tool/cli/src/commands/Goals/index.ts
+++ b/packages/tooling/tool/cli/src/commands/Goals/index.ts
@@ -6,6 +6,27 @@
  */
 
 /**
+ * Read-only adoption snapshot, pure adoption compiler, and adopt command.
+ *
+ * @category cli-commands
+ * @since 0.0.0
+ */
+export * from "./Adopt.ts";
+/**
+ * Materialization-plan schema surface.
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export * from "./Bootstrap.schemas.ts";
+/**
+ * Pure bootstrap plan compiler and bootstrap command.
+ *
+ * @category cli-commands
+ * @since 0.0.0
+ */
+export * from "./Bootstrap.ts";
+/**
  * Doctor command and baseline-ratchet exports.
  *
  * @category cli-commands

--- a/packages/tooling/tool/cli/src/test/Goals.test-kit.ts
+++ b/packages/tooling/tool/cli/src/test/Goals.test-kit.ts
@@ -5,6 +5,9 @@
  * @since 0.0.0
  */
 
+export * from "@beep/repo-cli/commands/Goals/Adopt";
+export * from "@beep/repo-cli/commands/Goals/Bootstrap";
+export * from "@beep/repo-cli/commands/Goals/Bootstrap.schemas";
 export * from "@beep/repo-cli/commands/Goals/Doctor";
 export * from "@beep/repo-cli/commands/Goals/Goals.command";
 export * from "@beep/repo-cli/commands/Goals/Goals.errors";

--- a/packages/tooling/tool/cli/test/fixtures/goals-plan/bootstrap-full.json
+++ b/packages/tooling/tool/cli/test/fixtures/goals-plan/bootstrap-full.json
@@ -1,0 +1,97 @@
+{
+  "compilerVersion": "goal-materialization-compiler/v1",
+  "conflicts": [],
+  "entries": [
+    {
+      "action": "create",
+      "ownership": "generated",
+      "path": "goals/full-example-goal/ops/manifest.json",
+      "payload": "{\n  \"schemaVersion\": \"initiative-manifest/v2\",\n  \"initiative\": {\n    \"id\": \"full-example-goal\",\n    \"packetId\": \"goal-packet/v1:93f6cca8d5e523455b2579e3202adc3ea1d98457d5fefaaa48df08b9e7e7ec3b\",\n    \"title\": \"Full Example Goal\",\n    \"status\": \"active\",\n    \"created\": \"2026-08-17\",\n    \"updated\": \"2026-08-17\",\n    \"packetAnchorDocument\": \"SPEC.md\"\n  },\n  \"packetPath\": \"goals/full-example-goal\",\n  \"lifecycle\": \"active\",\n  \"mission\": \"Prove the fully populated plan compiler.\",\n  \"executionCapable\": true,\n  \"reflectionRequired\": true,\n  \"provenance\": {\n    \"exploration\": \"explorations/plan-compiler-exploration\",\n    \"graduated\": \"2026-08-17\"\n  },\n  \"completionGate\": {\n    \"operator\": \"yeet\",\n    \"requiresPullRequest\": true,\n    \"requiresMergeable\": true,\n    \"statement\": \"Not achieved until this goal's work ships as a PR driven to mergeable via /yeet (bun run beep yeet: repair -> verify -> publish --pr -> monitor).\",\n    \"grandfathered\": false\n  },\n  \"currentSourceOfTruth\": [\n    \"AGENTS.md\",\n    \"CLAUDE.md\",\n    \"goals/full-example-goal/README.md\",\n    \"goals/full-example-goal/SPEC.md\",\n    \"goals/full-example-goal/PLAN.md\",\n    \"goals/full-example-goal/GOAL.md\",\n    \"goals/full-example-goal/research/SOURCES.md\"\n  ],\n  \"researchReports\": [\n    \"research/SOURCES.md\"\n  ],\n  \"agentLaunchers\": [\n    {\n      \"kind\": \"codex-goal\",\n      \"path\": \"GOAL.md\",\n      \"targetChars\": 3500,\n      \"maxChars\": 4000,\n      \"command\": \"/goal follow the instructions in goals/full-example-goal/GOAL.md\"\n    }\n  ],\n  \"provides\": [\n    \"goals/bootstrap\"\n  ],\n  \"requires\": [\n    \"knowledge/doctor\"\n  ],\n  \"phases\": [\n    {\n      \"id\": \"P0\",\n      \"name\": \"Research\",\n      \"status\": \"pending\"\n    },\n    {\n      \"id\": \"P1\",\n      \"name\": \"Implement\",\n      \"status\": \"pending\"\n    },\n    {\n      \"id\": \"P2\",\n      \"name\": \"Verify\",\n      \"status\": \"pending\"\n    },\n    {\n      \"id\": \"P3\",\n      \"name\": \"Yeet: PR to mergeable\",\n      \"status\": \"pending\"\n    },\n    {\n      \"id\": \"P4\",\n      \"name\": \"Close\",\n      \"status\": \"pending\"\n    }\n  ],\n  \"verificationCommands\": [\n    \"test \\\"$(wc -m < goals/full-example-goal/GOAL.md)\\\" -le 4000\",\n    \"jq . goals/full-example-goal/ops/manifest.json\",\n    \"rg -n \\\"full-example-goal|GOAL.md|agentLaunchers|packetAnchorDocument\\\" goals/full-example-goal\",\n    \"git diff --check -- goals/full-example-goal\",\n    \"bun run beep lint reflection-artifacts\"\n  ],\n  \"stopConditions\": [\n    \"Required source files are missing or materially contradictory.\",\n    \"The implementation would exceed named scope.\",\n    \"Verification requires unnamed credentials, cost, destructive side effects, or policy approval.\",\n    \"The same blocker repeats after reasonable investigation.\"\n  ]\n}\n",
+      "payloadDigest": "25b7e8716153667c4562330cb36c0968f2a9305f8707e77178825f98047da7ff",
+      "reason": "Every byte derives from the input and the archetype."
+    },
+    {
+      "action": "create",
+      "ownership": "generated-seed",
+      "path": "goals/full-example-goal/README.md",
+      "payload": "# Full Example Goal\n\n## Status\n\nLifecycle: `active`\n\nSource: [`ops/manifest.json`](./ops/manifest.json)\n\n## Mission\n\nProve the fully populated plan compiler.\n\n## Launch\n\nUse this command for execution-capable sessions:\n\n```text\n/goal follow the instructions in goals/full-example-goal/GOAL.md\n```\n\n`GOAL.md` is the compact launcher. `SPEC.md` remains the normative contract.\n\n## Read This First\n\n1. [`GOAL.md`](./GOAL.md) - compact `/goal` launcher.\n2. [`SPEC.md`](./SPEC.md) - normative source of truth.\n3. [`PLAN.md`](./PLAN.md) - active execution plan.\n4. [`ops/manifest.json`](./ops/manifest.json) - machine-readable routing.\n5. [`research/`](./research/) - supporting research, if present.\n6. [`history/`](./history/) - evidence and closeouts, if present.\n\n## Current Phase\n\nP0 Research — not started.\n\n## Latest Evidence\n\nNot started.\n\n## Notes\n\n<Record high-signal constraints or resume notes that do not belong in the\nnormative spec.>\n",
+      "payloadDigest": "86192491365e35b39959b055eb55e8acc5b123354e748595f2f0ecfb5895c569",
+      "reason": "Written once from input; human-owned immediately after."
+    },
+    {
+      "action": "create",
+      "ownership": "generated-seed",
+      "path": "goals/full-example-goal/GOAL.md",
+      "payload": "# GOAL: Full Example Goal\n\nRepo root: the current working directory — the `beep-effect` checkout you are\nrunning in. Do not assume an absolute path; several checkouts exist. All paths\nbelow are repo-relative.\n\nOutcome: Prove the fully populated plan compiler.\n\nThis is a compact `/goal` launcher. Treat the packet files as the detailed\ncontract:\n\n- `goals/full-example-goal/README.md`\n- `goals/full-example-goal/SPEC.md`\n- `goals/full-example-goal/PLAN.md`\n- `goals/full-example-goal/ops/manifest.json`\n\nRead those first, then read `AGENTS.md`, `CLAUDE.md`, and any governing\nstandards named by `SPEC.md`. Higher-priority repo standards outrank packet\nprose when they conflict.\n\nScope:\n\n- In: <paths, packages, docs, workflows, or artifacts this goal may change>.\n- Out: <non-goals and areas not to touch>.\n\nWorkflow:\n\n1. Inspect referenced files and current repo state.\n2. Make the smallest change that satisfies `SPEC.md`.\n3. Preserve unrelated user/worktree changes.\n4. Keep decisions tied to evidence from files, tests, docs, or command output.\n5. Update packet evidence/status if the implementation changes readiness.\n6. At the Close phase, write a closeout reflection to\n   `history/reflections/<YYYY-MM-DD>-<agent>.md` via the `/reflect` skill;\n   `bun run beep lint reflection-artifacts` must pass.\n\nAcceptance:\n\n- [ ] `SPEC.md` acceptance criteria are satisfied.\n- [ ] Required verification commands pass, or unrelated failures are reproduced\n      and recorded separately.\n- [ ] No unrelated refactors or formatting churn.\n\nVerification:\n\n```sh\ntest \"$(wc -m < goals/full-example-goal/GOAL.md)\" -le 4000\njq . goals/full-example-goal/ops/manifest.json\ngit diff --check -- goals/full-example-goal\n```\n\nStop and report before changing public API, schema, data migration, auth, infra,\nsecurity behavior, dependencies, lockfiles, generated files, or destructive\nstate unless `SPEC.md` explicitly requires it.\n\nDone only when acceptance passes and verification is complete, or when a blocker\nis reported with file/command evidence.\n",
+      "payloadDigest": "7a5f4a12470530e417ae377d3b3dccf1ffb4849d5163b19ff47277e4e5bbab9a",
+      "reason": "Written once from mission and scope inputs; human-owned immediately after."
+    },
+    {
+      "action": "create",
+      "ownership": "generated-seed",
+      "path": "goals/full-example-goal/SPEC.md",
+      "payload": "# Full Example Goal Spec\n\n## Objective\n\nProve the fully populated plan compiler.\n\n## Non-Goals\n\n- <Out-of-scope behavior, package, workflow, migration, or policy.>\n\n## Source Hierarchy\n\n1. User objective or issue that created this packet.\n2. `AGENTS.md`, `CLAUDE.md`, and required skills.\n3. Governing architecture/package standards.\n4. This `SPEC.md`.\n5. `PLAN.md`.\n6. `GOAL.md`.\n7. Supporting `research/`, `ops/`, and `history/` files.\n\nHigher sources outrank lower sources when they conflict.\n\n## Target Surfaces\n\n- <Package, app, docs, workflow, or artifact this goal may change.>\n\n## Constraints\n\n- <Hard requirement, boundary rule, compatibility concern, or quality bar.>\n\n## Acceptance Criteria\n\n- [ ] <Observable result that proves the goal is complete.>\n- [ ] No unrelated refactors or formatting churn.\n\n## Verification Matrix\n\n| Check | Command or evidence | Required result |\n| --- | --- | --- |\n| Packet launcher size | `test \"$(wc -m < goals/full-example-goal/GOAL.md)\" -le 4000` | Passes |\n| Manifest JSON | `jq . goals/full-example-goal/ops/manifest.json` | Passes |\n| Whitespace | `git diff --check -- goals/full-example-goal` | Passes |\n\n## Stop Conditions\n\n- Required source files are missing or materially contradictory.\n- The implementation would exceed named scope.\n- Verification requires credentials, cost, destructive side effects, or policy\n  approval not named in this spec.\n- The same blocker repeats after reasonable investigation.\n\n## Exception Ledger\n\n| Exception | Scope | Owner | Rationale | Removal condition |\n| --- | --- | --- | --- | --- |\n| None | N/A | N/A | N/A | N/A |\n",
+      "payloadDigest": "3291ee73c39a0ebb41981c8a0f2e20bf82457645d36c0e53f9eb9455021b63e7",
+      "reason": "Written once from input; human-owned immediately after."
+    },
+    {
+      "action": "create",
+      "ownership": "generated-seed",
+      "path": "goals/full-example-goal/PLAN.md",
+      "payload": "# Full Example Goal Plan\n\n## Status\n\nStatus: `pending`\n\n## Phases\n\n| Phase | Status | Goal | Exit criteria |\n| --- | --- | --- | --- |\n| P0 Research | pending | Inspect source hierarchy and confirm scope. | Required facts and blockers are recorded. |\n| P1 Implement | pending | Make the smallest changes that satisfy `SPEC.md`. | Acceptance criteria are met. |\n| P2 Verify | pending | Run required checks and capture evidence. | Verification is green or blockers are documented. |\n| P3 Yeet: PR to mergeable | pending | Publish through yeet and drive the PR to mergeable: required checks green, review comments answered and resolved. | `mergeStateStatus` is `CLEAN`; zero unresolved review threads. |\n| P4 Close | pending | Write the closeout reflection and flip packet state. | Packet status and evidence are updated; a closeout reflection exists. |\n\n## Closeout Checklist\n\nBefore marking the packet closed:\n\n1. Write a closeout reflection via the `/reflect` skill to\n   `history/reflections/<YYYY-MM-DD>-<agent>.md`. Its YAML frontmatter must\n   validate against `ReflectionFrontmatter`.\n2. Run `bun run beep lint reflection-artifacts`.\n3. Update `README.md` (status, latest evidence) and `ops/manifest.json` phase\n   statuses + `initiative.status`.\n\n## Execution Notes\n\n- Preserve unrelated worktree changes.\n- Keep `SPEC.md` normative and update it only when the contract changes.\n- Keep this plan current; archive old run outputs under `history/`.\n\n## Verification Commands\n\n```sh\ntest \"$(wc -m < goals/full-example-goal/GOAL.md)\" -le 4000\njq . goals/full-example-goal/ops/manifest.json\nrg -n \"full-example-goal|GOAL.md|agentLaunchers|packetAnchorDocument\" goals/full-example-goal\ngit diff --check -- goals/full-example-goal\n```\n",
+      "payloadDigest": "43f241bf2f9082850115768406b94d6f346a135bb37b4f0dc6b337f74b739cd1",
+      "reason": "Written once from the archetype phase table; human-owned immediately after."
+    },
+    {
+      "action": "create",
+      "ownership": "generated-seed",
+      "path": "goals/full-example-goal/research/SOURCES.md",
+      "payload": "# Full Example Goal — Sources & Provenance\n\n- **Source exploration:** `explorations/plan-compiler-exploration` — primary ledger:\n  `explorations/plan-compiler-exploration/research/SOURCES.md`.\n\n## 1. Mined source corpus\n\n| Source | Title | Upstream (repo) | Location (`file:line`) | Theme | Disposition |\n|--------|-------|-----------------|------------------------|-------|-------------|\n\n## 2. Upstream repositories & licenses\n\n| Repo | License | Port discipline | What we take |\n|------|---------|-----------------|--------------|\n\n## 3. External research sources\n\n## 4. In-repo capability references\n\n## 5. Cross-links & provenance\n",
+      "payloadDigest": "4b2138b7cb2fd500a5b84bd4501aacb21c23edb43da0f4497b5f112ff9a1181c",
+      "reason": "Written once from provenance inputs; human-owned immediately after."
+    },
+    {
+      "action": "create",
+      "ownership": "generated",
+      "path": "goals/full-example-goal/research/.gitkeep",
+      "payload": "\n",
+      "payloadDigest": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+      "reason": "Directory marker."
+    },
+    {
+      "action": "create",
+      "ownership": "generated",
+      "path": "goals/full-example-goal/history/.gitkeep",
+      "payload": "\n",
+      "payloadDigest": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+      "reason": "Directory marker."
+    },
+    {
+      "action": "create",
+      "ownership": "generated",
+      "path": "goals/full-example-goal/history/reflections/.gitkeep",
+      "payload": "",
+      "payloadDigest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "reason": "Directory marker."
+    },
+    {
+      "action": "report",
+      "ownership": "generated",
+      "path": "goals/INDEX.md",
+      "reason": "Disposable projection owned by producer://goals/index; regenerate with `bun run beep goals index --write` after publish."
+    }
+  ],
+  "mode": "bootstrap",
+  "packetPath": "goals/full-example-goal",
+  "planId": "goal-plan/v1:dc728a38aea66bf6dd69c7e4bcebee4d66ce5335c8fac7033966d6a31c102809",
+  "preservations": [],
+  "schemaVersion": "goal-materialization-plan/v1",
+  "slug": "full-example-goal",
+  "validations": [
+    "manifest-decodes",
+    "doctor-clean",
+    "index-regenerates",
+    "readme-lifecycle-line",
+    "goal-md-within-budget"
+  ]
+}

--- a/packages/tooling/tool/cli/test/fixtures/goals-plan/bootstrap-minimal.json
+++ b/packages/tooling/tool/cli/test/fixtures/goals-plan/bootstrap-minimal.json
@@ -1,0 +1,97 @@
+{
+  "compilerVersion": "goal-materialization-compiler/v1",
+  "conflicts": [],
+  "entries": [
+    {
+      "action": "create",
+      "ownership": "generated",
+      "path": "goals/example-goal/ops/manifest.json",
+      "payload": "{\n  \"schemaVersion\": \"initiative-manifest/v2\",\n  \"initiative\": {\n    \"id\": \"example-goal\",\n    \"packetId\": \"goal-packet/v1:6f63ced5c54def818790e27cc90babb4b7456fbb8007309645f6cc3bc7dbcca2\",\n    \"title\": \"Example Goal\",\n    \"status\": \"active\",\n    \"created\": \"2026-08-17\",\n    \"updated\": \"2026-08-17\",\n    \"packetAnchorDocument\": \"SPEC.md\"\n  },\n  \"packetPath\": \"goals/example-goal\",\n  \"lifecycle\": \"active\",\n  \"mission\": \"Prove the plan compiler.\",\n  \"executionCapable\": true,\n  \"reflectionRequired\": true,\n  \"completionGate\": {\n    \"operator\": \"yeet\",\n    \"requiresPullRequest\": true,\n    \"requiresMergeable\": true,\n    \"statement\": \"Not achieved until this goal's work ships as a PR driven to mergeable via /yeet (bun run beep yeet: repair -> verify -> publish --pr -> monitor).\",\n    \"grandfathered\": false\n  },\n  \"currentSourceOfTruth\": [\n    \"AGENTS.md\",\n    \"CLAUDE.md\",\n    \"goals/example-goal/README.md\",\n    \"goals/example-goal/SPEC.md\",\n    \"goals/example-goal/PLAN.md\",\n    \"goals/example-goal/GOAL.md\",\n    \"goals/example-goal/research/SOURCES.md\"\n  ],\n  \"researchReports\": [\n    \"research/SOURCES.md\"\n  ],\n  \"agentLaunchers\": [\n    {\n      \"kind\": \"codex-goal\",\n      \"path\": \"GOAL.md\",\n      \"targetChars\": 3500,\n      \"maxChars\": 4000,\n      \"command\": \"/goal follow the instructions in goals/example-goal/GOAL.md\"\n    }\n  ],\n  \"provides\": [],\n  \"requires\": [],\n  \"phases\": [\n    {\n      \"id\": \"P0\",\n      \"name\": \"Research\",\n      \"status\": \"pending\"\n    },\n    {\n      \"id\": \"P1\",\n      \"name\": \"Implement\",\n      \"status\": \"pending\"\n    },\n    {\n      \"id\": \"P2\",\n      \"name\": \"Verify\",\n      \"status\": \"pending\"\n    },\n    {\n      \"id\": \"P3\",\n      \"name\": \"Yeet: PR to mergeable\",\n      \"status\": \"pending\"\n    },\n    {\n      \"id\": \"P4\",\n      \"name\": \"Close\",\n      \"status\": \"pending\"\n    }\n  ],\n  \"verificationCommands\": [\n    \"test \\\"$(wc -m < goals/example-goal/GOAL.md)\\\" -le 4000\",\n    \"jq . goals/example-goal/ops/manifest.json\",\n    \"rg -n \\\"example-goal|GOAL.md|agentLaunchers|packetAnchorDocument\\\" goals/example-goal\",\n    \"git diff --check -- goals/example-goal\",\n    \"bun run beep lint reflection-artifacts\"\n  ],\n  \"stopConditions\": [\n    \"Required source files are missing or materially contradictory.\",\n    \"The implementation would exceed named scope.\",\n    \"Verification requires unnamed credentials, cost, destructive side effects, or policy approval.\",\n    \"The same blocker repeats after reasonable investigation.\"\n  ]\n}\n",
+      "payloadDigest": "c8d1032ef80f8ca298a8f2f72a2ea5562d58cd6620d3e7900d6794daa1bf7625",
+      "reason": "Every byte derives from the input and the archetype."
+    },
+    {
+      "action": "create",
+      "ownership": "generated-seed",
+      "path": "goals/example-goal/README.md",
+      "payload": "# Example Goal\n\n## Status\n\nLifecycle: `active`\n\nSource: [`ops/manifest.json`](./ops/manifest.json)\n\n## Mission\n\nProve the plan compiler.\n\n## Launch\n\nUse this command for execution-capable sessions:\n\n```text\n/goal follow the instructions in goals/example-goal/GOAL.md\n```\n\n`GOAL.md` is the compact launcher. `SPEC.md` remains the normative contract.\n\n## Read This First\n\n1. [`GOAL.md`](./GOAL.md) - compact `/goal` launcher.\n2. [`SPEC.md`](./SPEC.md) - normative source of truth.\n3. [`PLAN.md`](./PLAN.md) - active execution plan.\n4. [`ops/manifest.json`](./ops/manifest.json) - machine-readable routing.\n5. [`research/`](./research/) - supporting research, if present.\n6. [`history/`](./history/) - evidence and closeouts, if present.\n\n## Current Phase\n\nP0 Research — not started.\n\n## Latest Evidence\n\nNot started.\n\n## Notes\n\n<Record high-signal constraints or resume notes that do not belong in the\nnormative spec.>\n",
+      "payloadDigest": "f905beea11043e0ff83232f77cdca24d55379ff3a0c03d52277546faf5463318",
+      "reason": "Written once from input; human-owned immediately after."
+    },
+    {
+      "action": "create",
+      "ownership": "generated-seed",
+      "path": "goals/example-goal/GOAL.md",
+      "payload": "# GOAL: Example Goal\n\nRepo root: the current working directory — the `beep-effect` checkout you are\nrunning in. Do not assume an absolute path; several checkouts exist. All paths\nbelow are repo-relative.\n\nOutcome: Prove the plan compiler.\n\nThis is a compact `/goal` launcher. Treat the packet files as the detailed\ncontract:\n\n- `goals/example-goal/README.md`\n- `goals/example-goal/SPEC.md`\n- `goals/example-goal/PLAN.md`\n- `goals/example-goal/ops/manifest.json`\n\nRead those first, then read `AGENTS.md`, `CLAUDE.md`, and any governing\nstandards named by `SPEC.md`. Higher-priority repo standards outrank packet\nprose when they conflict.\n\nScope:\n\n- In: <paths, packages, docs, workflows, or artifacts this goal may change>.\n- Out: <non-goals and areas not to touch>.\n\nWorkflow:\n\n1. Inspect referenced files and current repo state.\n2. Make the smallest change that satisfies `SPEC.md`.\n3. Preserve unrelated user/worktree changes.\n4. Keep decisions tied to evidence from files, tests, docs, or command output.\n5. Update packet evidence/status if the implementation changes readiness.\n6. At the Close phase, write a closeout reflection to\n   `history/reflections/<YYYY-MM-DD>-<agent>.md` via the `/reflect` skill;\n   `bun run beep lint reflection-artifacts` must pass.\n\nAcceptance:\n\n- [ ] `SPEC.md` acceptance criteria are satisfied.\n- [ ] Required verification commands pass, or unrelated failures are reproduced\n      and recorded separately.\n- [ ] No unrelated refactors or formatting churn.\n\nVerification:\n\n```sh\ntest \"$(wc -m < goals/example-goal/GOAL.md)\" -le 4000\njq . goals/example-goal/ops/manifest.json\ngit diff --check -- goals/example-goal\n```\n\nStop and report before changing public API, schema, data migration, auth, infra,\nsecurity behavior, dependencies, lockfiles, generated files, or destructive\nstate unless `SPEC.md` explicitly requires it.\n\nDone only when acceptance passes and verification is complete, or when a blocker\nis reported with file/command evidence.\n",
+      "payloadDigest": "9082c0818e98aea763540abcf9be9e7cc33953d44bd4831ca74a9bbb7cd027f1",
+      "reason": "Written once from mission and scope inputs; human-owned immediately after."
+    },
+    {
+      "action": "create",
+      "ownership": "generated-seed",
+      "path": "goals/example-goal/SPEC.md",
+      "payload": "# Example Goal Spec\n\n## Objective\n\nProve the plan compiler.\n\n## Non-Goals\n\n- <Out-of-scope behavior, package, workflow, migration, or policy.>\n\n## Source Hierarchy\n\n1. User objective or issue that created this packet.\n2. `AGENTS.md`, `CLAUDE.md`, and required skills.\n3. Governing architecture/package standards.\n4. This `SPEC.md`.\n5. `PLAN.md`.\n6. `GOAL.md`.\n7. Supporting `research/`, `ops/`, and `history/` files.\n\nHigher sources outrank lower sources when they conflict.\n\n## Target Surfaces\n\n- <Package, app, docs, workflow, or artifact this goal may change.>\n\n## Constraints\n\n- <Hard requirement, boundary rule, compatibility concern, or quality bar.>\n\n## Acceptance Criteria\n\n- [ ] <Observable result that proves the goal is complete.>\n- [ ] No unrelated refactors or formatting churn.\n\n## Verification Matrix\n\n| Check | Command or evidence | Required result |\n| --- | --- | --- |\n| Packet launcher size | `test \"$(wc -m < goals/example-goal/GOAL.md)\" -le 4000` | Passes |\n| Manifest JSON | `jq . goals/example-goal/ops/manifest.json` | Passes |\n| Whitespace | `git diff --check -- goals/example-goal` | Passes |\n\n## Stop Conditions\n\n- Required source files are missing or materially contradictory.\n- The implementation would exceed named scope.\n- Verification requires credentials, cost, destructive side effects, or policy\n  approval not named in this spec.\n- The same blocker repeats after reasonable investigation.\n\n## Exception Ledger\n\n| Exception | Scope | Owner | Rationale | Removal condition |\n| --- | --- | --- | --- | --- |\n| None | N/A | N/A | N/A | N/A |\n",
+      "payloadDigest": "78e753952f159b6ddfb05f3f56cc4b4a3cf14f82b65d044f8d9e48799f1dbc59",
+      "reason": "Written once from input; human-owned immediately after."
+    },
+    {
+      "action": "create",
+      "ownership": "generated-seed",
+      "path": "goals/example-goal/PLAN.md",
+      "payload": "# Example Goal Plan\n\n## Status\n\nStatus: `pending`\n\n## Phases\n\n| Phase | Status | Goal | Exit criteria |\n| --- | --- | --- | --- |\n| P0 Research | pending | Inspect source hierarchy and confirm scope. | Required facts and blockers are recorded. |\n| P1 Implement | pending | Make the smallest changes that satisfy `SPEC.md`. | Acceptance criteria are met. |\n| P2 Verify | pending | Run required checks and capture evidence. | Verification is green or blockers are documented. |\n| P3 Yeet: PR to mergeable | pending | Publish through yeet and drive the PR to mergeable: required checks green, review comments answered and resolved. | `mergeStateStatus` is `CLEAN`; zero unresolved review threads. |\n| P4 Close | pending | Write the closeout reflection and flip packet state. | Packet status and evidence are updated; a closeout reflection exists. |\n\n## Closeout Checklist\n\nBefore marking the packet closed:\n\n1. Write a closeout reflection via the `/reflect` skill to\n   `history/reflections/<YYYY-MM-DD>-<agent>.md`. Its YAML frontmatter must\n   validate against `ReflectionFrontmatter`.\n2. Run `bun run beep lint reflection-artifacts`.\n3. Update `README.md` (status, latest evidence) and `ops/manifest.json` phase\n   statuses + `initiative.status`.\n\n## Execution Notes\n\n- Preserve unrelated worktree changes.\n- Keep `SPEC.md` normative and update it only when the contract changes.\n- Keep this plan current; archive old run outputs under `history/`.\n\n## Verification Commands\n\n```sh\ntest \"$(wc -m < goals/example-goal/GOAL.md)\" -le 4000\njq . goals/example-goal/ops/manifest.json\nrg -n \"example-goal|GOAL.md|agentLaunchers|packetAnchorDocument\" goals/example-goal\ngit diff --check -- goals/example-goal\n```\n",
+      "payloadDigest": "b4ded7475ad5177d619b9e96abc5fc921903f782a80413e84e45946b43ab969d",
+      "reason": "Written once from the archetype phase table; human-owned immediately after."
+    },
+    {
+      "action": "create",
+      "ownership": "generated-seed",
+      "path": "goals/example-goal/research/SOURCES.md",
+      "payload": "# Example Goal — Sources & Provenance\n\n- **Source exploration:** none — this goal was authored directly; build the\n  corpus during the first research phase.\n\n## 1. Mined source corpus\n\n| Source | Title | Upstream (repo) | Location (`file:line`) | Theme | Disposition |\n|--------|-------|-----------------|------------------------|-------|-------------|\n\n## 2. Upstream repositories & licenses\n\n| Repo | License | Port discipline | What we take |\n|------|---------|-----------------|--------------|\n\n## 3. External research sources\n\n## 4. In-repo capability references\n\n## 5. Cross-links & provenance\n",
+      "payloadDigest": "0ee2f337af584dde900938cdb77fad2ee0c920c7ff287391714701e47fb8ca24",
+      "reason": "Written once from provenance inputs; human-owned immediately after."
+    },
+    {
+      "action": "create",
+      "ownership": "generated",
+      "path": "goals/example-goal/research/.gitkeep",
+      "payload": "\n",
+      "payloadDigest": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+      "reason": "Directory marker."
+    },
+    {
+      "action": "create",
+      "ownership": "generated",
+      "path": "goals/example-goal/history/.gitkeep",
+      "payload": "\n",
+      "payloadDigest": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+      "reason": "Directory marker."
+    },
+    {
+      "action": "create",
+      "ownership": "generated",
+      "path": "goals/example-goal/history/reflections/.gitkeep",
+      "payload": "",
+      "payloadDigest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "reason": "Directory marker."
+    },
+    {
+      "action": "report",
+      "ownership": "generated",
+      "path": "goals/INDEX.md",
+      "reason": "Disposable projection owned by producer://goals/index; regenerate with `bun run beep goals index --write` after publish."
+    }
+  ],
+  "mode": "bootstrap",
+  "packetPath": "goals/example-goal",
+  "planId": "goal-plan/v1:76621ab1a39245c998729b55c1dcae53d0be0fc3e753917f806d09250cd6376d",
+  "preservations": [],
+  "schemaVersion": "goal-materialization-plan/v1",
+  "slug": "example-goal",
+  "validations": [
+    "manifest-decodes",
+    "doctor-clean",
+    "index-regenerates",
+    "readme-lifecycle-line",
+    "goal-md-within-budget"
+  ]
+}

--- a/packages/tooling/tool/cli/test/fixtures/goals-plan/bootstrap-report-first.json
+++ b/packages/tooling/tool/cli/test/fixtures/goals-plan/bootstrap-report-first.json
@@ -1,0 +1,97 @@
+{
+  "compilerVersion": "goal-materialization-compiler/v1",
+  "conflicts": [],
+  "entries": [
+    {
+      "action": "create",
+      "ownership": "generated",
+      "path": "goals/report-first-goal/ops/manifest.json",
+      "payload": "{\n  \"schemaVersion\": \"initiative-manifest/v2\",\n  \"initiative\": {\n    \"id\": \"report-first-goal\",\n    \"packetId\": \"goal-packet/v1:528398bceb5f4275f43df193092bd7d2d6c986e0e4c9b94c9e6765bac579e644\",\n    \"title\": \"Report First Goal\",\n    \"status\": \"active\",\n    \"created\": \"2026-08-17\",\n    \"updated\": \"2026-08-17\",\n    \"packetAnchorDocument\": \"SPEC.md\"\n  },\n  \"packetPath\": \"goals/report-first-goal\",\n  \"lifecycle\": \"active\",\n  \"mission\": \"Prove the report-first archetype.\",\n  \"executionCapable\": true,\n  \"reflectionRequired\": true,\n  \"completionGate\": {\n    \"operator\": \"yeet\",\n    \"requiresPullRequest\": true,\n    \"requiresMergeable\": true,\n    \"statement\": \"Not achieved until this goal's work ships as a PR driven to mergeable via /yeet (bun run beep yeet: repair -> verify -> publish --pr -> monitor).\",\n    \"grandfathered\": false\n  },\n  \"currentSourceOfTruth\": [\n    \"AGENTS.md\",\n    \"CLAUDE.md\",\n    \"goals/report-first-goal/README.md\",\n    \"goals/report-first-goal/SPEC.md\",\n    \"goals/report-first-goal/PLAN.md\",\n    \"goals/report-first-goal/GOAL.md\",\n    \"goals/report-first-goal/research/SOURCES.md\"\n  ],\n  \"researchReports\": [\n    \"research/SOURCES.md\"\n  ],\n  \"agentLaunchers\": [\n    {\n      \"kind\": \"codex-goal\",\n      \"path\": \"GOAL.md\",\n      \"targetChars\": 3500,\n      \"maxChars\": 4000,\n      \"command\": \"/goal follow the instructions in goals/report-first-goal/GOAL.md\"\n    }\n  ],\n  \"provides\": [],\n  \"requires\": [],\n  \"phases\": [\n    {\n      \"id\": \"P0\",\n      \"name\": \"Read-only report\",\n      \"status\": \"pending\"\n    },\n    {\n      \"id\": \"P1\",\n      \"name\": \"FP eyeball\",\n      \"status\": \"pending\"\n    },\n    {\n      \"id\": \"P2\",\n      \"name\": \"Gated mutation\",\n      \"status\": \"pending\"\n    },\n    {\n      \"id\": \"P3\",\n      \"name\": \"Yeet: PR to mergeable\",\n      \"status\": \"pending\"\n    },\n    {\n      \"id\": \"P4\",\n      \"name\": \"Close\",\n      \"status\": \"pending\"\n    }\n  ],\n  \"verificationCommands\": [\n    \"test \\\"$(wc -m < goals/report-first-goal/GOAL.md)\\\" -le 4000\",\n    \"jq . goals/report-first-goal/ops/manifest.json\",\n    \"rg -n \\\"report-first-goal|GOAL.md|agentLaunchers|packetAnchorDocument\\\" goals/report-first-goal\",\n    \"git diff --check -- goals/report-first-goal\",\n    \"bun run beep lint reflection-artifacts\"\n  ],\n  \"stopConditions\": [\n    \"Required source files are missing or materially contradictory.\",\n    \"The implementation would exceed named scope.\",\n    \"Verification requires unnamed credentials, cost, destructive side effects, or policy approval.\",\n    \"The same blocker repeats after reasonable investigation.\"\n  ]\n}\n",
+      "payloadDigest": "e20e3b14aa18462fdc555e8c1308133e59de51bb141f17653fb6720aeb2c3ca1",
+      "reason": "Every byte derives from the input and the archetype."
+    },
+    {
+      "action": "create",
+      "ownership": "generated-seed",
+      "path": "goals/report-first-goal/README.md",
+      "payload": "# Report First Goal\n\n## Status\n\nLifecycle: `active`\n\nSource: [`ops/manifest.json`](./ops/manifest.json)\n\n## Mission\n\nProve the report-first archetype.\n\n## Launch\n\nUse this command for execution-capable sessions:\n\n```text\n/goal follow the instructions in goals/report-first-goal/GOAL.md\n```\n\n`GOAL.md` is the compact launcher. `SPEC.md` remains the normative contract.\n\n## Read This First\n\n1. [`GOAL.md`](./GOAL.md) - compact `/goal` launcher.\n2. [`SPEC.md`](./SPEC.md) - normative source of truth.\n3. [`PLAN.md`](./PLAN.md) - active execution plan.\n4. [`ops/manifest.json`](./ops/manifest.json) - machine-readable routing.\n5. [`research/`](./research/) - supporting research, if present.\n6. [`history/`](./history/) - evidence and closeouts, if present.\n\n## Current Phase\n\nP0 Read-only report — not started.\n\n## Latest Evidence\n\nNot started.\n\n## Notes\n\n<Record high-signal constraints or resume notes that do not belong in the\nnormative spec.>\n",
+      "payloadDigest": "56d20f2b59e77c5f74aa9c7cda8c4ece641a7a2da401232d5454b993d6603240",
+      "reason": "Written once from input; human-owned immediately after."
+    },
+    {
+      "action": "create",
+      "ownership": "generated-seed",
+      "path": "goals/report-first-goal/GOAL.md",
+      "payload": "# GOAL: Report First Goal\n\nRepo root: the current working directory — the `beep-effect` checkout you are\nrunning in. Do not assume an absolute path; several checkouts exist. All paths\nbelow are repo-relative.\n\nOutcome: Prove the report-first archetype.\n\nThis is a compact `/goal` launcher. Treat the packet files as the detailed\ncontract:\n\n- `goals/report-first-goal/README.md`\n- `goals/report-first-goal/SPEC.md`\n- `goals/report-first-goal/PLAN.md`\n- `goals/report-first-goal/ops/manifest.json`\n\nRead those first, then read `AGENTS.md`, `CLAUDE.md`, and any governing\nstandards named by `SPEC.md`. Higher-priority repo standards outrank packet\nprose when they conflict.\n\nScope:\n\n- In: <paths, packages, docs, workflows, or artifacts this goal may change>.\n- Out: <non-goals and areas not to touch>.\n\nWorkflow:\n\n1. Inspect referenced files and current repo state.\n2. Make the smallest change that satisfies `SPEC.md`.\n3. Preserve unrelated user/worktree changes.\n4. Keep decisions tied to evidence from files, tests, docs, or command output.\n5. Update packet evidence/status if the implementation changes readiness.\n6. At the Close phase, write a closeout reflection to\n   `history/reflections/<YYYY-MM-DD>-<agent>.md` via the `/reflect` skill;\n   `bun run beep lint reflection-artifacts` must pass.\n\nAcceptance:\n\n- [ ] `SPEC.md` acceptance criteria are satisfied.\n- [ ] Required verification commands pass, or unrelated failures are reproduced\n      and recorded separately.\n- [ ] No unrelated refactors or formatting churn.\n\nVerification:\n\n```sh\ntest \"$(wc -m < goals/report-first-goal/GOAL.md)\" -le 4000\njq . goals/report-first-goal/ops/manifest.json\ngit diff --check -- goals/report-first-goal\n```\n\nStop and report before changing public API, schema, data migration, auth, infra,\nsecurity behavior, dependencies, lockfiles, generated files, or destructive\nstate unless `SPEC.md` explicitly requires it.\n\nDone only when acceptance passes and verification is complete, or when a blocker\nis reported with file/command evidence.\n",
+      "payloadDigest": "2e96b900ac4dc1f72f65d4421661d6f656de4ffa2009dbfef7c2668511a34ad7",
+      "reason": "Written once from mission and scope inputs; human-owned immediately after."
+    },
+    {
+      "action": "create",
+      "ownership": "generated-seed",
+      "path": "goals/report-first-goal/SPEC.md",
+      "payload": "# Report First Goal Spec\n\n## Objective\n\nProve the report-first archetype.\n\n## Non-Goals\n\n- <Out-of-scope behavior, package, workflow, migration, or policy.>\n\n## Source Hierarchy\n\n1. User objective or issue that created this packet.\n2. `AGENTS.md`, `CLAUDE.md`, and required skills.\n3. Governing architecture/package standards.\n4. This `SPEC.md`.\n5. `PLAN.md`.\n6. `GOAL.md`.\n7. Supporting `research/`, `ops/`, and `history/` files.\n\nHigher sources outrank lower sources when they conflict.\n\n## Target Surfaces\n\n- <Package, app, docs, workflow, or artifact this goal may change.>\n\n## Constraints\n\n- <Hard requirement, boundary rule, compatibility concern, or quality bar.>\n\n## Acceptance Criteria\n\n- [ ] <Observable result that proves the goal is complete.>\n- [ ] No unrelated refactors or formatting churn.\n\n## Verification Matrix\n\n| Check | Command or evidence | Required result |\n| --- | --- | --- |\n| Packet launcher size | `test \"$(wc -m < goals/report-first-goal/GOAL.md)\" -le 4000` | Passes |\n| Manifest JSON | `jq . goals/report-first-goal/ops/manifest.json` | Passes |\n| Whitespace | `git diff --check -- goals/report-first-goal` | Passes |\n\n## Stop Conditions\n\n- Required source files are missing or materially contradictory.\n- The implementation would exceed named scope.\n- Verification requires credentials, cost, destructive side effects, or policy\n  approval not named in this spec.\n- The same blocker repeats after reasonable investigation.\n\n## Exception Ledger\n\n| Exception | Scope | Owner | Rationale | Removal condition |\n| --- | --- | --- | --- | --- |\n| None | N/A | N/A | N/A | N/A |\n",
+      "payloadDigest": "378e2956bb7df4f3d68480b488a0aa594e723d68d3a238fb57f7551a8f72ed0f",
+      "reason": "Written once from input; human-owned immediately after."
+    },
+    {
+      "action": "create",
+      "ownership": "generated-seed",
+      "path": "goals/report-first-goal/PLAN.md",
+      "payload": "# Report First Goal Plan\n\n## Status\n\nStatus: `pending`\n\n## Phases\n\n| Phase | Status | Goal | Exit criteria |\n| --- | --- | --- | --- |\n| P0 Read-only report | pending | Ship the phase-0 read-only report command. | The report and a false-positive sample land for eyeball review. |\n| P1 FP eyeball | pending | Review the report's false-positive rate before any writer exists. | The eyeball verdict is recorded and the mutation gate is decided. |\n| P2 Gated mutation | pending | Implement the mutation pass behind the reviewed gate. | Acceptance criteria are met. |\n| P3 Yeet: PR to mergeable | pending | Publish through yeet and drive the PR to mergeable: required checks green, review comments answered and resolved. | `mergeStateStatus` is `CLEAN`; zero unresolved review threads. |\n| P4 Close | pending | Write the closeout reflection and flip packet state. | Packet status and evidence are updated; a closeout reflection exists. |\n\n## Closeout Checklist\n\nBefore marking the packet closed:\n\n1. Write a closeout reflection via the `/reflect` skill to\n   `history/reflections/<YYYY-MM-DD>-<agent>.md`. Its YAML frontmatter must\n   validate against `ReflectionFrontmatter`.\n2. Run `bun run beep lint reflection-artifacts`.\n3. Update `README.md` (status, latest evidence) and `ops/manifest.json` phase\n   statuses + `initiative.status`.\n\n## Execution Notes\n\n- Preserve unrelated worktree changes.\n- Keep `SPEC.md` normative and update it only when the contract changes.\n- Keep this plan current; archive old run outputs under `history/`.\n\n## Verification Commands\n\n```sh\ntest \"$(wc -m < goals/report-first-goal/GOAL.md)\" -le 4000\njq . goals/report-first-goal/ops/manifest.json\nrg -n \"report-first-goal|GOAL.md|agentLaunchers|packetAnchorDocument\" goals/report-first-goal\ngit diff --check -- goals/report-first-goal\n```\n",
+      "payloadDigest": "bad70cdcd4ab0ba1d8e61e8407249b2f6dc2c7119ed0dabe98d20be0dc37de25",
+      "reason": "Written once from the archetype phase table; human-owned immediately after."
+    },
+    {
+      "action": "create",
+      "ownership": "generated-seed",
+      "path": "goals/report-first-goal/research/SOURCES.md",
+      "payload": "# Report First Goal — Sources & Provenance\n\n- **Source exploration:** none — this goal was authored directly; build the\n  corpus during the first research phase.\n\n## 1. Mined source corpus\n\n| Source | Title | Upstream (repo) | Location (`file:line`) | Theme | Disposition |\n|--------|-------|-----------------|------------------------|-------|-------------|\n\n## 2. Upstream repositories & licenses\n\n| Repo | License | Port discipline | What we take |\n|------|---------|-----------------|--------------|\n\n## 3. External research sources\n\n## 4. In-repo capability references\n\n## 5. Cross-links & provenance\n",
+      "payloadDigest": "85bdc641e37d2b0cef7c245a417a24186e12e22a098ef89ab167c82064210bcd",
+      "reason": "Written once from provenance inputs; human-owned immediately after."
+    },
+    {
+      "action": "create",
+      "ownership": "generated",
+      "path": "goals/report-first-goal/research/.gitkeep",
+      "payload": "\n",
+      "payloadDigest": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+      "reason": "Directory marker."
+    },
+    {
+      "action": "create",
+      "ownership": "generated",
+      "path": "goals/report-first-goal/history/.gitkeep",
+      "payload": "\n",
+      "payloadDigest": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+      "reason": "Directory marker."
+    },
+    {
+      "action": "create",
+      "ownership": "generated",
+      "path": "goals/report-first-goal/history/reflections/.gitkeep",
+      "payload": "",
+      "payloadDigest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "reason": "Directory marker."
+    },
+    {
+      "action": "report",
+      "ownership": "generated",
+      "path": "goals/INDEX.md",
+      "reason": "Disposable projection owned by producer://goals/index; regenerate with `bun run beep goals index --write` after publish."
+    }
+  ],
+  "mode": "bootstrap",
+  "packetPath": "goals/report-first-goal",
+  "planId": "goal-plan/v1:ef8e7df0bcbc5b2d598a3be0ee0824528ba4b88b330bf814e6b89cddf240dae8",
+  "preservations": [],
+  "schemaVersion": "goal-materialization-plan/v1",
+  "slug": "report-first-goal",
+  "validations": [
+    "manifest-decodes",
+    "doctor-clean",
+    "index-regenerates",
+    "readme-lifecycle-line",
+    "goal-md-within-budget"
+  ]
+}

--- a/packages/tooling/tool/cli/test/goals-bootstrap-plan.test.ts
+++ b/packages/tooling/tool/cli/test/goals-bootstrap-plan.test.ts
@@ -1,0 +1,478 @@
+import {
+  BootstrapInput,
+  buildPortfolioIndexContent,
+  canonicalJsonTextPretty,
+  compileAdoptionPlan,
+  compileMaterializationPlan,
+  decodeGoalManifest,
+  GoalDoctorFindingKind,
+  GoalManifest,
+  GoalSlug,
+  goalsCommand,
+  isJsonRecord,
+  MaterializationPlan,
+  PacketSnapshot,
+  PORTFOLIO_INDEX_PATH,
+  parseGoalManifestText,
+  readPacketSnapshot,
+  validationRequirementsForGoalDoctorFinding,
+} from "@beep/repo-cli/test/Goals";
+import { findRepoRoot } from "@beep/repo-utils";
+import { provideScopedLayer } from "@beep/test-utils";
+import { NodeServices } from "@effect/platform-node";
+import { Effect, Exit, FileSystem, pipe } from "effect";
+import * as A from "effect/Array";
+import * as O from "effect/Option";
+import * as R from "effect/Record";
+import * as S from "effect/Schema";
+import { Command } from "effect/unstable/cli";
+import { describe, expect, it } from "vitest";
+import { expectReportedExit, withTempWorkingDirectory, writeProjectFile } from "./support/CommandTest.ts";
+import type { Path } from "effect";
+
+const FIXTURES_ROOT = new URL("./fixtures/goals-plan", import.meta.url).pathname;
+const REGEN = Bun.env.REGEN_GOLDENS === "1";
+const PILOT_SLUG = "knowledge-surface-automation";
+
+const encodeGoalManifest = S.encodeUnknownEffect(GoalManifest);
+
+const encodePlan = (plan: MaterializationPlan) =>
+  Effect.map(S.encodeUnknownEffect(MaterializationPlan)(plan), canonicalJsonTextPretty);
+
+const minimalInput = BootstrapInput.make({
+  slug: "example-goal",
+  title: "Example Goal",
+  mission: "Prove the plan compiler.",
+  today: "2026-08-17",
+});
+
+const fullInput = BootstrapInput.make({
+  slug: "full-example-goal",
+  title: "Full Example Goal",
+  mission: "Prove the fully populated plan compiler.",
+  provides: ["goals/bootstrap"],
+  requires: ["knowledge/doctor"],
+  provenanceExploration: "plan-compiler-exploration",
+  today: "2026-08-17",
+});
+
+const reportFirstInput = BootstrapInput.make({
+  slug: "report-first-goal",
+  title: "Report First Goal",
+  mission: "Prove the report-first archetype.",
+  archetype: "report-first",
+  today: "2026-08-17",
+});
+
+const expectGolden = Effect.fn("expectGolden")(function* (name: string, plan: MaterializationPlan) {
+  const fs = yield* FileSystem.FileSystem;
+  const rendered = yield* encodePlan(plan);
+  const goldenPath = `${FIXTURES_ROOT}/${name}.json`;
+  if (REGEN) {
+    yield* fs.makeDirectory(FIXTURES_ROOT, { recursive: true });
+    yield* fs.writeFileString(goldenPath, rendered);
+    return;
+  }
+  const golden = yield* fs.readFileString(goldenPath);
+  expect(rendered).toBe(golden);
+});
+
+const run = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path>) =>
+  Effect.runPromise(effect.pipe(provideScopedLayer(NodeServices.layer)));
+
+describe("goals bootstrap --plan golden fixtures", () => {
+  it("pins the minimal standard-delivery plan byte-for-byte", () =>
+    run(expectGolden("bootstrap-minimal", compileMaterializationPlan(minimalInput, []))));
+
+  it("pins the fully populated plan with capabilities and exploration provenance", () =>
+    run(expectGolden("bootstrap-full", compileMaterializationPlan(fullInput, []))));
+
+  it("pins the report-first archetype plan", () =>
+    run(expectGolden("bootstrap-report-first", compileMaterializationPlan(reportFirstInput, []))));
+});
+
+describe("goals bootstrap --plan determinism", () => {
+  it("compiles identical bytes and plan ids across repeated runs and permuted input field order", () =>
+    run(
+      Effect.gen(function* () {
+        const permuted = BootstrapInput.make({
+          today: "2026-08-17",
+          mission: "Prove the plan compiler.",
+          title: "Example Goal",
+          slug: "example-goal",
+        });
+        const first = compileMaterializationPlan(minimalInput, []);
+        const second = compileMaterializationPlan(minimalInput, []);
+        const third = compileMaterializationPlan(permuted, []);
+        expect(second.planId).toBe(first.planId);
+        expect(third.planId).toBe(first.planId);
+        const firstBytes = yield* encodePlan(first);
+        const secondBytes = yield* encodePlan(second);
+        expect(secondBytes).toBe(firstBytes);
+      })
+    ));
+});
+
+describe("goals bootstrap --plan input rejection", () => {
+  const decodeSlug = S.decodeUnknownEffect(GoalSlug);
+
+  it.each(["Uppercase-Slug", "slug/with/separators", "../escape", "spaced slug", "_template"])(
+    "rejects %j at the slug grammar",
+    (candidate) =>
+      Effect.runPromise(
+        Effect.gen(function* () {
+          const outcome = yield* Effect.exit(decodeSlug(candidate));
+          expect(outcome._tag).toBe("Failure");
+        })
+      )
+  );
+
+  it("fails closed with a slug-exists conflict and no entries", () => {
+    const plan = compileMaterializationPlan(minimalInput, ["example-goal"]);
+    expect(A.length(plan.conflicts)).toBe(1);
+    expect(plan.conflicts[0]?.reason).toBe("slug-exists");
+    expect(A.length(plan.entries)).toBe(0);
+    expect(A.length(plan.validations)).toBe(0);
+  });
+});
+
+describe("goals adopt --plan evergreen pilot", () => {
+  it(
+    "retains every live pilot file once, preserves the five unmodeled manifest keys, and creates nothing authored",
+    () =>
+      run(
+        Effect.gen(function* () {
+          const repoRoot = yield* findRepoRoot();
+          const snapshot = yield* readPacketSnapshot(PILOT_SLUG, repoRoot);
+          expect(snapshot.exists).toBe(true);
+          const plan = compileAdoptionPlan(snapshot, O.none());
+
+          expect(A.length(plan.conflicts)).toBe(0);
+          expect(plan.towardArchetype).toBe("report-first");
+          expect(plan.templateSnapshotHash).toBe(snapshot.templateSnapshotHash);
+
+          for (const file of snapshot.files) {
+            const fullPath = `${snapshot.packetPath}/${file.path}`;
+            const matches = A.filter(plan.entries, (entry) => entry.path === fullPath);
+            expect(A.length(matches)).toBe(1);
+            const action = file.path === "ops/manifest.json" ? "preserve" : "retain";
+            expect(matches[0]?.action).toBe(action);
+          }
+
+          const unmodeledKeys = pipe(
+            plan.preservations,
+            A.findFirst((row) => row.path === `${snapshot.packetPath}/ops/manifest.json`),
+            O.map((row) => [...row.unmodeledKeys]),
+            O.getOrElse(() => A.empty<string>())
+          );
+          expect(unmodeledKeys).toStrictEqual([
+            "agentLaunchers",
+            "currentSourceOfTruth",
+            "researchReports",
+            "stopConditions",
+            "verificationCommands",
+          ]);
+
+          const authoredCreates = A.filter(
+            plan.entries,
+            (entry) => entry.action === "create" && entry.ownership === "authored"
+          );
+          expect(A.length(authoredCreates)).toBe(0);
+
+          // Zero-write + doctor-input parity: compilation left every packet file's
+          // digest untouched, so any doctor run before and after sees identical input.
+          const after = yield* readPacketSnapshot(PILOT_SLUG, repoRoot);
+          expect(A.map(after.files, (file) => file.digest)).toStrictEqual(A.map(snapshot.files, (file) => file.digest));
+        })
+      ),
+    30_000
+  );
+
+  it(
+    "is idempotent and a fixed point: recompiling matches, and the simulated overlay plans zero creates",
+    () =>
+      run(
+        Effect.gen(function* () {
+          const repoRoot = yield* findRepoRoot();
+          const snapshot = yield* readPacketSnapshot(PILOT_SLUG, repoRoot);
+          const first = compileAdoptionPlan(snapshot, O.none());
+          const second = compileAdoptionPlan(snapshot, O.none());
+          expect(second.planId).toBe(first.planId);
+
+          const overlayFiles = A.appendAll(
+            snapshot.files,
+            A.getSomes(
+              A.map(first.entries, (entry) =>
+                entry.action === "create" && entry.payload !== undefined && entry.payloadDigest !== undefined
+                  ? O.some({
+                      path: entry.path.replace(`${snapshot.packetPath}/`, ""),
+                      text: entry.payload,
+                      digest: entry.payloadDigest,
+                    })
+                  : O.none<{ path: string; text: string; digest: string }>()
+              )
+            )
+          );
+          const overlay = PacketSnapshot.make({
+            slug: snapshot.slug,
+            packetPath: snapshot.packetPath,
+            exists: true,
+            files: overlayFiles,
+            templateFiles: snapshot.templateFiles,
+            templateSnapshotHash: snapshot.templateSnapshotHash,
+          });
+          const fixedPoint = compileAdoptionPlan(overlay, O.none());
+          const creates = A.filter(fixedPoint.entries, (entry) => entry.action === "create");
+          expect(A.length(creates)).toBe(0);
+        })
+      ),
+    30_000
+  );
+});
+
+describe("goals adopt --plan preservation counterfactual", () => {
+  it("proves the naive decode-encode round trip destroys the pilot's unmodeled keys", () =>
+    run(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const repoRoot = yield* findRepoRoot();
+        const manifestText = yield* fs.readFileString(`${repoRoot}/goals/${PILOT_SLUG}/ops/manifest.json`);
+        const parsedRecord = pipe(
+          parseGoalManifestText(manifestText),
+          O.filter(isJsonRecord),
+          O.getOrElse((): Readonly<Record<string, unknown>> => ({}))
+        );
+        const originalKeys = R.keys(parsedRecord);
+        expect(originalKeys).not.toStrictEqual([]);
+        const parsedUnknown: unknown = parsedRecord;
+        const decoded = yield* decodeGoalManifest(parsedUnknown);
+        const encoded: unknown = yield* encodeGoalManifest(decoded);
+        expect(isJsonRecord(encoded)).toBe(true);
+        const roundTripKeys = isJsonRecord(encoded) ? R.keys(encoded) : A.empty<string>();
+        for (const lost of [
+          "agentLaunchers",
+          "currentSourceOfTruth",
+          "researchReports",
+          "stopConditions",
+          "verificationCommands",
+        ]) {
+          expect(originalKeys).toContain(lost);
+          expect(roundTripKeys).not.toContain(lost);
+        }
+      })
+    ));
+});
+
+describe("goals adopt --plan manifest-less packet", () => {
+  it(
+    "plans exactly one generated manifest plus report rows, never writing the README",
+    () =>
+      Effect.runPromise(
+        withTempWorkingDirectory(
+          Effect.gen(function* () {
+            yield* writeProjectFile("goals/_template/README.md", "# <Goal Title>\n");
+            yield* writeProjectFile("goals/_template/SPEC.md", "# <Goal Title> Spec\n");
+            yield* writeProjectFile("goals/_template/ops/manifest.json", "{}\n");
+            yield* writeProjectFile("goals/_template/research/.gitkeep", "\n");
+            yield* writeProjectFile("goals/_template/history/reflections/_TEMPLATE.md", "# Reflection\n");
+            yield* writeProjectFile(
+              "goals/hand-rolled/README.md",
+              "# Hand Rolled\n\n## Status\n\nLifecycle: `active`\n\n## Mission\n\nA hand-rolled packet.\n"
+            );
+            yield* writeProjectFile("goals/hand-rolled/SPEC.md", "# Hand Rolled Spec\n");
+
+            const snapshot = yield* readPacketSnapshot("hand-rolled");
+            const plan = compileAdoptionPlan(snapshot, O.none());
+
+            const creates = A.filter(plan.entries, (entry) => entry.action === "create");
+            const manifestCreate = A.filter(creates, (entry) => entry.path === "goals/hand-rolled/ops/manifest.json");
+            expect(A.length(manifestCreate)).toBe(1);
+            expect(manifestCreate[0]?.ownership).toBe("generated");
+            expect(manifestCreate[0]?.payload).toContain('"id": "hand-rolled"');
+            expect(manifestCreate[0]?.payload).toContain('"title": "Hand Rolled"');
+            expect(manifestCreate[0]?.payload).toContain('"mission": "A hand-rolled packet."');
+
+            const readmeWrites = A.filter(
+              plan.entries,
+              (entry) => entry.path === "goals/hand-rolled/README.md" && entry.action !== "retain"
+            );
+            expect(A.length(readmeWrites)).toBe(0);
+
+            const reports = A.filter(plan.entries, (entry) => entry.action === "report");
+            expect(
+              A.some(reports, (entry) => entry.path === "goals/hand-rolled/history/reflections/_TEMPLATE.md")
+            ).toBe(true);
+            const authoredCreates = A.filter(creates, (entry) => entry.ownership === "authored");
+            expect(A.length(authoredCreates)).toBe(0);
+          })
+        ).pipe(provideScopedLayer(NodeServices.layer))
+      ),
+    30_000
+  );
+
+  it(
+    "fails closed with packet-not-found for a missing packet",
+    () =>
+      Effect.runPromise(
+        withTempWorkingDirectory(
+          Effect.gen(function* () {
+            yield* writeProjectFile("goals/_template/README.md", "# <Goal Title>\n");
+            const snapshot = yield* readPacketSnapshot("missing-goal");
+            const plan = compileAdoptionPlan(snapshot, O.none());
+            expect(plan.conflicts[0]?.reason).toBe("packet-not-found");
+            expect(A.length(plan.entries)).toBe(0);
+          })
+        ).pipe(provideScopedLayer(NodeServices.layer))
+      ),
+    30_000
+  );
+
+  it(
+    "fails closed with manifest-unparseable for a corrupt manifest",
+    () =>
+      Effect.runPromise(
+        withTempWorkingDirectory(
+          Effect.gen(function* () {
+            yield* writeProjectFile("goals/_template/README.md", "# <Goal Title>\n");
+            yield* writeProjectFile("goals/broken/ops/manifest.json", "{ not json");
+            const snapshot = yield* readPacketSnapshot("broken");
+            const plan = compileAdoptionPlan(snapshot, O.none());
+            expect(plan.conflicts[0]?.reason).toBe("manifest-unparseable");
+            expect(A.length(plan.entries)).toBe(0);
+          })
+        ).pipe(provideScopedLayer(NodeServices.layer))
+      ),
+    30_000
+  );
+});
+
+describe("goals adopt --plan index parity", () => {
+  it(
+    "regenerating the index around a retain-only pilot plan produces the tracked bytes",
+    () =>
+      run(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const repoRoot = yield* findRepoRoot();
+          const snapshot = yield* readPacketSnapshot(PILOT_SLUG, repoRoot);
+          const plan = compileAdoptionPlan(snapshot, O.none());
+          const manifestWrites = A.filter(
+            plan.entries,
+            (entry) => entry.path === `${snapshot.packetPath}/ops/manifest.json` && entry.action !== "preserve"
+          );
+          expect(A.length(manifestWrites)).toBe(0);
+          const regenerated = yield* buildPortfolioIndexContent(repoRoot);
+          const tracked = yield* fs.readFileString(`${repoRoot}/${PORTFOLIO_INDEX_PATH}`);
+          expect(regenerated).toBe(tracked);
+        })
+      ),
+    60_000
+  );
+});
+
+describe("goals plan validation mapping", () => {
+  const BLOCKING_KINDS: ReadonlyArray<GoalDoctorFindingKind> = [
+    "manifest-missing",
+    "manifest-invalid",
+    "lifecycle-mismatch",
+    "readme-status-line",
+    "goal-md-oversize",
+    "phases-terminal-but-active",
+    "reflection-frontmatter-invalid",
+  ];
+
+  it("maps every blocking doctor finding kind to at least one validation requirement", () => {
+    for (const kind of GoalDoctorFindingKind.Options) {
+      const requirements = validationRequirementsForGoalDoctorFinding(kind);
+      if (A.contains(BLOCKING_KINDS, kind)) {
+        expect(A.isReadonlyArrayNonEmpty(requirements)).toBe(true);
+      } else {
+        expect(Array.isArray(requirements)).toBe(true);
+      }
+    }
+  });
+});
+
+describe("goals bootstrap command gate", () => {
+  const runGoalsCommand = Command.runWith(goalsCommand, { version: "0.0.0" });
+
+  it(
+    "refuses without --plan, rejects a provides/requires self-cycle, and prints a JSON plan on the happy path",
+    () =>
+      Effect.runPromise(
+        withTempWorkingDirectory(
+          Effect.gen(function* () {
+            const missingPlan = yield* Effect.exit(
+              runGoalsCommand(["bootstrap", "--slug", "x-goal", "--title", "X", "--mission", "Y."])
+            );
+            expectReportedExit(missingPlan);
+
+            const selfCycle = yield* Effect.exit(
+              runGoalsCommand([
+                "bootstrap",
+                "--slug",
+                "cycle-goal",
+                "--title",
+                "Cycle",
+                "--mission",
+                "Self-cycle must refuse.",
+                "--today",
+                "2026-08-17",
+                "--provides",
+                "goals/bootstrap",
+                "--requires",
+                "goals/bootstrap",
+                "--plan",
+              ])
+            );
+            expectReportedExit(selfCycle);
+
+            const happy = yield* Effect.exit(
+              runGoalsCommand([
+                "bootstrap",
+                "--slug",
+                "fresh-goal",
+                "--title",
+                "Fresh Goal",
+                "--mission",
+                "Compile through the command surface.",
+                "--today",
+                "2026-08-17",
+                "--plan",
+                "--json",
+              ])
+            );
+            expect(Exit.isSuccess(happy)).toBe(true);
+          })
+        ).pipe(provideScopedLayer(NodeServices.layer))
+      ),
+    30_000
+  );
+});
+
+// The sealed design's empirical zero-write proof: git state is byte-identical
+// around compilation and snapshotting (equality, not emptiness, so a dirty
+// developer tree does not false-fail the suite).
+describe("goals plan zero-write proof", () => {
+  it(
+    "leaves git status byte-identical around compilation and snapshotting",
+    () =>
+      run(
+        Effect.gen(function* () {
+          const repoRoot = yield* findRepoRoot();
+          const porcelain = (): string =>
+            Bun.spawnSync(["git", "status", "--porcelain"], {
+              cwd: repoRoot,
+              stdout: "pipe",
+              stderr: "pipe",
+            }).stdout.toString();
+          const before = porcelain();
+          const snapshot = yield* readPacketSnapshot(PILOT_SLUG, repoRoot);
+          compileAdoptionPlan(snapshot, O.none());
+          compileMaterializationPlan(minimalInput, []);
+          expect(porcelain()).toBe(before);
+        })
+      ),
+    30_000
+  );
+});

--- a/packages/tooling/tool/cli/test/goals-bootstrap-plan.test.ts
+++ b/packages/tooling/tool/cli/test/goals-bootstrap-plan.test.ts
@@ -450,6 +450,43 @@ describe("goals bootstrap command gate", () => {
   );
 });
 
+describe("goals adopt command gate", () => {
+  const runGoalsCommand = Command.runWith(goalsCommand, { version: "0.0.0" });
+
+  it(
+    "refuses without --plan, prints a JSON plan for a fixture packet, and gates on packet-not-found",
+    () =>
+      Effect.runPromise(
+        withTempWorkingDirectory(
+          Effect.gen(function* () {
+            yield* writeProjectFile("goals/_template/README.md", "# <Goal Title>\n");
+            yield* writeProjectFile("goals/_template/ops/manifest.json", "{}\n");
+            yield* writeProjectFile("goals/_template/research/.gitkeep", "\n");
+            yield* writeProjectFile(
+              "goals/fixture-packet/README.md",
+              "# Fixture Packet\n\n## Status\n\nLifecycle: `active`\n\n## Mission\n\nAdopt me.\n"
+            );
+
+            const missingPlan = yield* Effect.exit(runGoalsCommand(["adopt", "fixture-packet"]));
+            expectReportedExit(missingPlan);
+
+            const happy = yield* Effect.exit(runGoalsCommand(["adopt", "fixture-packet", "--plan", "--json"]));
+            expect(Exit.isSuccess(happy)).toBe(true);
+
+            const human = yield* Effect.exit(
+              runGoalsCommand(["adopt", "fixture-packet", "--plan", "--toward", "standard-delivery"])
+            );
+            expect(Exit.isSuccess(human)).toBe(true);
+
+            const notFound = yield* Effect.exit(runGoalsCommand(["adopt", "missing-packet", "--plan"]));
+            expectReportedExit(notFound);
+          })
+        ).pipe(provideScopedLayer(NodeServices.layer))
+      ),
+    30_000
+  );
+});
+
 // The sealed design's empirical zero-write proof: git state is byte-identical
 // around compilation and snapshotting (equality, not emptiness, so a dirty
 // developer tree does not false-fail the suite).

--- a/standards/coverage.regression-baseline.jsonc
+++ b/standards/coverage.regression-baseline.jsonc
@@ -24855,15 +24855,15 @@
           }
         },
         "packages/tooling/tool/cli/src/internal/cli/EnvConfig.ts": {
-          "lines": 74.66,
-          "statements": 75,
+          "lines": 73.33,
+          "statements": 73.68,
           "branches": 80,
-          "functions": 77.77,
+          "functions": 74.07,
           "uncovered": {
-            "lines": 19,
-            "statements": 19,
+            "lines": 20,
+            "statements": 20,
             "branches": 9,
-            "functions": 6
+            "functions": 7
           }
         },
         "packages/tooling/tool/cli/src/internal/cli/ExitCodeError.ts": {

--- a/standards/coverage.regression-baseline.jsonc
+++ b/standards/coverage.regression-baseline.jsonc
@@ -3,8 +3,8 @@
 // Epsilon: 0.001 percentage points; only smaller floating-point noise is ignored.
 {
   "schema_version": 2,
-  "generated_at": "2026-08-17T17:25:36.217Z",
-  "git_sha": "c2767225b880d3e1a626f3514f63639dce80362d",
+  "generated_at": "2026-08-17T22:55:02.910Z",
+  "git_sha": "ed9cc4b8746133a8b19827374e24478850943a6b",
   "command": "bun run coverage:baseline:write",
   "epsilon": 0.001,
   "minimum": {
@@ -20007,15 +20007,15 @@
     },
     "@beep/repo-cli": {
       "path": "packages/tooling/tool/cli",
-      "lines": 72.51,
-      "statements": 72.25,
-      "branches": 58.93,
-      "functions": 65.16,
+      "lines": 72.98,
+      "statements": 72.72,
+      "branches": 59.39,
+      "functions": 65.74,
       "uncovered": {
-        "lines": 8403,
-        "statements": 8837,
-        "branches": 4691,
-        "functions": 3133
+        "lines": 8394,
+        "statements": 8827,
+        "branches": 4697,
+        "functions": 3132
       },
       "files": {
         "packages/tooling/tool/cli/src/bin-main.ts": {
@@ -21099,27 +21099,27 @@
           }
         },
         "packages/tooling/tool/cli/src/commands/DeletePackage/DeletePackage.command.ts": {
-          "lines": 65.1,
-          "statements": 63.15,
+          "lines": 70,
+          "statements": 67.64,
           "branches": 54.12,
-          "functions": 47.88,
+          "functions": 56.33,
           "uncovered": {
-            "lines": 97,
-            "statements": 112,
+            "lines": 84,
+            "statements": 99,
             "branches": 50,
-            "functions": 37
+            "functions": 31
           }
         },
         "packages/tooling/tool/cli/src/commands/DeletePackage/DeletePackage.policy.ts": {
-          "lines": 95.34,
-          "statements": 95.74,
-          "branches": 92.85,
-          "functions": 94.28,
+          "lines": 100,
+          "statements": 100,
+          "branches": 100,
+          "functions": 100,
           "uncovered": {
-            "lines": 2,
-            "statements": 2,
-            "branches": 2,
-            "functions": 2
+            "lines": 0,
+            "statements": 0,
+            "branches": 0,
+            "functions": 0
           }
         },
         "packages/tooling/tool/cli/src/commands/DeletePackage/DeletePackage.schemas.ts": {
@@ -21854,6 +21854,42 @@
             "functions": 18
           }
         },
+        "packages/tooling/tool/cli/src/commands/Goals/Adopt.ts": {
+          "lines": 95.34,
+          "statements": 95.71,
+          "branches": 82.5,
+          "functions": 91.66,
+          "uncovered": {
+            "lines": 6,
+            "statements": 6,
+            "branches": 7,
+            "functions": 4
+          }
+        },
+        "packages/tooling/tool/cli/src/commands/Goals/Bootstrap.schemas.ts": {
+          "lines": 100,
+          "statements": 100,
+          "branches": 100,
+          "functions": 100,
+          "uncovered": {
+            "lines": 0,
+            "statements": 0,
+            "branches": 0,
+            "functions": 0
+          }
+        },
+        "packages/tooling/tool/cli/src/commands/Goals/Bootstrap.ts": {
+          "lines": 94,
+          "statements": 94.28,
+          "branches": 88.46,
+          "functions": 83.33,
+          "uncovered": {
+            "lines": 6,
+            "statements": 6,
+            "branches": 3,
+            "functions": 6
+          }
+        },
         "packages/tooling/tool/cli/src/commands/Goals/Doctor.ts": {
           "lines": 63.34,
           "statements": 63.59,
@@ -21879,13 +21915,13 @@
           }
         },
         "packages/tooling/tool/cli/src/commands/Goals/Goals.errors.ts": {
-          "lines": 22.22,
-          "statements": 27.27,
+          "lines": 46.15,
+          "statements": 56.25,
           "branches": 100,
-          "functions": 20,
+          "functions": 50,
           "uncovered": {
             "lines": 7,
-            "statements": 8,
+            "statements": 7,
             "branches": 0,
             "functions": 4
           }
@@ -21905,12 +21941,12 @@
         "packages/tooling/tool/cli/src/commands/Goals/Inventory.ts": {
           "lines": 98.7,
           "statements": 98.71,
-          "branches": 93.47,
+          "branches": 95.65,
           "functions": 100,
           "uncovered": {
             "lines": 1,
             "statements": 1,
-            "branches": 3,
+            "branches": 2,
             "functions": 0
           }
         },
@@ -21951,8 +21987,8 @@
           }
         },
         "packages/tooling/tool/cli/src/commands/Goals/PacketCore/PacketDigest.ts": {
-          "lines": 95,
-          "statements": 95.52,
+          "lines": 95.08,
+          "statements": 95.65,
           "branches": 84.61,
           "functions": 100,
           "uncovered": {
@@ -21963,10 +21999,10 @@
           }
         },
         "packages/tooling/tool/cli/src/commands/Goals/PacketCore/PacketEventStore.ts": {
-          "lines": 92,
-          "statements": 91.35,
+          "lines": 92.3,
+          "statements": 91.66,
           "branches": 88.46,
-          "functions": 77.77,
+          "functions": 78.94,
           "uncovered": {
             "lines": 6,
             "statements": 7,
@@ -21975,9 +22011,9 @@
           }
         },
         "packages/tooling/tool/cli/src/commands/Goals/PacketCore/PacketFold.ts": {
-          "lines": 93.39,
-          "statements": 93.57,
-          "branches": 91.3,
+          "lines": 93.69,
+          "statements": 93.8,
+          "branches": 91.66,
           "functions": 92.3,
           "uncovered": {
             "lines": 7,
@@ -21987,50 +22023,50 @@
           }
         },
         "packages/tooling/tool/cli/src/commands/Goals/PacketCore/PacketTransitionWriter.ts": {
-          "lines": 95.08,
-          "statements": 95.16,
-          "branches": 91.66,
-          "functions": 81.81,
+          "lines": 97.56,
+          "statements": 97.59,
+          "branches": 100,
+          "functions": 88.88,
           "uncovered": {
-            "lines": 3,
-            "statements": 3,
-            "branches": 1,
+            "lines": 2,
+            "statements": 2,
+            "branches": 0,
             "functions": 2
           }
         },
         "packages/tooling/tool/cli/src/commands/Goals/PortfolioIndex.ts": {
           "lines": 71.42,
           "statements": 72.5,
-          "branches": 48.48,
+          "branches": 51.51,
           "functions": 83.33,
           "uncovered": {
             "lines": 22,
             "statements": 22,
-            "branches": 17,
+            "branches": 16,
             "functions": 2
           }
         },
         "packages/tooling/tool/cli/src/commands/Goals/SetRiskTier.ts": {
-          "lines": 80,
-          "statements": 80,
-          "branches": 68,
-          "functions": 62,
+          "lines": 86.2,
+          "statements": 84.74,
+          "branches": 75,
+          "functions": 69.23,
           "uncovered": {
-            "lines": 12,
-            "statements": 13,
-            "branches": 7,
-            "functions": 7
+            "lines": 8,
+            "statements": 9,
+            "branches": 4,
+            "functions": 4
           }
         },
         "packages/tooling/tool/cli/src/commands/Goals/SetStatus.ts": {
-          "lines": 62.65,
-          "statements": 61.9,
-          "branches": 41.02,
-          "functions": 53.33,
+          "lines": 63.95,
+          "statements": 63.21,
+          "branches": 42.68,
+          "functions": 54.83,
           "uncovered": {
             "lines": 62,
             "statements": 64,
-            "branches": 46,
+            "branches": 47,
             "functions": 14
           }
         },
@@ -22191,15 +22227,15 @@
           }
         },
         "packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.service.ts": {
-          "lines": 86.89,
-          "statements": 87.4,
-          "branches": 81.6,
-          "functions": 83.46,
+          "lines": 89.44,
+          "statements": 90.04,
+          "branches": 82.75,
+          "functions": 87.59,
           "uncovered": {
-            "lines": 49,
-            "statements": 50,
-            "branches": 16,
-            "functions": 21
+            "lines": 40,
+            "statements": 40,
+            "branches": 15,
+            "functions": 16
           }
         },
         "packages/tooling/tool/cli/src/commands/Knowledge/index.ts": {
@@ -22467,15 +22503,15 @@
           }
         },
         "packages/tooling/tool/cli/src/commands/Lint/ReflectionArtifact.ts": {
-          "lines": 95.45,
-          "statements": 94.38,
-          "branches": 79.41,
-          "functions": 86.66,
+          "lines": 97.64,
+          "statements": 96.55,
+          "branches": 82.35,
+          "functions": 92.85,
           "uncovered": {
-            "lines": 4,
-            "statements": 5,
-            "branches": 7,
-            "functions": 2
+            "lines": 2,
+            "statements": 3,
+            "branches": 6,
+            "functions": 1
           }
         },
         "packages/tooling/tool/cli/src/commands/Lint/RoadmapRefs.ts": {
@@ -22971,14 +23007,14 @@
           }
         },
         "packages/tooling/tool/cli/src/commands/Quality/internal/CoverageRegression.ts": {
-          "lines": 80.92,
-          "statements": 81.08,
-          "branches": 64.86,
-          "functions": 75.38,
+          "lines": 82.29,
+          "statements": 82.42,
+          "branches": 69.87,
+          "functions": 75.75,
           "uncovered": {
-            "lines": 58,
-            "statements": 59,
-            "branches": 26,
+            "lines": 57,
+            "statements": 58,
+            "branches": 25,
             "functions": 32
           }
         },
@@ -24338,6 +24374,18 @@
             "functions": 1
           }
         },
+        "packages/tooling/tool/cli/src/commands/Yeet/internal/Inbox.ts": {
+          "lines": 100,
+          "statements": 100,
+          "branches": 100,
+          "functions": 100,
+          "uncovered": {
+            "lines": 0,
+            "statements": 0,
+            "branches": 0,
+            "functions": 0
+          }
+        },
         "packages/tooling/tool/cli/src/commands/Yeet/internal/IssueArtifacts.ts": {
           "lines": 87.03,
           "statements": 87.27,
@@ -24528,6 +24576,18 @@
             "statements": 3,
             "branches": 1,
             "functions": 3
+          }
+        },
+        "packages/tooling/tool/cli/src/commands/Yeet/internal/Remediation.ts": {
+          "lines": 100,
+          "statements": 100,
+          "branches": 100,
+          "functions": 100,
+          "uncovered": {
+            "lines": 0,
+            "statements": 0,
+            "branches": 0,
+            "functions": 0
           }
         },
         "packages/tooling/tool/cli/src/commands/Yeet/internal/Reply.schemas.ts": {
@@ -24795,15 +24855,15 @@
           }
         },
         "packages/tooling/tool/cli/src/internal/cli/EnvConfig.ts": {
-          "lines": 73.33,
-          "statements": 73.68,
+          "lines": 74.66,
+          "statements": 75,
           "branches": 80,
-          "functions": 74.07,
+          "functions": 77.77,
           "uncovered": {
-            "lines": 20,
-            "statements": 20,
+            "lines": 19,
+            "statements": 19,
             "branches": 9,
-            "functions": 7
+            "functions": 6
           }
         },
         "packages/tooling/tool/cli/src/internal/cli/ExitCodeError.ts": {
@@ -25023,14 +25083,14 @@
           }
         },
         "packages/tooling/tool/cli/src/internal/cli/RegistrationGeometry/RegistrationGeometry.probes.ts": {
-          "lines": 86.25,
-          "statements": 83.7,
-          "branches": 70,
-          "functions": 69.73,
+          "lines": 86.36,
+          "statements": 83.82,
+          "branches": 71.54,
+          "functions": 70.12,
           "uncovered": {
             "lines": 33,
             "statements": 44,
-            "branches": 36,
+            "branches": 35,
             "functions": 23
           }
         },
@@ -25275,15 +25335,15 @@
           }
         },
         "packages/tooling/tool/cli/src/internal/repo-run/GitExec.ts": {
-          "lines": 56.71,
-          "statements": 56.61,
-          "branches": 30.15,
-          "functions": 61.53,
+          "lines": 60.68,
+          "statements": 60.54,
+          "branches": 34.32,
+          "functions": 67.44,
           "uncovered": {
-            "lines": 58,
-            "statements": 59,
+            "lines": 57,
+            "statements": 58,
             "branches": 44,
-            "functions": 15
+            "functions": 14
           }
         },
         "packages/tooling/tool/cli/src/internal/repo-run/RepoRun.executor.ts": {

--- a/standards/coverage.regression-baseline.jsonc
+++ b/standards/coverage.regression-baseline.jsonc
@@ -20007,15 +20007,15 @@
     },
     "@beep/repo-cli": {
       "path": "packages/tooling/tool/cli",
-      "lines": 72.98,
-      "statements": 72.72,
-      "branches": 59.39,
-      "functions": 65.74,
+      "lines": 72.51,
+      "statements": 72.25,
+      "branches": 58.93,
+      "functions": 65.16,
       "uncovered": {
-        "lines": 8394,
-        "statements": 8827,
-        "branches": 4697,
-        "functions": 3132
+        "lines": 8403,
+        "statements": 8837,
+        "branches": 4691,
+        "functions": 3133
       },
       "files": {
         "packages/tooling/tool/cli/src/bin-main.ts": {

--- a/standards/schema-first.inventory.jsonc
+++ b/standards/schema-first.inventory.jsonc
@@ -800,6 +800,16 @@
       "status": "exception",
       "owner": "@beep/repo-cli",
       "reason": "One-call formatting contract intentionally couples runtime colorizer functions with their glyph and fraction operands; it has no decode or persistence boundary."
+    },
+    {
+      "file": "packages/tooling/tool/cli/test/goals-bootstrap-plan.test.ts",
+      "symbol": "schema-codec-tests",
+      "kind": "schema-policy-advisory",
+      "status": "exception",
+      "ruleId": "SFV4-arbitrary-tests",
+      "line": 37,
+      "owner": "@beep/repo-cli",
+      "reason": "Intentionally golden/regression-only coverage: the sealed Workstream E phase-0 design mandates byte-golden plan fixtures, and determinism is pinned by repeated and permuted compilation rather than schema-derived arbitraries."
     }
   ]
 }


### PR DESCRIPTION
Ships the read-only materialization-plan slice ratified in `goals/knowledge-surface-automation`
(`research/p1-bootstrap-adopt-plan-design.md`; mini-grill decisions E1–E7).

- `beep goals bootstrap --slug <s> --title <t> --mission <m> --plan [--json]` — a pure
  `compileMaterializationPlan` maps the decoded input through phase-archetype constructors
  (`standard-delivery`, `report-first`) to a content-addressed `MaterializationPlan` carrying
  every path, ownership boundary, payload byte, digest, and validation requirement. The generated
  manifest mints the E4 PacketId beacon.
- `beep goals adopt <slug> --plan [--json] [--toward <archetype>]` — a read-only
  `readPacketSnapshot` (byte-exact digests) feeds a pure `compileAdoptionPlan` that retains
  authored files, preserves the manifest byte-for-byte while enumerating its unmodeled top-level
  keys, reports absent authored artifacts instead of inventing them, and records the archetype +
  `goals/_template` snapshot hash it measured against.
- **No writer exists in this slice**: `--plan` is the only mode; plans are hash-pinned
  (`goal-plan/v1:<sha256>` over canonical JSON); the suite carries a porcelain-equality
  zero-write proof.
- Self-hosting pilot: adopting `knowledge-surface-automation` compiles with **zero authored-file
  creations** and preserves exactly the five predicted unmodeled manifest keys.
- 20 tests cover the sealed design's eleven test classes (committed goldens with a
  `REGEN_GOLDENS=1` regen path, determinism under permuted input, grammar rejection, evergreen
  pilot, preservation counterfactual, fixed-point overlay, index parity, exhaustive
  doctor-finding → validation mapping, command-surface gate).
- The committed E4 FP-eyeball artifact is `research/p1-report-bootstrap-adopt-plan.md` —
  Workstream E's mutation work stays blocked until Benjamin reviews it (PLAN P4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUaZTN6dN4yoA8j5tSVExt

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789594920&installation_model_id=424656&pr_number=762&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F762&signature=2fbea21b7fca45bef4d8a130409d2af667e88f745ac0e1ffe21a7898ba00f762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->