### PR TITLE
docs(explorations): count all three queued amendments and align reopen triggers

### DIFF
--- a/explorations/ATLAS.md
+++ b/explorations/ATLAS.md
@@ -157,7 +157,8 @@ The lego pieces already built. Authoritative inventories (link, never copy):
   agents as FDEs; clone-and-go distribution) plus the training-data-flywheel
   coda. Critical path already lives in packet-system-redesign Amendments
   H/I/J and protocol-as-value. Reopen when H/I/J are ruled, the
-  substrate/instance partition goes live, or the cold-agent eval is wanted.
+  substrate/instance partition goes live, the cold-agent eval is wanted, or
+  the training-data-flywheel coda is picked up as a docs-surface goal.
 - [`project-intelligence`](./project-intelligence/README.md) — parked
   2026-08-13, superseded by the operating loop in
   `goals/nightly-research-routine`; resume when a legal-grade provenance

--- a/explorations/knowledge-endgame/README.md
+++ b/explorations/knowledge-endgame/README.md
@@ -22,8 +22,9 @@ the critical path.
 
 None — parked at capture by design (see `DECISIONS.md` 2026-08-25). Reopen
 triggers: packet-system-redesign Amendments H/I/J get ruled on; the
-substrate/instance workspace-geometry partition becomes a live question; or
-the cold-agent eval (Part III) is wanted as a real harness.
+substrate/instance workspace-geometry partition becomes a live question; the
+cold-agent eval (Part III) is wanted as a real harness; or the
+training-data-flywheel coda is picked up as a real docs-surface goal.
 
 ## Read This First
 

--- a/explorations/packet-system-redesign/MAP.md
+++ b/explorations/packet-system-redesign/MAP.md
@@ -95,10 +95,14 @@ machinery and bounds stream opt-in.
 
 Proposed, not ratified. Queued for the Session B grill that charters the
 fleet convention-migration campaign; they enter the amendment record above
-only if the operator ratifies them there. Source and mapping evidence:
+only if the operator ratifies them there. Three amendments are queued: H and
+I draw their mapping evidence from
 [`research/2026-08-25-agento-ontology-mapping.md`](./research/2026-08-25-agento-ontology-mapping.md)
-(AgentO, ESWC 2026, CC BY 4.0, reference-only). Both land inside existing
-candidates; neither opens a packet.
+(AgentO, ESWC 2026, CC BY 4.0, reference-only), and J draws its certificate
+shape from
+[`research/2026-08-25-ontology-tooling-recon.md`](./research/2026-08-25-ontology-tooling-recon.md)
+(open-ontologies `Certificate` disposition). All three land inside existing
+candidates; none opens a packet.
 
 - **Amendment H (candidate 3) — typed `PacketWorkPlan`, rendered
   launchers.** The manifest gains a schema-first work plan: each phase step


### PR DESCRIPTION
Follow-up to #828, which was merged while this review-fix commit was still in the local proof. Addresses both openclaw review threads from that PR:

- **MAP intro undercounts queued amendments**: the packet-system-redesign queued-amendments intro now names H, I, and J, and cites both evidence notes — the AgentO mapping for H/I and the ontology-tooling recon (open-ontologies Certificate disposition) for J.
- **Parked reopen triggers drift from DECISIONS**: the knowledge-endgame reopen triggers in the explorations ATLAS and the packet README now carry the fourth trigger recorded in DECISIONS.md (training-data-flywheel picked up as a docs-surface goal).

Full local yeet proof green on this head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790309744&installation_model_id=424656&pr_number=830&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F830&signature=9ea6381c9caf42a8e0c53b5171a6d65087faa7808d78fd6d5768bd93c0a17efd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->