### PR TITLE
docs(goals): pin minimum-depth survival for unlockPath slug dedupe

### DIFF
--- a/goals/knowledge-surface-automation/research/p4-goals-projection-design.md
+++ b/goals/knowledge-surface-automation/research/p4-goals-projection-design.md
@@ -183,7 +183,8 @@ Sketches; binding comes from the differential, not this prose.
   another can never false-positive, `ORDER BY depth LIMIT 1`
   per capability, D7 annotation joined from `packets.execution_capable`.
   `unlockPath` merges the per-capability shortest paths as a union deduplicated by
-  slug, ordered by `(depth, slug)` — a stable "work these, shallowest first" list,
+  slug — a slug appearing on several paths at different depths keeps its MINIMUM
+  depth — ordered by `(depth, slug)`: a stable "work these, shallowest first" list,
   not a globally minimal unlock set (Steiner-style global minimization is
   explicitly out of v1; if the eyeball wants it, that is a new fixture and its own
   decision). When the only path crosses a non-execution-capable packet the step


### PR DESCRIPTION
One-line follow-up from the #767 review threads: when a slug appears on several
per-capability shortest paths at different depths, its **minimum** depth survives the dedupe for
the `(depth, slug)` ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUaZTN6dN4yoA8j5tSVExt

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789610252&installation_model_id=424656&pr_number=768&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F768&signature=a8180fa94fbf7481d32f1e7dd0e9b13011be961c9d28bafa5d50534e440d5fff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->