### PR TITLE
feat(skill-contract): retrofit the full qa judge as a typed SkillContract instance

### DIFF
--- a/goals/skill-contract-kernel/research/OPPORTUNITIES.md
+++ b/goals/skill-contract-kernel/research/OPPORTUNITIES.md
@@ -19,3 +19,9 @@ Receipts recorded when work is slower or riskier than the repo workflow should m
 - **Doing:** running the generated package's exact Turbo test task for the first-slice proof.
 - **Evidence:** both default fork workers timed out after 60 seconds before collecting either test file; the same seven tests completed immediately with `--pool=threads`, and the package coverage command then reported 100% for statements, branches, functions, and lines.
 - **Prevented by:** a repo-supported sandbox test profile that selects Vitest threads when child-process workers cannot start, while leaving ordinary local and CI defaults unchanged.
+
+## 2026-08-25: the TS2589 quarantine's lane rerun fails under peer-session load
+
+- **Doing:** first `yeet publish --pr` proof for the P1(c) judge retrofit, while two sibling checkouts ran their own proofs (load average ~28 on the same box).
+- **Evidence:** `quality:build` reported no-location `error TS2589` from `@beep/ui`, `@beep/xai`, and `@beep/box` — packages the PR does not touch; the quarantine reran and logged `lane rerun failed with exit 2; keeping failure hard`, so the whole ~25 min proof was lost to one environment-only class. `bunx turbo run build --filter=@beep/ui --filter=@beep/xai --filter=@beep/box --force --concurrency=1` then passed 11/11 at the same commit.
+- **Prevented by:** the quarantine rerunning the attributed packages at `--concurrency=1` (the disproof that always passes) instead of a full-lane rerun that inherits the same scheduling pressure, or a load-aware pre-flight that defers the full proof when the box is above a threshold.

--- a/packages/tooling/tool/cli/src/commands/Qa/JudgeCheck.ts
+++ b/packages/tooling/tool/cli/src/commands/Qa/JudgeCheck.ts
@@ -22,6 +22,16 @@ import {
   CitedArtifactExistsVerdict,
   evaluateCitedArtifactExists,
 } from "./CitedArtifactExistsGate.ts";
+import {
+  CitedEventIdExistsInput,
+  DeclaredRoundCoherentInput,
+  DeclaredRoundCoherentVerdict,
+  EvidenceCrossCheckCleanInput,
+  EvidenceCrossCheckCleanVerdict,
+  evaluateCitedEventIdExists,
+  evaluateDeclaredRoundCoherent,
+  evaluateEvidenceCrossCheckClean,
+} from "./JudgeContract.ts";
 import { QaCommandError } from "./Qa.errors.ts";
 import type { RoundLayout } from "@beep/qa-capture";
 import type { FileSystem, Path } from "effect";
@@ -249,6 +259,36 @@ export const citedArtifactVerdictToCrossCheck: {
   (verdict: CitedArtifactExistsVerdict, missingEventIds: ReadonlyArray<number>): EvidenceCrossCheck;
 } = dual(2, citedArtifactVerdictToCrossCheckImpl);
 
+const evidenceCrossCheckVerdictToCrossCheckImpl = (verdict: EvidenceCrossCheckCleanVerdict): EvidenceCrossCheck =>
+  EvidenceCrossCheckCleanVerdict.match(verdict, {
+    allowed: () => EvidenceCrossCheck.make({ missingEventIds: A.empty<number>(), missingPaths: A.empty<string>() }),
+    denied: ({ audit }) => EvidenceCrossCheck.make(audit.detail),
+  });
+
+/**
+ * Projects the derived aggregate gate verdict into the legacy cross-check model.
+ *
+ * **Details**
+ *
+ * Leaf verdict audits remain available to typed callers. This projection keeps
+ * only the ordered missing artifact paths and event ids exposed by the existing
+ * renderer and command adapters.
+ *
+ * **Example** (Inspect the projection)
+ *
+ * ```ts
+ * import { evidenceCrossCheckVerdictToCrossCheck } from "@beep/repo-cli/commands/Qa/JudgeCheck"
+ *
+ * console.log(typeof evidenceCrossCheckVerdictToCrossCheck) // "function"
+ * ```
+ *
+ * @param verdict - Derived artifact-and-event aggregate verdict.
+ * @returns Legacy evidence cross-check projection.
+ * @category projections
+ * @since 0.0.0
+ */
+export const evidenceCrossCheckVerdictToCrossCheck = evidenceCrossCheckVerdictToCrossCheckImpl;
+
 /**
  * Render a cross-check failure into an operator-readable error.
  *
@@ -322,12 +362,19 @@ export const crossCheckAgainstRound = Effect.fn("QaJudgeCheck.crossCheckAgainstR
   inventory: QaInventory,
   eventLog: QaEventLog
 ): Effect.fn.Return<EvidenceCrossCheck, never, FileSystem.FileSystem | Path.Path> {
-  const verdict = yield* evaluateCitedArtifactExists(
+  const artifactVerdict = yield* evaluateCitedArtifactExists(
     CitedArtifactExistsInput.make({ citedPaths: citedPaths(inventory), roundRoot: layout.root })
   );
-  const knownEventIds = HashSet.fromIterable(A.map(eventLog.events, (event) => event.seq));
-  const missingEventIds = A.filter(citedEventIds(inventory), (seq) => !HashSet.has(knownEventIds, seq));
-  return citedArtifactVerdictToCrossCheck(verdict, missingEventIds);
+  const eventIdVerdict = yield* evaluateCitedEventIdExists(
+    CitedEventIdExistsInput.make({
+      citedEventIds: citedEventIds(inventory),
+      knownEventIds: A.map(eventLog.events, (event) => event.seq),
+    })
+  );
+  const aggregateVerdict = yield* evaluateEvidenceCrossCheckClean(
+    EvidenceCrossCheckCleanInput.make({ artifactVerdict, eventIdVerdict })
+  );
+  return evidenceCrossCheckVerdictToCrossCheck(aggregateVerdict);
 });
 
 /**
@@ -356,8 +403,28 @@ export const raiseCrossCheckFailure: {
       : Effect.fail(QaCommandError.make({ message: renderCrossCheckFailure(round, check) }))
 );
 
+const requireInventoryRoundImpl = Effect.fn("QaJudgeCheck.requireInventoryRound")(function* (
+  round: number,
+  inventory: QaInventory
+): Effect.fn.Return<void, QaCommandError> {
+  const verdict = yield* evaluateDeclaredRoundCoherent(
+    DeclaredRoundCoherentInput.make({ declaredRound: inventory.round, requestedRound: round })
+  );
+  return yield* DeclaredRoundCoherentVerdict.match(verdict, {
+    allowed: () => Effect.void,
+    denied: ({ audit }) =>
+      Effect.fail(
+        QaCommandError.make({
+          message: `qa judge inventory declares round ${audit.detail.declaredRound} but round ${audit.detail.requestedRound} was requested.`,
+        })
+      ),
+  });
+});
+
 /**
  * Fail when an inventory declares a different round than the one requested.
+ *
+ * **Details**
  *
  * Witness sequence numbers restart per round and frame names repeat across
  * rounds, so a copied inventory can genuinely pass another round's evidence
@@ -386,17 +453,7 @@ export const raiseCrossCheckFailure: {
 export const requireInventoryRound: {
   (inventory: QaInventory): (round: number) => Effect.Effect<void, QaCommandError>;
   (round: number, inventory: QaInventory): Effect.Effect<void, QaCommandError>;
-} = dual(
-  2,
-  (round: number, inventory: QaInventory): Effect.Effect<void, QaCommandError> =>
-    inventory.round === round
-      ? Effect.void
-      : Effect.fail(
-          QaCommandError.make({
-            message: `qa judge inventory declares round ${inventory.round} but round ${round} was requested.`,
-          })
-        )
-);
+} = dual(2, requireInventoryRoundImpl);
 
 const FENCED_JSON = /```json\s*\r?\n([\s\S]*?)```/g;
 const FENCED_ANY = /```\s*\r?\n(\{[\s\S]*?\})\s*```/g;

--- a/packages/tooling/tool/cli/src/commands/Qa/JudgeContract.ts
+++ b/packages/tooling/tool/cli/src/commands/Qa/JudgeContract.ts
@@ -14,7 +14,6 @@ import { ISOStr } from "@beep/schema/Timestamp";
 import { Unknown } from "@beep/schema/Unknown";
 import {
   AlwaysGateApplicability,
-  ConditionalGateApplicability,
   EvidenceDigest,
   EvidenceLadderReceiptTypes,
   EvidencePredicateType,
@@ -553,11 +552,42 @@ class JudgeOutputInventoryDecodesAllowed extends S.Class<JudgeOutputInventoryDec
   })
 ) {}
 
-const JudgeOutputDecodeFailure = LiteralKit(["malformed-json", "inventory-schema-rejected"]).pipe(
+/**
+ * Decode stage that denies a judge-output inventory candidate.
+ *
+ * **Details**
+ *
+ * Adapters match on this domain to restore their flow-specific operator
+ * messages (`judge-ingest` and `judge-lint` word the same failure differently)
+ * while the gate reason itself stays flow-neutral.
+ *
+ * **Example** (Match a decode failure)
+ *
+ * ```ts
+ * import { JudgeOutputDecodeFailure } from "@beep/repo-cli/commands/Qa"
+ *
+ * console.log(JudgeOutputDecodeFailure.$match("malformed-json", {
+ *   "inventory-schema-rejected": () => "schema",
+ *   "malformed-json": () => "json"
+ * })) // "json"
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const JudgeOutputDecodeFailure = LiteralKit(["malformed-json", "inventory-schema-rejected"]).pipe(
   $I.annoteSchema("JudgeOutputDecodeFailure", {
-    description: "Fail-closed reasons emitted after judge-output extraction succeeds.",
+    description: "Fail-closed decode stages that deny a judge-output inventory candidate.",
   })
 );
+
+/**
+ * Runtime type decoded by {@link JudgeOutputDecodeFailure}.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export type JudgeOutputDecodeFailure = typeof JudgeOutputDecodeFailure.Type;
 
 class JudgeOutputInventoryDecodesDenied extends S.Class<JudgeOutputInventoryDecodesDenied>(
   $I`JudgeOutputInventoryDecodesDenied`
@@ -602,33 +632,33 @@ export const JudgeOutputInventoryDecodesVerdict = GateVerdict(
 export type JudgeOutputInventoryDecodesVerdict = typeof JudgeOutputInventoryDecodesVerdict.Type;
 
 /**
- * Conditional blocking declaration for extracted judge-output inventory decode.
+ * Blocking declaration for judge-output inventory decode.
+ *
+ * **Details**
+ *
+ * The gate is always applicable: `judge-ingest` feeds it the JSON block
+ * extracted from raw judge output and `judge-lint` feeds it the committed
+ * inventory file, so both flows run every declared gate and the kernel's
+ * completion evaluator never sees an unverifiable conditional blocker.
  *
  * **Example** (Inspect decode gate applicability)
  *
  * ```ts
  * import { JudgeOutputInventoryDecodesGate } from "@beep/repo-cli/commands/Qa"
  *
- * console.log(JudgeOutputInventoryDecodesGate.applicability.kind) // "conditional"
+ * console.log(JudgeOutputInventoryDecodesGate.applicability.kind) // "always"
  * ```
  *
  * @category models
  * @since 0.0.0
  */
-export const JudgeOutputInventoryDecodesGate = GateDeclaration.make({
-  applicability: ConditionalGateApplicability.make({
-    condition: SchemaReference.make({
-      schemaId: SchemaReferenceId.make("https://beep-effect.dev/qa/conditions/qa-source-kind/v1"),
-    }),
-  }),
-  evidence: GateEvidenceRequirement.make({ predicateType: judgeOutputInventoryPredicateType }),
-  id: judgeOutputInventoryDecodesGateId,
-  remediationOwner,
-  severity: "blocking",
-});
+export const JudgeOutputInventoryDecodesGate = alwaysBlockingGate(
+  judgeOutputInventoryDecodesGateId,
+  judgeOutputInventoryPredicateType
+);
 
 const outputDecodeDenial = (
-  failure: typeof JudgeOutputDecodeFailure.Type,
+  failure: JudgeOutputDecodeFailure,
   issue: string,
   occurredAt: ISOStr
 ): JudgeOutputInventoryDecodesVerdict =>
@@ -640,9 +670,8 @@ const outputDecodeDenial = (
       occurredAt,
       outcome: "denied",
       reason: JudgeOutputDecodeFailure.$match(failure, {
-        "inventory-schema-rejected": () =>
-          "qa judge-ingest rejected the judge inventory. Check schemaVersion, finding ids (R<round>-<nn>), lens values, and that requiredCount equals the P0+P1 count.",
-        "malformed-json": () => "qa judge-ingest could not parse the judge's final JSON block.",
+        "inventory-schema-rejected": () => "The judge output candidate does not decode as qa-inventory/v1.",
+        "malformed-json": () => "The judge output candidate does not parse as JSON.",
       }),
     },
   });
@@ -654,8 +683,8 @@ const outputDecodeDenial = (
  *
  * Malformed JSON and inventory-schema rejection are denied verdict values that
  * carry the rendered decoder issue, so adapters keep the parser or schema
- * detail as the error cause. The adapter retains the existing `QaCommandError`
- * messages.
+ * detail as the error cause and match the failure stage to restore their
+ * existing `QaCommandError` messages.
  *
  * **Example** (Build an output-decode evaluation)
  *
@@ -747,10 +776,12 @@ export const QaJudgeContractSubject = EvidenceSubject.make({
  *
  * **Details**
  *
- * Declaration order is observable and matches judge execution: artifact and
- * event leaves, round coherence, aggregate settlement, then conditional output
- * decode. The output-decode declaration is conditional because lint starts
- * from a committed JSON inventory rather than raw judge output.
+ * Declaration order is observable and matches the executable dependency order
+ * shared by `judge-ingest` and `judge-lint`: output decode first (its allowed
+ * detail is the inventory every later gate reads), round coherence, the
+ * artifact and event leaves, then aggregate settlement. Every declaration is
+ * always applicable, so the kernel's completion evaluator can settle this
+ * contract from a gate summary.
  *
  * **Example** (Inspect gate order)
  *
@@ -768,11 +799,11 @@ export const QaJudgeContract = SkillContract.make({
   evidenceSubject: QaJudgeContractSubject,
   gates: GateRegistry.make({
     declarations: [
+      JudgeOutputInventoryDecodesGate,
+      DeclaredRoundCoherentGate,
       CitedArtifactExistsGate,
       CitedEventIdExistsGate,
-      DeclaredRoundCoherentGate,
       EvidenceCrossCheckCleanGate,
-      JudgeOutputInventoryDecodesGate,
     ],
   }),
   id: qaJudgeContractId,

--- a/packages/tooling/tool/cli/src/commands/Qa/JudgeContract.ts
+++ b/packages/tooling/tool/cli/src/commands/Qa/JudgeContract.ts
@@ -32,8 +32,8 @@ import {
   SkillContract,
   SkillContractId,
 } from "@beep/skill-contract";
-import { A, O } from "@beep/utils";
-import { DateTime, Effect, HashSet } from "effect";
+import { A } from "@beep/utils";
+import { DateTime, Effect, HashSet, Result } from "effect";
 import * as S from "effect/Schema";
 import { CitedArtifactExistsGate, CitedArtifactExistsVerdict } from "./CitedArtifactExistsGate.ts";
 import { decodeQaInventory, QaInventory } from "./Inventory.schemas.ts";
@@ -562,9 +562,14 @@ const JudgeOutputDecodeFailure = LiteralKit(["malformed-json", "inventory-schema
 class JudgeOutputInventoryDecodesDenied extends S.Class<JudgeOutputInventoryDecodesDenied>(
   $I`JudgeOutputInventoryDecodesDenied`
 )(
-  { failure: JudgeOutputDecodeFailure },
+  {
+    failure: JudgeOutputDecodeFailure,
+    issue: S.String.annotateKey({
+      description: "Rendered parser or schema issue that denied the candidate, kept for diagnostics.",
+    }),
+  },
   $I.annote("JudgeOutputInventoryDecodesDenied", {
-    description: "Decode stage that denied an extracted judge-output inventory candidate.",
+    description: "Decode stage and rendered issue that denied an extracted judge-output inventory candidate.",
   })
 ) {}
 
@@ -624,11 +629,12 @@ export const JudgeOutputInventoryDecodesGate = GateDeclaration.make({
 
 const outputDecodeDenial = (
   failure: typeof JudgeOutputDecodeFailure.Type,
+  issue: string,
   occurredAt: ISOStr
 ): JudgeOutputInventoryDecodesVerdict =>
   JudgeOutputInventoryDecodesVerdict.cases.denied.make({
     audit: {
-      detail: JudgeOutputInventoryDecodesDenied.make({ failure }),
+      detail: JudgeOutputInventoryDecodesDenied.make({ failure, issue }),
       evaluator: "@beep/repo-cli/qa/judge-output-inventory-decodes",
       gateId: judgeOutputInventoryDecodesGateId,
       occurredAt,
@@ -646,8 +652,10 @@ const outputDecodeDenial = (
  *
  * **Details**
  *
- * Malformed JSON and inventory-schema rejection are denied verdict values.
- * The adapter retains the existing `QaCommandError` messages.
+ * Malformed JSON and inventory-schema rejection are denied verdict values that
+ * carry the rendered decoder issue, so adapters keep the parser or schema
+ * detail as the error cause. The adapter retains the existing `QaCommandError`
+ * messages.
  *
  * **Example** (Build an output-decode evaluation)
  *
@@ -674,16 +682,16 @@ export const evaluateJudgeOutputInventoryDecodes: GateEvaluator<
   input: JudgeOutputInventoryDecodesInput
 ): Effect.fn.Return<JudgeOutputInventoryDecodesVerdict> {
   const occurredAt = yield* auditTimestamp;
-  const parsed = yield* Effect.option(Unknown.decodeEffectFromJsonString(input.candidate));
+  const parsed = yield* Effect.result(Unknown.decodeEffectFromJsonString(input.candidate));
 
-  return yield* O.match(parsed, {
-    onNone: () => Effect.succeed(outputDecodeDenial("malformed-json", occurredAt)),
-    onSome: (value) =>
-      Effect.option(decodeQaInventory(value)).pipe(
+  return yield* Result.match(parsed, {
+    onFailure: (issue) => Effect.succeed(outputDecodeDenial("malformed-json", issue.message, occurredAt)),
+    onSuccess: (value) =>
+      Effect.result(decodeQaInventory(value)).pipe(
         Effect.map(
-          O.match({
-            onNone: () => outputDecodeDenial("inventory-schema-rejected", occurredAt),
-            onSome: (inventory) =>
+          Result.match({
+            onFailure: (issue) => outputDecodeDenial("inventory-schema-rejected", issue.message, occurredAt),
+            onSuccess: (inventory) =>
               JudgeOutputInventoryDecodesVerdict.cases.allowed.make({
                 audit: {
                   detail: JudgeOutputInventoryDecodesAllowed.make({ inventory }),

--- a/packages/tooling/tool/cli/src/commands/Qa/JudgeContract.ts
+++ b/packages/tooling/tool/cli/src/commands/Qa/JudgeContract.ts
@@ -1,0 +1,791 @@
+/**
+ * Typed gate composition for the complete `qa-inventory/v1` judge.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { RoundNumber } from "@beep/qa-capture";
+import { LiteralKit } from "@beep/schema/LiteralKit";
+import { SemanticVersion } from "@beep/schema/SemanticVersion";
+import { Sha256Hex } from "@beep/schema/Sha256";
+import { ISOStr } from "@beep/schema/Timestamp";
+import { Unknown } from "@beep/schema/Unknown";
+import {
+  AlwaysGateApplicability,
+  ConditionalGateApplicability,
+  EvidenceDigest,
+  EvidenceLadderReceiptTypes,
+  EvidencePredicateType,
+  EvidenceSubject,
+  FailurePredicateType,
+  GateDeclaration,
+  GateEvidenceRequirement,
+  GateRegistry,
+  GateSummaryPredicateType,
+  GateVerdict,
+  NoRecoveryPolicy,
+  ReceiptTypeBindings,
+  SchemaReference,
+  SchemaReferenceId,
+  SkillContract,
+  SkillContractId,
+} from "@beep/skill-contract";
+import { A, O } from "@beep/utils";
+import { DateTime, Effect, HashSet } from "effect";
+import * as S from "effect/Schema";
+import { CitedArtifactExistsGate, CitedArtifactExistsVerdict } from "./CitedArtifactExistsGate.ts";
+import { decodeQaInventory, QaInventory } from "./Inventory.schemas.ts";
+import { QaJudgeGateId } from "./QaJudgeGateId.ts";
+import type { GateEvaluator } from "@beep/skill-contract";
+
+const $I = $RepoCliId.create("commands/Qa/JudgeContract");
+const remediationOwner = "@beep/repo-cli/Qa";
+const auditTimestamp = DateTime.now.pipe(Effect.map(DateTime.formatIso), Effect.map(ISOStr.make));
+
+const citedEventIdExistsGateId = QaJudgeGateId.make("cited-event-id-exists");
+const declaredRoundCoherentGateId = QaJudgeGateId.make("declared-round-coherent");
+const evidenceCrossCheckCleanGateId = QaJudgeGateId.make("evidence-cross-check-clean");
+const judgeOutputInventoryDecodesGateId = QaJudgeGateId.make("judge-output-inventory-decodes");
+
+const citedEventIdExistsPredicateType = EvidencePredicateType.make(
+  "https://beep-effect.dev/qa/evidence/cited-event-id-exists/v1"
+);
+const declaredRoundCoherentPredicateType = EvidencePredicateType.make(
+  "https://beep-effect.dev/qa/evidence/declared-round-coherent/v1"
+);
+const evidenceCrossCheckPredicateType = EvidencePredicateType.make(
+  "https://beep-effect.dev/qa/evidence/evidence-cross-check/v1"
+);
+const judgeOutputInventoryPredicateType = EvidencePredicateType.make(
+  "https://beep-effect.dev/qa/evidence/judge-output-inventory/v1"
+);
+
+const alwaysBlockingGate = (id: QaJudgeGateId, predicateType: EvidencePredicateType): GateDeclaration =>
+  GateDeclaration.make({
+    applicability: AlwaysGateApplicability.make({}),
+    evidence: GateEvidenceRequirement.make({ predicateType }),
+    id,
+    remediationOwner,
+    severity: "blocking",
+  });
+
+/**
+ * Ordered event citations and witness ids consumed by the event-existence gate.
+ *
+ * **Example** (Create event gate input)
+ *
+ * ```ts
+ * import { CitedEventIdExistsInput } from "@beep/repo-cli/commands/Qa"
+ *
+ * const input = CitedEventIdExistsInput.make({ citedEventIds: [4, 7], knownEventIds: [4] })
+ * console.log(input.citedEventIds) // [4, 7]
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class CitedEventIdExistsInput extends S.Class<CitedEventIdExistsInput>($I`CitedEventIdExistsInput`)(
+  {
+    citedEventIds: S.Array(S.Int),
+    knownEventIds: S.Array(S.Int),
+  },
+  $I.annote("CitedEventIdExistsInput", {
+    description: "Ordered event citations and known witness ids consumed by the event-existence gate.",
+  })
+) {}
+
+class CitedEventIdExistsAllowed extends S.Class<CitedEventIdExistsAllowed>($I`CitedEventIdExistsAllowed`)(
+  { checkedEventIds: S.Array(S.Int) },
+  $I.annote("CitedEventIdExistsAllowed", {
+    description: "Event citations inspected by an allowed event-existence evaluation.",
+  })
+) {}
+
+class CitedEventIdExistsDenied extends S.Class<CitedEventIdExistsDenied>($I`CitedEventIdExistsDenied`)(
+  {
+    checkedEventIds: S.Array(S.Int),
+    missingEventIds: S.NonEmptyArray(S.Int),
+  },
+  $I.annote("CitedEventIdExistsDenied", {
+    description: "Event citations inspected by a denied evaluation and the ids absent from the witness log.",
+  })
+) {}
+
+/**
+ * Audited verdict for witness-event citation existence.
+ *
+ * **Example** (Inspect verdict cases)
+ *
+ * ```ts
+ * import { CitedEventIdExistsVerdict } from "@beep/repo-cli/commands/Qa"
+ *
+ * console.log(CitedEventIdExistsVerdict.discriminants) // ["allowed", "denied"]
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const CitedEventIdExistsVerdict = GateVerdict(
+  "CitedEventIdExistsVerdict",
+  CitedEventIdExistsAllowed,
+  CitedEventIdExistsDenied
+);
+
+/**
+ * Runtime type decoded by {@link CitedEventIdExistsVerdict}.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export type CitedEventIdExistsVerdict = typeof CitedEventIdExistsVerdict.Type;
+
+/**
+ * Blocking declaration for witness-event citation existence.
+ *
+ * **Example** (Inspect the event gate)
+ *
+ * ```ts
+ * import { CitedEventIdExistsGate } from "@beep/repo-cli/commands/Qa"
+ *
+ * console.log(CitedEventIdExistsGate.id) // "cited-event-id-exists"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const CitedEventIdExistsGate = alwaysBlockingGate(citedEventIdExistsGateId, citedEventIdExistsPredicateType);
+
+/**
+ * Finds cited event ids absent from the witness log in first-citation order.
+ *
+ * **Example** (Build an event evaluation)
+ *
+ * ```ts
+ * import { CitedEventIdExistsInput, evaluateCitedEventIdExists } from "@beep/repo-cli/commands/Qa"
+ * import { Effect } from "effect"
+ *
+ * const program = evaluateCitedEventIdExists(
+ *   CitedEventIdExistsInput.make({ citedEventIds: [4, 7], knownEventIds: [4] })
+ * )
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const evaluateCitedEventIdExists: GateEvaluator<CitedEventIdExistsInput, CitedEventIdExistsVerdict> = Effect.fn(
+  "QaJudgeContract.evaluateCitedEventIdExists"
+)(function* (input: CitedEventIdExistsInput): Effect.fn.Return<CitedEventIdExistsVerdict> {
+  const checkedEventIds = A.dedupe(input.citedEventIds);
+  const knownEventIds = HashSet.fromIterable(input.knownEventIds);
+  const missingEventIds = A.filter(checkedEventIds, (eventId) => !HashSet.has(knownEventIds, eventId));
+  const occurredAt = yield* auditTimestamp;
+
+  return A.match(missingEventIds, {
+    onEmpty: () =>
+      CitedEventIdExistsVerdict.cases.allowed.make({
+        audit: {
+          detail: CitedEventIdExistsAllowed.make({ checkedEventIds }),
+          evaluator: "@beep/repo-cli/qa/cited-event-id-exists",
+          gateId: citedEventIdExistsGateId,
+          occurredAt,
+          outcome: "allowed",
+          reason: "Every cited event id appears in the round witness log.",
+        },
+      }),
+    onNonEmpty: (missing) =>
+      CitedEventIdExistsVerdict.cases.denied.make({
+        audit: {
+          detail: CitedEventIdExistsDenied.make({ checkedEventIds, missingEventIds: missing }),
+          evaluator: "@beep/repo-cli/qa/cited-event-id-exists",
+          gateId: citedEventIdExistsGateId,
+          occurredAt,
+          outcome: "denied",
+          reason: "One or more cited event ids are absent from the round witness log.",
+        },
+      }),
+  });
+});
+
+/**
+ * Requested and declared round numbers consumed by the coherence gate.
+ *
+ * **Example** (Create round-coherence input)
+ *
+ * ```ts
+ * import { DeclaredRoundCoherentInput } from "@beep/repo-cli/commands/Qa"
+ *
+ * const input = DeclaredRoundCoherentInput.make({ declaredRound: 2, requestedRound: 1 })
+ * console.log(input.declaredRound) // 2
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class DeclaredRoundCoherentInput extends S.Class<DeclaredRoundCoherentInput>($I`DeclaredRoundCoherentInput`)(
+  {
+    declaredRound: RoundNumber,
+    requestedRound: RoundNumber,
+  },
+  $I.annote("DeclaredRoundCoherentInput", {
+    description: "Requested and inventory-declared round numbers consumed by the coherence gate.",
+  })
+) {}
+
+class DeclaredRoundCoherenceDetail extends S.Class<DeclaredRoundCoherenceDetail>($I`DeclaredRoundCoherenceDetail`)(
+  {
+    declaredRound: RoundNumber,
+    requestedRound: RoundNumber,
+  },
+  $I.annote("DeclaredRoundCoherenceDetail", {
+    description: "Requested and declared round numbers recorded by a coherence verdict.",
+  })
+) {}
+
+/**
+ * Audited verdict for inventory round coherence.
+ *
+ * **Example** (Inspect verdict cases)
+ *
+ * ```ts
+ * import { DeclaredRoundCoherentVerdict } from "@beep/repo-cli/commands/Qa"
+ *
+ * console.log(DeclaredRoundCoherentVerdict.discriminants) // ["allowed", "denied"]
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const DeclaredRoundCoherentVerdict = GateVerdict(
+  "DeclaredRoundCoherentVerdict",
+  DeclaredRoundCoherenceDetail,
+  DeclaredRoundCoherenceDetail
+);
+
+/**
+ * Runtime type decoded by {@link DeclaredRoundCoherentVerdict}.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export type DeclaredRoundCoherentVerdict = typeof DeclaredRoundCoherentVerdict.Type;
+
+/**
+ * Blocking declaration for requested and declared round coherence.
+ *
+ * **Example** (Inspect the round gate)
+ *
+ * ```ts
+ * import { DeclaredRoundCoherentGate } from "@beep/repo-cli/commands/Qa"
+ *
+ * console.log(DeclaredRoundCoherentGate.id) // "declared-round-coherent"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const DeclaredRoundCoherentGate = alwaysBlockingGate(
+  declaredRoundCoherentGateId,
+  declaredRoundCoherentPredicateType
+);
+
+const roundNumberEquivalence = S.toEquivalence(RoundNumber);
+
+/**
+ * Compares the requested round with the round declared by an inventory.
+ *
+ * **Example** (Build a round evaluation)
+ *
+ * ```ts
+ * import { DeclaredRoundCoherentInput, evaluateDeclaredRoundCoherent } from "@beep/repo-cli/commands/Qa"
+ * import { Effect } from "effect"
+ *
+ * const program = evaluateDeclaredRoundCoherent(
+ *   DeclaredRoundCoherentInput.make({ declaredRound: 1, requestedRound: 1 })
+ * )
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const evaluateDeclaredRoundCoherent: GateEvaluator<DeclaredRoundCoherentInput, DeclaredRoundCoherentVerdict> =
+  Effect.fn("QaJudgeContract.evaluateDeclaredRoundCoherent")(function* (
+    input: DeclaredRoundCoherentInput
+  ): Effect.fn.Return<DeclaredRoundCoherentVerdict> {
+    const occurredAt = yield* auditTimestamp;
+    const detail = DeclaredRoundCoherenceDetail.make(input);
+    return roundNumberEquivalence(input.declaredRound, input.requestedRound)
+      ? DeclaredRoundCoherentVerdict.cases.allowed.make({
+          audit: {
+            detail,
+            evaluator: "@beep/repo-cli/qa/declared-round-coherent",
+            gateId: declaredRoundCoherentGateId,
+            occurredAt,
+            outcome: "allowed",
+            reason: "The inventory declares the requested QA round.",
+          },
+        })
+      : DeclaredRoundCoherentVerdict.cases.denied.make({
+          audit: {
+            detail,
+            evaluator: "@beep/repo-cli/qa/declared-round-coherent",
+            gateId: declaredRoundCoherentGateId,
+            occurredAt,
+            outcome: "denied",
+            reason: "The inventory declares a different QA round than the requested round.",
+          },
+        });
+  });
+
+/**
+ * Artifact and event leaf verdicts consumed by the aggregate consistency gate.
+ *
+ * **Example** (Inspect aggregate input fields)
+ *
+ * ```ts
+ * import { EvidenceCrossCheckCleanInput } from "@beep/repo-cli/commands/Qa"
+ *
+ * console.log(EvidenceCrossCheckCleanInput.fields.artifactVerdict !== undefined) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class EvidenceCrossCheckCleanInput extends S.Class<EvidenceCrossCheckCleanInput>(
+  $I`EvidenceCrossCheckCleanInput`
+)(
+  {
+    artifactVerdict: CitedArtifactExistsVerdict,
+    eventIdVerdict: CitedEventIdExistsVerdict,
+  },
+  $I.annote("EvidenceCrossCheckCleanInput", {
+    description: "Artifact and event leaf verdicts consumed by the aggregate evidence consistency gate.",
+  })
+) {}
+
+class EvidenceCrossCheckCleanAllowed extends S.Class<EvidenceCrossCheckCleanAllowed>(
+  $I`EvidenceCrossCheckCleanAllowed`
+)(
+  {},
+  $I.annote("EvidenceCrossCheckCleanAllowed", {
+    description: "Observation detail for an evidence cross-check with no missing citations.",
+  })
+) {}
+
+const EvidenceCrossCheckCleanDeniedFields = S.Struct({
+  missingEventIds: S.Array(S.Int),
+  missingPaths: S.Array(S.String),
+});
+const EvidenceCrossCheckHasMissingCitation = S.makeFilter(
+  (detail: typeof EvidenceCrossCheckCleanDeniedFields.Type) =>
+    A.isReadonlyArrayNonEmpty(detail.missingPaths) || A.isReadonlyArrayNonEmpty(detail.missingEventIds),
+  {
+    identifier: $I`EvidenceCrossCheckHasMissingCitation`,
+    title: "Evidence cross-check has a missing citation",
+    description: "A denied aggregate cross-check names at least one missing artifact or event id.",
+    message: "Expected at least one missing artifact path or event id",
+  }
+);
+
+class EvidenceCrossCheckCleanDenied extends S.Class<EvidenceCrossCheckCleanDenied>($I`EvidenceCrossCheckCleanDenied`)(
+  EvidenceCrossCheckCleanDeniedFields.check(EvidenceCrossCheckHasMissingCitation),
+  $I.annote("EvidenceCrossCheckCleanDenied", {
+    description: "Ordered missing artifact paths and event ids recorded by a denied aggregate cross-check.",
+  })
+) {}
+
+/**
+ * Audited verdict for the derived evidence consistency check.
+ *
+ * **Example** (Inspect aggregate verdict cases)
+ *
+ * ```ts
+ * import { EvidenceCrossCheckCleanVerdict } from "@beep/repo-cli/commands/Qa"
+ *
+ * console.log(EvidenceCrossCheckCleanVerdict.discriminants) // ["allowed", "denied"]
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const EvidenceCrossCheckCleanVerdict = GateVerdict(
+  "EvidenceCrossCheckCleanVerdict",
+  EvidenceCrossCheckCleanAllowed,
+  EvidenceCrossCheckCleanDenied
+);
+
+/**
+ * Runtime type decoded by {@link EvidenceCrossCheckCleanVerdict}.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export type EvidenceCrossCheckCleanVerdict = typeof EvidenceCrossCheckCleanVerdict.Type;
+
+/**
+ * Blocking declaration for the derived artifact-and-event settlement.
+ *
+ * **Example** (Inspect the aggregate gate)
+ *
+ * ```ts
+ * import { EvidenceCrossCheckCleanGate } from "@beep/repo-cli/commands/Qa"
+ *
+ * console.log(EvidenceCrossCheckCleanGate.id) // "evidence-cross-check-clean"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const EvidenceCrossCheckCleanGate = alwaysBlockingGate(
+  evidenceCrossCheckCleanGateId,
+  evidenceCrossCheckPredicateType
+);
+
+const missingPathsFromArtifactVerdict = (verdict: CitedArtifactExistsVerdict): ReadonlyArray<string> =>
+  CitedArtifactExistsVerdict.match(verdict, {
+    allowed: A.empty<string>,
+    denied: ({ audit }) => audit.detail.missingPaths,
+  });
+
+const missingEventIdsFromVerdict = (verdict: CitedEventIdExistsVerdict): ReadonlyArray<number> =>
+  CitedEventIdExistsVerdict.match(verdict, {
+    allowed: A.empty<number>,
+    denied: ({ audit }) => audit.detail.missingEventIds,
+  });
+
+/**
+ * Settles artifact and event leaf verdicts as one derived aggregate verdict.
+ *
+ * **Example** (Inspect the evaluator)
+ *
+ * ```ts
+ * import { evaluateEvidenceCrossCheckClean } from "@beep/repo-cli/commands/Qa"
+ *
+ * console.log(typeof evaluateEvidenceCrossCheckClean) // "function"
+ * ```
+ *
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const evaluateEvidenceCrossCheckClean: GateEvaluator<
+  EvidenceCrossCheckCleanInput,
+  EvidenceCrossCheckCleanVerdict
+> = Effect.fn("QaJudgeContract.evaluateEvidenceCrossCheckClean")(function* (
+  input: EvidenceCrossCheckCleanInput
+): Effect.fn.Return<EvidenceCrossCheckCleanVerdict> {
+  const missingPaths = missingPathsFromArtifactVerdict(input.artifactVerdict);
+  const missingEventIds = missingEventIdsFromVerdict(input.eventIdVerdict);
+  const occurredAt = yield* auditTimestamp;
+
+  return A.match(missingPaths, {
+    onEmpty: () =>
+      A.match(missingEventIds, {
+        onEmpty: () =>
+          EvidenceCrossCheckCleanVerdict.cases.allowed.make({
+            audit: {
+              detail: EvidenceCrossCheckCleanAllowed.make({}),
+              evaluator: "@beep/repo-cli/qa/evidence-cross-check-clean",
+              gateId: evidenceCrossCheckCleanGateId,
+              occurredAt,
+              outcome: "allowed",
+              reason: "Every artifact and event citation is backed by the round.",
+            },
+          }),
+        onNonEmpty: (events) =>
+          EvidenceCrossCheckCleanVerdict.cases.denied.make({
+            audit: {
+              detail: EvidenceCrossCheckCleanDenied.make({ missingEventIds: events, missingPaths: A.empty() }),
+              evaluator: "@beep/repo-cli/qa/evidence-cross-check-clean",
+              gateId: evidenceCrossCheckCleanGateId,
+              occurredAt,
+              outcome: "denied",
+              reason: "One or more artifact or event citations are not backed by the round.",
+            },
+          }),
+      }),
+    onNonEmpty: (paths) =>
+      EvidenceCrossCheckCleanVerdict.cases.denied.make({
+        audit: {
+          detail: EvidenceCrossCheckCleanDenied.make({ missingEventIds, missingPaths: paths }),
+          evaluator: "@beep/repo-cli/qa/evidence-cross-check-clean",
+          gateId: evidenceCrossCheckCleanGateId,
+          occurredAt,
+          outcome: "denied",
+          reason: "One or more artifact or event citations are not backed by the round.",
+        },
+      }),
+  });
+});
+
+/**
+ * Extracted JSON candidate consumed by the conditional inventory-decode gate.
+ *
+ * **Example** (Create output-decode input)
+ *
+ * ```ts
+ * import { JudgeOutputInventoryDecodesInput } from "@beep/repo-cli/commands/Qa"
+ *
+ * const input = JudgeOutputInventoryDecodesInput.make({ candidate: "{}" })
+ * console.log(input.candidate) // "{}"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class JudgeOutputInventoryDecodesInput extends S.Class<JudgeOutputInventoryDecodesInput>(
+  $I`JudgeOutputInventoryDecodesInput`
+)(
+  { candidate: S.String },
+  $I.annote("JudgeOutputInventoryDecodesInput", {
+    description: "JSON candidate already extracted from judge output for inventory schema decoding.",
+  })
+) {}
+
+class JudgeOutputInventoryDecodesAllowed extends S.Class<JudgeOutputInventoryDecodesAllowed>(
+  $I`JudgeOutputInventoryDecodesAllowed`
+)(
+  { inventory: QaInventory },
+  $I.annote("JudgeOutputInventoryDecodesAllowed", {
+    description: "Schema-decoded QA inventory carried by an allowed judge-output verdict.",
+  })
+) {}
+
+const JudgeOutputDecodeFailure = LiteralKit(["malformed-json", "inventory-schema-rejected"]).pipe(
+  $I.annoteSchema("JudgeOutputDecodeFailure", {
+    description: "Fail-closed reasons emitted after judge-output extraction succeeds.",
+  })
+);
+
+class JudgeOutputInventoryDecodesDenied extends S.Class<JudgeOutputInventoryDecodesDenied>(
+  $I`JudgeOutputInventoryDecodesDenied`
+)(
+  { failure: JudgeOutputDecodeFailure },
+  $I.annote("JudgeOutputInventoryDecodesDenied", {
+    description: "Decode stage that denied an extracted judge-output inventory candidate.",
+  })
+) {}
+
+/**
+ * Audited verdict for an extracted judge-output inventory candidate.
+ *
+ * **Example** (Inspect decode verdict cases)
+ *
+ * ```ts
+ * import { JudgeOutputInventoryDecodesVerdict } from "@beep/repo-cli/commands/Qa"
+ *
+ * console.log(JudgeOutputInventoryDecodesVerdict.discriminants) // ["allowed", "denied"]
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const JudgeOutputInventoryDecodesVerdict = GateVerdict(
+  "JudgeOutputInventoryDecodesVerdict",
+  JudgeOutputInventoryDecodesAllowed,
+  JudgeOutputInventoryDecodesDenied
+);
+
+/**
+ * Runtime type decoded by {@link JudgeOutputInventoryDecodesVerdict}.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export type JudgeOutputInventoryDecodesVerdict = typeof JudgeOutputInventoryDecodesVerdict.Type;
+
+/**
+ * Conditional blocking declaration for extracted judge-output inventory decode.
+ *
+ * **Example** (Inspect decode gate applicability)
+ *
+ * ```ts
+ * import { JudgeOutputInventoryDecodesGate } from "@beep/repo-cli/commands/Qa"
+ *
+ * console.log(JudgeOutputInventoryDecodesGate.applicability.kind) // "conditional"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const JudgeOutputInventoryDecodesGate = GateDeclaration.make({
+  applicability: ConditionalGateApplicability.make({
+    condition: SchemaReference.make({
+      schemaId: SchemaReferenceId.make("https://beep-effect.dev/qa/conditions/qa-source-kind/v1"),
+    }),
+  }),
+  evidence: GateEvidenceRequirement.make({ predicateType: judgeOutputInventoryPredicateType }),
+  id: judgeOutputInventoryDecodesGateId,
+  remediationOwner,
+  severity: "blocking",
+});
+
+const outputDecodeDenial = (
+  failure: typeof JudgeOutputDecodeFailure.Type,
+  occurredAt: ISOStr
+): JudgeOutputInventoryDecodesVerdict =>
+  JudgeOutputInventoryDecodesVerdict.cases.denied.make({
+    audit: {
+      detail: JudgeOutputInventoryDecodesDenied.make({ failure }),
+      evaluator: "@beep/repo-cli/qa/judge-output-inventory-decodes",
+      gateId: judgeOutputInventoryDecodesGateId,
+      occurredAt,
+      outcome: "denied",
+      reason: JudgeOutputDecodeFailure.$match(failure, {
+        "inventory-schema-rejected": () =>
+          "qa judge-ingest rejected the judge inventory. Check schemaVersion, finding ids (R<round>-<nn>), lens values, and that requiredCount equals the P0+P1 count.",
+        "malformed-json": () => "qa judge-ingest could not parse the judge's final JSON block.",
+      }),
+    },
+  });
+
+/**
+ * Schema-decodes an extracted judge-output candidate without moving extraction into the gate.
+ *
+ * **Details**
+ *
+ * Malformed JSON and inventory-schema rejection are denied verdict values.
+ * The adapter retains the existing `QaCommandError` messages.
+ *
+ * **Example** (Build an output-decode evaluation)
+ *
+ * ```ts
+ * import {
+ *   JudgeOutputInventoryDecodesInput,
+ *   evaluateJudgeOutputInventoryDecodes
+ * } from "@beep/repo-cli/commands/Qa"
+ * import { Effect } from "effect"
+ *
+ * const program = evaluateJudgeOutputInventoryDecodes(
+ *   JudgeOutputInventoryDecodesInput.make({ candidate: "{}" })
+ * )
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @category use-cases
+ * @since 0.0.0
+ */
+export const evaluateJudgeOutputInventoryDecodes: GateEvaluator<
+  JudgeOutputInventoryDecodesInput,
+  JudgeOutputInventoryDecodesVerdict
+> = Effect.fn("QaJudgeContract.evaluateJudgeOutputInventoryDecodes")(function* (
+  input: JudgeOutputInventoryDecodesInput
+): Effect.fn.Return<JudgeOutputInventoryDecodesVerdict> {
+  const occurredAt = yield* auditTimestamp;
+  const parsed = yield* Effect.option(Unknown.decodeEffectFromJsonString(input.candidate));
+
+  return yield* O.match(parsed, {
+    onNone: () => Effect.succeed(outputDecodeDenial("malformed-json", occurredAt)),
+    onSome: (value) =>
+      Effect.option(decodeQaInventory(value)).pipe(
+        Effect.map(
+          O.match({
+            onNone: () => outputDecodeDenial("inventory-schema-rejected", occurredAt),
+            onSome: (inventory) =>
+              JudgeOutputInventoryDecodesVerdict.cases.allowed.make({
+                audit: {
+                  detail: JudgeOutputInventoryDecodesAllowed.make({ inventory }),
+                  evaluator: "@beep/repo-cli/qa/judge-output-inventory-decodes",
+                  gateId: judgeOutputInventoryDecodesGateId,
+                  occurredAt,
+                  outcome: "allowed",
+                  reason: "The extracted judge output decodes as qa-inventory/v1.",
+                },
+              }),
+          })
+        )
+      ),
+  });
+});
+
+const qaReceiptType = (name: string): EvidencePredicateType =>
+  EvidencePredicateType.make(`https://beep-effect.dev/qa/receipts/${name}/v1`);
+
+const qaJudgeContractId = SkillContractId.make("https://beep-effect.dev/contracts/qa-inventory/v1");
+const qaJudgeContractVersion = SemanticVersion.make("1.0.0");
+
+/**
+ * Evidence subject every gate summary for the judge contract must be bound to.
+ *
+ * **Details**
+ *
+ * The subject names the contract identity as `<id>@<version>` and carries the
+ * SHA-256 of that UTF-8 name. The digest is pinned here and re-derived in the
+ * parity suite, so a version bump that forgets the digest fails a test rather
+ * than silently rebinding completion evidence.
+ *
+ * **Example** (Inspect the contract subject)
+ *
+ * ```ts
+ * import { QaJudgeContractSubject } from "@beep/repo-cli/commands/Qa"
+ *
+ * console.log(QaJudgeContractSubject.name) // "https://beep-effect.dev/contracts/qa-inventory/v1@1.0.0"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const QaJudgeContractSubject = EvidenceSubject.make({
+  digest: EvidenceDigest.make({
+    sha256: Sha256Hex.make("607c532eaa5180a3c2d2018fbfc0d82cc1daa6dd20597967cfae6f82f2d809ae"),
+  }),
+  name: `${qaJudgeContractId}@${qaJudgeContractVersion}`,
+});
+
+/**
+ * Complete typed contract instance for the `qa-inventory/v1` judge.
+ *
+ * **Details**
+ *
+ * Declaration order is observable and matches judge execution: artifact and
+ * event leaves, round coherence, aggregate settlement, then conditional output
+ * decode. The output-decode declaration is conditional because lint starts
+ * from a committed JSON inventory rather than raw judge output.
+ *
+ * **Example** (Inspect gate order)
+ *
+ * ```ts
+ * import { QaJudgeContract } from "@beep/repo-cli/commands/Qa"
+ * import * as A from "effect/Array"
+ *
+ * console.log(A.map(QaJudgeContract.gates.declarations, (gate) => gate.id))
+ * ```
+ *
+ * @category aggregates
+ * @since 0.0.0
+ */
+export const QaJudgeContract = SkillContract.make({
+  evidenceSubject: QaJudgeContractSubject,
+  gates: GateRegistry.make({
+    declarations: [
+      CitedArtifactExistsGate,
+      CitedEventIdExistsGate,
+      DeclaredRoundCoherentGate,
+      EvidenceCrossCheckCleanGate,
+      JudgeOutputInventoryDecodesGate,
+    ],
+  }),
+  id: qaJudgeContractId,
+  input: SchemaReference.make({
+    schemaId: SchemaReferenceId.make("https://beep-effect.dev/schemas/qa-judge-input/v1"),
+  }),
+  output: SchemaReference.make({
+    schemaId: SchemaReferenceId.make("https://beep-effect.dev/schemas/qa-judge-settlement/v1"),
+  }),
+  promise: "Validate a qa-inventory/v1 value against its declared round and cited evidence.",
+  receiptTypes: ReceiptTypeBindings.make({
+    failure: FailurePredicateType,
+    gateSummary: GateSummaryPredicateType,
+    ladder: EvidenceLadderReceiptTypes.make({
+      accepted: qaReceiptType("accepted"),
+      delivered: qaReceiptType("delivered"),
+      persisted: qaReceiptType("persisted"),
+      semanticallyApplied: qaReceiptType("semantically-applied"),
+    }),
+    recoveryAttempt: qaReceiptType("recovery-attempt"),
+  }),
+  recovery: NoRecoveryPolicy.make({}),
+  version: qaJudgeContractVersion,
+});

--- a/packages/tooling/tool/cli/src/commands/Qa/JudgeIngest.ts
+++ b/packages/tooling/tool/cli/src/commands/Qa/JudgeIngest.ts
@@ -17,8 +17,16 @@ import { A, O } from "@beep/utils";
 import { Effect, FileSystem, Path } from "effect";
 import { dual } from "effect/Function";
 import { printLines } from "../../internal/cli/Printer.ts";
-import { decodeQaInventory, encodeQaInventory } from "./Inventory.schemas.ts";
+import { encodeQaInventory } from "./Inventory.schemas.ts";
 import { crossCheckAgainstRound, extractLastJsonBlock, raiseCrossCheckFailure } from "./JudgeCheck.ts";
+import {
+  DeclaredRoundCoherentInput,
+  DeclaredRoundCoherentVerdict,
+  evaluateDeclaredRoundCoherent,
+  evaluateJudgeOutputInventoryDecodes,
+  JudgeOutputInventoryDecodesInput,
+  JudgeOutputInventoryDecodesVerdict,
+} from "./JudgeContract.ts";
 import { QaCommandError } from "./Qa.errors.ts";
 import { renderInventoryMarkdown } from "./Qa.render.ts";
 import { qaRootPath, readEventLog } from "./Qa.session.ts";
@@ -121,14 +129,13 @@ export const parseJudgeOutput = Effect.fn("QaJudgeIngest.parseJudgeOutput")(func
       ),
     onSome: Effect.succeed,
   });
-  const parsed = yield* Unknown.decodeEffectFromJsonString(block).pipe(
-    QaCommandError.mapError("qa judge-ingest could not parse the judge's final JSON block.")
+  const verdict = yield* evaluateJudgeOutputInventoryDecodes(
+    JudgeOutputInventoryDecodesInput.make({ candidate: block })
   );
-  return yield* decodeQaInventory(parsed).pipe(
-    QaCommandError.mapError(
-      "qa judge-ingest rejected the judge inventory. Check schemaVersion, finding ids (R<round>-<nn>), lens values, and that requiredCount equals the P0+P1 count."
-    )
-  );
+  return yield* JudgeOutputInventoryDecodesVerdict.match(verdict, {
+    allowed: ({ audit }) => Effect.succeed(audit.detail.inventory),
+    denied: ({ audit }) => Effect.fail(QaCommandError.make({ message: audit.reason })),
+  });
 });
 
 /**
@@ -165,11 +172,18 @@ export const runQaJudgeIngest = Effect.fn("QaJudgeIngest.run")(function* (
     .pipe(QaCommandError.mapError(`qa judge-ingest could not read the judge output at ${options.from}.`));
   const inventory = yield* parseJudgeOutput(raw);
 
-  if (inventory.round !== options.round) {
-    return yield* QaCommandError.make({
-      message: `qa judge-ingest was asked for round ${options.round} but the inventory declares round ${inventory.round}.`,
-    });
-  }
+  const roundVerdict = yield* evaluateDeclaredRoundCoherent(
+    DeclaredRoundCoherentInput.make({ declaredRound: inventory.round, requestedRound: options.round })
+  );
+  yield* DeclaredRoundCoherentVerdict.match(roundVerdict, {
+    allowed: () => Effect.void,
+    denied: ({ audit }) =>
+      Effect.fail(
+        QaCommandError.make({
+          message: `qa judge-ingest was asked for round ${audit.detail.requestedRound} but the inventory declares round ${audit.detail.declaredRound}.`,
+        })
+      ),
+  });
 
   const eventLog = yield* readEventLog(layout.eventsPath);
   const check = yield* crossCheckAgainstRound(layout, inventory, eventLog);

--- a/packages/tooling/tool/cli/src/commands/Qa/JudgeIngest.ts
+++ b/packages/tooling/tool/cli/src/commands/Qa/JudgeIngest.ts
@@ -134,7 +134,7 @@ export const parseJudgeOutput = Effect.fn("QaJudgeIngest.parseJudgeOutput")(func
   );
   return yield* JudgeOutputInventoryDecodesVerdict.match(verdict, {
     allowed: ({ audit }) => Effect.succeed(audit.detail.inventory),
-    denied: ({ audit }) => Effect.fail(QaCommandError.make({ message: audit.reason })),
+    denied: ({ audit }) => Effect.fail(QaCommandError.make({ cause: audit.detail.issue, message: audit.reason })),
   });
 });
 

--- a/packages/tooling/tool/cli/src/commands/Qa/JudgeIngest.ts
+++ b/packages/tooling/tool/cli/src/commands/Qa/JudgeIngest.ts
@@ -24,6 +24,7 @@ import {
   DeclaredRoundCoherentVerdict,
   evaluateDeclaredRoundCoherent,
   evaluateJudgeOutputInventoryDecodes,
+  JudgeOutputDecodeFailure,
   JudgeOutputInventoryDecodesInput,
   JudgeOutputInventoryDecodesVerdict,
 } from "./JudgeContract.ts";
@@ -134,7 +135,17 @@ export const parseJudgeOutput = Effect.fn("QaJudgeIngest.parseJudgeOutput")(func
   );
   return yield* JudgeOutputInventoryDecodesVerdict.match(verdict, {
     allowed: ({ audit }) => Effect.succeed(audit.detail.inventory),
-    denied: ({ audit }) => Effect.fail(QaCommandError.make({ cause: audit.detail.issue, message: audit.reason })),
+    denied: ({ audit }) =>
+      Effect.fail(
+        QaCommandError.make({
+          cause: audit.detail.issue,
+          message: JudgeOutputDecodeFailure.$match(audit.detail.failure, {
+            "inventory-schema-rejected": () =>
+              "qa judge-ingest rejected the judge inventory. Check schemaVersion, finding ids (R<round>-<nn>), lens values, and that requiredCount equals the P0+P1 count.",
+            "malformed-json": () => "qa judge-ingest could not parse the judge's final JSON block.",
+          }),
+        })
+      ),
   });
 });
 

--- a/packages/tooling/tool/cli/src/commands/Qa/JudgeLint.ts
+++ b/packages/tooling/tool/cli/src/commands/Qa/JudgeLint.ts
@@ -11,18 +11,22 @@
  */
 
 import { SessionStore } from "@beep/qa-capture";
-import { Unknown } from "@beep/schema/Unknown";
 import { A } from "@beep/utils";
 import { Effect, FileSystem, Path } from "effect";
 import { failWithReportedExit } from "../../internal/cli/ExitCodeError.ts";
 import { printLines } from "../../internal/cli/Printer.ts";
-import { decodeQaInventory } from "./Inventory.schemas.ts";
 import {
   crossCheckAgainstRound,
   isCrossCheckClean,
   renderCrossCheckFailure,
   requireInventoryRound,
 } from "./JudgeCheck.ts";
+import {
+  evaluateJudgeOutputInventoryDecodes,
+  JudgeOutputDecodeFailure,
+  JudgeOutputInventoryDecodesInput,
+  JudgeOutputInventoryDecodesVerdict,
+} from "./JudgeContract.ts";
 import { inventoryJsonPath } from "./JudgeIngest.ts";
 import { QaCommandError } from "./Qa.errors.ts";
 import { qaRootPath, readEventLog } from "./Qa.session.ts";
@@ -63,12 +67,23 @@ export const runQaJudgeLint = Effect.fn("QaJudgeLint.run")(function* (
         `qa judge-lint could not read ${inventoryPath}; run \`bun run beep qa judge-ingest --round ${options.round} --from <file>\` first.`
       )
     );
-  const parsed = yield* Unknown.decodeEffectFromJsonString(raw).pipe(
-    QaCommandError.mapError(`qa judge-lint could not parse ${inventoryPath} as JSON.`)
+  const decodeVerdict = yield* evaluateJudgeOutputInventoryDecodes(
+    JudgeOutputInventoryDecodesInput.make({ candidate: raw })
   );
-  const inventory = yield* decodeQaInventory(parsed).pipe(
-    QaCommandError.mapError(`qa judge-lint rejected ${inventoryPath} against the qa-inventory/v1 schema.`)
-  );
+  const inventory = yield* JudgeOutputInventoryDecodesVerdict.match(decodeVerdict, {
+    allowed: ({ audit }) => Effect.succeed(audit.detail.inventory),
+    denied: ({ audit }) =>
+      Effect.fail(
+        QaCommandError.make({
+          cause: audit.detail.issue,
+          message: JudgeOutputDecodeFailure.$match(audit.detail.failure, {
+            "inventory-schema-rejected": () =>
+              `qa judge-lint rejected ${inventoryPath} against the qa-inventory/v1 schema.`,
+            "malformed-json": () => `qa judge-lint could not parse ${inventoryPath} as JSON.`,
+          }),
+        })
+      ),
+  });
   // A copied inventory can pass another round's cross-check (seqs restart per
   // round, frame names repeat), so round coherence is checked explicitly.
   yield* requireInventoryRound(options.round, inventory);

--- a/packages/tooling/tool/cli/src/commands/Qa/QaJudgeGateId.ts
+++ b/packages/tooling/tool/cli/src/commands/Qa/QaJudgeGateId.ts
@@ -13,8 +13,8 @@ import { makeGateId } from "@beep/skill-contract";
  *
  * **Details**
  *
- * PR 1 contains only the migrated cited-artifact gate. PR 2 widens this one
- * registry-owned domain when the remaining judge rules become typed gates.
+ * This is the only gate-id literal domain for the QA judge. Declarations,
+ * evaluators, and the aggregate contract all derive their ids from it.
  *
  * **Example** (Construct the cited-artifact gate id)
  *
@@ -27,7 +27,15 @@ import { makeGateId } from "@beep/skill-contract";
  * @category identifiers
  * @since 0.0.0
  */
-export const QaJudgeGateId = makeGateId(LiteralKit(["cited-artifact-exists"]));
+export const QaJudgeGateId = makeGateId(
+  LiteralKit([
+    "cited-artifact-exists",
+    "cited-event-id-exists",
+    "declared-round-coherent",
+    "evidence-cross-check-clean",
+    "judge-output-inventory-decodes",
+  ])
+);
 
 /**
  * Runtime type decoded by {@link QaJudgeGateId}.

--- a/packages/tooling/tool/cli/src/commands/Qa/index.ts
+++ b/packages/tooling/tool/cli/src/commands/Qa/index.ts
@@ -48,6 +48,13 @@ export * from "./Inventory.schemas.ts";
  */
 export * from "./JudgeCheck.ts";
 /**
+ * Complete typed gate composition for the qa-inventory judge.
+ *
+ * @category aggregates
+ * @since 0.0.0
+ */
+export * from "./JudgeContract.ts";
+/**
  * The `qa judge-ingest` inventory writer.
  *
  * @category use-cases

--- a/packages/tooling/tool/cli/test/qa-judge-contract-parity.test.ts
+++ b/packages/tooling/tool/cli/test/qa-judge-contract-parity.test.ts
@@ -401,6 +401,16 @@ describe("commands/Qa complete judge contract parity", () => {
       expect(wrongCount.verdict).toBe("denied");
       expect(emptyEvidence.audit.reason).toContain("rejected the judge inventory");
       expect(wrongCount.audit.reason).toContain("requiredCount equals the P0+P1 count");
+
+      const deniedDetail = (verdict: JudgeOutputInventoryDecodesVerdict) =>
+        JudgeOutputInventoryDecodesVerdict.match(verdict, {
+          allowed: () => O.none(),
+          denied: ({ audit }) => O.some(audit.detail),
+        });
+      expect(O.map(deniedDetail(malformed), (detail) => detail.failure)).toEqual(O.some("malformed-json"));
+      expect(O.map(deniedDetail(wrongCount), (detail) => detail.failure)).toEqual(O.some("inventory-schema-rejected"));
+      expect(O.exists(deniedDetail(malformed), (detail) => S.is(S.NonEmptyString)(detail.issue))).toBe(true);
+      expect(O.exists(deniedDetail(wrongCount), (detail) => S.is(S.NonEmptyString)(detail.issue))).toBe(true);
     })
   );
 

--- a/packages/tooling/tool/cli/test/qa-judge-contract-parity.test.ts
+++ b/packages/tooling/tool/cli/test/qa-judge-contract-parity.test.ts
@@ -17,6 +17,8 @@ import {
   evaluateDeclaredRoundCoherent,
   evaluateEvidenceCrossCheckClean,
   evaluateJudgeOutputInventoryDecodes,
+  evidenceCrossCheckVerdictToCrossCheck,
+  JudgeOutputInventoryDecodesGate,
   JudgeOutputInventoryDecodesInput,
   JudgeOutputInventoryDecodesVerdict,
   QaEventLog,
@@ -28,20 +30,37 @@ import {
   raiseCrossCheckFailure,
   renderCrossCheckFailure,
 } from "@beep/repo-cli/commands/Qa";
-import { Sha256HexFromBytes } from "@beep/schema/Sha256";
+import { Sha256Hex, Sha256HexFromBytes } from "@beep/schema/Sha256";
 import { ISOStr } from "@beep/schema/Timestamp";
 import { Unknown } from "@beep/schema/Unknown";
-import { GateRegistry, SkillContract } from "@beep/skill-contract";
+import { URLStr } from "@beep/schema/URL";
+import {
+  AttestationResource,
+  EvaluateSkillCompletionInput,
+  EvidenceDigest,
+  EvidenceReceiptReference,
+  EvidenceSubject,
+  evaluateSkillCompletion,
+  GateRegistry,
+  GateResultSummary,
+  GateSummary,
+  GateSummaryPredicateType,
+  GateSummaryReceipt,
+  GateSummaryVerifier,
+  SemanticallyApplied,
+  SkillContract,
+} from "@beep/skill-contract";
 import { fcRuns, provideScopedLayer } from "@beep/test-utils";
 import { A } from "@beep/utils";
 import * as BunCrypto from "@effect/platform-bun/BunCrypto";
 import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
 import * as NodePath from "@effect/platform-node/NodePath";
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, Exit, FileSystem, HashSet, Layer, Path, Result } from "effect";
+import { Effect, Equal, Exit, FileSystem, HashSet, Layer, Path, Result } from "effect";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
 import { FastCheck as fc } from "effect/testing";
+import type { EvidencePredicateType, GateDeclaration } from "@beep/skill-contract";
 
 const PlatformLayer = Layer.mergeAll(NodeFileSystem.layer, NodePath.layer);
 
@@ -255,11 +274,11 @@ describe("commands/Qa complete judge contract parity", () => {
   it("composes the five declarations from the single ordered gate-id registry", () => {
     expect(QaJudgeContract.id).toBe("https://beep-effect.dev/contracts/qa-inventory/v1");
     expect(A.map(QaJudgeContract.gates.declarations, (gate) => gate.id)).toEqual([
+      "judge-output-inventory-decodes",
+      "declared-round-coherent",
       "cited-artifact-exists",
       "cited-event-id-exists",
-      "declared-round-coherent",
       "evidence-cross-check-clean",
-      "judge-output-inventory-decodes",
     ]);
     expect(A.map(QaJudgeContract.gates.declarations, (gate) => gate.severity)).toEqual([
       "blocking",
@@ -273,7 +292,7 @@ describe("commands/Qa complete judge contract parity", () => {
       "always",
       "always",
       "always",
-      "conditional",
+      "always",
     ]);
   });
 
@@ -396,11 +415,11 @@ describe("commands/Qa complete judge contract parity", () => {
 
       expect(allowed.verdict).toBe("allowed");
       expect(malformed.verdict).toBe("denied");
-      expect(malformed.audit.reason).toBe("qa judge-ingest could not parse the judge's final JSON block.");
+      expect(malformed.audit.reason).toBe("The judge output candidate does not parse as JSON.");
       expect(emptyEvidence.verdict).toBe("denied");
       expect(wrongCount.verdict).toBe("denied");
-      expect(emptyEvidence.audit.reason).toContain("rejected the judge inventory");
-      expect(wrongCount.audit.reason).toContain("requiredCount equals the P0+P1 count");
+      expect(emptyEvidence.audit.reason).toBe("The judge output candidate does not decode as qa-inventory/v1.");
+      expect(wrongCount.audit.reason).toBe("The judge output candidate does not decode as qa-inventory/v1.");
 
       const deniedDetail = (verdict: JudgeOutputInventoryDecodesVerdict) =>
         JudgeOutputInventoryDecodesVerdict.match(verdict, {
@@ -468,4 +487,116 @@ describe("commands/Qa complete judge contract parity", () => {
       }),
       fcRuns(25)
     ));
+});
+
+describe("commands/Qa judge contract completion through the kernel evaluator", () => {
+  const digest = EvidenceDigest.make({
+    sha256: Sha256Hex.make("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"),
+  });
+  const outputSubject = EvidenceSubject.make({ digest, name: "qa/rounds/1/inventory.json" });
+  const summarySubject = EvidenceSubject.make({ digest, name: "qa/rounds/1/gate-summary.json" });
+  const reference = (
+    predicateType: EvidencePredicateType,
+    subjects: A.NonEmptyReadonlyArray<EvidenceSubject> = [summarySubject]
+  ) => EvidenceReceiptReference.make({ predicateType, receipt: summarySubject, subjects });
+  const ladderTypes = QaJudgeContract.receiptTypes.ladder;
+  const ladder = SemanticallyApplied.make({
+    accepted: reference(ladderTypes.accepted),
+    delivered: reference(ladderTypes.delivered),
+    persisted: reference(ladderTypes.persisted),
+    semanticallyApplied: reference(ladderTypes.semanticallyApplied, [outputSubject]),
+  });
+  const gateResult = (declaration: GateDeclaration, outcome: "allowed" | "denied") =>
+    GateResultSummary.make({
+      applicable: true,
+      evidenceSubjects: [summarySubject],
+      evidenceType: declaration.evidence.predicateType,
+      gateId: declaration.id,
+      outcome,
+      severity: declaration.severity,
+    });
+  const summaryFor = (gateResults: ReadonlyArray<GateResultSummary>) => {
+    const passed = A.every(gateResults, (result) => result.outcome === "allowed");
+    return GateSummaryReceipt.make({
+      predicate: GateSummary.make({
+        contractSubject: QaJudgeContractSubject,
+        gateResults,
+        inputAttestations: [
+          AttestationResource.make({ digest, uri: URLStr.make("https://beep-effect.dev/qa/attestations/input/v1") }),
+        ],
+        policy: AttestationResource.make({ digest, uri: URLStr.make("https://beep-effect.dev/qa/policy/judge/v1") }),
+        resourceUri: URLStr.make("https://beep-effect.dev/qa/rounds/1/inventory.json"),
+        timeVerified: ISOStr.make("2026-08-25T00:00:00.000Z"),
+        verificationResult: passed ? "PASSED" : "FAILED",
+        verifiedLevels: passed ? ["BEEP_SKILL_CONTRACT_BLOCKING_GATES"] : ["FAILED"],
+        verifier: GateSummaryVerifier.make({
+          id: URLStr.make("https://beep-effect.dev/qa/verifier/judge/v1"),
+          version: { kernel: "1.0.0" },
+        }),
+      }),
+      predicateType: GateSummaryPredicateType,
+      subject: [summarySubject],
+    });
+  };
+  const evaluate = (gateResults: ReadonlyArray<GateResultSummary>) =>
+    evaluateSkillCompletion(
+      EvaluateSkillCompletionInput.make({
+        contract: QaJudgeContract,
+        gateSummary: summaryFor(gateResults),
+        ladder,
+        outputSubjects: [outputSubject],
+      })
+    );
+
+  it.effect("reaches live completion once every declared gate is allowed", () =>
+    Effect.gen(function* () {
+      const evaluation = yield* evaluate(
+        A.map(QaJudgeContract.gates.declarations, (declaration) => gateResult(declaration, "allowed"))
+      );
+
+      expect(evaluation.verdict).toBe("allowed");
+    })
+  );
+
+  it.effect("denies completion as a verdict value when the decode gate is denied", () =>
+    Effect.gen(function* () {
+      const evaluation = yield* evaluate(
+        A.map(QaJudgeContract.gates.declarations, (declaration) =>
+          gateResult(
+            declaration,
+            Equal.equals(declaration.id, JudgeOutputInventoryDecodesGate.id) ? "denied" : "allowed"
+          )
+        )
+      );
+
+      expect(evaluation.verdict).toBe("denied");
+    })
+  );
+});
+
+describe("commands/Qa aggregate cross-check settlement", () => {
+  it.effect("denies on missing event ids alone and refuses a denied detail with nothing missing", () =>
+    withTempDir(
+      Effect.fnUntraced(function* (root) {
+        const artifactVerdict = yield* evaluateCitedArtifactExists(
+          CitedArtifactExistsInput.make({ citedPaths: [], roundRoot: root })
+        );
+        const eventIdVerdict = yield* evaluateCitedEventIdExists(
+          CitedEventIdExistsInput.make({ citedEventIds: [3], knownEventIds: [] })
+        );
+        const aggregate = yield* evaluateEvidenceCrossCheckClean(
+          EvidenceCrossCheckCleanInput.make({ artifactVerdict, eventIdVerdict })
+        );
+        const nothingMissing = yield* S.decodeUnknownEffect(EvidenceCrossCheckCleanVerdict)({
+          audit: { ...aggregate.audit, detail: { missingEventIds: [], missingPaths: [] } },
+          verdict: "denied",
+        }).pipe(Effect.flip);
+
+        expect(artifactVerdict.verdict).toBe("allowed");
+        expect(aggregate.verdict).toBe("denied");
+        expect(evidenceCrossCheckVerdictToCrossCheck(aggregate)).toEqual({ missingEventIds: [3], missingPaths: [] });
+        expect(nothingMissing.message).toContain("Expected at least one missing artifact path or event id");
+      })
+    )
+  );
 });

--- a/packages/tooling/tool/cli/test/qa-judge-contract-parity.test.ts
+++ b/packages/tooling/tool/cli/test/qa-judge-contract-parity.test.ts
@@ -3,24 +3,45 @@ import {
   CitedArtifactExistsGate,
   CitedArtifactExistsInput,
   CitedArtifactExistsVerdict,
+  CitedEventIdExistsInput,
+  CitedEventIdExistsVerdict,
   citedArtifactVerdictToCrossCheck,
   crossCheckAgainstRound,
   crossCheckEvidence,
+  DeclaredRoundCoherentInput,
+  DeclaredRoundCoherentVerdict,
+  EvidenceCrossCheckCleanInput,
+  EvidenceCrossCheckCleanVerdict,
   evaluateCitedArtifactExists,
+  evaluateCitedEventIdExists,
+  evaluateDeclaredRoundCoherent,
+  evaluateEvidenceCrossCheckClean,
+  evaluateJudgeOutputInventoryDecodes,
+  JudgeOutputInventoryDecodesInput,
+  JudgeOutputInventoryDecodesVerdict,
   QaEventLog,
   QaFindingId,
   QaInventory,
+  QaJudgeContract,
+  QaJudgeContractSubject,
   QaJudgeRef,
   raiseCrossCheckFailure,
   renderCrossCheckFailure,
 } from "@beep/repo-cli/commands/Qa";
+import { Sha256HexFromBytes } from "@beep/schema/Sha256";
 import { ISOStr } from "@beep/schema/Timestamp";
-import { provideScopedLayer } from "@beep/test-utils";
+import { Unknown } from "@beep/schema/Unknown";
+import { GateRegistry, SkillContract } from "@beep/skill-contract";
+import { fcRuns, provideScopedLayer } from "@beep/test-utils";
+import { A } from "@beep/utils";
+import * as BunCrypto from "@effect/platform-bun/BunCrypto";
 import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
 import * as NodePath from "@effect/platform-node/NodePath";
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, Exit, FileSystem, HashSet, Layer, Path } from "effect";
+import { Effect, Exit, FileSystem, HashSet, Layer, Path, Result } from "effect";
 import * as O from "effect/Option";
+import * as S from "effect/Schema";
+import { FastCheck as fc } from "effect/testing";
 
 const PlatformLayer = Layer.mergeAll(NodeFileSystem.layer, NodePath.layer);
 
@@ -210,4 +231,231 @@ describe("commands/Qa cited-artifact typed gate parity", () => {
       missingPaths: ["frames/ghost.png"],
     });
   });
+
+  it.effect("treats regular-file existence as sufficient without claiming content integrity", () =>
+    withTempDir(
+      Effect.fnUntraced(function* (root) {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const artifact = path.join(root, "frame.png");
+        const input = CitedArtifactExistsInput.make({ citedPaths: ["frame.png"], roundRoot: root });
+        yield* fs.writeFileString(artifact, "first contents");
+        const before = yield* evaluateCitedArtifactExists(input);
+        yield* fs.writeFileString(artifact, "different contents");
+        const after = yield* evaluateCitedArtifactExists(input);
+
+        expect(before.verdict).toBe("allowed");
+        expect(after.verdict).toBe("allowed");
+      })
+    )
+  );
+});
+
+describe("commands/Qa complete judge contract parity", () => {
+  it("composes the five declarations from the single ordered gate-id registry", () => {
+    expect(QaJudgeContract.id).toBe("https://beep-effect.dev/contracts/qa-inventory/v1");
+    expect(A.map(QaJudgeContract.gates.declarations, (gate) => gate.id)).toEqual([
+      "cited-artifact-exists",
+      "cited-event-id-exists",
+      "declared-round-coherent",
+      "evidence-cross-check-clean",
+      "judge-output-inventory-decodes",
+    ]);
+    expect(A.map(QaJudgeContract.gates.declarations, (gate) => gate.severity)).toEqual([
+      "blocking",
+      "blocking",
+      "blocking",
+      "blocking",
+      "blocking",
+    ]);
+    expect(A.map(QaJudgeContract.gates.declarations, (gate) => gate.applicability.kind)).toEqual([
+      "always",
+      "always",
+      "always",
+      "always",
+      "conditional",
+    ]);
+  });
+
+  it.effect("binds the contract evidence subject to the SHA-256 of its own identity", () =>
+    Effect.gen(function* () {
+      const digest = yield* S.decodeEffect(Sha256HexFromBytes)(new TextEncoder().encode(QaJudgeContractSubject.name));
+
+      expect(QaJudgeContractSubject.name).toBe(`${QaJudgeContract.id}@${QaJudgeContract.version}`);
+      expect(QaJudgeContract.evidenceSubject).toBe(QaJudgeContractSubject);
+      expect(QaJudgeContractSubject.digest.sha256).toBe(digest);
+    }).pipe(provideScopedLayer(BunCrypto.layer))
+  );
+
+  it.effect("detects missing event ids in first-citation order and deduplicates repeats", () =>
+    Effect.gen(function* () {
+      const verdict = yield* evaluateCitedEventIdExists(
+        CitedEventIdExistsInput.make({ citedEventIds: [9, 2, 9, 7], knownEventIds: [2, 3] })
+      );
+
+      expect(verdict.verdict).toBe("denied");
+      expect(
+        CitedEventIdExistsVerdict.match(verdict, {
+          allowed: () => [],
+          denied: ({ audit }) => audit.detail.checkedEventIds,
+        })
+      ).toEqual([9, 2, 7]);
+      expect(
+        CitedEventIdExistsVerdict.match(verdict, {
+          allowed: () => [],
+          denied: ({ audit }) => audit.detail.missingEventIds,
+        })
+      ).toEqual([9, 7]);
+    })
+  );
+
+  it.effect("allows a coherent declared round and denies a copied inventory round", () =>
+    Effect.gen(function* () {
+      const allowed = yield* evaluateDeclaredRoundCoherent(
+        DeclaredRoundCoherentInput.make({ declaredRound: 4, requestedRound: 4 })
+      );
+      const denied = yield* evaluateDeclaredRoundCoherent(
+        DeclaredRoundCoherentInput.make({ declaredRound: 5, requestedRound: 4 })
+      );
+
+      expect(allowed.verdict).toBe("allowed");
+      expect(denied.verdict).toBe("denied");
+      expect(
+        DeclaredRoundCoherentVerdict.match(denied, {
+          allowed: () => ({ declaredRound: 0, requestedRound: 0 }),
+          denied: ({ audit }) => audit.detail,
+        })
+      ).toMatchObject({ declaredRound: 5, requestedRound: 4 });
+    })
+  );
+
+  it.effect("keeps aggregate settlement distinct from the artifact and event leaf verdicts", () =>
+    withTempDir(
+      Effect.fnUntraced(function* (root) {
+        const artifactVerdict = yield* evaluateCitedArtifactExists(
+          CitedArtifactExistsInput.make({ citedPaths: ["frames/ghost.png"], roundRoot: root })
+        );
+        const eventIdVerdict = yield* evaluateCitedEventIdExists(
+          CitedEventIdExistsInput.make({ citedEventIds: [8], knownEventIds: [] })
+        );
+        const aggregate = yield* evaluateEvidenceCrossCheckClean(
+          EvidenceCrossCheckCleanInput.make({ artifactVerdict, eventIdVerdict })
+        );
+
+        expect(artifactVerdict.audit.gateId).toBe("cited-artifact-exists");
+        expect(eventIdVerdict.audit.gateId).toBe("cited-event-id-exists");
+        expect(aggregate.audit.gateId).toBe("evidence-cross-check-clean");
+        expect(aggregate.verdict).toBe("denied");
+        expect(
+          EvidenceCrossCheckCleanVerdict.match(aggregate, {
+            allowed: () => ({ missingEventIds: [], missingPaths: [] }),
+            denied: ({ audit }) => audit.detail,
+          })
+        ).toMatchObject({ missingEventIds: [8], missingPaths: ["frames/ghost.png"] });
+      })
+    )
+  );
+
+  it.effect("decodes valid output and denies malformed JSON, empty evidence, and incoherent P0/P1 counts", () =>
+    Effect.gen(function* () {
+      const finding = {
+        evidence: [{ eventIds: [2], kind: "strip", path: "frames/a.png" }],
+        fix: "Fix the drag behavior.",
+        id: "R4-01",
+        lens: "selection-smear",
+        repro: "Drag the sash.",
+        severity: "P0",
+        title: "Selection smear",
+      };
+      const inventory = {
+        findings: [finding],
+        judge: { effort: "high", model: "gpt-5.6-sol" },
+        requiredCount: 1,
+        round: 4,
+        schemaVersion: "qa-inventory/v1",
+        sessionRef: "session.json",
+      };
+      const validCandidate = yield* Unknown.encodeEffectFromJsonString(inventory);
+      const emptyEvidenceCandidate = yield* Unknown.encodeEffectFromJsonString({
+        ...inventory,
+        findings: [{ ...finding, evidence: [] }],
+      });
+      const wrongCountCandidate = yield* Unknown.encodeEffectFromJsonString({ ...inventory, requiredCount: 0 });
+      const allowed = yield* evaluateJudgeOutputInventoryDecodes(
+        JudgeOutputInventoryDecodesInput.make({ candidate: validCandidate })
+      );
+      const malformed = yield* evaluateJudgeOutputInventoryDecodes(
+        JudgeOutputInventoryDecodesInput.make({ candidate: "{" })
+      );
+      const emptyEvidence = yield* evaluateJudgeOutputInventoryDecodes(
+        JudgeOutputInventoryDecodesInput.make({ candidate: emptyEvidenceCandidate })
+      );
+      const wrongCount = yield* evaluateJudgeOutputInventoryDecodes(
+        JudgeOutputInventoryDecodesInput.make({ candidate: wrongCountCandidate })
+      );
+
+      expect(allowed.verdict).toBe("allowed");
+      expect(malformed.verdict).toBe("denied");
+      expect(malformed.audit.reason).toBe("qa judge-ingest could not parse the judge's final JSON block.");
+      expect(emptyEvidence.verdict).toBe("denied");
+      expect(wrongCount.verdict).toBe("denied");
+      expect(emptyEvidence.audit.reason).toContain("rejected the judge inventory");
+      expect(wrongCount.audit.reason).toContain("requiredCount equals the P0+P1 count");
+    })
+  );
+
+  it.effect("accepts coherent P0 and P1 required counts while excluding P2", () =>
+    Effect.gen(function* () {
+      const finding = (id: string, severity: "P0" | "P1" | "P2") => ({
+        evidence: [{ eventIds: [], kind: "frame", path: `frames/${id}.png` }],
+        fix: "Fix it.",
+        id,
+        lens: "drag-ghost",
+        repro: "Drag it.",
+        severity,
+        title: id,
+      });
+      const candidate = yield* Unknown.encodeEffectFromJsonString({
+        findings: [finding("R4-01", "P0"), finding("R4-02", "P1"), finding("R4-03", "P2")],
+        judge: { effort: "high", model: "gpt-5.6-sol" },
+        requiredCount: 2,
+        round: 4,
+        schemaVersion: "qa-inventory/v1",
+        sessionRef: "session.json",
+      });
+      const verdict = yield* evaluateJudgeOutputInventoryDecodes(JudgeOutputInventoryDecodesInput.make({ candidate }));
+
+      expect(verdict.verdict).toBe("allowed");
+      expect(
+        JudgeOutputInventoryDecodesVerdict.match(verdict, {
+          allowed: ({ audit }) => audit.detail.inventory.requiredCount,
+          denied: () => -1,
+        })
+      ).toBe(2);
+    })
+  );
+
+  it.effect("round-trips the contract and rejects duplicate QA gate ids at external decode", () =>
+    Effect.gen(function* () {
+      const encoded = yield* S.encodeUnknownEffect(SkillContract)(QaJudgeContract);
+      const decoded = yield* S.decodeEffect(SkillContract)(encoded);
+      const duplicate = yield* S.decodeEffect(GateRegistry)({
+        declarations: [CitedArtifactExistsGate, CitedArtifactExistsGate],
+      }).pipe(Effect.flip);
+
+      expect(S.toEquivalence(SkillContract)(decoded, QaJudgeContract)).toBe(true);
+      expect(duplicate.message).toContain("unique gate ids");
+    })
+  );
+
+  it("round-trips schema-derived event gate inputs", () =>
+    fc.assert(
+      fc.property(S.toArbitrary(CitedEventIdExistsInput)(fc), (candidate) => {
+        const encoded = Result.getOrThrow(S.encodeUnknownResult(CitedEventIdExistsInput)(candidate));
+        const decoded = Result.getOrThrow(S.decodeResult(CitedEventIdExistsInput)(encoded));
+
+        expect(S.toEquivalence(CitedEventIdExistsInput)(decoded, candidate)).toBe(true);
+      }),
+      fcRuns(25)
+    ));
 });

--- a/packages/tooling/tool/cli/test/qa-pure.test.ts
+++ b/packages/tooling/tool/cli/test/qa-pure.test.ts
@@ -732,6 +732,19 @@ describe("commands/Qa judge output parsing", () => {
       expect(malformed.message).toContain("no parseable JSON inventory object (fenced or unfenced)");
     })
   );
+
+  it.effect("preserves malformed-JSON and schema-rejection adapter messages", () =>
+    Effect.gen(function* () {
+      const invalidInventory = yield* encodeJson({});
+      const malformed = yield* Effect.flip(parseJudgeOutput(`${fence}json\n{\n${fence}\n`));
+      const rejected = yield* Effect.flip(parseJudgeOutput(`${fence}json\n${invalidInventory}\n${fence}\n`));
+
+      expect(malformed.message).toBe("qa judge-ingest could not parse the judge's final JSON block.");
+      expect(rejected.message).toBe(
+        "qa judge-ingest rejected the judge inventory. Check schemaVersion, finding ids (R<round>-<nn>), lens values, and that requiredCount equals the P0+P1 count."
+      );
+    })
+  );
 });
 
 describe("commands/Qa extract --dry-run driver isolation", () => {

--- a/packages/tooling/tool/cli/test/qa-round-pipeline.test.ts
+++ b/packages/tooling/tool/cli/test/qa-round-pipeline.test.ts
@@ -491,6 +491,35 @@ describe("commands/Qa judge ingest and lint", () => {
     )
   );
 
+  it.effect("fails judge-lint with the decode-gate messages for malformed and schema-rejected inventories", () =>
+    withTempCwd(
+      Effect.fnUntraced(function* (cwd) {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const { layout } = yield* prepareRound(cwd, 1);
+        const inventoryPath = path.join(layout.root, "inventory.json");
+        const lint = () =>
+          runQaJudgeLint(cwd, QaJudgeLintOptions.make({ round: RoundNumber.make(1) })).pipe(Effect.flip);
+
+        yield* fs.writeFileString(inventoryPath, "{");
+        const malformed = yield* lint();
+        yield* fs.writeFileString(inventoryPath, '{"schemaVersion":"qa-inventory/v0"}');
+        const rejected = yield* lint();
+
+        expect(malformed).toMatchObject({
+          _tag: "QaCommandError",
+          message: `qa judge-lint could not parse ${inventoryPath} as JSON.`,
+        });
+        expect(rejected).toMatchObject({
+          _tag: "QaCommandError",
+          message: `qa judge-lint rejected ${inventoryPath} against the qa-inventory/v1 schema.`,
+        });
+        expect(P.isString(malformed.cause) && malformed.cause.length > 0).toBe(true);
+        expect(P.isString(rejected.cause) && rejected.cause.length > 0).toBe(true);
+      })
+    )
+  );
+
   it.effect("fails judge-lint when the round has no inventory yet", () =>
     Effect.gen(function* () {
       const exit = yield* Effect.exit(

--- a/packages/tooling/tool/cli/test/qa-round-pipeline.test.ts
+++ b/packages/tooling/tool/cli/test/qa-round-pipeline.test.ts
@@ -573,6 +573,29 @@ describe("commands/Qa judge ingest and lint", () => {
     })
   );
 
+  it.effect("preserves the ingest-specific declared-round error and writes no inventory", () =>
+    withTempCwd(
+      Effect.fnUntraced(function* (cwd) {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const { layout } = yield* prepareRound(cwd, 1);
+        const transcript = path.join(cwd, "judge-stdout.txt");
+        const inventoryPath = path.join(layout.root, "inventory.json");
+        const inventoryMarkdownPath = path.join(layout.root, "inventory.md");
+        yield* fs.writeFileString(transcript, yield* inventoryText(2));
+
+        const error = yield* runQaJudgeIngest(
+          cwd,
+          QaJudgeIngestOptions.make({ from: transcript, round: RoundNumber.make(1) })
+        ).pipe(Effect.flip);
+
+        expect(error.message).toBe("qa judge-ingest was asked for round 1 but the inventory declares round 2.");
+        expect(yield* fs.exists(inventoryPath)).toBe(false);
+        expect(yield* fs.exists(inventoryMarkdownPath)).toBe(false);
+      })
+    )
+  );
+
   it("fails judge-lint when the committed inventory declares another round", () =>
     Effect.runPromise(
       withTempCwd(


### PR DESCRIPTION
goals/skill-contract-kernel P1(c) — PR 2 of 3 in the widening design (full judge retrofit; the SKILL.md projection is PR 3). Builds on #791 and #792.

## What ships (all in `@beep/repo-cli` `commands/Qa`)

- **`JudgeContract.ts`** — the remaining judge rules become typed fail-closed gates, each with an input model, a `GateVerdict` (distinct allowed/denied detail classes), a blocking `GateDeclaration`, and an `Effect.fn` evaluator: `cited-event-id-exists`, `declared-round-coherent`, `evidence-cross-check-clean` (derived aggregate of the artifact + event leaves), and the *conditional* `judge-output-inventory-decodes` (conditional because `judge-lint` starts from a committed inventory, not raw judge output).
- **`QaJudgeContract`** — the complete `SkillContract` instance for `qa-inventory/v1`: five declarations in judge-execution order from the single `QaJudgeGateId` registry, schema *references* for input/output, receipt-type bindings, `NoRecoveryPolicy`, and an `evidenceSubject` bound to the contract's own identity (`<id>@<version>` with its SHA-256 pinned and re-derived in the parity suite via `Sha256HexFromBytes`).
- **Adapters, not rewrites** — `crossCheckAgainstRound`, `requireInventoryRound`, and `parseJudgeOutput` now route through the gate evaluators and project the verdicts back into the legacy `EvidenceCrossCheck` / `QaCommandError` shapes. Every operator-facing message string is unchanged; `judge-lint` semantics (missing-event-id detection, declared-round coherence, and the schema-level inventory rules in `decodeQaInventory`) are preserved.
- Parity suite widened (qa-judge-contract-parity, qa-pure, qa-round-pipeline: 82 tests) including verdict/audit shape checks, first-citation ordering, and schema-derived property round-trips.

Implemented by gpt-5.6-sol (xhigh) in an isolated worktree under session orchestration; rebased onto the post-#792 `SkillContract` (`evidenceSubject` binding) by the orchestrator; full local yeet proof green on this exact tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
