### PR TITLE
docs(goals): projection design review fixes from PR 765 threads

### DIFF
--- a/goals/knowledge-surface-automation/research/p4-goals-projection-design.md
+++ b/goals/knowledge-surface-automation/research/p4-goals-projection-design.md
@@ -101,6 +101,7 @@ export class GoalFrontierEntry extends S.Class(...)({
 export class GoalFrontierReport extends S.Class(...)({
   schemaVersion: S.tag("goal-frontier/v1"),
   readiness: CapabilityReadiness,
+  evidence: S.optionalKey(S.Unknown),                                  // reserved (contract 5): absent until D9/D10
   frontier: S.Array(GoalFrontierEntry),                                // sorted by slug
   fog: S.Array(CapabilitySlug),                                        // orphan capabilities, sorted
   cycles: S.Array(S.Array(S.String)),                                  // sorted SCCs of packet slugs
@@ -112,6 +113,7 @@ export class GoalUnlockStep extends S.Class(...)({
 }) {}
 export class GoalExplainReport extends S.Class(...)({
   schemaVersion: S.tag("goal-explain/v1"),
+  evidence: S.optionalKey(S.Unknown),                                  // reserved (contract 5): absent until D9/D10
   slug: S.String,
   status: GoalStatus,
   executionCapable: S.Boolean,
@@ -122,7 +124,8 @@ export class GoalExplainReport extends S.Class(...)({
 }) {}
 export class CapabilityCatalogEntry extends S.Class(...)({
   capability: CapabilitySlug,
-  providers: S.Array(S.String), consumers: S.Array(S.String),
+  providers: S.Array(CapabilityProviderRow),                           // slug + status: reference-provides visible
+  consumers: S.Array(S.String),
   collision: S.Boolean,                                                // >1 provider (informational, D4)
   orphan: S.Boolean,                                                   // consumers without providers
   duplicates: S.Array(S.String),                                       // packets declaring it twice (D5)
@@ -135,8 +138,9 @@ export class CapabilityCatalogReport extends S.Class(...)({
 ```
 
 The catalog IS the phase-0 report for the D5/D8 finding classes
-(duplicate-declaration, stranded-capability, reference-provides): they surface as
-catalog fields first; doctor gates arrive in a later PR only after the catalog's
+(duplicate-declaration, stranded-capability, reference-provides): providers carry
+their packet status so a `reference` provider is directly visible in the report,
+duplicates and strands are explicit fields, and every class surfaces here first; doctor gates arrive in a later PR only after the catalog's
 false-positive rate is eyeballed, mirroring the A/B/C pattern.
 
 ## Command surface
@@ -174,10 +178,17 @@ Sketches; binding comes from the differential, not this prose.
   `reach(a,b) AND reach(b,a)`, grouped and sorted. Fixture 3 pins it.
 - **shortest-unlock**: `WITH RECURSIVE walk(frontier_path, tail, depth)` BFS from
   the target's unsatisfied capabilities toward providers, path stored as a
-  `/`-joined slug string with an `instr` cycle guard, `ORDER BY depth LIMIT 1`
-  per capability, D7 annotation joined from `packets.execution_capable`. When the
-  only path crosses a non-execution-capable packet the step says so; when the
-  target sits in an SCC the report returns the cycle instead of a path (fixture 3).
+  slug string joined AND bounded by `/` (`'/a/b/'`), with the cycle guard testing
+  `instr(frontier_path, '/' || candidate || '/')` so one slug being a substring of
+  another can never false-positive, `ORDER BY depth LIMIT 1`
+  per capability, D7 annotation joined from `packets.execution_capable`.
+  `unlockPath` merges the per-capability shortest paths as a union deduplicated by
+  slug, ordered by `(depth, slug)` — a stable "work these, shallowest first" list,
+  not a globally minimal unlock set (Steiner-style global minimization is
+  explicitly out of v1; if the eyeball wants it, that is a new fixture and its own
+  decision). When the only path crosses a non-execution-capable packet the step
+  says so; when the target sits in an SCC the report returns the cycle instead of
+  a path (fixture 3).
 
 The pure-TS evaluator implements the same four questions with `HashMap`/`HashSet`
 set algebra and explicit BFS — small enough to review as obviously correct, which


### PR DESCRIPTION
Applies the four Greptile catches on the merged Workstream D projection design (#765):

- Delimiter-bounded unlock-BFS cycle guard (`'/a/b/'` + `instr(path, '/x/')`) — substring slugs
  can no longer false-positive.
- Catalog providers carry packet status (`CapabilityProviderRow`), making `reference-provides`
  candidates directly visible in the phase-0 report.
- Both report sketches carry the reserved optional `evidence` key promised by decided-contract
  item 5.
- `unlockPath` merging defined: union of per-capability shortest paths, deduplicated by slug,
  ordered by `(depth, slug)`; Steiner-style global minimization explicitly out of v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUaZTN6dN4yoA8j5tSVExt

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/767"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789609476&installation_model_id=424656&pr_number=767&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F767&signature=558ba0ae904bb7144b438018ee5ba74be3b9bbb2436ca86f2827f8d22ac49c4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->