### PR TITLE
fix(nlp): carry mentions and spans through the Handoff envelope

### DIFF
--- a/.changeset/nlp-handoff-mentions.md
+++ b/.changeset/nlp-handoff-mentions.md
@@ -1,0 +1,15 @@
+---
+"@beep/nlp": minor
+"@beep/langextract": patch
+---
+
+`AnnotatedDocument` now carries `mentions: ReadonlyArray<Mention>` and pins
+`version: "nlp-ir/1.1"`. Entities always referred to mentions by id, but no
+producer ever placed a `Mention` in the envelope, so every per-occurrence
+character span was dropped at the handoff boundary. The `Span` annotation now
+states its unit: zero-based UTF-16 code units, which is what alignment and
+`String.length` produce.
+
+`@beep/langextract` `toAnnotatedDocument` emits one `Mention` per aligned
+extraction, carrying the aligned `span` and `matchedText` against the single
+document chunk, alongside the entity that references it.

--- a/packages/foundation/capability/langextract/src/Extraction/Extraction.model.ts
+++ b/packages/foundation/capability/langextract/src/Extraction/Extraction.model.ts
@@ -362,9 +362,10 @@ export class LangExtractDiagnostics extends S.Class<LangExtractDiagnostics>($I`L
  * const annotatedDocument = Contract.AnnotatedDocument.make({
  *   chunks: [],
  *   entities: [],
+ *   mentions: [],
  *   provenance,
  *   relations: [],
- *   version: "nlp-ir/1.0"
+ *   version: "nlp-ir/1.1"
  * })
  * console.log(LangExtractResult.make({
  *   annotatedDocument,

--- a/packages/foundation/capability/langextract/src/Handoff/Handoff.behavior.ts
+++ b/packages/foundation/capability/langextract/src/Handoff/Handoff.behavior.ts
@@ -21,18 +21,27 @@ type AlignedGroundedExtraction =
 
 const alignedExtraction = GroundedExtraction.isAnyOf(["match_exact", "match_lesser", "match_fuzzy"]);
 
-const makeEntity =
-  (documentId: DocumentId, provenance: Contract.Provenance) =>
-  (extraction: AlignedGroundedExtraction, index: number): Contract.Entity => {
+const makeAnnotation =
+  (documentId: DocumentId, chunkId: Contract.ChunkId, provenance: Contract.Provenance) =>
+  (extraction: AlignedGroundedExtraction, index: number): readonly [Contract.Mention, Contract.Entity] => {
     const mentionId = Contract.MentionId.make(`${documentId}:mention:${index}`);
-    return Contract.Entity.make({
-      canonicalName: extraction.text,
-      id: Contract.EntityId.make(`${documentId}:entity:${index}`),
-      mentions: A.of(mentionId),
-      provenance,
-      type: extraction.label,
-      ...O.getSomesStruct({ confidence: extraction.confidence }),
-    });
+    return [
+      Contract.Mention.make({
+        chunkId,
+        id: mentionId,
+        provenance,
+        span: extraction.span,
+        text: extraction.matchedText,
+      }),
+      Contract.Entity.make({
+        canonicalName: extraction.text,
+        id: Contract.EntityId.make(`${documentId}:entity:${index}`),
+        mentions: A.of(mentionId),
+        provenance,
+        type: extraction.label,
+        ...O.getSomesStruct({ confidence: extraction.confidence }),
+      }),
+    ];
   };
 
 /**
@@ -65,6 +74,7 @@ export const toAnnotatedDocument = (input: AnnotatedDocumentInput): Contract.Ann
   });
   const chunkId = Contract.ChunkId.make(`${input.documentId}:chunk:0`);
   const aligned = A.filter(input.extractions, alignedExtraction);
+  const [mentions, entities] = A.unzip(A.map(aligned, makeAnnotation(input.documentId, chunkId, provenance)));
 
   const chunks = A.of(
     Contract.TextChunk.make({
@@ -78,9 +88,10 @@ export const toAnnotatedDocument = (input: AnnotatedDocumentInput): Contract.Ann
 
   return Contract.AnnotatedDocument.make({
     chunks,
-    entities: A.map(aligned, makeEntity(input.documentId, provenance)),
+    entities,
+    mentions,
     provenance,
     relations: A.empty(),
-    version: "nlp-ir/1.0",
+    version: "nlp-ir/1.1",
   });
 };

--- a/packages/foundation/capability/langextract/src/Service/Service.service.ts
+++ b/packages/foundation/capability/langextract/src/Service/Service.service.ts
@@ -81,9 +81,10 @@ export interface LangExtractRemotePolicyShape {
  * const annotatedDocument = Contract.AnnotatedDocument.make({
  *   chunks: [],
  *   entities: [],
+ *   mentions: [],
  *   provenance,
  *   relations: [],
- *   version: "nlp-ir/1.0"
+ *   version: "nlp-ir/1.1"
  * })
  * const TestLangExtract = Layer.succeed(
  *   LangExtractService,

--- a/packages/foundation/capability/langextract/test/Handoff.test.ts
+++ b/packages/foundation/capability/langextract/test/Handoff.test.ts
@@ -6,6 +6,7 @@ import { NonNegativeInt } from "@beep/schema";
 import * as O from "@beep/utils/Option";
 import { describe, expect, it } from "@effect/vitest";
 import * as A from "effect/Array";
+import * as Str from "effect/String";
 
 describe("toAnnotatedDocument", () => {
   it("projects only source-aligned extractions into handoff entities", () => {
@@ -33,5 +34,38 @@ describe("toAnnotatedDocument", () => {
     expect(A.length(document.chunks)).toBe(1);
     expect(A.length(document.entities)).toBe(1);
     expect(O.map(A.head(document.entities), (entity) => entity.canonicalName)).toEqual(O.some("Ada Lovelace"));
+  });
+
+  it("emits one mention per aligned extraction carrying the aligned span into the document chunk", () => {
+    const documentId = DocumentId.make("doc-1");
+    const sourceText = "Ada Lovelace wrote notes.";
+    const span = Contract.Span.make({ end: NonNegativeInt.make(12), start: NonNegativeInt.make(0) });
+    const aligned = GroundedExtraction.cases.match_exact.make({
+      label: "person",
+      matchedText: "Ada Lovelace",
+      span,
+      text: "Ada Lovelace",
+    });
+
+    const document = toAnnotatedDocument({
+      documentId,
+      extractions: [aligned, GroundedExtraction.cases.unaligned.make({ label: "place", text: "Paris" })],
+      generatedBy: "@beep/langextract:test",
+      text: sourceText,
+      timestamp: 0,
+    });
+
+    const mention = A.head(document.mentions);
+    const entity = A.head(document.entities);
+    const chunk = A.head(document.chunks);
+
+    expect(document.version).toBe("nlp-ir/1.1");
+    expect(A.length(document.mentions)).toBe(1);
+    expect(O.map(mention, (m) => m.span)).toEqual(O.some(span));
+    expect(O.map(mention, (m) => Str.slice(m.span.start, m.span.end)(sourceText))).toEqual(
+      O.map(mention, (m) => m.text)
+    );
+    expect(O.map(mention, (m) => m.id)).toEqual(O.flatMap(entity, (e) => A.head(e.mentions)));
+    expect(O.map(mention, (m) => m.chunkId)).toEqual(O.map(chunk, (c) => c.id));
   });
 });

--- a/packages/foundation/capability/langextract/test/Service.test.ts
+++ b/packages/foundation/capability/langextract/test/Service.test.ts
@@ -116,6 +116,7 @@ describe("LangExtractService", () => {
         expect(result.extractions).toHaveLength(2);
         expect(result.diagnostics.alignedCount).toBe(2);
         expect(result.annotatedDocument.entities).toHaveLength(2);
+        expect(result.annotatedDocument.mentions).toHaveLength(2);
         expect(result.annotatedDocument.chunks[0]?.span.end).toBe(Str.length("Alice founded Acme."));
       })
     );

--- a/packages/foundation/modeling/nlp/README.md
+++ b/packages/foundation/modeling/nlp/README.md
@@ -36,9 +36,9 @@ console.log(config.norm)
 
 | Consumer | Surface used | Notes |
 | --- | --- | --- |
-| `@beep/nlp-processing` | `Core`, `Graph`, `Handoff` | Provider-neutral processing contracts and services built on these models. |
-| `@beep/wink` | `Core` | wink-nlp driver using shared document, token, vectorization, and similarity models. |
-| `@beep/nlp-mcp` | `Core`, `Handoff` | MCP driver exposing processing tools plus shared handoff models. |
+| `@beep/langextract` | `Core`, `Handoff` | Emits the `AnnotatedDocument` handoff envelope (chunks, mentions, entities) from grounded extractions. |
+| `@beep/nlp-processing` | `Core`, `Graph` | Provider-neutral processing contracts and services built on these models. |
+| `@beep/wink` | `Core`, `Graph` | wink-nlp driver using shared document, token, vectorization, and similarity models. |
 
 ## Development
 

--- a/packages/foundation/modeling/nlp/THEORY.md
+++ b/packages/foundation/modeling/nlp/THEORY.md
@@ -134,7 +134,7 @@ what lets `@beep/nlp-mcp` re-expose each as an independent MCP tool.
 ## 8. The generic IR: a free object at the boundary
 
 `src/Handoff/Contract.ts` is the product-neutral handoff: `TextChunk`,
-`Mention`, `Entity`, `Relation`, `AnnotatedDocument` (version `nlp-ir/1.0`),
+`Mention`, `Entity`, `Relation`, `AnnotatedDocument` (version `nlp-ir/1.1`),
 with branded ids, character `Span`s, and PROV-O-style `Provenance`
 (source/generatedBy/timestamp/confidence). It is deliberately the **free
 object**: it carries a generic `type` discriminant on entities/relations and no

--- a/packages/foundation/modeling/nlp/src/Handoff/Contract.ts
+++ b/packages/foundation/modeling/nlp/src/Handoff/Contract.ts
@@ -256,7 +256,8 @@ export const Span = SpanFields.check(
   })
   .pipe(
     $I.annoteSchema("Span", {
-      description: "A half-open character span [start, end) into the source text (zero-based offsets).",
+      description:
+        "A half-open span [start, end) into the source text, measured in zero-based UTF-16 code units (the unit `String.length` and `slice` use).",
     }),
     SchemaUtils.withCodecStatics
   );
@@ -475,8 +476,15 @@ export class Relation extends S.Class<Relation>($I`Relation`)(
 
 /**
  * The top-level handoff envelope: a fully annotated document — its chunks,
- * entities, and relations — emitted by `@beep/nlp` for downstream consumption.
- * The `version` pins the contract revision.
+ * mentions, entities, and relations — emitted by `@beep/nlp` for downstream
+ * consumption. The `version` pins the contract revision.
+ *
+ * **Details**
+ *
+ * `mentions` carries every {@link Mention} an {@link Entity} refers to by id, so
+ * the per-occurrence character `span` survives the handoff instead of being
+ * dropped at the boundary. `nlp-ir/1.1` added the field; `nlp-ir/1.0`
+ * envelopes carried entities whose `mentions` ids resolved to nothing.
  *
  * **Example** (Make empty document)
  *
@@ -487,11 +495,12 @@ export class Relation extends S.Class<Relation>($I`Relation`)(
  * const document = AnnotatedDocument.make({
  *   chunks: [],
  *   entities: [],
+ *   mentions: [],
  *   provenance,
  *   relations: [],
- *   version: "nlp-ir/1.0"
+ *   version: "nlp-ir/1.1"
  * })
- * console.log(document.version) // "nlp-ir/1.0"
+ * console.log(document.version) // "nlp-ir/1.1"
  * ```
  *
  * @category models
@@ -501,12 +510,14 @@ export class AnnotatedDocument extends S.Class<AnnotatedDocument>($I`AnnotatedDo
   {
     chunks: S.Array(TextChunk),
     entities: S.Array(Entity),
+    mentions: S.Array(Mention),
     provenance: Provenance,
     relations: S.Array(Relation),
-    version: S.Literal("nlp-ir/1.0"),
+    version: S.Literal("nlp-ir/1.1"),
   },
   $I.annote("AnnotatedDocument", {
-    description: "The top-level handoff envelope: a fully annotated document (chunks + entities + relations).",
+    description:
+      "The top-level handoff envelope: a fully annotated document (chunks + mentions + entities + relations).",
   })
 ) {}
 

--- a/packages/foundation/modeling/nlp/test/Handoff/Contract.test.ts
+++ b/packages/foundation/modeling/nlp/test/Handoff/Contract.test.ts
@@ -8,9 +8,12 @@ import { Contract } from "@beep/nlp/Handoff";
 import { NonNegativeInt } from "@beep/schema";
 import { fcRuns } from "@beep/test-utils";
 import { describe, expect, it } from "@effect/vitest";
+import * as A from "effect/Array";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
+import * as O from "effect/Option";
 import * as S from "effect/Schema";
+import * as Str from "effect/String";
 import { FastCheck as fc } from "effect/testing";
 
 const AnnotatedDocumentArbitrary = S.toArbitrary(Contract.AnnotatedDocument)(fc);
@@ -40,6 +43,15 @@ const sampleDocument = Contract.AnnotatedDocument.make({
       type: "PLACE",
     }),
   ],
+  mentions: [
+    Contract.Mention.make({
+      chunkId: Contract.ChunkId.make("chunk-1"),
+      id: Contract.MentionId.make("mention-1"),
+      provenance: sampleProvenance,
+      span: Contract.Span.make({ end: NonNegativeInt.make(11), start: NonNegativeInt.make(6) }),
+      text: "world",
+    }),
+  ],
   provenance: sampleProvenance,
   relations: [
     Contract.Relation.make({
@@ -50,7 +62,7 @@ const sampleDocument = Contract.AnnotatedDocument.make({
       type: "MENTIONS",
     }),
   ],
-  version: "nlp-ir/1.0",
+  version: "nlp-ir/1.1",
 });
 
 describe("AnnotatedDocument round-trip", () => {
@@ -59,20 +71,38 @@ describe("AnnotatedDocument round-trip", () => {
     Effect.fnUntraced(function* () {
       const encoded = yield* S.encodeUnknownEffect(Contract.AnnotatedDocument)(sampleDocument);
       const decoded = yield* S.decodeEffect(Contract.AnnotatedDocument)(encoded);
-      expect(decoded.version).toBe("nlp-ir/1.0");
+      expect(decoded.version).toBe("nlp-ir/1.1");
       expect(decoded.chunks.length).toBe(1);
       expect(decoded.entities.length).toBe(1);
+      expect(decoded.mentions.length).toBe(1);
       expect(decoded.relations.length).toBe(1);
       expect(decoded.chunks[0]?.text).toBe("Hello world");
     })
   );
 
   it.effect(
-    "every chunk, entity, and relation carries provenance",
+    "mentions resolve to their entity and chunk with the span cut from the chunk text",
+    Effect.fnUntraced(function* () {
+      const encoded = yield* S.encodeUnknownEffect(Contract.AnnotatedDocument)(sampleDocument);
+      const decoded = yield* S.decodeEffect(Contract.AnnotatedDocument)(encoded);
+      const mention = A.head(decoded.mentions);
+      const entity = A.head(decoded.entities);
+      const chunk = A.head(decoded.chunks);
+      expect(O.map(mention, (m) => m.id)).toEqual(O.flatMap(entity, (e) => A.head(e.mentions)));
+      expect(O.map(mention, (m) => m.chunkId)).toEqual(O.map(chunk, (c) => c.id));
+      expect(O.map(mention, (m) => m.text)).toEqual(
+        O.zipWith(mention, chunk, (m, c) => Str.slice(m.span.start, m.span.end)(c.text))
+      );
+    })
+  );
+
+  it.effect(
+    "every chunk, mention, entity, and relation carries provenance",
     Effect.fnUntraced(function* () {
       const encoded = yield* S.encodeUnknownEffect(Contract.AnnotatedDocument)(sampleDocument);
       const decoded = yield* S.decodeEffect(Contract.AnnotatedDocument)(encoded);
       expect(decoded.chunks.every((c) => typeof c.provenance.source === "string")).toBe(true);
+      expect(decoded.mentions.every((m) => typeof m.provenance.source === "string")).toBe(true);
       expect(decoded.entities.every((e) => typeof e.provenance.generatedBy === "string")).toBe(true);
       expect(decoded.relations.every((r) => typeof r.provenance.timestamp === "number")).toBe(true);
     })

--- a/standards/schema-catalog.generated.jsonc
+++ b/standards/schema-catalog.generated.jsonc
@@ -15079,7 +15079,7 @@
       "kind": "schema-class",
       "owner": "@beep/nlp",
       "identity": "AnnotatedDocument",
-      "description": "The top-level handoff envelope: a fully annotated document (chunks + entities + relations)."
+      "description": "The top-level handoff envelope: a fully annotated document (chunks + mentions + entities + relations)."
     },
     {
       "file": "packages/foundation/modeling/nlp/src/Handoff/Contract.ts",


### PR DESCRIPTION
## fix(nlp): carry mentions and spans through the Handoff envelope

AnnotatedDocument gains `mentions: S.Array(Mention)` and pins version
`nlp-ir/1.1`. Entities always referenced mentions by id, but no producer
ever placed a Mention in the envelope, so every aligned character span was
dropped at the handoff boundary (decision M2, explorations/semantica-lab).

- Contract.ts: add the field, bump the version literal, document the
  envelope change, and state that Span offsets are UTF-16 code units.
- langextract Handoff.behavior.ts: build a Mention (aligned span +
  matchedText against the document chunk) alongside each Entity and
  unzip both into the envelope. Relations stay empty (separate issue).
- Tests: nlp Contract round-trip carries a mention resolving to its
  entity and chunk, and the provenance proof covers mentions; langextract
  asserts the emitted mention's own span slices the source text to its
  text, and the fake-LM service path emits mentions in the envelope.
- Docs: THEORY.md version literal; README consumer table now lists the
  real Handoff consumer (@beep/langextract) and corrects the surfaces
  used by nlp-processing and wink; nlp-mcp imports nothing from @beep/nlp.
  schema-catalog: hand-correct the AnnotatedDocument description line.
- Changeset: @beep/nlp minor, @beep/langextract patch.

Follow-up: the property test derives documents via S.toArbitrary, so a
mention/entity referential-integrity check needs a custom arbitrary.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

## Local proof

- publish:head-install-preflight: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/fix_nlp-handoff-mentions-588e8da7aad3/verdict.json

---

## Provenance

- Branch: <code>fix/nlp-handoff-mentions</code>
- Harness: `codex`

<!-- yeet-provenance
{
  "schemaVersion": 1,
  "branch": "fix/nlp-handoff-mentions",
  "harness": "codex"
}
-->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790201485&installation_model_id=424656&pr_number=801&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F801&signature=593310a46f171533d46980037260be8d6855e5b08f0e8c04b3a329dfdfdf9ba5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->