### PR TITLE
ci(codegen): treat root dependency files as Codegen Drift inputs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -145,9 +145,8 @@ jobs:
               git fetch --quiet --no-tags --depth=100 origin "${GITHUB_BASE_REF:-main}:refs/remotes/origin/${GITHUB_BASE_REF:-main}"
             fi
             changed_files="$(git diff --name-only "${base_ref}...HEAD")"
-            # The shared kit directory covers output-affecting implementation and package config. Root package.json
-            # and bun.lock stay excluded because matching them would run codegen for unrelated dependency churn.
-            if ! grep -Eq '(^packages/drivers/(acp|ecfr|govinfo|runpod)/(openapi[^/]*\.json|spec/|scripts/|src/_generated/)|^packages/tooling/library/codegen-kit/|^packages/tooling/tool/cli/src/commands/Ci/CiLane\.ts$|^packages/_internal/db-admin/drizzle/|^apps/professional-desktop/(package\.json|scripts/sync-migration-bundle\.ts|src/runtime/Migrations\.gen\.ts)$)' <<< "$changed_files"; then
+            # Root dependency resolution changes the resolved generator or formatter, so these files are drift inputs.
+            if ! grep -Eq '(^packages/drivers/(acp|ecfr|govinfo|runpod)/(openapi[^/]*\.json|spec/|scripts/|src/_generated/)|^packages/tooling/library/codegen-kit/|^packages/tooling/tool/cli/src/commands/Ci/CiLane\.ts$|^packages/_internal/db-admin/drizzle/|^apps/professional-desktop/(package\.json|scripts/sync-migration-bundle\.ts|src/runtime/Migrations\.gen\.ts)$|^(package\.json|bun\.lock)$)' <<< "$changed_files"; then
               should_run=false
             fi
           fi


### PR DESCRIPTION
## Summary

Follow-up to #822 addressing the Greptile P1 raised after its last push: a pull request that only bumps
root `package.json` catalog versions or `bun.lock` resolutions changes the resolved
`@effect/openapi-generator` / formatter, yet the Codegen Drift lane gate skipped it. The gate now treats
root `package.json` and `bun.lock` (root files only, not package manifests) as drift inputs. The lane is five
offline `generate:check` steps (~7s), so the earlier noise exclusion is reversed.

## Verification

- Filter samples: root `bun.lock` → run, root `package.json` → run, `packages/drivers/box/package.json` → skip,
  docs-only → skip, kit-only → run. YAML parses with the repo's `yaml` package.
- `bun run beep yeet publish` local proof + hosted checks on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)