### PR TITLE
chore(semantica): sync the lab tsconfig references for the schema dependencies

### DIFF
--- a/apps/labs/semantica/fixtures/f1/index.json
+++ b/apps/labs/semantica/fixtures/f1/index.json
@@ -56,7 +56,7 @@
       "relativePath": "documents/html-truncated.html",
       "mediaType": "text/html",
       "expectation": "degraded",
-      "degradedKind": "malformed-structure",
+      "degradedKind": "truncated",
       "sha256": "c106fce0a6387dd9539bc26f6a7b8ada744d17fa4bd329eddbf6e9c9b3aebeaf",
       "bytes": 631,
       "summary": "Academic HTML cut off inside an attribute after a deliberately bogus charset declaration."
@@ -86,7 +86,7 @@
       "relativePath": "documents/pdf-truncated.pdf",
       "mediaType": "application/pdf",
       "expectation": "degraded",
-      "degradedKind": "truncated",
+      "degradedKind": "extraction-failed",
       "sha256": "d6402d6f7cdd4a60fdaadbf0d26ae7ba4c235126d801bb446ccf2aec00991201",
       "bytes": 2672,
       "summary": "The two-column PDF cut immediately before its explicit xref table."

--- a/apps/labs/semantica/package.json
+++ b/apps/labs/semantica/package.json
@@ -33,7 +33,10 @@
     "test": "bun run beep:test"
   },
   "dependencies": {
+    "@beep/epistemic-domain": "workspace:^",
+    "@beep/file-processing": "workspace:^",
     "@beep/identity": "workspace:^",
+    "@beep/provenance": "workspace:^",
     "@beep/schema": "workspace:^",
     "@effect/platform-bun": "catalog:",
     "@noble/hashes": "catalog:",

--- a/apps/labs/semantica/scripts/generate-f1-index.ts
+++ b/apps/labs/semantica/scripts/generate-f1-index.ts
@@ -79,7 +79,7 @@ const fixtureSpecs: ReadonlyArray<FixtureSpec> = [
     relativePath: "documents/html-truncated.html",
     mediaType: "text/html",
     expectation: "degraded",
-    degradedKind: O.some("malformed-structure"),
+    degradedKind: O.some("truncated"),
     summary: "Academic HTML cut off inside an attribute after a deliberately bogus charset declaration.",
   },
   {
@@ -103,7 +103,7 @@ const fixtureSpecs: ReadonlyArray<FixtureSpec> = [
     relativePath: "documents/pdf-truncated.pdf",
     mediaType: "application/pdf",
     expectation: "degraded",
-    degradedKind: O.some("truncated"),
+    degradedKind: O.some("extraction-failed"),
     summary: "The two-column PDF cut immediately before its explicit xref table.",
   },
 ];

--- a/apps/labs/semantica/src/canary/Command.ts
+++ b/apps/labs/semantica/src/canary/Command.ts
@@ -1,35 +1,14 @@
 import { $SemanticaId } from "@beep/identity/packages";
-import { LiteralKit } from "@beep/schema";
 import { Console, Effect, FileSystem, Path } from "effect";
 import * as S from "effect/Schema";
 import { Command, Flag } from "effect/unstable/cli";
 import { CorpusManifest, ManifestWriteFailed } from "@/corpus/Manifest";
 import { CorpusManifestBuilder } from "@/corpus/ManifestBuilder";
+import { CanaryStage } from "@/schema/Eval";
+
+export { CanaryStage } from "@/schema/Eval";
 
 const $I = $SemanticaId.create("canary/Command");
-
-/**
- * Canary stages exposed by the headless Semantica command.
- *
- * **Example** (Check a stage)
- *
- * ```ts
- * import { CanaryStage } from "@/canary/Command"
- *
- * console.log(CanaryStage.is.c0("c0")) // true
- * ```
- *
- * @category schemas
- * @since 0.0.0
- */
-export const CanaryStage = LiteralKit(["c0", "c1", "c2"]).pipe(
-  $I.annoteSchema("CanaryStage", {
-    description: "Headless Semantica canary stages available through the lab command.",
-  })
-);
-
-// Runtime value accepted by `CanaryStage`; app-local until a consumer outside this module exists.
-type CanaryStage = typeof CanaryStage.Type;
 
 /**
  * Parsed options shared by every Semantica canary stage.

--- a/apps/labs/semantica/src/fixtures/F1.ts
+++ b/apps/labs/semantica/src/fixtures/F1.ts
@@ -6,6 +6,8 @@ import * as O from "effect/Option";
 import * as S from "effect/Schema";
 import * as Str from "effect/String";
 import { ByteDrift, ByteExpectation, verifyByteExpectations } from "@/corpus/ByteWitness";
+import { DegradedKind } from "@/schema/Degraded";
+import { MediaType } from "@/schema/MediaType";
 
 const $I = $SemanticaId.create("fixtures/F1");
 
@@ -44,6 +46,16 @@ export const F1FixtureId = S.String.check(
 /**
  * Decoded value accepted by {@link F1FixtureId}.
  *
+ * **Example** (Annotate a fixture id)
+ *
+ * ```ts
+ * import { F1FixtureId } from "@/fixtures/F1"
+ * import type { F1FixtureId as FixtureId } from "@/fixtures/F1"
+ *
+ * const id: FixtureId = F1FixtureId.make("md-structure")
+ * console.log(id) // "md-structure"
+ * ```
+ *
  * @see {@link F1FixtureId} for validation and branding.
  * @category models
  * @since 0.0.0
@@ -81,14 +93,19 @@ export const isF1FixtureId = S.is(F1FixtureId);
  * @category schemas
  * @since 0.0.0
  */
-export const FixtureMediaType = LiteralKit(["text/markdown", "text/html", "application/pdf"]).annotate(
-  $I.annote("FixtureMediaType", {
-    description: "Markdown, HTML, and born-digital PDF media types exercised by F1.",
-  })
-);
+export const FixtureMediaType = MediaType;
 
 /**
  * Decoded literal accepted by {@link FixtureMediaType}.
+ *
+ * **Example** (Annotate a fixture media type)
+ *
+ * ```ts
+ * import type { FixtureMediaType } from "@/fixtures/F1"
+ *
+ * const mediaType: FixtureMediaType = "text/html"
+ * console.log(mediaType) // "text/html"
+ * ```
  *
  * @see {@link FixtureMediaType} for literal helpers and validation.
  * @category models
@@ -119,6 +136,15 @@ export const FixtureExpectation = LiteralKit(["parses", "degraded"]).annotate(
 /**
  * Decoded literal accepted by {@link FixtureExpectation}.
  *
+ * **Example** (Annotate a fixture expectation)
+ *
+ * ```ts
+ * import type { FixtureExpectation } from "@/fixtures/F1"
+ *
+ * const expectation: FixtureExpectation = "degraded"
+ * console.log(expectation) // "degraded"
+ * ```
+ *
  * @see {@link FixtureExpectation} for literal helpers and validation.
  * @category models
  * @since 0.0.0
@@ -139,14 +165,25 @@ export type FixtureExpectation = typeof FixtureExpectation.Type;
  * @category schemas
  * @since 0.0.0
  */
-export const FixtureDegradedKind = LiteralKit(["invalid-utf8", "truncated", "malformed-structure"]).annotate(
+export const FixtureDegradedKind = LiteralKit(
+  DegradedKind.pickOptions(["invalid-utf8", "truncated", "extraction-failed"])
+).annotate(
   $I.annote("FixtureDegradedKind", {
-    description: "Invalid UTF-8, truncation, or malformed structure declared by a degraded F1 fixture.",
+    description: "Invalid UTF-8, truncation, or extraction failure declared by a degraded F1 fixture.",
   })
 );
 
 /**
  * Decoded literal accepted by {@link FixtureDegradedKind}.
+ *
+ * **Example** (Annotate a fixture degradation)
+ *
+ * ```ts
+ * import type { FixtureDegradedKind } from "@/fixtures/F1"
+ *
+ * const kind: FixtureDegradedKind = "extraction-failed"
+ * console.log(kind) // "extraction-failed"
+ * ```
  *
  * @see {@link FixtureDegradedKind} for literal helpers and validation.
  * @category models
@@ -346,6 +383,15 @@ export const F1Diff = F1DriftKind.toTaggedUnion("kind")({
 /**
  * Runtime type for {@link F1Diff}.
  *
+ * **Example** (Inspect an F1 diff type)
+ *
+ * ```ts
+ * import type { F1Diff } from "@/fixtures/F1"
+ *
+ * const inspect = (diff: F1Diff) => diff.kind
+ * console.log(typeof inspect) // "function"
+ * ```
+ *
  * @see {@link F1Diff} for constructors and discriminator-aware helpers.
  * @category models
  * @since 0.0.0
@@ -417,6 +463,15 @@ export class F1Drift extends S.TaggedError<F1Drift>($I`F1Drift`)(
 
 /**
  * Service shape for loading and verifying the committed F1 index.
+ *
+ * **Example** (Inspect the catalog load type)
+ *
+ * ```ts
+ * import type { F1CatalogShape } from "@/fixtures/F1"
+ *
+ * const inspect = (catalog: F1CatalogShape) => catalog.load
+ * console.log(typeof inspect) // "function"
+ * ```
  *
  * @category services
  * @since 0.0.0

--- a/apps/labs/semantica/src/schema/Degraded.ts
+++ b/apps/labs/semantica/src/schema/Degraded.ts
@@ -1,0 +1,52 @@
+import { $SemanticaId } from "@beep/identity/packages";
+import { LiteralKit } from "@beep/schema";
+
+const $I = $SemanticaId.create("schema/Degraded");
+
+/**
+ * Closed degraded-state vocabulary for the C0 parse and extraction stages.
+ *
+ * **Example** (Check provider degradation)
+ *
+ * ```ts
+ * import { DegradedKind } from "@/schema/Degraded"
+ *
+ * console.log(DegradedKind.is["provider-unavailable"]("provider-unavailable")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const DegradedKind = LiteralKit([
+  "invalid-utf8",
+  "truncated",
+  "empty-text-layer",
+  "extraction-failed",
+  "input-limit",
+  "provider-unavailable",
+  "model-output-invalid",
+  "fabricated-span",
+  "relation-unresolved",
+]).pipe(
+  $I.annoteSchema("DegradedKind", {
+    description: "Exhaustive typed parse and extraction degradation kinds admitted by C0.",
+  })
+);
+
+/**
+ * Decoded literal accepted by {@link DegradedKind}.
+ *
+ * **Example** (Annotate a degraded state)
+ *
+ * ```ts
+ * import type { DegradedKind } from "@/schema/Degraded"
+ *
+ * const kind: DegradedKind = "extraction-failed"
+ * console.log(kind) // "extraction-failed"
+ * ```
+ *
+ * @see {@link DegradedKind} for literal helpers and validation.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type DegradedKind = typeof DegradedKind.Type;

--- a/apps/labs/semantica/src/schema/Digest.ts
+++ b/apps/labs/semantica/src/schema/Digest.ts
@@ -1,0 +1,167 @@
+import { Sha256Hex, Sha256HexFromBytes } from "@beep/schema";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { Effect, Encoding, Result, Struct } from "effect";
+import { dual } from "effect/Function";
+import * as S from "effect/Schema";
+import { canonicalJson } from "@/corpus/Canonical";
+import type { Crypto } from "effect";
+
+const utf8Encoder = new TextEncoder();
+
+const sha256CanonicalEffect = (value: unknown) =>
+  Sha256HexFromBytes.decodeEffect(utf8Encoder.encode(canonicalJson(value)));
+
+const sha256CanonicalSync = (value: unknown): Sha256Hex =>
+  Sha256Hex.make(Encoding.encodeHex(sha256(utf8Encoder.encode(canonicalJson(value)))));
+
+type DigestEffect<Type> = Type extends unknown
+  ? (value: Type) => Effect.Effect<Sha256Hex, S.SchemaError, Crypto.Crypto>
+  : never;
+
+type DigestResult<Type> = Type extends unknown ? (value: Type) => Result.Result<Sha256Hex, S.SchemaError> : never;
+
+/**
+ * Encodes a schema value, canonicalizes its wire form, and hashes the result.
+ *
+ * **Example** (Build a content digest effect)
+ *
+ * ```ts
+ * import { contentDigest } from "@/schema/Digest"
+ * import { Effect } from "effect"
+ * import * as S from "effect/Schema"
+ *
+ * const digest = contentDigest(S.Struct({ a: S.Number }))({ a: 1 })
+ * console.log(Effect.isEffect(digest)) // true
+ * ```
+ *
+ * @category encoding
+ * @since 0.0.0
+ */
+export const contentDigest = <Type, Encoded>(schema: S.Codec<Type, Encoded, never, never>) =>
+  Effect.fn("SemanticaSchema.contentDigest")((value: Type) =>
+    S.encodeEffect(schema)(value).pipe(Effect.flatMap(sha256CanonicalEffect))
+  );
+
+/**
+ * Encodes an object while omitting one wire field from the digest preimage.
+ *
+ * **Details**
+ *
+ * The field is removed only after schema encoding, so transforms and `Option`
+ * wire forms remain part of the canonical preimage.
+ *
+ * **Example** (Exclude a self digest)
+ *
+ * ```ts
+ * import { digestOmitting } from "@/schema/Digest"
+ * import { Effect } from "effect"
+ * import * as S from "effect/Schema"
+ *
+ * const Report = S.Struct({ value: S.Number, digest: S.String })
+ * const digest = digestOmitting(Report, "digest")({ value: 1, digest: "pending" })
+ * console.log(Effect.isEffect(digest)) // true
+ * ```
+ *
+ * @category encoding
+ * @since 0.0.0
+ */
+export const digestOmitting: {
+  <Encoded extends object, Key extends keyof Encoded>(
+    field: Key
+  ): <Type>(schema: S.Codec<Type, Encoded, never, never>) => DigestEffect<Type>;
+  <Type, Encoded extends object, Key extends keyof Encoded>(
+    schema: S.Codec<Type, Encoded, never, never>,
+    field: Key
+  ): DigestEffect<Type>;
+} = dual(
+  2,
+  <Type, Encoded extends object, Key extends keyof Encoded>(schema: S.Codec<Type, Encoded, never, never>, field: Key) =>
+    Effect.fn("SemanticaSchema.digestOmitting")((value: Type) =>
+      S.encodeEffect(schema)(value).pipe(
+        Effect.map((encoded) => Struct.omit(encoded, [field])),
+        Effect.flatMap(sha256CanonicalEffect)
+      )
+    )
+);
+
+/**
+ * Synchronous noble-hashes twin used only by schema refinements.
+ *
+ * **Gotchas**
+ *
+ * Application workflows should use {@link contentDigest}; this form exists so
+ * pure `Schema.check` predicates can verify content-addressed fields.
+ *
+ * **Example** (Inspect a synchronous digest result)
+ *
+ * ```ts
+ * import { contentDigestSync } from "@/schema/Digest"
+ * import { Result } from "effect"
+ * import * as S from "effect/Schema"
+ *
+ * const result = contentDigestSync(S.Struct({ a: S.Number }))({ a: 1 })
+ * console.log(Result.isSuccess(result)) // true
+ * ```
+ *
+ * @category encoding
+ * @since 0.0.0
+ */
+export const contentDigestSync =
+  <Type, Encoded>(schema: S.Codec<Type, Encoded, never, never>) =>
+  (value: Type): Result.Result<Sha256Hex, S.SchemaError> =>
+    Result.map(S.encodeResult(schema)(value), sha256CanonicalSync);
+
+/**
+ * Synchronous field-omitting digest twin used by self-digest refinements.
+ *
+ * **Gotchas**
+ *
+ * Application workflows should use {@link digestOmitting}; this form is
+ * reserved for pure schema checks.
+ *
+ * **Example** (Hash a report body without its digest)
+ *
+ * ```ts
+ * import { digestOmittingSync } from "@/schema/Digest"
+ * import { Result } from "effect"
+ * import * as S from "effect/Schema"
+ *
+ * const Report = S.Struct({ value: S.Number, digest: S.String })
+ * const result = digestOmittingSync(Report, "digest")({ value: 1, digest: "pending" })
+ * console.log(Result.isSuccess(result)) // true
+ * ```
+ *
+ * @category encoding
+ * @since 0.0.0
+ */
+export const digestOmittingSync: {
+  <Encoded extends object, Key extends keyof Encoded>(
+    field: Key
+  ): <Type>(schema: S.Codec<Type, Encoded, never, never>) => DigestResult<Type>;
+  <Type, Encoded extends object, Key extends keyof Encoded>(
+    schema: S.Codec<Type, Encoded, never, never>,
+    field: Key
+  ): DigestResult<Type>;
+} = dual(
+  2,
+  <Type, Encoded extends object, Key extends keyof Encoded>(schema: S.Codec<Type, Encoded, never, never>, field: Key) =>
+    (value: Type): Result.Result<Sha256Hex, S.SchemaError> =>
+      Result.map(S.encodeResult(schema)(value), (encoded) => sha256CanonicalSync(Struct.omit(encoded, [field])))
+);
+
+/**
+ * Hashes exact UTF-8 text without JSON quoting for digest refinements.
+ *
+ * **Example** (Hash exact response text)
+ *
+ * ```ts
+ * import { sha256TextSync } from "@/schema/Digest"
+ *
+ * console.log(sha256TextSync("response").length) // 64
+ * ```
+ *
+ * @category encoding
+ * @since 0.0.0
+ */
+export const sha256TextSync = (text: string): Sha256Hex =>
+  Sha256Hex.make(Encoding.encodeHex(sha256(utf8Encoder.encode(text))));

--- a/apps/labs/semantica/src/schema/Digest.ts
+++ b/apps/labs/semantica/src/schema/Digest.ts
@@ -11,7 +11,27 @@ const utf8Encoder = new TextEncoder();
 const sha256CanonicalEffect = (value: unknown) =>
   Sha256HexFromBytes.decodeEffect(utf8Encoder.encode(canonicalJson(value)));
 
-const sha256CanonicalSync = (value: unknown): Sha256Hex =>
+/**
+ * Hashes an already encoded JSON-compatible preimage with canonical key order.
+ *
+ * **Gotchas**
+ *
+ * Callers must schema-encode domain values before passing them here. Schema
+ * refinements use this synchronous noble-hashes twin because checks cannot
+ * require the Effect `Crypto` service.
+ *
+ * **Example** (Hash an encoded preimage)
+ *
+ * ```ts
+ * import { sha256CanonicalSync } from "@/schema/Digest"
+ *
+ * console.log(sha256CanonicalSync({ document: "example" }).length) // 64
+ * ```
+ *
+ * @category encoding
+ * @since 0.0.0
+ */
+export const sha256CanonicalSync = (value: unknown): Sha256Hex =>
   Sha256Hex.make(Encoding.encodeHex(sha256(utf8Encoder.encode(canonicalJson(value)))));
 
 type DigestEffect<Type> = Type extends unknown

--- a/apps/labs/semantica/src/schema/Document.ts
+++ b/apps/labs/semantica/src/schema/Document.ts
@@ -1,10 +1,10 @@
 import { $SemanticaId } from "@beep/identity/packages";
 import { LiteralKit, NonNegativeInt, Sha256Hex } from "@beep/schema";
-import { identity, Tuple } from "effect";
+import { identity, Option, Tuple } from "effect";
 import * as S from "effect/Schema";
 import * as Str from "effect/String";
 import { CorpusPaperId } from "@/corpus/Manifest";
-import { F1FixtureId } from "@/fixtures/F1";
+import { F1FixtureId, FixtureDegradedKind, FixtureExpectation } from "@/fixtures/F1";
 import { DocumentId, ProvenanceEventId } from "@/schema/Ids";
 import { MediaType } from "@/schema/MediaType";
 
@@ -22,11 +22,54 @@ class W1PaperOrigin extends S.Class<W1PaperOrigin>($I`W1PaperOrigin`)(
   })
 ) {}
 
+const FixtureDeclarationFields = S.Struct({
+  expectation: FixtureExpectation,
+  degradedKind: S.OptionFromNullOr(FixtureDegradedKind),
+});
+
+const FixtureDeclarationCheck = S.makeFilter(
+  (declaration: typeof FixtureDeclarationFields.Type) =>
+    FixtureExpectation.$match(declaration.expectation, {
+      parses: () => Option.isNone(declaration.degradedKind),
+      degraded: () => Option.isSome(declaration.degradedKind),
+    }),
+  {
+    identifier: $I`FixtureDeclarationCheck`,
+    title: "Fixture origin declaration",
+    description: "Requires degraded fixture origins to name a degradation and parsing origins to omit one.",
+    message: "Fixture origin degradedKind must be Some exactly when expectation is degraded.",
+  }
+);
+
+/**
+ * Parser expectation copied from the selected F1 index row.
+ *
+ * **Example** (Declare a parsing fixture)
+ *
+ * ```ts
+ * import { FixtureDeclaration } from "@/schema/Document"
+ * import * as O from "effect/Option"
+ *
+ * const declared = FixtureDeclaration.make({ expectation: "parses", degradedKind: O.none() })
+ * console.log(declared.expectation) // "parses"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class FixtureDeclaration extends S.Class<FixtureDeclaration>($I`FixtureDeclaration`)(
+  FixtureDeclarationFields.check(FixtureDeclarationCheck),
+  $I.annote("FixtureDeclaration", {
+    description: "Fixture parse expectation and optional declared degradation copied into source provenance.",
+  })
+) {}
+
 class FixtureOrigin extends S.Class<FixtureOrigin>($I`FixtureOrigin`)(
   {
     kind: S.tag("Fixture"),
     fixtureId: F1FixtureId,
     relativePath: S.NonEmptyString,
+    declared: FixtureDeclaration,
   },
   $I.annote("FixtureOrigin", {
     description: "Committed synthetic F1 fixture origin.",
@@ -43,11 +86,13 @@ const OriginKind = LiteralKit(["W1Paper", "Fixture"]);
  * ```ts
  * import { Origin } from "@/schema/Document"
  * import { F1FixtureId } from "@/fixtures/F1"
+ * import { Option } from "effect"
  *
  * const origin = Origin.cases.Fixture.make({
  *   kind: "Fixture",
  *   fixtureId: F1FixtureId.make("md-structure"),
- *   relativePath: "documents/md-structure.md"
+ *   relativePath: "documents/md-structure.md",
+ *   declared: { expectation: "parses", degradedKind: Option.none() }
  * })
  * console.log(origin.kind) // "Fixture"
  * ```
@@ -72,11 +117,13 @@ export const Origin = OriginKind.mapMembers(Tuple.evolve([() => W1PaperOrigin, (
  * import { Origin } from "@/schema/Document"
  * import { F1FixtureId } from "@/fixtures/F1"
  * import type { Origin as OriginValue } from "@/schema/Document"
+ * import { Option } from "effect"
  *
  * const origin: OriginValue = Origin.cases.Fixture.make({
  *   kind: "Fixture",
  *   fixtureId: F1FixtureId.make("md-structure"),
- *   relativePath: "documents/md-structure.md"
+ *   relativePath: "documents/md-structure.md",
+ *   declared: { expectation: "parses", degradedKind: Option.none() }
  * })
  * console.log(origin.kind) // "Fixture"
  * ```

--- a/apps/labs/semantica/src/schema/Document.ts
+++ b/apps/labs/semantica/src/schema/Document.ts
@@ -1,0 +1,128 @@
+import { $SemanticaId } from "@beep/identity/packages";
+import { LiteralKit, NonNegativeInt, Sha256Hex } from "@beep/schema";
+import { identity, Tuple } from "effect";
+import * as S from "effect/Schema";
+import * as Str from "effect/String";
+import { CorpusPaperId } from "@/corpus/Manifest";
+import { F1FixtureId } from "@/fixtures/F1";
+import { DocumentId, ProvenanceEventId } from "@/schema/Ids";
+import { MediaType } from "@/schema/MediaType";
+
+const $I = $SemanticaId.create("schema/Document");
+
+class W1PaperOrigin extends S.Class<W1PaperOrigin>($I`W1PaperOrigin`)(
+  {
+    kind: S.tag("W1Paper"),
+    corpusId: S.NonEmptyString,
+    paperId: CorpusPaperId,
+    relativePath: S.NonEmptyString,
+  },
+  $I.annote("W1PaperOrigin", {
+    description: "Manifest-backed origin for one W1 academia paper.",
+  })
+) {}
+
+class FixtureOrigin extends S.Class<FixtureOrigin>($I`FixtureOrigin`)(
+  {
+    kind: S.tag("Fixture"),
+    fixtureId: F1FixtureId,
+    relativePath: S.NonEmptyString,
+  },
+  $I.annote("FixtureOrigin", {
+    description: "Committed synthetic F1 fixture origin.",
+  })
+) {}
+
+const OriginKind = LiteralKit(["W1Paper", "Fixture"]);
+
+/**
+ * Manifest or fixture provenance for a source document.
+ *
+ * **Example** (Create a fixture origin)
+ *
+ * ```ts
+ * import { Origin } from "@/schema/Document"
+ * import { F1FixtureId } from "@/fixtures/F1"
+ *
+ * const origin = Origin.cases.Fixture.make({
+ *   kind: "Fixture",
+ *   fixtureId: F1FixtureId.make("md-structure"),
+ *   relativePath: "documents/md-structure.md"
+ * })
+ * console.log(origin.kind) // "Fixture"
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const Origin = OriginKind.mapMembers(Tuple.evolve([() => W1PaperOrigin, () => FixtureOrigin]))
+  .annotate(
+    $I.annote("Origin", {
+      description: "Tagged source origin for a W1 paper or synthetic F1 fixture.",
+    })
+  )
+  .pipe(S.toTaggedUnion("kind"));
+
+/**
+ * Decoded source-document origin.
+ *
+ * **Example** (Annotate a fixture origin)
+ *
+ * ```ts
+ * import { Origin } from "@/schema/Document"
+ * import { F1FixtureId } from "@/fixtures/F1"
+ * import type { Origin as OriginValue } from "@/schema/Document"
+ *
+ * const origin: OriginValue = Origin.cases.Fixture.make({
+ *   kind: "Fixture",
+ *   fixtureId: F1FixtureId.make("md-structure"),
+ *   relativePath: "documents/md-structure.md"
+ * })
+ * console.log(origin.kind) // "Fixture"
+ * ```
+ *
+ * @see {@link Origin} for variants.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type Origin = typeof Origin.Type;
+
+const SourceDocumentFields = S.Struct({
+  id: DocumentId,
+  mediaType: MediaType,
+  origin: Origin,
+  bytes: NonNegativeInt,
+  sha256: Sha256Hex,
+  acquired: ProvenanceEventId,
+});
+
+const SourceDocumentIdentityCheck = S.makeFilter(
+  (document: typeof SourceDocumentFields.Type) => Str.Equivalence(document.id, document.sha256),
+  {
+    identifier: $I`SourceDocumentIdentityCheck`,
+    title: "Source document identity",
+    description: "Requires the document id to equal the full SHA-256 digest of its source bytes.",
+    message: "SourceDocument sha256 must equal id.",
+  }
+);
+
+/**
+ * Content-addressed metadata for one exact source document.
+ *
+ * **Example** (Inspect the identity field)
+ *
+ * ```ts
+ * import { SourceDocument } from "@/schema/Document"
+ *
+ * console.log(SourceDocument.fields.id !== undefined) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class SourceDocument extends S.Class<SourceDocument>($I`SourceDocument`)(
+  SourceDocumentFields.mapFields(identity).check(SourceDocumentIdentityCheck),
+  $I.annote("SourceDocument", {
+    description: "Full byte identity, media type, origin, size, and ingest event for one source document.",
+  })
+) {}

--- a/apps/labs/semantica/src/schema/Errors.ts
+++ b/apps/labs/semantica/src/schema/Errors.ts
@@ -1,0 +1,195 @@
+import { $SemanticaId } from "@beep/identity/packages";
+import { VerifiedTextAnchorError } from "@beep/provenance";
+import { Sha256Hex } from "@beep/schema";
+import * as S from "effect/Schema";
+import { DegradedKind } from "@/schema/Degraded";
+
+const $I = $SemanticaId.create("schema/Errors");
+
+/**
+ * Reports that a requested source document cannot be listed or read.
+ *
+ * **Example** (Create a document failure)
+ *
+ * ```ts
+ * import { DocumentUnavailable } from "@/schema/Errors"
+ *
+ * const error = DocumentUnavailable.make({ message: "Document is unavailable." })
+ * console.log(error._tag) // "DocumentUnavailable"
+ * ```
+ *
+ * @category errors
+ * @since 0.0.0
+ */
+export class DocumentUnavailable extends S.TaggedError<DocumentUnavailable>($I`DocumentUnavailable`)(
+  "DocumentUnavailable",
+  { message: S.NonEmptyString },
+  $I.annoteError<DocumentUnavailable>("DocumentUnavailable", {
+    description: "Expected source-document listing or read failure.",
+  })
+) {}
+
+/**
+ * Reports a parser boundary failure classified into the C0 degraded vocabulary.
+ *
+ * **Example** (Create an extraction failure)
+ *
+ * ```ts
+ * import { ParserFailed } from "@/schema/Errors"
+ *
+ * const error = ParserFailed.make({ message: "PDF extraction failed.", kind: "extraction-failed" })
+ * console.log(error.kind) // "extraction-failed"
+ * ```
+ *
+ * @category errors
+ * @since 0.0.0
+ */
+export class ParserFailed extends S.TaggedError<ParserFailed>($I`ParserFailed`)(
+  "ParserFailed",
+  { message: S.NonEmptyString, kind: DegradedKind },
+  $I.annoteError<ParserFailed>("ParserFailed", {
+    description: "Expected parser failure carrying its typed degraded classification.",
+  })
+) {}
+
+/**
+ * Wraps a shared provenance error when a candidate text anchor is rejected.
+ *
+ * **Example** (Inspect the cause field)
+ *
+ * ```ts
+ * import { AnchorRejected } from "@/schema/Errors"
+ *
+ * console.log(AnchorRejected.fields.cause !== undefined) // true
+ * ```
+ *
+ * @category errors
+ * @since 0.0.0
+ */
+export class AnchorRejected extends S.TaggedError<AnchorRejected>($I`AnchorRejected`)(
+  "AnchorRejected",
+  { message: S.NonEmptyString, cause: VerifiedTextAnchorError },
+  $I.annoteError<AnchorRejected>("AnchorRejected", {
+    description: "Expected canonical-text anchor rejection preserving the shared verification error.",
+  })
+) {}
+
+/**
+ * Reports a live provider failure or an offline provider-cache miss.
+ *
+ * **Example** (Create an offline cache miss)
+ *
+ * ```ts
+ * import { ProviderUnavailable } from "@/schema/Errors"
+ * import { Sha256Hex } from "@beep/schema"
+ *
+ * const error = ProviderUnavailable.make({
+ *   message: "Provider response is unavailable.",
+ *   offline: true,
+ *   cacheKey: Sha256Hex.make("0".repeat(64))
+ * })
+ * console.log(error.offline) // true
+ * ```
+ *
+ * @category errors
+ * @since 0.0.0
+ */
+export class ProviderUnavailable extends S.TaggedError<ProviderUnavailable>($I`ProviderUnavailable`)(
+  "ProviderUnavailable",
+  { message: S.NonEmptyString, offline: S.Boolean, cacheKey: Sha256Hex },
+  $I.annoteError<ProviderUnavailable>("ProviderUnavailable", {
+    description: "Expected provider unavailability, including content-addressed offline cache misses.",
+  })
+) {}
+
+/**
+ * Reports an invalid or conflicting immutable provider-cache entry.
+ *
+ * **Example** (Create a cache corruption error)
+ *
+ * ```ts
+ * import { ProviderCacheCorrupt } from "@/schema/Errors"
+ *
+ * const error = ProviderCacheCorrupt.make({ message: "Cache digests disagree." })
+ * console.log(error._tag) // "ProviderCacheCorrupt"
+ * ```
+ *
+ * @category errors
+ * @since 0.0.0
+ */
+export class ProviderCacheCorrupt extends S.TaggedError<ProviderCacheCorrupt>($I`ProviderCacheCorrupt`)(
+  "ProviderCacheCorrupt",
+  { message: S.NonEmptyString },
+  $I.annoteError<ProviderCacheCorrupt>("ProviderCacheCorrupt", {
+    description: "Expected provider-cache integrity or write-once conflict failure.",
+  })
+) {}
+
+/**
+ * Reports an append-only ledger operation failure with a stable reason.
+ *
+ * **Example** (Create a conflicting-row error)
+ *
+ * ```ts
+ * import { LedgerFailed } from "@/schema/Errors"
+ *
+ * const error = LedgerFailed.make({ message: "Ledger row conflicts.", reason: "conflicting-row" })
+ * console.log(error.reason) // "conflicting-row"
+ * ```
+ *
+ * @category errors
+ * @since 0.0.0
+ */
+export class LedgerFailed extends S.TaggedError<LedgerFailed>($I`LedgerFailed`)(
+  "LedgerFailed",
+  { message: S.NonEmptyString, reason: S.NonEmptyString },
+  $I.annoteError<LedgerFailed>("LedgerFailed", {
+    description: "Expected append-only ledger failure carrying a stable machine-readable reason.",
+  })
+) {}
+
+/**
+ * Reports that required gold-v1 labels or their digest are unavailable.
+ *
+ * **Example** (Create a gold availability error)
+ *
+ * ```ts
+ * import { GoldUnavailable } from "@/schema/Errors"
+ *
+ * const error = GoldUnavailable.make({ message: "Gold labels are unavailable." })
+ * console.log(error._tag) // "GoldUnavailable"
+ * ```
+ *
+ * @category errors
+ * @since 0.0.0
+ */
+export class GoldUnavailable extends S.TaggedError<GoldUnavailable>($I`GoldUnavailable`)(
+  "GoldUnavailable",
+  { message: S.NonEmptyString },
+  $I.annoteError<GoldUnavailable>("GoldUnavailable", {
+    description: "Expected missing, undecodable, or digest-invalid gold-v1 label failure.",
+  })
+) {}
+
+/**
+ * Reports that an evaluation report violates its schema refinements.
+ *
+ * **Example** (Create a report validation error)
+ *
+ * ```ts
+ * import { ReportInvalid } from "@/schema/Errors"
+ *
+ * const error = ReportInvalid.make({ message: "Report digest is invalid." })
+ * console.log(error._tag) // "ReportInvalid"
+ * ```
+ *
+ * @category errors
+ * @since 0.0.0
+ */
+export class ReportInvalid extends S.TaggedError<ReportInvalid>($I`ReportInvalid`)(
+  "ReportInvalid",
+  { message: S.NonEmptyString },
+  $I.annoteError<ReportInvalid>("ReportInvalid", {
+    description: "Expected failure raised when an evaluation report violates its schema invariants.",
+  })
+) {}

--- a/apps/labs/semantica/src/schema/Eval.ts
+++ b/apps/labs/semantica/src/schema/Eval.ts
@@ -5,14 +5,16 @@ import { Equal, HashMap, HashSet, identity, Number as N, Option, Result } from "
 import * as A from "effect/Array";
 import * as S from "effect/Schema";
 import * as Str from "effect/String";
-import { F1FixtureId } from "@/fixtures/F1";
+import { CorpusPaperId } from "@/corpus/Manifest";
+import { F1FixtureId, FixtureExpectation } from "@/fixtures/F1";
 import { DegradedKind } from "@/schema/Degraded";
 import { contentDigestSync, digestOmittingSync } from "@/schema/Digest";
 import { Origin } from "@/schema/Document";
-import { ExtractionLane } from "@/schema/Evidence";
+import { declaredLosses, ExtractionLane } from "@/schema/Evidence";
 import { GoldRef } from "@/schema/Gold";
 import { DocumentId, RunId } from "@/schema/Ids";
 import { ModelIdentity } from "@/schema/Model";
+import type { LossDeclaration } from "@/schema/Evidence";
 
 const $I = $SemanticaId.create("schema/Eval");
 
@@ -54,6 +56,62 @@ export const CanaryStage = LiteralKit(["c0", "c1", "c2"]).pipe(
  */
 export type CanaryStage = typeof CanaryStage.Type;
 
+const EvalSelectionFields = S.Struct({
+  w1: S.Array(CorpusPaperId),
+  f1: S.NonEmptyArray(F1FixtureId),
+});
+
+type EvalSelectionFields = typeof EvalSelectionFields.Type;
+
+const hasUniqueValues = <Value>(values: ReadonlyArray<Value>): boolean =>
+  Equal.equals(HashSet.size(HashSet.fromIterable(values)), A.length(values));
+
+const EvalSelectionChecks = S.makeFilterGroup(
+  [
+    S.makeFilter((selection: EvalSelectionFields) => hasUniqueValues(selection.w1), {
+      identifier: $I`EvalSelectionW1Unique`,
+      title: "Evaluation W1 selection uniqueness",
+      description: "Requires every W1 paper id to appear at most once in the run selection.",
+      message: "EvalRun selection.w1 must contain unique paper ids.",
+    }),
+    S.makeFilter((selection: EvalSelectionFields) => hasUniqueValues(selection.f1), {
+      identifier: $I`EvalSelectionF1Unique`,
+      title: "Evaluation F1 selection uniqueness",
+      description: "Requires every F1 fixture id to appear at most once in the run selection.",
+      message: "EvalRun selection.f1 must contain unique fixture ids.",
+    }),
+  ],
+  {
+    identifier: $I`EvalSelectionChecks`,
+    title: "Evaluation selection",
+    description: "Checks uniqueness of the W1 and F1 document identities selected for an evaluation run.",
+    message: "EvalRun selection ids must be unique.",
+  }
+);
+
+/**
+ * W1 paper and F1 fixture identities selected for one evaluation run.
+ *
+ * **Example** (Select one F1 fixture)
+ *
+ * ```ts
+ * import { EvalSelection } from "@/schema/Eval"
+ * import { F1FixtureId } from "@/fixtures/F1"
+ *
+ * const selection = EvalSelection.make({ w1: [], f1: [F1FixtureId.make("md-structure")] })
+ * console.log(selection.f1.length) // 1
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class EvalSelection extends S.Class<EvalSelection>($I`EvalSelection`)(
+  EvalSelectionFields.check(EvalSelectionChecks),
+  $I.annote("EvalSelection", {
+    description: "Unique W1 paper ids and non-empty F1 fixture ids selected for one evaluation run.",
+  })
+) {}
+
 const EvalRunBody = S.Struct({
   stage: CanaryStage,
   corpusHash: Sha256Hex,
@@ -61,6 +119,7 @@ const EvalRunBody = S.Struct({
   gold: GoldRef,
   extractor: ModelIdentity,
   patternLane: ModelIdentity,
+  selection: EvalSelection,
 });
 
 const EvalRunFields = S.Struct({
@@ -83,6 +142,18 @@ const EvalRunChecks = S.makeFilterGroup([
     description: "Requires the hosted model identity to represent extraction rather than gold proposal.",
     message: "EvalRun extractor.taskType must equal extraction.",
   }),
+  S.makeFilter((run: EvalRunFields) => run.patternLane.provider === "wink", {
+    identifier: $I`EvalRunPatternProvider`,
+    title: "Evaluation pattern provider",
+    description: "Requires the pattern-lane model identity to use the pinned Wink provider family.",
+    message: "EvalRun patternLane.provider must equal wink.",
+  }),
+  S.makeFilter((run: EvalRunFields) => run.patternLane.taskType === "extraction", {
+    identifier: $I`EvalRunPatternTask`,
+    title: "Evaluation pattern task",
+    description: "Requires the pattern-lane model identity to represent extraction rather than gold proposal.",
+    message: "EvalRun patternLane.taskType must equal extraction.",
+  }),
   S.makeFilter(
     (run: EvalRunFields) =>
       contentDigestSync(EvalRunBody)({
@@ -92,6 +163,7 @@ const EvalRunChecks = S.makeFilterGroup([
         gold: run.gold,
         extractor: run.extractor,
         patternLane: run.patternLane,
+        selection: run.selection,
       }).pipe(
         Result.match({
           onFailure: () => false,
@@ -258,13 +330,33 @@ const MetricScoreFields = S.Struct({
   support: NonNegativeInt,
 });
 
-const MetricScoreSupportCheck = S.makeFilter(
-  (score: typeof MetricScoreFields.Type) => score.status !== "scored" || N.isGreaterThanOrEqualTo(score.support, 1),
+const MetricScoreChecks = S.makeFilterGroup(
+  [
+    S.makeFilter(
+      (score: typeof MetricScoreFields.Type) => score.status !== "scored" || N.isGreaterThanOrEqualTo(score.support, 1),
+      {
+        identifier: $I`MetricScoreSupportCheck`,
+        title: "Scored metric support",
+        description: "Requires every computed metric score to have at least one supporting gold item.",
+        message: "MetricScore support must be at least one when status is scored.",
+      }
+    ),
+    S.makeFilter(
+      (score: typeof MetricScoreFields.Type) =>
+        score.status !== "unsupported" || (Equal.equals(score.value, 0) && Equal.equals(score.support, 0)),
+      {
+        identifier: $I`MetricScoreUnsupportedZero`,
+        title: "Unsupported metric zero value",
+        description: "Requires unsupported metrics to carry zero value and zero support.",
+        message: "MetricScore value and support must both equal zero when status is unsupported.",
+      }
+    ),
+  ],
   {
-    identifier: $I`MetricScoreSupportCheck`,
-    title: "Scored metric support",
-    description: "Requires every computed metric score to have at least one supporting gold item.",
-    message: "MetricScore support must be at least one when status is scored.",
+    identifier: $I`MetricScoreChecks`,
+    title: "Metric score",
+    description: "Checks support arithmetic for scored and unsupported metric rows.",
+    message: "MetricScore support and value must match its status.",
   }
 );
 
@@ -283,7 +375,7 @@ const MetricScoreSupportCheck = S.makeFilter(
  * @since 0.0.0
  */
 export class MetricScore extends S.Class<MetricScore>($I`MetricScore`)(
-  MetricScoreFields.mapFields(identity).check(MetricScoreSupportCheck),
+  MetricScoreFields.mapFields(identity).check(MetricScoreChecks),
   $I.annote("MetricScore", {
     description: "Unit-interval metric value with subset, lane, support count, and explicit support status.",
   })
@@ -404,18 +496,6 @@ export class DocumentOutcome extends S.Class<DocumentOutcome>($I`DocumentOutcome
   })
 ) {}
 
-const expectedF1Parse = HashMap.make(
-  [F1FixtureId.make("md-structure"), "parsed"],
-  [F1FixtureId.make("md-unicode"), "parsed"],
-  [F1FixtureId.make("md-invalid-utf8"), "invalid-utf8"],
-  [F1FixtureId.make("html-article"), "parsed"],
-  [F1FixtureId.make("html-entities-tables"), "parsed"],
-  [F1FixtureId.make("html-truncated"), "truncated"],
-  [F1FixtureId.make("pdf-two-column"), "parsed"],
-  [F1FixtureId.make("pdf-multipage"), "parsed"],
-  [F1FixtureId.make("pdf-truncated"), "extraction-failed"]
-);
-
 const EvalReportFields = S.Struct({
   schemaVersion: S.Literal("eval-report/v1"),
   run: EvalRun,
@@ -440,23 +520,100 @@ const hasCompleteMetrics = (report: EvalReportFields): boolean => {
   );
 };
 
-const patternLaneUnsupportedSubsets = HashSet.fromIterable<MetricSubset>(["relation", "structure"]);
+const lossForMetricSubset = (subset: MetricSubset): Option.Option<LossDeclaration> =>
+  MetricSubset.$match(subset, {
+    structure: () => Option.some<LossDeclaration>("structure-not-supported"),
+    entity: () => Option.none<LossDeclaration>(),
+    relation: () => Option.some<LossDeclaration>("relations-not-supported"),
+    all: () => Option.none<LossDeclaration>(),
+  });
 
 const unsupportedMetricIsDeclared = (score: MetricScore): boolean =>
   score.status !== "unsupported" ||
-  (score.lane === "pattern" && HashSet.has(patternLaneUnsupportedSubsets, score.subset));
+  lossForMetricSubset(score.subset).pipe(
+    Option.match({
+      onNone: () => false,
+      onSome: (loss) => {
+        const method = ExtractionLane.$match(score.lane, {
+          hosted: () => "hosted-langextract" as const,
+          pattern: () => "pattern-wink" as const,
+        });
+        return HashMap.get(declaredLosses, method).pipe(
+          Option.match({
+            onNone: () => false,
+            onSome: (losses) => HashSet.has(losses, loss),
+          })
+        );
+      },
+    })
+  );
 
 const fixtureParseIsExpected = (document: DocumentOutcome): boolean =>
   Origin.match(document.origin, {
     W1Paper: () => true,
     Fixture: (origin) =>
-      HashMap.get(expectedF1Parse, origin.fixtureId).pipe(
-        Option.match({
-          onNone: () => false,
-          onSome: (expected) => Str.Equivalence(expected, document.parse),
-        })
-      ),
+      FixtureExpectation.$match(origin.declared.expectation, {
+        parses: () => Str.Equivalence(document.parse, "parsed"),
+        degraded: () =>
+          origin.declared.degradedKind.pipe(
+            Option.match({
+              onNone: () => false,
+              onSome: (expected) => Str.Equivalence(expected, document.parse),
+            })
+          ),
+      }),
   });
+
+const documentIdsAreUnique = (report: EvalReportFields): boolean =>
+  hasUniqueValues(A.map(report.documents, (document) => document.document));
+
+const reportCoversSelection = (report: EvalReportFields): boolean => {
+  const actualW1 = HashSet.fromIterable(
+    A.getSomes(
+      A.map(report.documents, (document) =>
+        Origin.match(document.origin, {
+          W1Paper: (origin) => Option.some(origin.paperId),
+          Fixture: () => Option.none<CorpusPaperId>(),
+        })
+      )
+    )
+  );
+  const actualF1 = HashSet.fromIterable(
+    A.getSomes(
+      A.map(report.documents, (document) =>
+        Origin.match(document.origin, {
+          W1Paper: () => Option.none<F1FixtureId>(),
+          Fixture: (origin) => Option.some(origin.fixtureId),
+        })
+      )
+    )
+  );
+  const selectedW1 = HashSet.fromIterable(report.run.selection.w1);
+  const selectedF1 = HashSet.fromIterable(report.run.selection.f1);
+  const selectedCount = A.length(report.run.selection.w1) + A.length(report.run.selection.f1);
+
+  return (
+    Equal.equals(A.length(report.documents), selectedCount) &&
+    Equal.equals(actualW1, selectedW1) &&
+    Equal.equals(actualF1, selectedF1)
+  );
+};
+
+const selectedRelationPapersHaveHostedClaims = (report: EvalReportFields): boolean => {
+  const selectedW1 = HashSet.fromIterable(report.run.selection.w1);
+  return A.every(
+    report.run.gold.subsets.relation,
+    (paperId) =>
+      !HashSet.has(selectedW1, paperId) ||
+      A.some(report.documents, (document) =>
+        Origin.match(document.origin, {
+          W1Paper: (origin) =>
+            Str.Equivalence(origin.paperId, paperId) && N.isGreaterThanOrEqualTo(document.claims.hosted.relation, 1),
+          Fixture: () => false,
+        })
+      )
+  );
+};
 
 const isUnexpectedlyDegraded = (document: DocumentOutcome): boolean =>
   Origin.match(document.origin, {
@@ -464,69 +621,95 @@ const isUnexpectedlyDegraded = (document: DocumentOutcome): boolean =>
     Fixture: () => !fixtureParseIsExpected(document),
   });
 
-const EvalReportChecks = S.makeFilterGroup([
-  S.makeFilter(hasCompleteMetrics, {
-    identifier: $I`EvalReportCompleteMetrics`,
-    title: "Evaluation report metric completeness",
-    description: "Requires exactly one score for every stage-required metric, subset, and lane coordinate.",
-    message: "EvalReport metrics must exactly equal the stage's RequiredMetrics coordinates.",
-  }),
-  S.makeFilter(
-    (report: EvalReportFields) =>
-      A.every(report.metrics, (score) => score.lane !== "hosted" || score.status === "scored"),
-    {
-      identifier: $I`EvalReportHostedMetricsScored`,
-      title: "Hosted evaluation metric status",
-      description: "Requires every hosted-lane metric entry to carry a computed score.",
-      message: "EvalReport hosted metrics must all be scored.",
-    }
-  ),
-  S.makeFilter((report: EvalReportFields) => A.every(report.metrics, unsupportedMetricIsDeclared), {
-    identifier: $I`EvalReportUnsupportedMetricsDeclared`,
-    title: "Unsupported evaluation metrics",
-    description:
-      "Allows unsupported status only for the pattern lane's declared relation and structure capability losses.",
-    message: "EvalReport unsupported metrics must match a declared pattern-lane loss.",
-  }),
-  S.makeFilter(
-    (report: EvalReportFields) =>
-      Equal.equals(A.length(A.filter(report.documents, isUnexpectedlyDegraded)), report.unexpectedDegraded),
-    {
-      identifier: $I`EvalReportUnexpectedDegradedArithmetic`,
-      title: "Unexpected degraded document arithmetic",
+const EvalReportChecks = S.makeFilterGroup(
+  [
+    S.makeFilter(hasCompleteMetrics, {
+      identifier: $I`EvalReportCompleteMetrics`,
+      title: "Evaluation report metric completeness",
+      description: "Requires exactly one score for every stage-required metric, subset, and lane coordinate.",
+      message: "EvalReport metrics must exactly equal the stage's RequiredMetrics coordinates.",
+    }),
+    S.makeFilter(
+      (report: EvalReportFields) =>
+        A.every(report.metrics, (score) => score.lane !== "hosted" || score.status === "scored"),
+      {
+        identifier: $I`EvalReportHostedMetricsScored`,
+        title: "Hosted evaluation metric status",
+        description: "Requires every hosted-lane metric entry to carry a computed score.",
+        message: "EvalReport hosted metrics must all be scored.",
+      }
+    ),
+    S.makeFilter((report: EvalReportFields) => A.every(report.metrics, unsupportedMetricIsDeclared), {
+      identifier: $I`EvalReportUnsupportedMetricsDeclared`,
+      title: "Unsupported evaluation metrics",
+      description: "Allows unsupported status only when the lane method's declared-loss table names the metric subset.",
+      message: "EvalReport unsupported metrics must match declaredLosses for their lane method.",
+    }),
+    S.makeFilter(documentIdsAreUnique, {
+      identifier: $I`EvalReportDocumentIdsUnique`,
+      title: "Evaluation report document identity uniqueness",
+      description: "Requires each content-addressed document id to appear at most once in the report.",
+      message: "EvalReport documents must have unique document ids.",
+    }),
+    S.makeFilter(reportCoversSelection, {
+      identifier: $I`EvalReportSelectionCoverage`,
+      title: "Evaluation report selection coverage",
       description:
-        "Requires unexpectedDegraded to equal failed W1 parses/hosted extracts plus F1 expectation mismatches.",
-      message: "EvalReport unexpectedDegraded must equal the derived document count.",
-    }
-  ),
-  S.makeFilter(
-    (report: EvalReportFields) => A.every(report.documents, (document) => Equal.equals(document.anchorsFailed, 0)),
-    {
-      identifier: $I`EvalReportAnchorsVerified`,
-      title: "Evaluation report anchor verification",
-      description: "Requires every reported document to have zero failed anchor verifications.",
-      message: "EvalReport documents must all have anchorsFailed equal to zero.",
-    }
-  ),
-  S.makeFilter(
-    (report: EvalReportFields) =>
-      digestOmittingSync(
-        EvalReportFields,
-        "reportDigest"
-      )(report).pipe(
-        Result.match({
-          onFailure: () => false,
-          onSuccess: (digest) => Str.Equivalence(digest, report.reportDigest),
-        })
-      ),
-    {
-      identifier: $I`EvalReportDigest`,
-      title: "Evaluation report digest",
-      description: "Requires reportDigest to hash the canonical encoded report after removing only reportDigest.",
-      message: "EvalReport reportDigest must match the canonical field-omitting digest.",
-    }
-  ),
-]);
+        "Requires report origins to cover every selected W1 paper and F1 fixture exactly once and no others.",
+      message: "EvalReport documents must exactly cover run.selection.",
+    }),
+    S.makeFilter(selectedRelationPapersHaveHostedClaims, {
+      identifier: $I`EvalReportHostedRelationClaims`,
+      title: "Evaluation report hosted relation claims",
+      description: "Requires at least one hosted relation claim for each selected relation-gold paper.",
+      message: "EvalReport selected relation-gold papers must each have at least one hosted relation claim.",
+    }),
+    S.makeFilter(
+      (report: EvalReportFields) =>
+        Equal.equals(A.length(A.filter(report.documents, isUnexpectedlyDegraded)), report.unexpectedDegraded),
+      {
+        identifier: $I`EvalReportUnexpectedDegradedArithmetic`,
+        title: "Unexpected degraded document arithmetic",
+        description:
+          "Requires unexpectedDegraded to equal failed W1 parses/hosted extracts plus F1 expectation mismatches.",
+        message: "EvalReport unexpectedDegraded must equal the derived document count.",
+      }
+    ),
+    S.makeFilter(
+      (report: EvalReportFields) => A.every(report.documents, (document) => Equal.equals(document.anchorsFailed, 0)),
+      {
+        identifier: $I`EvalReportAnchorsVerified`,
+        title: "Evaluation report anchor verification",
+        description: "Requires every reported document to have zero failed anchor verifications.",
+        message: "EvalReport documents must all have anchorsFailed equal to zero.",
+      }
+    ),
+    S.makeFilter(
+      (report: EvalReportFields) =>
+        digestOmittingSync(
+          EvalReportFields,
+          "reportDigest"
+        )(report).pipe(
+          Result.match({
+            onFailure: () => false,
+            onSuccess: (digest) => Str.Equivalence(digest, report.reportDigest),
+          })
+        ),
+      {
+        identifier: $I`EvalReportDigest`,
+        title: "Evaluation report digest",
+        description: "Requires reportDigest to hash the canonical encoded report after removing only reportDigest.",
+        message: "EvalReport reportDigest must match the canonical field-omitting digest.",
+      }
+    ),
+  ],
+  {
+    identifier: $I`EvalReportChecks`,
+    title: "Evaluation report",
+    description: "Checks metric, selection, degradation, anchor, relation, and digest invariants for a report.",
+    message: "EvalReport must satisfy every report completeness and identity check.",
+  }
+);
 
 /**
  * Replay-stable C0 evaluation report with complete metrics and zero failed anchors.

--- a/apps/labs/semantica/src/schema/Eval.ts
+++ b/apps/labs/semantica/src/schema/Eval.ts
@@ -1,0 +1,550 @@
+import { $SemanticaId } from "@beep/identity/packages";
+import { LiteralKit, NonNegativeInt, Sha256Hex } from "@beep/schema";
+import { UnitInterval } from "@beep/schema/UnitInterval";
+import { Equal, HashMap, HashSet, identity, Number as N, Option, Result } from "effect";
+import * as A from "effect/Array";
+import * as S from "effect/Schema";
+import * as Str from "effect/String";
+import { F1FixtureId } from "@/fixtures/F1";
+import { DegradedKind } from "@/schema/Degraded";
+import { contentDigestSync, digestOmittingSync } from "@/schema/Digest";
+import { Origin } from "@/schema/Document";
+import { ExtractionLane } from "@/schema/Evidence";
+import { GoldRef } from "@/schema/Gold";
+import { DocumentId, RunId } from "@/schema/Ids";
+import { ModelIdentity } from "@/schema/Model";
+
+const $I = $SemanticaId.create("schema/Eval");
+
+/**
+ * Canary stages exposed by the headless Semantica command.
+ *
+ * **Example** (Check a stage)
+ *
+ * ```ts
+ * import { CanaryStage } from "@/schema/Eval"
+ *
+ * console.log(CanaryStage.is.c0("c0")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const CanaryStage = LiteralKit(["c0", "c1", "c2"]).pipe(
+  $I.annoteSchema("CanaryStage", {
+    description: "Headless Semantica canary stages available through the lab command.",
+  })
+);
+
+/**
+ * Decoded Semantica canary stage.
+ *
+ * **Example** (Annotate a canary stage)
+ *
+ * ```ts
+ * import type { CanaryStage } from "@/schema/Eval"
+ *
+ * const stage: CanaryStage = "c0"
+ * console.log(stage) // "c0"
+ * ```
+ *
+ * @see {@link CanaryStage} for literals.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type CanaryStage = typeof CanaryStage.Type;
+
+const EvalRunBody = S.Struct({
+  stage: CanaryStage,
+  corpusHash: Sha256Hex,
+  fixtureIndexDigest: Sha256Hex,
+  gold: GoldRef,
+  extractor: ModelIdentity,
+  patternLane: ModelIdentity,
+});
+
+const EvalRunFields = S.Struct({
+  id: RunId,
+  ...EvalRunBody.fields,
+});
+
+type EvalRunFields = typeof EvalRunFields.Type;
+
+const EvalRunChecks = S.makeFilterGroup([
+  S.makeFilter((run: EvalRunFields) => !Str.Equivalence(run.gold.proposer.provider, run.extractor.provider), {
+    identifier: $I`EvalRunIndependentProviders`,
+    title: "Evaluation provider independence",
+    description: "Requires the gold proposer and scored hosted extractor to use different provider families.",
+    message: "EvalRun gold proposer provider must differ from extractor provider.",
+  }),
+  S.makeFilter((run: EvalRunFields) => run.extractor.taskType === "extraction", {
+    identifier: $I`EvalRunExtractorTask`,
+    title: "Evaluation extractor task",
+    description: "Requires the hosted model identity to represent extraction rather than gold proposal.",
+    message: "EvalRun extractor.taskType must equal extraction.",
+  }),
+  S.makeFilter(
+    (run: EvalRunFields) =>
+      contentDigestSync(EvalRunBody)({
+        stage: run.stage,
+        corpusHash: run.corpusHash,
+        fixtureIndexDigest: run.fixtureIndexDigest,
+        gold: run.gold,
+        extractor: run.extractor,
+        patternLane: run.patternLane,
+      }).pipe(
+        Result.match({
+          onFailure: () => false,
+          onSuccess: (digest) => Str.Equivalence(digest, run.id),
+        })
+      ),
+    {
+      identifier: $I`EvalRunIdentity`,
+      title: "Evaluation run identity",
+      description: "Requires id to hash the canonical encoded stage, corpus, gold, and model identities.",
+      message: "EvalRun id must match the canonical run body digest.",
+    }
+  ),
+]);
+
+/**
+ * Content-addressed canary protocol inputs and independent model identities.
+ *
+ * **Example** (Inspect the stage field)
+ *
+ * ```ts
+ * import { EvalRun } from "@/schema/Eval"
+ *
+ * console.log(EvalRun.fields.stage !== undefined) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class EvalRun extends S.Class<EvalRun>($I`EvalRun`)(
+  EvalRunFields.mapFields(identity).check(EvalRunChecks),
+  $I.annote("EvalRun", {
+    description: "Replay-stable evaluation inputs with independent gold and hosted-extraction provider families.",
+  })
+) {}
+
+/**
+ * C0 correctness metric names adopted from the upstream issue-574 vocabulary.
+ *
+ * **Example** (Check entity span F1)
+ *
+ * ```ts
+ * import { MetricName } from "@/schema/Eval"
+ *
+ * console.log(MetricName.is["entity-span-f1"]("entity-span-f1")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const MetricName = LiteralKit([
+  "structure-span-f1",
+  "entity-span-f1",
+  "rebel-end-to-end-triple-f1",
+  "pairwise-f1",
+  "b-cubed",
+]).pipe(
+  $I.annoteSchema("MetricName", {
+    description:
+      "Structure span, entity span, REBEL-style triple, pairwise, and B-Cubed correctness metrics used by C0 (structure-span-f1 is lab-local; the rest are the #574 names the law table adopts).",
+  })
+);
+
+/**
+ * Decoded evaluation metric name.
+ *
+ * **Example** (Annotate a metric name)
+ *
+ * ```ts
+ * import type { MetricName } from "@/schema/Eval"
+ *
+ * const name: MetricName = "entity-span-f1"
+ * console.log(name) // "entity-span-f1"
+ * ```
+ *
+ * @see {@link MetricName} for literals.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type MetricName = typeof MetricName.Type;
+
+/**
+ * Gold subset addressed by one metric score.
+ *
+ * **Example** (Check the all-documents subset)
+ *
+ * ```ts
+ * import { MetricSubset } from "@/schema/Eval"
+ *
+ * console.log(MetricSubset.is.all("all")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const MetricSubset = LiteralKit(["structure", "entity", "relation", "all"]).pipe(
+  $I.annoteSchema("MetricSubset", {
+    description: "Structure, entity, relation, or all-document evaluation subset.",
+  })
+);
+
+/**
+ * Decoded metric subset.
+ *
+ * **Example** (Annotate a metric subset)
+ *
+ * ```ts
+ * import type { MetricSubset } from "@/schema/Eval"
+ *
+ * const subset: MetricSubset = "relation"
+ * console.log(subset) // "relation"
+ * ```
+ *
+ * @see {@link MetricSubset} for literals.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type MetricSubset = typeof MetricSubset.Type;
+
+/**
+ * Whether a metric was scored or explicitly unsupported by the lane.
+ *
+ * **Example** (Check an unsupported score)
+ *
+ * ```ts
+ * import { MetricStatus } from "@/schema/Eval"
+ *
+ * console.log(MetricStatus.is.unsupported("unsupported")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const MetricStatus = LiteralKit(["scored", "unsupported"]).pipe(
+  $I.annoteSchema("MetricStatus", {
+    description: "Computed score or explicit unsupported-capability status.",
+  })
+);
+
+/**
+ * Decoded metric status.
+ *
+ * **Example** (Annotate a metric status)
+ *
+ * ```ts
+ * import type { MetricStatus } from "@/schema/Eval"
+ *
+ * const status: MetricStatus = "unsupported"
+ * console.log(status) // "unsupported"
+ * ```
+ *
+ * @see {@link MetricStatus} for literals.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type MetricStatus = typeof MetricStatus.Type;
+
+const MetricScoreFields = S.Struct({
+  name: MetricName,
+  subset: MetricSubset,
+  lane: ExtractionLane,
+  status: MetricStatus,
+  value: UnitInterval,
+  support: NonNegativeInt,
+});
+
+const MetricScoreSupportCheck = S.makeFilter(
+  (score: typeof MetricScoreFields.Type) => score.status !== "scored" || N.isGreaterThanOrEqualTo(score.support, 1),
+  {
+    identifier: $I`MetricScoreSupportCheck`,
+    title: "Scored metric support",
+    description: "Requires every computed metric score to have at least one supporting gold item.",
+    message: "MetricScore support must be at least one when status is scored.",
+  }
+);
+
+/**
+ * One lane-specific correctness score or explicit unsupported result.
+ *
+ * **Example** (Inspect the support field)
+ *
+ * ```ts
+ * import { MetricScore } from "@/schema/Eval"
+ *
+ * console.log(MetricScore.fields.support !== undefined) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class MetricScore extends S.Class<MetricScore>($I`MetricScore`)(
+  MetricScoreFields.mapFields(identity).check(MetricScoreSupportCheck),
+  $I.annote("MetricScore", {
+    description: "Unit-interval metric value with subset, lane, support count, and explicit support status.",
+  })
+) {}
+
+/**
+ * One required metric/subset/lane coordinate in the stage metric table.
+ *
+ * **Example** (Inspect the lane field)
+ *
+ * ```ts
+ * import { RequiredMetric } from "@/schema/Eval"
+ *
+ * console.log(RequiredMetric.fields.lane !== undefined) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class RequiredMetric extends S.Class<RequiredMetric>($I`RequiredMetric`)(
+  {
+    name: MetricName,
+    subset: MetricSubset,
+    lane: ExtractionLane,
+  },
+  $I.annote("RequiredMetric", {
+    description: "Required evaluation coordinate composed of metric name, gold subset, and extraction lane.",
+  })
+) {}
+
+const C0RequiredMetrics: ReadonlyArray<RequiredMetric> = [
+  RequiredMetric.make({ name: "structure-span-f1", subset: "structure", lane: "hosted" }),
+  RequiredMetric.make({ name: "structure-span-f1", subset: "structure", lane: "pattern" }),
+  RequiredMetric.make({ name: "entity-span-f1", subset: "entity", lane: "hosted" }),
+  RequiredMetric.make({ name: "entity-span-f1", subset: "entity", lane: "pattern" }),
+  RequiredMetric.make({ name: "rebel-end-to-end-triple-f1", subset: "relation", lane: "hosted" }),
+  RequiredMetric.make({ name: "rebel-end-to-end-triple-f1", subset: "relation", lane: "pattern" }),
+  RequiredMetric.make({ name: "pairwise-f1", subset: "entity", lane: "hosted" }),
+  RequiredMetric.make({ name: "pairwise-f1", subset: "entity", lane: "pattern" }),
+  RequiredMetric.make({ name: "b-cubed", subset: "entity", lane: "hosted" }),
+  RequiredMetric.make({ name: "b-cubed", subset: "entity", lane: "pattern" }),
+];
+
+/**
+ * Readonly stage table of exact metric coordinates required by each canary report.
+ *
+ * **Details**
+ *
+ * C1 and C2 retain the C0 correctness floor until their own metric laws are
+ * introduced; lookup is data-driven and contains no stage branches.
+ *
+ * **Example** (Look up C0 requirements)
+ *
+ * ```ts
+ * import { RequiredMetrics } from "@/schema/Eval"
+ * import { HashMap, Option } from "effect"
+ *
+ * console.log(Option.getOrThrow(HashMap.get(RequiredMetrics, "c0")).length) // 10
+ * ```
+ *
+ * @category constants
+ * @since 0.0.0
+ */
+const RequiredMetricEntries: ReadonlyArray<readonly [CanaryStage, ReadonlyArray<RequiredMetric>]> = [
+  ["c0", C0RequiredMetrics],
+  ["c1", C0RequiredMetrics],
+  ["c2", C0RequiredMetrics],
+];
+
+export const RequiredMetrics: HashMap.HashMap<CanaryStage, ReadonlyArray<RequiredMetric>> = HashMap.fromIterable(
+  RequiredMetricEntries
+);
+
+const DocumentParseOutcome = LiteralKit(["parsed", ...DegradedKind.Options]);
+const DocumentExtractionOutcome = LiteralKit(["extracted", ...DegradedKind.Options]);
+const DocumentClaimCounts = S.Struct({
+  entity: NonNegativeInt,
+  relation: NonNegativeInt,
+  structure: NonNegativeInt,
+});
+
+/**
+ * Per-document parse, extraction, claim, anchor, and cache accounting.
+ *
+ * **Example** (Inspect the anchor-failure field)
+ *
+ * ```ts
+ * import { DocumentOutcome } from "@/schema/Eval"
+ *
+ * console.log(DocumentOutcome.fields.anchorsFailed !== undefined) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class DocumentOutcome extends S.Class<DocumentOutcome>($I`DocumentOutcome`)(
+  {
+    document: DocumentId,
+    origin: Origin,
+    parse: DocumentParseOutcome,
+    extraction: S.Struct({
+      hosted: DocumentExtractionOutcome,
+      pattern: DocumentExtractionOutcome,
+    }),
+    chunks: NonNegativeInt,
+    claims: S.Struct({
+      hosted: DocumentClaimCounts,
+      pattern: DocumentClaimCounts,
+    }),
+    degradedClaims: NonNegativeInt,
+    anchorsVerified: NonNegativeInt,
+    anchorsFailed: NonNegativeInt,
+    cacheKeys: S.Array(Sha256Hex),
+  },
+  $I.annote("DocumentOutcome", {
+    description:
+      "Per-document accounting for parsing, both extraction lanes, claims, anchors, and provider cache keys.",
+  })
+) {}
+
+const expectedF1Parse = HashMap.make(
+  [F1FixtureId.make("md-structure"), "parsed"],
+  [F1FixtureId.make("md-unicode"), "parsed"],
+  [F1FixtureId.make("md-invalid-utf8"), "invalid-utf8"],
+  [F1FixtureId.make("html-article"), "parsed"],
+  [F1FixtureId.make("html-entities-tables"), "parsed"],
+  [F1FixtureId.make("html-truncated"), "truncated"],
+  [F1FixtureId.make("pdf-two-column"), "parsed"],
+  [F1FixtureId.make("pdf-multipage"), "parsed"],
+  [F1FixtureId.make("pdf-truncated"), "extraction-failed"]
+);
+
+const EvalReportFields = S.Struct({
+  schemaVersion: S.Literal("eval-report/v1"),
+  run: EvalRun,
+  documents: S.NonEmptyArray(DocumentOutcome),
+  metrics: S.NonEmptyArray(MetricScore),
+  unexpectedDegraded: NonNegativeInt,
+  reportDigest: Sha256Hex,
+});
+
+type EvalReportFields = typeof EvalReportFields.Type;
+
+const metricCoordinate = (metric: Pick<MetricScore, "lane" | "name" | "subset">): string =>
+  `${metric.name}:${metric.subset}:${metric.lane}`;
+
+const hasCompleteMetrics = (report: EvalReportFields): boolean => {
+  const required = HashMap.get(RequiredMetrics, report.run.stage).pipe(Option.getOrElse(() => []));
+  const actualCoordinates = HashSet.fromIterable(A.map(report.metrics, metricCoordinate));
+  return (
+    Equal.equals(A.length(report.metrics), A.length(required)) &&
+    Equal.equals(HashSet.size(actualCoordinates), A.length(report.metrics)) &&
+    A.every(required, (metric) => HashSet.has(actualCoordinates, metricCoordinate(metric)))
+  );
+};
+
+const patternLaneUnsupportedSubsets = HashSet.fromIterable<MetricSubset>(["relation", "structure"]);
+
+const unsupportedMetricIsDeclared = (score: MetricScore): boolean =>
+  score.status !== "unsupported" ||
+  (score.lane === "pattern" && HashSet.has(patternLaneUnsupportedSubsets, score.subset));
+
+const fixtureParseIsExpected = (document: DocumentOutcome): boolean =>
+  Origin.match(document.origin, {
+    W1Paper: () => true,
+    Fixture: (origin) =>
+      HashMap.get(expectedF1Parse, origin.fixtureId).pipe(
+        Option.match({
+          onNone: () => false,
+          onSome: (expected) => Str.Equivalence(expected, document.parse),
+        })
+      ),
+  });
+
+const isUnexpectedlyDegraded = (document: DocumentOutcome): boolean =>
+  Origin.match(document.origin, {
+    W1Paper: () => document.parse !== "parsed" || document.extraction.hosted !== "extracted",
+    Fixture: () => !fixtureParseIsExpected(document),
+  });
+
+const EvalReportChecks = S.makeFilterGroup([
+  S.makeFilter(hasCompleteMetrics, {
+    identifier: $I`EvalReportCompleteMetrics`,
+    title: "Evaluation report metric completeness",
+    description: "Requires exactly one score for every stage-required metric, subset, and lane coordinate.",
+    message: "EvalReport metrics must exactly equal the stage's RequiredMetrics coordinates.",
+  }),
+  S.makeFilter(
+    (report: EvalReportFields) =>
+      A.every(report.metrics, (score) => score.lane !== "hosted" || score.status === "scored"),
+    {
+      identifier: $I`EvalReportHostedMetricsScored`,
+      title: "Hosted evaluation metric status",
+      description: "Requires every hosted-lane metric entry to carry a computed score.",
+      message: "EvalReport hosted metrics must all be scored.",
+    }
+  ),
+  S.makeFilter((report: EvalReportFields) => A.every(report.metrics, unsupportedMetricIsDeclared), {
+    identifier: $I`EvalReportUnsupportedMetricsDeclared`,
+    title: "Unsupported evaluation metrics",
+    description:
+      "Allows unsupported status only for the pattern lane's declared relation and structure capability losses.",
+    message: "EvalReport unsupported metrics must match a declared pattern-lane loss.",
+  }),
+  S.makeFilter(
+    (report: EvalReportFields) =>
+      Equal.equals(A.length(A.filter(report.documents, isUnexpectedlyDegraded)), report.unexpectedDegraded),
+    {
+      identifier: $I`EvalReportUnexpectedDegradedArithmetic`,
+      title: "Unexpected degraded document arithmetic",
+      description:
+        "Requires unexpectedDegraded to equal failed W1 parses/hosted extracts plus F1 expectation mismatches.",
+      message: "EvalReport unexpectedDegraded must equal the derived document count.",
+    }
+  ),
+  S.makeFilter(
+    (report: EvalReportFields) => A.every(report.documents, (document) => Equal.equals(document.anchorsFailed, 0)),
+    {
+      identifier: $I`EvalReportAnchorsVerified`,
+      title: "Evaluation report anchor verification",
+      description: "Requires every reported document to have zero failed anchor verifications.",
+      message: "EvalReport documents must all have anchorsFailed equal to zero.",
+    }
+  ),
+  S.makeFilter(
+    (report: EvalReportFields) =>
+      digestOmittingSync(
+        EvalReportFields,
+        "reportDigest"
+      )(report).pipe(
+        Result.match({
+          onFailure: () => false,
+          onSuccess: (digest) => Str.Equivalence(digest, report.reportDigest),
+        })
+      ),
+    {
+      identifier: $I`EvalReportDigest`,
+      title: "Evaluation report digest",
+      description: "Requires reportDigest to hash the canonical encoded report after removing only reportDigest.",
+      message: "EvalReport reportDigest must match the canonical field-omitting digest.",
+    }
+  ),
+]);
+
+/**
+ * Replay-stable C0 evaluation report with complete metrics and zero failed anchors.
+ *
+ * **Example** (Inspect the self-digest field)
+ *
+ * ```ts
+ * import { EvalReport } from "@/schema/Eval"
+ *
+ * console.log(EvalReport.fields.reportDigest !== undefined) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class EvalReport extends S.Class<EvalReport>($I`EvalReport`)(
+  EvalReportFields.mapFields(identity).check(EvalReportChecks),
+  $I.annote("EvalReport", {
+    description: "Content-addressed evaluation report with exact stage metrics and derived degradation accounting.",
+  })
+) {}

--- a/apps/labs/semantica/src/schema/Evidence.ts
+++ b/apps/labs/semantica/src/schema/Evidence.ts
@@ -1,0 +1,538 @@
+import { Confidence } from "@beep/epistemic-domain";
+import { $SemanticaId } from "@beep/identity/packages";
+import { TextAnchor, TextAnchorFields, TextAnchorVerificationReceipt, TextAnchorWidthCheck } from "@beep/provenance";
+import { LiteralKit, NonNegativeInt, Sha256Hex } from "@beep/schema";
+import { Equal, HashSet, identity, Tuple } from "effect";
+import * as A from "effect/Array";
+import * as S from "effect/Schema";
+import * as Str from "effect/String";
+import { DegradedKind } from "@/schema/Degraded";
+import { BatchId, ChunkId, ClaimId, DocumentId } from "@/schema/Ids";
+import { ModelIdentity } from "@/schema/Model";
+
+const $I = $SemanticaId.create("schema/Evidence");
+
+/**
+ * Hosted and local-pattern extraction lanes.
+ *
+ * **Example** (Check the hosted lane)
+ *
+ * ```ts
+ * import { ExtractionLane } from "@/schema/Evidence"
+ *
+ * console.log(ExtractionLane.is.hosted("hosted")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const ExtractionLane = LiteralKit(["hosted", "pattern"]).pipe(
+  $I.annoteSchema("ExtractionLane", {
+    description: "Hosted LangExtract and local Wink extraction lanes.",
+  })
+);
+
+/**
+ * Decoded extraction lane.
+ *
+ * **Example** (Annotate an extraction lane)
+ *
+ * ```ts
+ * import type { ExtractionLane } from "@/schema/Evidence"
+ *
+ * const lane: ExtractionLane = "hosted"
+ * console.log(lane) // "hosted"
+ * ```
+ *
+ * @see {@link ExtractionLane} for literals.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type ExtractionLane = typeof ExtractionLane.Type;
+
+/**
+ * Concrete extraction implementations represented in evidence batches.
+ *
+ * **Example** (Check the pattern method)
+ *
+ * ```ts
+ * import { ExtractionMethod } from "@/schema/Evidence"
+ *
+ * console.log(ExtractionMethod.is["pattern-wink"]("pattern-wink")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const ExtractionMethod = LiteralKit(["hosted-langextract", "pattern-wink"]).pipe(
+  $I.annoteSchema("ExtractionMethod", {
+    description: "Pinned hosted LangExtract and local Wink extraction methods.",
+  })
+);
+
+/**
+ * Decoded extraction method.
+ *
+ * **Example** (Annotate an extraction method)
+ *
+ * ```ts
+ * import type { ExtractionMethod } from "@/schema/Evidence"
+ *
+ * const method: ExtractionMethod = "pattern-wink"
+ * console.log(method) // "pattern-wink"
+ * ```
+ *
+ * @see {@link ExtractionMethod} for literals.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type ExtractionMethod = typeof ExtractionMethod.Type;
+
+/**
+ * Structural roles extracted from canonical paper text.
+ *
+ * **Example** (Check an abstract role)
+ *
+ * ```ts
+ * import { StructureRole } from "@/schema/Evidence"
+ *
+ * console.log(StructureRole.is.abstract("abstract")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const StructureRole = LiteralKit(["title", "abstract", "section", "reference"]).pipe(
+  $I.annoteSchema("StructureRole", {
+    description: "Title, abstract, section, and reference roles in a paper's structure.",
+  })
+);
+
+/**
+ * Decoded structure role.
+ *
+ * **Example** (Annotate a structure role)
+ *
+ * ```ts
+ * import type { StructureRole } from "@/schema/Evidence"
+ *
+ * const role: StructureRole = "abstract"
+ * console.log(role) // "abstract"
+ * ```
+ *
+ * @see {@link StructureRole} for literals.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type StructureRole = typeof StructureRole.Type;
+
+/**
+ * Capability losses explicitly declared by an extraction lane.
+ *
+ * **Example** (Declare unsupported relations)
+ *
+ * ```ts
+ * import { LossDeclaration } from "@/schema/Evidence"
+ *
+ * console.log(LossDeclaration.is["relations-not-supported"]("relations-not-supported")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const LossDeclaration = LiteralKit(["relations-not-supported", "structure-not-supported"]).pipe(
+  $I.annoteSchema("LossDeclaration", {
+    description: "Relation or structure capability absent from an extraction lane by design.",
+  })
+);
+
+/**
+ * Decoded extraction loss declaration.
+ *
+ * **Example** (Annotate a loss declaration)
+ *
+ * ```ts
+ * import type { LossDeclaration } from "@/schema/Evidence"
+ *
+ * const loss: LossDeclaration = "relations-not-supported"
+ * console.log(loss) // "relations-not-supported"
+ * ```
+ *
+ * @see {@link LossDeclaration} for literals.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type LossDeclaration = typeof LossDeclaration.Type;
+
+const EntityBodyFields = S.Struct({
+  kind: S.tag("Entity"),
+  label: S.NonEmptyString,
+  entityType: S.NonEmptyString,
+  ...TextAnchorFields,
+});
+
+class EntityClaimBody extends S.Class<EntityClaimBody>($I`EntityClaimBody`)(
+  EntityBodyFields.mapFields(identity).check(TextAnchorWidthCheck),
+  $I.annote("EntityClaimBody", {
+    description: "Grounded entity label and type with an exact UTF-16 text anchor.",
+  })
+) {}
+
+const RelationBodyFields = S.Struct({
+  kind: S.tag("Relation"),
+  predicate: S.NonEmptyString,
+  subject: ClaimId,
+  object: ClaimId,
+  ...TextAnchorFields,
+});
+
+class RelationClaimBody extends S.Class<RelationClaimBody>($I`RelationClaimBody`)(
+  RelationBodyFields.mapFields(identity).check(TextAnchorWidthCheck),
+  $I.annote("RelationClaimBody", {
+    description: "Grounded relation predicate and entity-claim endpoints with an exact text anchor.",
+  })
+) {}
+
+const StructureBodyFields = S.Struct({
+  kind: S.tag("Structure"),
+  role: StructureRole,
+  depth: NonNegativeInt,
+  ...TextAnchorFields,
+});
+
+class StructureClaimBody extends S.Class<StructureClaimBody>($I`StructureClaimBody`)(
+  StructureBodyFields.mapFields(identity).check(TextAnchorWidthCheck),
+  $I.annote("StructureClaimBody", {
+    description: "Grounded structural role and depth with an exact UTF-16 text anchor.",
+  })
+) {}
+
+const ClaimBodyKind = LiteralKit(["Entity", "Relation", "Structure"]);
+
+/**
+ * Grounded entity, relation, or structural evidence body.
+ *
+ * **Example** (Create an entity body)
+ *
+ * ```ts
+ * import { ClaimBody } from "@/schema/Evidence"
+ * import { NonNegativeInt } from "@beep/schema"
+ *
+ * const body = ClaimBody.cases.Entity.make({
+ *   kind: "Entity",
+ *   label: "Effect",
+ *   entityType: "software",
+ *   startChar: NonNegativeInt.make(0),
+ *   endChar: NonNegativeInt.make(6),
+ *   quote: "Effect"
+ * })
+ * console.log(body.kind) // "Entity"
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const ClaimBody = ClaimBodyKind.mapMembers(
+  Tuple.evolve([() => EntityClaimBody, () => RelationClaimBody, () => StructureClaimBody])
+)
+  .annotate(
+    $I.annote("ClaimBody", {
+      description: "Exhaustive anchored entity, relation, and structure evidence bodies.",
+    })
+  )
+  .pipe(S.toTaggedUnion("kind"));
+
+/**
+ * Decoded evidence claim body.
+ *
+ * **Example** (Inspect a claim body type)
+ *
+ * ```ts
+ * import type { ClaimBody } from "@/schema/Evidence"
+ *
+ * const inspect = (body: ClaimBody) => body.kind
+ * console.log(typeof inspect) // "function"
+ * ```
+ *
+ * @see {@link ClaimBody} for variants.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type ClaimBody = typeof ClaimBody.Type;
+
+const EvidenceClaimFields = S.Struct({
+  id: ClaimId,
+  document: DocumentId,
+  chunk: ChunkId,
+  body: ClaimBody,
+  confidence: Confidence,
+  method: ExtractionMethod,
+  model: ModelIdentity,
+  cacheKey: S.OptionFromNullOr(Sha256Hex),
+  receipt: TextAnchorVerificationReceipt,
+});
+
+const EvidenceClaimReceiptCheck = S.makeFilter(
+  (claim: typeof EvidenceClaimFields.Type) =>
+    S.toEquivalence(TextAnchor)(claim.receipt.anchor, TextAnchor.make(claim.body)),
+  {
+    identifier: $I`EvidenceClaimReceiptCheck`,
+    title: "Evidence claim anchor receipt",
+    description: "Requires the verification receipt to contain the evidence body's exact anchor.",
+    message: "EvidenceClaim receipt.anchor must equal the anchor carried by body.",
+  }
+);
+
+/**
+ * Content-addressed grounded evidence claim and its verification receipt.
+ *
+ * **Example** (Inspect the body field)
+ *
+ * ```ts
+ * import { EvidenceClaim } from "@/schema/Evidence"
+ *
+ * console.log(EvidenceClaim.fields.body !== undefined) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class EvidenceClaim extends S.Class<EvidenceClaim>($I`EvidenceClaim`)(
+  EvidenceClaimFields.mapFields(identity).check(EvidenceClaimReceiptCheck),
+  $I.annote("EvidenceClaim", {
+    description: "Grounded claim with model, method, confidence, cache provenance, and verified anchor receipt.",
+  })
+) {}
+
+/**
+ * Chunk-scoped extraction that could not become an evidence claim.
+ *
+ * **Example** (Create a fabricated-span degradation)
+ *
+ * ```ts
+ * import { DegradedClaim } from "@/schema/Evidence"
+ * import { ChunkId } from "@/schema/Ids"
+ *
+ * const degraded = DegradedClaim.make({
+ *   kind: "fabricated-span",
+ *   detail: "The returned quote was absent.",
+ *   chunk: ChunkId.make("0".repeat(64))
+ * })
+ * console.log(degraded.kind) // "fabricated-span"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class DegradedClaim extends S.Class<DegradedClaim>($I`DegradedClaim`)(
+  {
+    kind: DegradedKind,
+    detail: S.NonEmptyString,
+    chunk: ChunkId,
+  },
+  $I.annote("DegradedClaim", {
+    description: "Typed chunk-scoped extraction degradation that never silently becomes a claim.",
+  })
+) {}
+
+const EvidenceBatchFields = S.Struct({
+  id: BatchId,
+  document: DocumentId,
+  method: ExtractionMethod,
+  model: ModelIdentity,
+  inputs: S.NonEmptyArray(ChunkId),
+  claims: S.Array(EvidenceClaim),
+  degraded: S.Array(DegradedClaim),
+  lossy: S.Array(LossDeclaration),
+});
+
+type EvidenceBatchFields = typeof EvidenceBatchFields.Type;
+
+const claimIdsAreUnique = (batch: EvidenceBatchFields): boolean =>
+  Equal.equals(HashSet.size(HashSet.fromIterable(A.map(batch.claims, (claim) => claim.id))), A.length(batch.claims));
+
+const claimsMatchBatch = (batch: EvidenceBatchFields): boolean => {
+  const sameModel = S.toEquivalence(ModelIdentity);
+  return A.every(
+    batch.claims,
+    (claim) =>
+      Str.Equivalence(claim.document, batch.document) &&
+      Str.Equivalence(claim.method, batch.method) &&
+      sameModel(claim.model, batch.model)
+  );
+};
+
+const EvidenceBatchChecks = S.makeFilterGroup([
+  S.makeFilter(claimIdsAreUnique, {
+    identifier: $I`EvidenceBatchClaimIdsUnique`,
+    title: "Evidence batch claim identity uniqueness",
+    description: "Requires every evidence claim in a batch to have a unique content-addressed id.",
+    message: "EvidenceBatch claims must have unique ids.",
+  }),
+  S.makeFilter(claimsMatchBatch, {
+    identifier: $I`EvidenceBatchClaimCoherence`,
+    title: "Evidence batch claim coherence",
+    description: "Requires each claim's document, extraction method, and model to equal its batch.",
+    message: "EvidenceBatch claims must match the batch document, method, and model.",
+  }),
+]);
+
+/**
+ * One document-and-lane extraction batch with claims, degradations, and declared loss.
+ *
+ * **Example** (Inspect the loss declarations)
+ *
+ * ```ts
+ * import { EvidenceBatch } from "@/schema/Evidence"
+ *
+ * console.log(EvidenceBatch.fields.lossy !== undefined) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class EvidenceBatch extends S.Class<EvidenceBatch>($I`EvidenceBatch`)(
+  EvidenceBatchFields.mapFields(identity).check(EvidenceBatchChecks),
+  $I.annote("EvidenceBatch", {
+    description: "Coherent extraction batch with unique claims and explicit unsupported-capability declarations.",
+  })
+) {}
+
+class ExtractedOutcome extends S.Class<ExtractedOutcome>($I`ExtractedOutcome`)(
+  {
+    outcome: S.tag("Extracted"),
+    batch: EvidenceBatch,
+  },
+  $I.annote("ExtractedOutcome", {
+    description: "Successful extraction represented by a validated evidence batch.",
+  })
+) {}
+
+class DegradedExtractOutcome extends S.Class<DegradedExtractOutcome>($I`DegradedExtractOutcome`)(
+  {
+    outcome: S.tag("Degraded"),
+    document: DocumentId,
+    lane: ExtractionLane,
+    kind: DegradedKind,
+    detail: S.NonEmptyString,
+  },
+  $I.annote("DegradedExtractOutcome", {
+    description: "Typed document-and-lane extraction degradation retained as a value.",
+  })
+) {}
+
+const ExtractOutcomeKind = LiteralKit(["Extracted", "Degraded"]);
+
+/**
+ * Successful or explicitly degraded extraction result.
+ *
+ * **Example** (Create a degraded extraction result)
+ *
+ * ```ts
+ * import { ExtractOutcome } from "@/schema/Evidence"
+ * import { DocumentId } from "@/schema/Ids"
+ *
+ * const result = ExtractOutcome.cases.Degraded.make({
+ *   outcome: "Degraded",
+ *   document: DocumentId.make("0".repeat(64)),
+ *   lane: "hosted",
+ *   kind: "provider-unavailable",
+ *   detail: "Provider cache miss."
+ * })
+ * console.log(result.outcome) // "Degraded"
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const ExtractOutcome = ExtractOutcomeKind.mapMembers(
+  Tuple.evolve([() => ExtractedOutcome, () => DegradedExtractOutcome])
+)
+  .annotate(
+    $I.annote("ExtractOutcome", {
+      description: "Extraction result preserving either a validated batch or a typed degraded state.",
+    })
+  )
+  .pipe(S.toTaggedUnion("outcome"));
+
+/**
+ * Decoded extraction outcome.
+ *
+ * **Example** (Inspect an extraction outcome type)
+ *
+ * ```ts
+ * import type { ExtractOutcome } from "@/schema/Evidence"
+ *
+ * const inspect = (outcome: ExtractOutcome) => outcome.outcome
+ * console.log(typeof inspect) // "function"
+ * ```
+ *
+ * @see {@link ExtractOutcome} for variants.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type ExtractOutcome = typeof ExtractOutcome.Type;
+
+/**
+ * Reasons two claims form an explicit conflict witness.
+ *
+ * **Example** (Check an anchor conflict)
+ *
+ * ```ts
+ * import { ConflictBasis } from "@/schema/Evidence"
+ *
+ * console.log(ConflictBasis.is["same-anchor-different-label"]("same-anchor-different-label")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const ConflictBasis = LiteralKit(["same-anchor-different-label", "same-pair-different-predicate"]).pipe(
+  $I.annoteSchema("ConflictBasis", {
+    description: "Same-anchor label disagreement or same-endpoint predicate disagreement.",
+  })
+);
+
+/**
+ * Decoded conflict basis.
+ *
+ * **Example** (Annotate a conflict basis)
+ *
+ * ```ts
+ * import type { ConflictBasis } from "@/schema/Evidence"
+ *
+ * const basis: ConflictBasis = "same-anchor-different-label"
+ * console.log(basis) // "same-anchor-different-label"
+ * ```
+ *
+ * @see {@link ConflictBasis} for literals.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type ConflictBasis = typeof ConflictBasis.Type;
+
+/**
+ * Persisted witness connecting two conflicting claims without merging them.
+ *
+ * **Example** (Inspect the endpoint fields)
+ *
+ * ```ts
+ * import { ConflictWitness } from "@/schema/Evidence"
+ *
+ * console.log(ConflictWitness.fields.left !== undefined) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class ConflictWitness extends S.Class<ConflictWitness>($I`ConflictWitness`)(
+  {
+    id: Sha256Hex,
+    left: ClaimId,
+    right: ClaimId,
+    basis: ConflictBasis,
+  },
+  $I.annote("ConflictWitness", {
+    description: "Content-addressed record that keeps two conflicting evidence claims as separate nodes.",
+  })
+) {}

--- a/apps/labs/semantica/src/schema/Evidence.ts
+++ b/apps/labs/semantica/src/schema/Evidence.ts
@@ -2,11 +2,12 @@ import { Confidence } from "@beep/epistemic-domain";
 import { $SemanticaId } from "@beep/identity/packages";
 import { TextAnchor, TextAnchorFields, TextAnchorVerificationReceipt, TextAnchorWidthCheck } from "@beep/provenance";
 import { LiteralKit, NonNegativeInt, Sha256Hex } from "@beep/schema";
-import { Equal, HashSet, identity, Tuple } from "effect";
+import { Equal, HashMap, HashSet, identity, Option, Order, Result, Tuple } from "effect";
 import * as A from "effect/Array";
 import * as S from "effect/Schema";
 import * as Str from "effect/String";
 import { DegradedKind } from "@/schema/Degraded";
+import { sha256CanonicalSync } from "@/schema/Digest";
 import { BatchId, ChunkId, ClaimId, DocumentId } from "@/schema/Ids";
 import { ModelIdentity } from "@/schema/Model";
 
@@ -164,6 +165,31 @@ export const LossDeclaration = LiteralKit(["relations-not-supported", "structure
  */
 export type LossDeclaration = typeof LossDeclaration.Type;
 
+/**
+ * Exact capability losses declared by each extraction implementation.
+ *
+ * **Example** (Inspect the pattern losses)
+ *
+ * ```ts
+ * import { declaredLosses } from "@/schema/Evidence"
+ * import { HashMap, HashSet, Option } from "effect"
+ *
+ * const losses = Option.getOrThrow(HashMap.get(declaredLosses, "pattern-wink"))
+ * console.log(HashSet.size(losses)) // 2
+ * ```
+ *
+ * @category constants
+ * @since 0.0.0
+ */
+const DeclaredLossEntries: ReadonlyArray<readonly [ExtractionMethod, HashSet.HashSet<LossDeclaration>]> = [
+  ["hosted-langextract", HashSet.empty<LossDeclaration>()],
+  ["pattern-wink", HashSet.fromIterable<LossDeclaration>(["relations-not-supported", "structure-not-supported"])],
+];
+
+export const declaredLosses: HashMap.HashMap<ExtractionMethod, HashSet.HashSet<LossDeclaration>> = HashMap.fromIterable(
+  DeclaredLossEntries
+);
+
 const EntityBodyFields = S.Struct({
   kind: S.tag("Entity"),
   label: S.NonEmptyString,
@@ -272,6 +298,56 @@ const EvidenceClaimFields = S.Struct({
   receipt: TextAnchorVerificationReceipt,
 });
 
+const ClaimIdPreimage = S.Struct({
+  document: DocumentId,
+  chunk: ChunkId,
+  body: ClaimBody,
+  method: ExtractionMethod,
+  model: ModelIdentity,
+});
+
+type ClaimIdSource = Pick<typeof EvidenceClaimFields.Type, "body" | "chunk" | "document" | "method" | "model">;
+
+/**
+ * Schema-encodes the canonical content preimage for an evidence claim id.
+ *
+ * **Example** (Inspect the preimage builder)
+ *
+ * ```ts
+ * import { claimIdPreimage } from "@/schema/Evidence"
+ *
+ * console.log(typeof claimIdPreimage) // "function"
+ * ```
+ *
+ * @category encoding
+ * @since 0.0.0
+ */
+export const claimIdPreimage = (claim: ClaimIdSource): Result.Result<typeof ClaimIdPreimage.Encoded, S.SchemaError> =>
+  S.encodeResult(ClaimIdPreimage)({
+    document: claim.document,
+    chunk: claim.chunk,
+    body: claim.body,
+    method: claim.method,
+    model: claim.model,
+  });
+
+/**
+ * Builds the content-addressed id for a grounded evidence claim.
+ *
+ * **Example** (Inspect the claim id builder)
+ *
+ * ```ts
+ * import { makeClaimId } from "@/schema/Evidence"
+ *
+ * console.log(typeof makeClaimId) // "function"
+ * ```
+ *
+ * @category constructors
+ * @since 0.0.0
+ */
+export const makeClaimId = (claim: ClaimIdSource): Result.Result<ClaimId, S.SchemaError> =>
+  Result.map(claimIdPreimage(claim), (preimage) => ClaimId.make(sha256CanonicalSync(preimage)));
+
 const EvidenceClaimReceiptCheck = S.makeFilter(
   (claim: typeof EvidenceClaimFields.Type) =>
     S.toEquivalence(TextAnchor)(claim.receipt.anchor, TextAnchor.make(claim.body)),
@@ -282,6 +358,29 @@ const EvidenceClaimReceiptCheck = S.makeFilter(
     message: "EvidenceClaim receipt.anchor must equal the anchor carried by body.",
   }
 );
+
+const EvidenceClaimIdentityCheck = S.makeFilter(
+  (claim: typeof EvidenceClaimFields.Type) =>
+    makeClaimId(claim).pipe(
+      Result.match({
+        onFailure: () => false,
+        onSuccess: (id) => Str.Equivalence(id, claim.id),
+      })
+    ),
+  {
+    identifier: $I`EvidenceClaimIdentityCheck`,
+    title: "Evidence claim content identity",
+    description: "Requires id to hash the canonical encoded document, chunk, body, method, and model.",
+    message: "EvidenceClaim id must match the canonical claim preimage digest.",
+  }
+);
+
+const EvidenceClaimChecks = S.makeFilterGroup([EvidenceClaimReceiptCheck, EvidenceClaimIdentityCheck], {
+  identifier: $I`EvidenceClaimChecks`,
+  title: "Evidence claim",
+  description: "Checks the anchor receipt and canonical content identity of an evidence claim.",
+  message: "EvidenceClaim must have a matching receipt and content id.",
+});
 
 /**
  * Content-addressed grounded evidence claim and its verification receipt.
@@ -298,7 +397,7 @@ const EvidenceClaimReceiptCheck = S.makeFilter(
  * @since 0.0.0
  */
 export class EvidenceClaim extends S.Class<EvidenceClaim>($I`EvidenceClaim`)(
-  EvidenceClaimFields.mapFields(identity).check(EvidenceClaimReceiptCheck),
+  EvidenceClaimFields.mapFields(identity).check(EvidenceClaimChecks),
   $I.annote("EvidenceClaim", {
     description: "Grounded claim with model, method, confidence, cache provenance, and verified anchor receipt.",
   })
@@ -348,6 +447,54 @@ const EvidenceBatchFields = S.Struct({
 
 type EvidenceBatchFields = typeof EvidenceBatchFields.Type;
 
+const BatchIdPreimage = S.Struct({
+  document: DocumentId,
+  method: ExtractionMethod,
+  model: ModelIdentity,
+  inputs: S.NonEmptyArray(ChunkId),
+});
+
+type BatchIdSource = Pick<EvidenceBatchFields, "document" | "inputs" | "method" | "model">;
+
+/**
+ * Schema-encodes the canonical content preimage for an evidence batch id.
+ *
+ * **Example** (Inspect the preimage builder)
+ *
+ * ```ts
+ * import { batchIdPreimage } from "@/schema/Evidence"
+ *
+ * console.log(typeof batchIdPreimage) // "function"
+ * ```
+ *
+ * @category encoding
+ * @since 0.0.0
+ */
+export const batchIdPreimage = (batch: BatchIdSource): Result.Result<typeof BatchIdPreimage.Encoded, S.SchemaError> =>
+  S.encodeResult(BatchIdPreimage)({
+    document: batch.document,
+    method: batch.method,
+    model: batch.model,
+    inputs: batch.inputs,
+  });
+
+/**
+ * Builds the content-addressed id for one document-and-lane extraction batch.
+ *
+ * **Example** (Inspect the batch id builder)
+ *
+ * ```ts
+ * import { makeBatchId } from "@/schema/Evidence"
+ *
+ * console.log(typeof makeBatchId) // "function"
+ * ```
+ *
+ * @category constructors
+ * @since 0.0.0
+ */
+export const makeBatchId = (batch: BatchIdSource): Result.Result<BatchId, S.SchemaError> =>
+  Result.map(batchIdPreimage(batch), (preimage) => BatchId.make(sha256CanonicalSync(preimage)));
+
 const claimIdsAreUnique = (batch: EvidenceBatchFields): boolean =>
   Equal.equals(HashSet.size(HashSet.fromIterable(A.map(batch.claims, (claim) => claim.id))), A.length(batch.claims));
 
@@ -362,20 +509,102 @@ const claimsMatchBatch = (batch: EvidenceBatchFields): boolean => {
   );
 };
 
-const EvidenceBatchChecks = S.makeFilterGroup([
-  S.makeFilter(claimIdsAreUnique, {
-    identifier: $I`EvidenceBatchClaimIdsUnique`,
-    title: "Evidence batch claim identity uniqueness",
-    description: "Requires every evidence claim in a batch to have a unique content-addressed id.",
-    message: "EvidenceBatch claims must have unique ids.",
-  }),
-  S.makeFilter(claimsMatchBatch, {
-    identifier: $I`EvidenceBatchClaimCoherence`,
-    title: "Evidence batch claim coherence",
-    description: "Requires each claim's document, extraction method, and model to equal its batch.",
-    message: "EvidenceBatch claims must match the batch document, method, and model.",
-  }),
-]);
+const outputsReferenceInputs = (batch: EvidenceBatchFields): boolean => {
+  const inputIds = HashSet.fromIterable(batch.inputs);
+  return (
+    A.every(batch.claims, (claim) => HashSet.has(inputIds, claim.chunk)) &&
+    A.every(batch.degraded, (degraded) => HashSet.has(inputIds, degraded.chunk))
+  );
+};
+
+const relationEndpointsAreEntityClaims = (batch: EvidenceBatchFields): boolean => {
+  const entityClaimIds = HashSet.fromIterable(
+    A.getSomes(
+      A.map(batch.claims, (claim) =>
+        ClaimBody.match(claim.body, {
+          Entity: () => Option.some(claim.id),
+          Relation: () => Option.none<ClaimId>(),
+          Structure: () => Option.none<ClaimId>(),
+        })
+      )
+    )
+  );
+
+  return A.every(batch.claims, (claim) =>
+    ClaimBody.match(claim.body, {
+      Entity: () => true,
+      Relation: (relation) =>
+        HashSet.has(entityClaimIds, relation.subject) && HashSet.has(entityClaimIds, relation.object),
+      Structure: () => true,
+    })
+  );
+};
+
+const lossesMatchMethod = (batch: EvidenceBatchFields): boolean =>
+  HashMap.get(declaredLosses, batch.method).pipe(
+    Option.match({
+      onNone: () => false,
+      onSome: (expected) => {
+        const actual = HashSet.fromIterable(batch.lossy);
+        return Equal.equals(HashSet.size(actual), A.length(batch.lossy)) && Equal.equals(actual, expected);
+      },
+    })
+  );
+
+const batchIdMatchesPreimage = (batch: EvidenceBatchFields): boolean =>
+  makeBatchId(batch).pipe(
+    Result.match({
+      onFailure: () => false,
+      onSuccess: (id) => Str.Equivalence(id, batch.id),
+    })
+  );
+
+const EvidenceBatchChecks = S.makeFilterGroup(
+  [
+    S.makeFilter(claimIdsAreUnique, {
+      identifier: $I`EvidenceBatchClaimIdsUnique`,
+      title: "Evidence batch claim identity uniqueness",
+      description: "Requires every evidence claim in a batch to have a unique content-addressed id.",
+      message: "EvidenceBatch claims must have unique ids.",
+    }),
+    S.makeFilter(claimsMatchBatch, {
+      identifier: $I`EvidenceBatchClaimCoherence`,
+      title: "Evidence batch claim coherence",
+      description: "Requires each claim's document, extraction method, and model to equal its batch.",
+      message: "EvidenceBatch claims must match the batch document, method, and model.",
+    }),
+    S.makeFilter(outputsReferenceInputs, {
+      identifier: $I`EvidenceBatchOutputInputBinding`,
+      title: "Evidence batch output input binding",
+      description: "Requires every claim and degraded claim to reference a chunk listed in batch inputs.",
+      message: "EvidenceBatch claim and degraded chunk ids must belong to inputs.",
+    }),
+    S.makeFilter(relationEndpointsAreEntityClaims, {
+      identifier: $I`EvidenceBatchRelationEndpoints`,
+      title: "Evidence batch relation endpoints",
+      description: "Requires each relation endpoint to identify an entity claim in the same batch.",
+      message: "EvidenceBatch relation subject and object must identify same-batch entity claims.",
+    }),
+    S.makeFilter(lossesMatchMethod, {
+      identifier: $I`EvidenceBatchDeclaredLosses`,
+      title: "Evidence batch declared losses",
+      description: "Requires lossy to equal the method's declared capability-loss set without duplicates.",
+      message: "EvidenceBatch lossy must exactly match declaredLosses for method.",
+    }),
+    S.makeFilter(batchIdMatchesPreimage, {
+      identifier: $I`EvidenceBatchIdentity`,
+      title: "Evidence batch content identity",
+      description: "Requires id to hash the canonical encoded document, method, model, and ordered inputs.",
+      message: "EvidenceBatch id must match the canonical batch preimage digest.",
+    }),
+  ],
+  {
+    identifier: $I`EvidenceBatchChecks`,
+    title: "Evidence batch",
+    description: "Checks evidence-batch coherence, provenance, declared losses, endpoints, and content identity.",
+    message: "EvidenceBatch must satisfy every batch coherence and identity check.",
+  }
+);
 
 /**
  * One document-and-lane extraction batch with claims, degradations, and declared loss.
@@ -511,6 +740,65 @@ export const ConflictBasis = LiteralKit(["same-anchor-different-label", "same-pa
  */
 export type ConflictBasis = typeof ConflictBasis.Type;
 
+const ConflictWitnessFields = S.Struct({
+  id: Sha256Hex,
+  left: ClaimId,
+  right: ClaimId,
+  basis: ConflictBasis,
+});
+
+const ConflictWitnessPreimage = S.Struct({
+  left: ClaimId,
+  right: ClaimId,
+  basis: ConflictBasis,
+});
+
+const ConflictWitnessChecks = S.makeFilterGroup(
+  [
+    S.makeFilter((witness: typeof ConflictWitnessFields.Type) => !Str.Equivalence(witness.left, witness.right), {
+      identifier: $I`ConflictWitnessDistinctEndpoints`,
+      title: "Conflict witness distinct endpoints",
+      description: "Requires a conflict witness to connect two different evidence claims.",
+      message: "ConflictWitness left and right must differ.",
+    }),
+    S.makeFilter(
+      (witness: typeof ConflictWitnessFields.Type) => Order.isLessThan(Order.String)(witness.left, witness.right),
+      {
+        identifier: $I`ConflictWitnessCanonicalOrder`,
+        title: "Conflict witness canonical order",
+        description: "Requires conflict endpoints to use ascending string order for one canonical preimage.",
+        message: "ConflictWitness left must sort before right.",
+      }
+    ),
+    S.makeFilter(
+      (witness: typeof ConflictWitnessFields.Type) =>
+        S.encodeResult(ConflictWitnessPreimage)({
+          left: witness.left,
+          right: witness.right,
+          basis: witness.basis,
+        }).pipe(
+          Result.map(sha256CanonicalSync),
+          Result.match({
+            onFailure: () => false,
+            onSuccess: (id) => Str.Equivalence(id, witness.id),
+          })
+        ),
+      {
+        identifier: $I`ConflictWitnessIdentity`,
+        title: "Conflict witness content identity",
+        description: "Requires id to hash the canonical encoded left, right, and conflict basis.",
+        message: "ConflictWitness id must match the canonical conflict preimage digest.",
+      }
+    ),
+  ],
+  {
+    identifier: $I`ConflictWitnessChecks`,
+    title: "Conflict witness",
+    description: "Checks distinct ordered endpoints and the canonical conflict-witness content id.",
+    message: "ConflictWitness must have distinct ordered endpoints and a matching content id.",
+  }
+);
+
 /**
  * Persisted witness connecting two conflicting claims without merging them.
  *
@@ -526,12 +814,7 @@ export type ConflictBasis = typeof ConflictBasis.Type;
  * @since 0.0.0
  */
 export class ConflictWitness extends S.Class<ConflictWitness>($I`ConflictWitness`)(
-  {
-    id: Sha256Hex,
-    left: ClaimId,
-    right: ClaimId,
-    basis: ConflictBasis,
-  },
+  ConflictWitnessFields.check(ConflictWitnessChecks),
   $I.annote("ConflictWitness", {
     description: "Content-addressed record that keeps two conflicting evidence claims as separate nodes.",
   })

--- a/apps/labs/semantica/src/schema/Gold.ts
+++ b/apps/labs/semantica/src/schema/Gold.ts
@@ -51,14 +51,14 @@ const GoldSubsetChecks = S.makeFilterGroup([
   ),
   S.makeFilter(
     (subsets: GoldSubsetFields) =>
-      N.isLessThanOrEqualTo(A.length(subsets.structure), 10) &&
-      N.isLessThanOrEqualTo(A.length(subsets.entity), 5) &&
-      N.isLessThanOrEqualTo(A.length(subsets.relation), 3),
+      Equal.equals(A.length(subsets.structure), 10) &&
+      Equal.equals(A.length(subsets.entity), 5) &&
+      Equal.equals(A.length(subsets.relation), 3),
     {
-      identifier: $I`GoldSubsetMaximumSizes`,
-      title: "Gold subset maximum sizes",
-      description: "Bounds structure, entity, and relation subsets to ten, five, and three papers respectively.",
-      message: "GoldSubset sizes must not exceed structure=10, entity=5, and relation=3.",
+      identifier: $I`GoldSubsetExactSizes`,
+      title: "Gold subset exact sizes",
+      description: "Requires structure, entity, and relation subsets to contain exactly ten, five, and three papers.",
+      message: "GoldSubset sizes must equal structure=10, entity=5, and relation=3.",
     }
   ),
 ]);
@@ -80,8 +80,7 @@ const GoldSubsetChecks = S.makeFilterGroup([
 export class GoldSubset extends S.Class<GoldSubset>($I`GoldSubset`)(
   GoldSubsetFields.mapFields(identity).check(GoldSubsetChecks),
   $I.annote("GoldSubset", {
-    description:
-      "Unique, size-bounded gold paper ids satisfying relation proper-subset entity proper-subset structure.",
+    description: "Unique, exact-sized gold paper ids satisfying relation proper-subset entity proper-subset structure.",
   })
 ) {}
 

--- a/apps/labs/semantica/src/schema/Gold.ts
+++ b/apps/labs/semantica/src/schema/Gold.ts
@@ -1,0 +1,309 @@
+import { $SemanticaId } from "@beep/identity/packages";
+import { TextAnchorFields, TextAnchorWidthCheck } from "@beep/provenance";
+import { LiteralKit, NonNegativeInt, Sha256Hex } from "@beep/schema";
+import { UnitInterval } from "@beep/schema/UnitInterval";
+import { Equal, HashSet, identity, Number as N, Tuple } from "effect";
+import * as A from "effect/Array";
+import * as S from "effect/Schema";
+import { CorpusPaperId } from "@/corpus/Manifest";
+import { StructureRole } from "@/schema/Evidence";
+import { ModelIdentity } from "@/schema/Model";
+
+const $I = $SemanticaId.create("schema/Gold");
+
+const GoldSubsetFields = S.Struct({
+  structure: S.Array(CorpusPaperId),
+  entity: S.Array(CorpusPaperId),
+  relation: S.Array(CorpusPaperId),
+});
+
+type GoldSubsetFields = typeof GoldSubsetFields.Type;
+
+const hasUniqueIds = (ids: ReadonlyArray<CorpusPaperId>): boolean =>
+  Equal.equals(HashSet.size(HashSet.fromIterable(ids)), A.length(ids));
+
+const isProperSubset = (subset: ReadonlyArray<CorpusPaperId>, superset: ReadonlyArray<CorpusPaperId>): boolean => {
+  const subsetSet = HashSet.fromIterable(subset);
+  const supersetSet = HashSet.fromIterable(superset);
+  return HashSet.isSubset(subsetSet, supersetSet) && N.isLessThan(HashSet.size(subsetSet), HashSet.size(supersetSet));
+};
+
+const GoldSubsetChecks = S.makeFilterGroup([
+  S.makeFilter(
+    (subsets: GoldSubsetFields) =>
+      hasUniqueIds(subsets.structure) && hasUniqueIds(subsets.entity) && hasUniqueIds(subsets.relation),
+    {
+      identifier: $I`GoldSubsetUniqueIds`,
+      title: "Gold subset identity uniqueness",
+      description: "Requires every paper id to appear at most once within each scored subset.",
+      message: "GoldSubset arrays must contain unique paper ids.",
+    }
+  ),
+  S.makeFilter(
+    (subsets: GoldSubsetFields) =>
+      isProperSubset(subsets.entity, subsets.structure) && isProperSubset(subsets.relation, subsets.entity),
+    {
+      identifier: $I`GoldSubsetContainment`,
+      title: "Gold subset strict containment",
+      description: "Requires relation to be a proper subset of entity and entity to be a proper subset of structure.",
+      message: "GoldSubset must satisfy relation ⊂ entity ⊂ structure.",
+    }
+  ),
+  S.makeFilter(
+    (subsets: GoldSubsetFields) =>
+      N.isLessThanOrEqualTo(A.length(subsets.structure), 10) &&
+      N.isLessThanOrEqualTo(A.length(subsets.entity), 5) &&
+      N.isLessThanOrEqualTo(A.length(subsets.relation), 3),
+    {
+      identifier: $I`GoldSubsetMaximumSizes`,
+      title: "Gold subset maximum sizes",
+      description: "Bounds structure, entity, and relation subsets to ten, five, and three papers respectively.",
+      message: "GoldSubset sizes must not exceed structure=10, entity=5, and relation=3.",
+    }
+  ),
+]);
+
+/**
+ * Frozen nested W1 paper ids used for structure, entity, and relation scoring.
+ *
+ * **Example** (Inspect the relation subset)
+ *
+ * ```ts
+ * import { GoldSubset } from "@/schema/Gold"
+ *
+ * console.log(GoldSubset.fields.relation !== undefined) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class GoldSubset extends S.Class<GoldSubset>($I`GoldSubset`)(
+  GoldSubsetFields.mapFields(identity).check(GoldSubsetChecks),
+  $I.annote("GoldSubset", {
+    description:
+      "Unique, size-bounded gold paper ids satisfying relation proper-subset entity proper-subset structure.",
+  })
+) {}
+
+const GoldRefFields = S.Struct({
+  version: S.Literal("gold/v1"),
+  digest: Sha256Hex,
+  proposer: ModelIdentity,
+  spotCheckedFraction: UnitInterval,
+  subsets: GoldSubset,
+});
+
+const GoldRefProposerCheck = S.makeFilter(
+  (gold: typeof GoldRefFields.Type) => gold.proposer.taskType === "gold-proposal",
+  {
+    identifier: $I`GoldRefProposerCheck`,
+    title: "Gold proposer task",
+    description: "Requires the pinned proposer model identity to carry the gold-proposal task role.",
+    message: "GoldRef proposer.taskType must equal gold-proposal.",
+  }
+);
+
+/**
+ * Versioned digest and independent proposer identity for the frozen gold corpus.
+ *
+ * **Example** (Inspect the fixed gold version)
+ *
+ * ```ts
+ * import { GoldRef } from "@/schema/Gold"
+ *
+ * console.log(GoldRef.fields.version.literals[0]) // "gold/v1"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class GoldRef extends S.Class<GoldRef>($I`GoldRef`)(
+  GoldRefFields.mapFields(identity).check(GoldRefProposerCheck),
+  $I.annote("GoldRef", {
+    description: "Content-addressed gold-v1 reference with spot-check coverage and an independent proposer model.",
+  })
+) {}
+
+const GoldStructureLabelFields = S.Struct({
+  role: StructureRole,
+  depth: NonNegativeInt,
+  ...TextAnchorFields,
+  verified: S.Boolean,
+});
+
+/**
+ * Anchored structural gold label with a human spot-check marker.
+ *
+ * **Example** (Inspect the verified field)
+ *
+ * ```ts
+ * import { GoldStructureLabel } from "@/schema/Gold"
+ *
+ * console.log(GoldStructureLabel.fields.verified !== undefined) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class GoldStructureLabel extends S.Class<GoldStructureLabel>($I`GoldStructureLabel`)(
+  GoldStructureLabelFields.mapFields(identity).check(TextAnchorWidthCheck),
+  $I.annote("GoldStructureLabel", {
+    description: "Paper structural role and depth grounded to canonical text with a spot-check marker.",
+  })
+) {}
+
+const GoldEntityLabelFields = S.Struct({
+  label: S.NonEmptyString,
+  entityType: S.NonEmptyString,
+  ...TextAnchorFields,
+  verified: S.Boolean,
+});
+
+/**
+ * Anchored entity gold label with a human spot-check marker.
+ *
+ * **Example** (Inspect the entity type field)
+ *
+ * ```ts
+ * import { GoldEntityLabel } from "@/schema/Gold"
+ *
+ * console.log(GoldEntityLabel.fields.entityType !== undefined) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class GoldEntityLabel extends S.Class<GoldEntityLabel>($I`GoldEntityLabel`)(
+  GoldEntityLabelFields.mapFields(identity).check(TextAnchorWidthCheck),
+  $I.annote("GoldEntityLabel", {
+    description: "Entity surface label and type grounded to canonical paper text with a spot-check marker.",
+  })
+) {}
+
+const GoldRelationLabelFields = S.Struct({
+  predicate: S.NonEmptyString,
+  subject: S.NonEmptyString,
+  object: S.NonEmptyString,
+  ...TextAnchorFields,
+  verified: S.Boolean,
+});
+
+/**
+ * Anchored relation gold label with deterministic endpoint surfaces.
+ *
+ * **Example** (Inspect the predicate field)
+ *
+ * ```ts
+ * import { GoldRelationLabel } from "@/schema/Gold"
+ *
+ * console.log(GoldRelationLabel.fields.predicate !== undefined) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class GoldRelationLabel extends S.Class<GoldRelationLabel>($I`GoldRelationLabel`)(
+  GoldRelationLabelFields.mapFields(identity).check(TextAnchorWidthCheck),
+  $I.annote("GoldRelationLabel", {
+    description: "Relation predicate and endpoint surfaces grounded to canonical paper text with a spot-check marker.",
+  })
+) {}
+
+class GoldStructureFile extends S.Class<GoldStructureFile>($I`GoldStructureFile`)(
+  {
+    version: S.Literal("gold/v1"),
+    paperId: CorpusPaperId,
+    subset: S.tag("structure"),
+    labels: S.Array(GoldStructureLabel),
+    proposer: ModelIdentity,
+  },
+  $I.annote("GoldStructureFile", {
+    description: "Gold-v1 structural labels for one W1 paper.",
+  })
+) {}
+
+class GoldEntityFile extends S.Class<GoldEntityFile>($I`GoldEntityFile`)(
+  {
+    version: S.Literal("gold/v1"),
+    paperId: CorpusPaperId,
+    subset: S.tag("entity"),
+    labels: S.Array(GoldEntityLabel),
+    proposer: ModelIdentity,
+  },
+  $I.annote("GoldEntityFile", {
+    description: "Gold-v1 entity labels for one W1 paper.",
+  })
+) {}
+
+class GoldRelationFile extends S.Class<GoldRelationFile>($I`GoldRelationFile`)(
+  {
+    version: S.Literal("gold/v1"),
+    paperId: CorpusPaperId,
+    subset: S.tag("relation"),
+    labels: S.Array(GoldRelationLabel),
+    proposer: ModelIdentity,
+  },
+  $I.annote("GoldRelationFile", {
+    description: "Gold-v1 relation labels for one W1 paper.",
+  })
+) {}
+
+const GoldFileSubset = LiteralKit(["structure", "entity", "relation"]);
+
+const GoldFileDefinition = GoldFileSubset.mapMembers(
+  Tuple.evolve([() => GoldStructureFile, () => GoldEntityFile, () => GoldRelationFile])
+)
+  .annotate(
+    $I.annote("GoldFileDefinition", {
+      description: "Subset-indexed gold-v1 label file variants.",
+    })
+  )
+  .pipe(S.toTaggedUnion("subset"));
+
+const GoldFileProposerCheck = S.makeFilter(
+  (file: typeof GoldFileDefinition.Type) => file.proposer.taskType === "gold-proposal",
+  {
+    identifier: $I`GoldFileProposerCheck`,
+    title: "Gold file proposer task",
+    description: "Requires every gold label file to record a model with the gold-proposal task role.",
+    message: "GoldFile proposer.taskType must equal gold-proposal.",
+  }
+);
+
+/**
+ * Subset-indexed label file written by the independent gold proposer.
+ *
+ * **Example** (Inspect the structure constructor)
+ *
+ * ```ts
+ * import { GoldFile } from "@/schema/Gold"
+ *
+ * console.log(GoldFile.ast !== undefined) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const GoldFile = GoldFileDefinition.check(GoldFileProposerCheck).pipe(
+  $I.annoteSchema("GoldFile", {
+    description: "Gold-v1 structure, entity, or relation labels for one paper and pinned proposer.",
+  })
+);
+
+/**
+ * Decoded gold label file.
+ *
+ * **Example** (Inspect a gold file type)
+ *
+ * ```ts
+ * import type { GoldFile } from "@/schema/Gold"
+ *
+ * const inspect = (file: GoldFile) => file.subset
+ * console.log(typeof inspect) // "function"
+ * ```
+ *
+ * @see {@link GoldFile} for subset-indexed variants.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type GoldFile = typeof GoldFile.Type;

--- a/apps/labs/semantica/src/schema/Ids.ts
+++ b/apps/labs/semantica/src/schema/Ids.ts
@@ -1,0 +1,341 @@
+import { $SemanticaId } from "@beep/identity/packages";
+import { Sha256Hex } from "@beep/schema";
+import * as S from "effect/Schema";
+
+const $I = $SemanticaId.create("schema/Ids");
+
+/**
+ * Full SHA-256 identity of one source document's exact bytes.
+ *
+ * **Example** (Recognize a document id)
+ *
+ * ```ts
+ * import { isDocumentId } from "@/schema/Ids"
+ *
+ * console.log(isDocumentId("0".repeat(64))) // true
+ * ```
+ *
+ * @category entity-ids
+ * @since 0.0.0
+ */
+export const DocumentId = Sha256Hex.pipe(
+  S.brand("DocumentId"),
+  $I.annoteSchema("DocumentId", {
+    description: "Full SHA-256 identity of one source document's exact bytes.",
+  })
+);
+
+/**
+ * Decoded value accepted by {@link DocumentId}.
+ *
+ * **Example** (Annotate a document id)
+ *
+ * ```ts
+ * import { DocumentId } from "@/schema/Ids"
+ * import type { DocumentId as DocumentIdValue } from "@/schema/Ids"
+ *
+ * const id: DocumentIdValue = DocumentId.make("0".repeat(64))
+ * console.log(id.length) // 64
+ * ```
+ *
+ * @see {@link DocumentId} for validation and branding.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type DocumentId = typeof DocumentId.Type;
+
+/**
+ * Schema-derived guard for full document ids.
+ *
+ * **Example** (Reject a truncated id)
+ *
+ * ```ts
+ * import { isDocumentId } from "@/schema/Ids"
+ *
+ * console.log(isDocumentId("0".repeat(12))) // false
+ * ```
+ *
+ * @category guards
+ * @since 0.0.0
+ */
+export const isDocumentId = S.is(DocumentId);
+
+/**
+ * Full SHA-256 identity of one document-scoped canonical-text chunk.
+ *
+ * **Example** (Construct a chunk id)
+ *
+ * ```ts
+ * import { ChunkId } from "@/schema/Ids"
+ *
+ * console.log(ChunkId.make("1".repeat(64)).length) // 64
+ * ```
+ *
+ * @category entity-ids
+ * @since 0.0.0
+ */
+export const ChunkId = Sha256Hex.pipe(
+  S.brand("ChunkId"),
+  $I.annoteSchema("ChunkId", {
+    description: "Full SHA-256 identity of one document-scoped canonical-text chunk.",
+  })
+);
+
+/**
+ * Decoded value accepted by {@link ChunkId}.
+ *
+ * **Example** (Annotate a chunk id)
+ *
+ * ```ts
+ * import { ChunkId } from "@/schema/Ids"
+ * import type { ChunkId as ChunkIdValue } from "@/schema/Ids"
+ *
+ * const id: ChunkIdValue = ChunkId.make("1".repeat(64))
+ * console.log(id.length) // 64
+ * ```
+ *
+ * @see {@link ChunkId} for validation and branding.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type ChunkId = typeof ChunkId.Type;
+
+/**
+ * Schema-derived guard for full chunk ids.
+ *
+ * **Example** (Recognize a chunk id)
+ *
+ * ```ts
+ * import { isChunkId } from "@/schema/Ids"
+ *
+ * console.log(isChunkId("1".repeat(64))) // true
+ * ```
+ *
+ * @category guards
+ * @since 0.0.0
+ */
+export const isChunkId = S.is(ChunkId);
+
+/**
+ * Full SHA-256 identity of one grounded evidence claim.
+ *
+ * **Example** (Construct a claim id)
+ *
+ * ```ts
+ * import { ClaimId } from "@/schema/Ids"
+ *
+ * console.log(ClaimId.make("2".repeat(64)).length) // 64
+ * ```
+ *
+ * @category entity-ids
+ * @since 0.0.0
+ */
+export const ClaimId = Sha256Hex.pipe(
+  S.brand("ClaimId"),
+  $I.annoteSchema("ClaimId", {
+    description: "Full SHA-256 identity of one grounded evidence claim.",
+  })
+);
+
+/**
+ * Decoded value accepted by {@link ClaimId}.
+ *
+ * **Example** (Annotate a claim id)
+ *
+ * ```ts
+ * import { ClaimId } from "@/schema/Ids"
+ * import type { ClaimId as ClaimIdValue } from "@/schema/Ids"
+ *
+ * const id: ClaimIdValue = ClaimId.make("2".repeat(64))
+ * console.log(id.length) // 64
+ * ```
+ *
+ * @see {@link ClaimId} for validation and branding.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type ClaimId = typeof ClaimId.Type;
+
+/**
+ * Schema-derived guard for full claim ids.
+ *
+ * **Example** (Recognize a claim id)
+ *
+ * ```ts
+ * import { isClaimId } from "@/schema/Ids"
+ *
+ * console.log(isClaimId("2".repeat(64))) // true
+ * ```
+ *
+ * @category guards
+ * @since 0.0.0
+ */
+export const isClaimId = S.is(ClaimId);
+
+/**
+ * Full SHA-256 identity of one extraction batch.
+ *
+ * **Example** (Construct a batch id)
+ *
+ * ```ts
+ * import { BatchId } from "@/schema/Ids"
+ *
+ * console.log(BatchId.make("3".repeat(64)).length) // 64
+ * ```
+ *
+ * @category entity-ids
+ * @since 0.0.0
+ */
+export const BatchId = Sha256Hex.pipe(
+  S.brand("BatchId"),
+  $I.annoteSchema("BatchId", {
+    description: "Full SHA-256 identity of one extraction batch.",
+  })
+);
+
+/**
+ * Decoded value accepted by {@link BatchId}.
+ *
+ * **Example** (Annotate a batch id)
+ *
+ * ```ts
+ * import { BatchId } from "@/schema/Ids"
+ * import type { BatchId as BatchIdValue } from "@/schema/Ids"
+ *
+ * const id: BatchIdValue = BatchId.make("3".repeat(64))
+ * console.log(id.length) // 64
+ * ```
+ *
+ * @see {@link BatchId} for validation and branding.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type BatchId = typeof BatchId.Type;
+
+/**
+ * Schema-derived guard for full batch ids.
+ *
+ * **Example** (Recognize a batch id)
+ *
+ * ```ts
+ * import { isBatchId } from "@/schema/Ids"
+ *
+ * console.log(isBatchId("3".repeat(64))) // true
+ * ```
+ *
+ * @category guards
+ * @since 0.0.0
+ */
+export const isBatchId = S.is(BatchId);
+
+/**
+ * Full SHA-256 identity of one append-only provenance event.
+ *
+ * **Example** (Construct a provenance event id)
+ *
+ * ```ts
+ * import { ProvenanceEventId } from "@/schema/Ids"
+ *
+ * console.log(ProvenanceEventId.make("4".repeat(64)).length) // 64
+ * ```
+ *
+ * @category entity-ids
+ * @since 0.0.0
+ */
+export const ProvenanceEventId = Sha256Hex.pipe(
+  S.brand("ProvenanceEventId"),
+  $I.annoteSchema("ProvenanceEventId", {
+    description: "Full SHA-256 identity of one append-only provenance event.",
+  })
+);
+
+/**
+ * Decoded value accepted by {@link ProvenanceEventId}.
+ *
+ * **Example** (Annotate an event id)
+ *
+ * ```ts
+ * import { ProvenanceEventId } from "@/schema/Ids"
+ * import type { ProvenanceEventId as EventId } from "@/schema/Ids"
+ *
+ * const id: EventId = ProvenanceEventId.make("4".repeat(64))
+ * console.log(id.length) // 64
+ * ```
+ *
+ * @see {@link ProvenanceEventId} for validation and branding.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type ProvenanceEventId = typeof ProvenanceEventId.Type;
+
+/**
+ * Schema-derived guard for full provenance event ids.
+ *
+ * **Example** (Recognize a provenance event id)
+ *
+ * ```ts
+ * import { isProvenanceEventId } from "@/schema/Ids"
+ *
+ * console.log(isProvenanceEventId("4".repeat(64))) // true
+ * ```
+ *
+ * @category guards
+ * @since 0.0.0
+ */
+export const isProvenanceEventId = S.is(ProvenanceEventId);
+
+/**
+ * Full SHA-256 identity of one replay-stable evaluation run.
+ *
+ * **Example** (Construct a run id)
+ *
+ * ```ts
+ * import { RunId } from "@/schema/Ids"
+ *
+ * console.log(RunId.make("5".repeat(64)).length) // 64
+ * ```
+ *
+ * @category entity-ids
+ * @since 0.0.0
+ */
+export const RunId = Sha256Hex.pipe(
+  S.brand("RunId"),
+  $I.annoteSchema("RunId", {
+    description: "Full SHA-256 identity of one replay-stable evaluation run.",
+  })
+);
+
+/**
+ * Decoded value accepted by {@link RunId}.
+ *
+ * **Example** (Annotate a run id)
+ *
+ * ```ts
+ * import { RunId } from "@/schema/Ids"
+ * import type { RunId as RunIdValue } from "@/schema/Ids"
+ *
+ * const id: RunIdValue = RunId.make("5".repeat(64))
+ * console.log(id.length) // 64
+ * ```
+ *
+ * @see {@link RunId} for validation and branding.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type RunId = typeof RunId.Type;
+
+/**
+ * Schema-derived guard for full run ids.
+ *
+ * **Example** (Recognize a run id)
+ *
+ * ```ts
+ * import { isRunId } from "@/schema/Ids"
+ *
+ * console.log(isRunId("5".repeat(64))) // true
+ * ```
+ *
+ * @category guards
+ * @since 0.0.0
+ */
+export const isRunId = S.is(RunId);

--- a/apps/labs/semantica/src/schema/MediaType.ts
+++ b/apps/labs/semantica/src/schema/MediaType.ts
@@ -1,0 +1,42 @@
+import { $SemanticaId } from "@beep/identity/packages";
+import { LiteralKit } from "@beep/schema";
+
+const $I = $SemanticaId.create("schema/MediaType");
+
+/**
+ * Source media types supported by the C0 parser contract.
+ *
+ * **Example** (Check a PDF media type)
+ *
+ * ```ts
+ * import { MediaType } from "@/schema/MediaType"
+ *
+ * console.log(MediaType.is["application/pdf"]("application/pdf")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const MediaType = LiteralKit(["text/markdown", "text/html", "application/pdf"]).pipe(
+  $I.annoteSchema("MediaType", {
+    description: "Markdown, HTML, and born-digital PDF media types accepted by the C0 parser.",
+  })
+);
+
+/**
+ * Decoded literal accepted by {@link MediaType}.
+ *
+ * **Example** (Annotate a media type)
+ *
+ * ```ts
+ * import type { MediaType } from "@/schema/MediaType"
+ *
+ * const mediaType: MediaType = "application/pdf"
+ * console.log(mediaType) // "application/pdf"
+ * ```
+ *
+ * @see {@link MediaType} for literal helpers and validation.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type MediaType = typeof MediaType.Type;

--- a/apps/labs/semantica/src/schema/Model.ts
+++ b/apps/labs/semantica/src/schema/Model.ts
@@ -1,0 +1,116 @@
+import { $SemanticaId } from "@beep/identity/packages";
+import { LiteralKit, Sha256Hex } from "@beep/schema";
+import * as S from "effect/Schema";
+
+const $I = $SemanticaId.create("schema/Model");
+
+/**
+ * Provider families that may produce C0 extraction or gold output.
+ *
+ * **Example** (Check the offline pattern provider)
+ *
+ * ```ts
+ * import { ProviderFamily } from "@/schema/Model"
+ *
+ * console.log(ProviderFamily.is.wink("wink")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const ProviderFamily = LiteralKit(["anthropic", "xai", "wink"]).pipe(
+  $I.annoteSchema("ProviderFamily", {
+    description: "Anthropic and xAI hosted providers plus the local Wink pattern provider.",
+  })
+);
+
+/**
+ * Decoded literal accepted by {@link ProviderFamily}.
+ *
+ * **Example** (Annotate a provider family)
+ *
+ * ```ts
+ * import type { ProviderFamily } from "@/schema/Model"
+ *
+ * const provider: ProviderFamily = "anthropic"
+ * console.log(provider) // "anthropic"
+ * ```
+ *
+ * @see {@link ProviderFamily} for literal helpers and validation.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type ProviderFamily = typeof ProviderFamily.Type;
+
+/**
+ * Task roles that affect model identity and cache behavior.
+ *
+ * **Example** (Check the gold-proposal task)
+ *
+ * ```ts
+ * import { TaskType } from "@/schema/Model"
+ *
+ * console.log(TaskType.is["gold-proposal"]("gold-proposal")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const TaskType = LiteralKit(["extraction", "gold-proposal"]).pipe(
+  $I.annoteSchema("TaskType", {
+    description: "Extraction and gold-proposal roles that distinguish otherwise identical models.",
+  })
+);
+
+/**
+ * Decoded literal accepted by {@link TaskType}.
+ *
+ * **Example** (Annotate a task type)
+ *
+ * ```ts
+ * import type { TaskType } from "@/schema/Model"
+ *
+ * const task: TaskType = "gold-proposal"
+ * console.log(task) // "gold-proposal"
+ * ```
+ *
+ * @see {@link TaskType} for literal helpers and validation.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type TaskType = typeof TaskType.Type;
+
+/**
+ * Pinned provider, model, revision, artifact, and task identity.
+ *
+ * **Example** (Describe an extraction model)
+ *
+ * ```ts
+ * import { ModelIdentity } from "@/schema/Model"
+ * import { Sha256Hex } from "@beep/schema"
+ *
+ * const model = ModelIdentity.make({
+ *   provider: "anthropic",
+ *   name: "claude",
+ *   revision: "2026-08-25",
+ *   artifactHash: Sha256Hex.make("0".repeat(64)),
+ *   taskType: "extraction"
+ * })
+ * console.log(model.provider) // "anthropic"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class ModelIdentity extends S.Class<ModelIdentity>($I`ModelIdentity`)(
+  {
+    provider: ProviderFamily,
+    name: S.NonEmptyString,
+    revision: S.NonEmptyString,
+    artifactHash: Sha256Hex,
+    taskType: TaskType,
+  },
+  $I.annote("ModelIdentity", {
+    description: "Pinned provider family, model name, revision, prompt artifact hash, and task role.",
+  })
+) {}

--- a/apps/labs/semantica/src/schema/Provenance.ts
+++ b/apps/labs/semantica/src/schema/Provenance.ts
@@ -1,0 +1,183 @@
+import { $SemanticaId } from "@beep/identity/packages";
+import { SourceTextExtractor } from "@beep/provenance";
+import { LiteralKit } from "@beep/schema";
+import { identity, Result, Tuple } from "effect";
+import * as S from "effect/Schema";
+import * as Str from "effect/String";
+import { DegradedKind } from "@/schema/Degraded";
+import { contentDigestSync } from "@/schema/Digest";
+import { BatchId, ChunkId, ClaimId, DocumentId, ProvenanceEventId } from "@/schema/Ids";
+import { ModelIdentity } from "@/schema/Model";
+
+const $I = $SemanticaId.create("schema/Provenance");
+
+const ParseEventOutcome = LiteralKit(["parsed", ...DegradedKind.Options]);
+
+class IngestedEventBody extends S.Class<IngestedEventBody>($I`IngestedEventBody`)(
+  {
+    kind: S.tag("Ingested"),
+    document: DocumentId,
+  },
+  $I.annote("IngestedEventBody", {
+    description: "Records ingestion of one exact source document.",
+  })
+) {}
+
+class ParsedEventBody extends S.Class<ParsedEventBody>($I`ParsedEventBody`)(
+  {
+    kind: S.tag("Parsed"),
+    document: DocumentId,
+    outcome: ParseEventOutcome,
+    extractor: SourceTextExtractor,
+  },
+  $I.annote("ParsedEventBody", {
+    description: "Records the typed parser outcome and pinned extractor for a document.",
+  })
+) {}
+
+class ChunkedEventBody extends S.Class<ChunkedEventBody>($I`ChunkedEventBody`)(
+  {
+    kind: S.tag("Chunked"),
+    document: DocumentId,
+    chunks: S.Array(ChunkId),
+  },
+  $I.annote("ChunkedEventBody", {
+    description: "Records the ordered content-addressed chunks emitted for a document.",
+  })
+) {}
+
+class ExtractedEventBody extends S.Class<ExtractedEventBody>($I`ExtractedEventBody`)(
+  {
+    kind: S.tag("Extracted"),
+    batch: BatchId,
+    model: ModelIdentity,
+  },
+  $I.annote("ExtractedEventBody", {
+    description: "Records one extraction batch and the pinned model that produced it.",
+  })
+) {}
+
+class AssertedEventBody extends S.Class<AssertedEventBody>($I`AssertedEventBody`)(
+  {
+    kind: S.tag("Asserted"),
+    claims: S.Array(ClaimId),
+  },
+  $I.annote("AssertedEventBody", {
+    description: "Records evidence claims asserted into the append-only ledger.",
+  })
+) {}
+
+class InvalidatedEventBody extends S.Class<InvalidatedEventBody>($I`InvalidatedEventBody`)(
+  {
+    kind: S.tag("Invalidated"),
+    claim: ClaimId,
+    reason: S.NonEmptyString,
+  },
+  $I.annote("InvalidatedEventBody", {
+    description: "Records a reasoned tombstone for an evidence claim without deleting it.",
+  })
+) {}
+
+const EventKind = LiteralKit(["Ingested", "Parsed", "Chunked", "Extracted", "Asserted", "Invalidated"]);
+
+/**
+ * Timestamp-free body of one append-only provenance event.
+ *
+ * **Example** (Create an ingest event body)
+ *
+ * ```ts
+ * import { EventBody } from "@/schema/Provenance"
+ * import { DocumentId } from "@/schema/Ids"
+ *
+ * const body = EventBody.cases.Ingested.make({
+ *   kind: "Ingested",
+ *   document: DocumentId.make("0".repeat(64))
+ * })
+ * console.log(body.kind) // "Ingested"
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const EventBody = EventKind.mapMembers(
+  Tuple.evolve([
+    () => IngestedEventBody,
+    () => ParsedEventBody,
+    () => ChunkedEventBody,
+    () => ExtractedEventBody,
+    () => AssertedEventBody,
+    () => InvalidatedEventBody,
+  ])
+)
+  .annotate(
+    $I.annote("EventBody", {
+      description: "Exhaustive timestamp-free C0 provenance event bodies.",
+    })
+  )
+  .pipe(S.toTaggedUnion("kind"));
+
+/**
+ * Decoded provenance event body.
+ *
+ * **Example** (Inspect an event body type)
+ *
+ * ```ts
+ * import type { EventBody } from "@/schema/Provenance"
+ *
+ * const inspect = (body: EventBody) => body.kind
+ * console.log(typeof inspect) // "function"
+ * ```
+ *
+ * @see {@link EventBody} for variants.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type EventBody = typeof EventBody.Type;
+
+const ProvenanceEventPreimage = S.Struct({
+  prev: S.OptionFromNullOr(ProvenanceEventId),
+  body: EventBody,
+});
+
+const ProvenanceEventFields = S.Struct({
+  id: ProvenanceEventId,
+  prev: S.OptionFromNullOr(ProvenanceEventId),
+  body: EventBody,
+});
+
+const ProvenanceEventIdCheck = S.makeFilter(
+  (event: typeof ProvenanceEventFields.Type) =>
+    contentDigestSync(ProvenanceEventPreimage)({ prev: event.prev, body: event.body }).pipe(
+      Result.match({
+        onFailure: () => false,
+        onSuccess: (digest) => Str.Equivalence(digest, event.id),
+      })
+    ),
+  {
+    identifier: $I`ProvenanceEventIdCheck`,
+    title: "Provenance event identity",
+    description: "Requires id to hash canonical JSON of only prev and body, with no wall-clock field.",
+    message: "ProvenanceEvent id must match the canonical prev-and-body digest.",
+  }
+);
+
+/**
+ * Content-addressed link in a timestamp-free provenance hash chain.
+ *
+ * **Example** (Inspect the optional predecessor)
+ *
+ * ```ts
+ * import { ProvenanceEvent } from "@/schema/Provenance"
+ *
+ * console.log(ProvenanceEvent.fields.prev !== undefined) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class ProvenanceEvent extends S.Class<ProvenanceEvent>($I`ProvenanceEvent`)(
+  ProvenanceEventFields.mapFields(identity).check(ProvenanceEventIdCheck),
+  $I.annote("ProvenanceEvent", {
+    description: "Replay-stable provenance event whose id hashes only its predecessor and typed body.",
+  })
+) {}

--- a/apps/labs/semantica/src/schema/ProviderCache.ts
+++ b/apps/labs/semantica/src/schema/ProviderCache.ts
@@ -1,0 +1,127 @@
+import { $SemanticaId } from "@beep/identity/packages";
+import { LiteralKit, Sha256Hex } from "@beep/schema";
+import { identity, Result } from "effect";
+import * as S from "effect/Schema";
+import * as Str from "effect/String";
+import { contentDigestSync, sha256TextSync } from "@/schema/Digest";
+import { ModelIdentity } from "@/schema/Model";
+
+const $I = $SemanticaId.create("schema/ProviderCache");
+
+/**
+ * Provider request variants represented by the C0 cache.
+ *
+ * **Example** (Check a text-generation request)
+ *
+ * ```ts
+ * import { RequestKind } from "@/schema/ProviderCache"
+ *
+ * console.log(RequestKind.is["generate-text"]("generate-text")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const RequestKind = LiteralKit(["generate-text"]).pipe(
+  $I.annoteSchema("RequestKind", {
+    description: "Provider request kinds supported by the C0 content-addressed cache.",
+  })
+);
+
+/**
+ * Decoded provider request kind.
+ *
+ * **Example** (Annotate a request kind)
+ *
+ * ```ts
+ * import type { RequestKind } from "@/schema/ProviderCache"
+ *
+ * const kind: RequestKind = "generate-text"
+ * console.log(kind) // "generate-text"
+ * ```
+ *
+ * @see {@link RequestKind} for literals.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type RequestKind = typeof RequestKind.Type;
+
+/**
+ * Stable provider identity and input digest used as a cache preimage.
+ *
+ * **Example** (Inspect the cache version)
+ *
+ * ```ts
+ * import { ProviderCacheKey } from "@/schema/ProviderCache"
+ *
+ * console.log(ProviderCacheKey.fields.schemaVersion.literals[0]) // "provider-cache/v1"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class ProviderCacheKey extends S.Class<ProviderCacheKey>($I`ProviderCacheKey`)(
+  {
+    schemaVersion: S.Literal("provider-cache/v1"),
+    model: ModelIdentity,
+    requestKind: RequestKind,
+    inputDigest: Sha256Hex,
+  },
+  $I.annote("ProviderCacheKey", {
+    description: "Versioned provider model, request kind, and exact input digest used as a cache key preimage.",
+  })
+) {}
+
+const ProviderCacheEntryFields = S.Struct({
+  key: ProviderCacheKey,
+  cacheKey: Sha256Hex,
+  response: S.NonEmptyString,
+  responseDigest: Sha256Hex,
+});
+
+const cacheKeyMatches = (entry: typeof ProviderCacheEntryFields.Type): boolean =>
+  contentDigestSync(ProviderCacheKey)(entry.key).pipe(
+    Result.match({
+      onFailure: () => false,
+      onSuccess: (digest) => Str.Equivalence(digest, entry.cacheKey),
+    })
+  );
+
+const responseDigestMatches = (entry: typeof ProviderCacheEntryFields.Type): boolean =>
+  Str.Equivalence(sha256TextSync(entry.response), entry.responseDigest);
+
+const ProviderCacheEntryChecks = S.makeFilterGroup([
+  S.makeFilter(cacheKeyMatches, {
+    identifier: $I`ProviderCacheEntryKeyCheck`,
+    title: "Provider cache key digest",
+    description: "Requires cacheKey to hash the canonical encoded ProviderCacheKey.",
+    message: "ProviderCacheEntry cacheKey must match the canonical key digest.",
+  }),
+  S.makeFilter(responseDigestMatches, {
+    identifier: $I`ProviderCacheEntryResponseCheck`,
+    title: "Provider response digest",
+    description: "Requires responseDigest to hash the exact UTF-8 response text without JSON quoting.",
+    message: "ProviderCacheEntry responseDigest must match the exact response text digest.",
+  }),
+]);
+
+/**
+ * Immutable content-addressed provider response cache entry.
+ *
+ * **Example** (Inspect the response field)
+ *
+ * ```ts
+ * import { ProviderCacheEntry } from "@/schema/ProviderCache"
+ *
+ * console.log(ProviderCacheEntry.fields.response !== undefined) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class ProviderCacheEntry extends S.Class<ProviderCacheEntry>($I`ProviderCacheEntry`)(
+  ProviderCacheEntryFields.mapFields(identity).check(ProviderCacheEntryChecks),
+  $I.annote("ProviderCacheEntry", {
+    description: "Write-once provider response whose key and exact text digest are both verified.",
+  })
+) {}

--- a/apps/labs/semantica/src/schema/Telemetry.ts
+++ b/apps/labs/semantica/src/schema/Telemetry.ts
@@ -1,0 +1,47 @@
+import { $SemanticaId } from "@beep/identity/packages";
+import { LiteralKit, NonNegativeInt, Sha256Hex } from "@beep/schema";
+import * as S from "effect/Schema";
+import { RunId } from "@/schema/Ids";
+
+const $I = $SemanticaId.create("schema/Telemetry");
+
+const EvaluationMode = LiteralKit(["live", "replay"]);
+
+/**
+ * Non-replay-stable performance sidecar for one evaluation execution.
+ *
+ * **Details**
+ *
+ * This is the only C0 schema that admits wall-clock time. It is never included
+ * in a content-addressed id or evaluation report digest.
+ *
+ * **Example** (Inspect the fixed telemetry version)
+ *
+ * ```ts
+ * import { EvalRunTelemetry } from "@/schema/Telemetry"
+ *
+ * console.log(EvalRunTelemetry.fields.schemaVersion.literals[0]) // "eval-telemetry/v1"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class EvalRunTelemetry extends S.Class<EvalRunTelemetry>($I`EvalRunTelemetry`)(
+  {
+    schemaVersion: S.Literal("eval-telemetry/v1"),
+    reportDigest: Sha256Hex,
+    runId: RunId,
+    mode: EvaluationMode,
+    startedAt: S.DateTimeUtcFromString,
+    wallClockMs: NonNegativeInt,
+    coldStartMs: NonNegativeInt,
+    p95Ms: NonNegativeInt,
+    rssBytes: NonNegativeInt,
+    diskGrowthBytes: NonNegativeInt,
+    dependencyBytes: NonNegativeInt,
+    modelBytes: NonNegativeInt,
+  },
+  $I.annote("EvalRunTelemetry", {
+    description: "Live-or-replay timing and byte measurements kept outside every replay-stable digest preimage.",
+  })
+) {}

--- a/apps/labs/semantica/src/schema/Text.ts
+++ b/apps/labs/semantica/src/schema/Text.ts
@@ -1,10 +1,12 @@
 import { ResolvedSourceText } from "@beep/file-processing/SourceText";
 import { $SemanticaId } from "@beep/identity/packages";
-import { SourceTextExtractor, TextAnchor, TextAnchorVerificationReceipt } from "@beep/provenance";
+import { SourceTextDigest, SourceTextExtractor, TextAnchor, TextAnchorVerificationReceipt } from "@beep/provenance";
 import { LiteralKit, NonNegativeInt } from "@beep/schema";
-import { identity, Tuple } from "effect";
+import { identity, Result, Tuple } from "effect";
 import * as S from "effect/Schema";
+import * as Str from "effect/String";
 import { DegradedKind } from "@/schema/Degraded";
+import { sha256CanonicalSync } from "@/schema/Digest";
 import { ChunkId, DocumentId } from "@/schema/Ids";
 
 const $I = $SemanticaId.create("schema/Text");
@@ -170,6 +172,54 @@ const ChunkFields = S.Struct({
   receipt: TextAnchorVerificationReceipt,
 });
 
+const ChunkIdPreimage = S.Struct({
+  document: DocumentId,
+  textDigest: SourceTextDigest,
+  startChar: NonNegativeInt,
+  endChar: NonNegativeInt,
+});
+
+type ChunkIdSource = Pick<typeof ChunkFields.Type, "anchor" | "document" | "receipt">;
+
+/**
+ * Schema-encodes the canonical content preimage for a chunk id.
+ *
+ * **Example** (Inspect the preimage builder)
+ *
+ * ```ts
+ * import { chunkIdPreimage } from "@/schema/Text"
+ *
+ * console.log(typeof chunkIdPreimage) // "function"
+ * ```
+ *
+ * @category encoding
+ * @since 0.0.0
+ */
+export const chunkIdPreimage = (chunk: ChunkIdSource): Result.Result<typeof ChunkIdPreimage.Encoded, S.SchemaError> =>
+  S.encodeResult(ChunkIdPreimage)({
+    document: chunk.document,
+    textDigest: chunk.receipt.source.textDigest,
+    startChar: chunk.anchor.startChar,
+    endChar: chunk.anchor.endChar,
+  });
+
+/**
+ * Builds the content-addressed id for a canonical-text chunk.
+ *
+ * **Example** (Inspect the chunk id builder)
+ *
+ * ```ts
+ * import { makeChunkId } from "@/schema/Text"
+ *
+ * console.log(typeof makeChunkId) // "function"
+ * ```
+ *
+ * @category constructors
+ * @since 0.0.0
+ */
+export const makeChunkId = (chunk: ChunkIdSource): Result.Result<ChunkId, S.SchemaError> =>
+  Result.map(chunkIdPreimage(chunk), (preimage) => ChunkId.make(sha256CanonicalSync(preimage)));
+
 const ChunkReceiptCheck = S.makeFilter(
   (chunk: typeof ChunkFields.Type) => S.toEquivalence(TextAnchor)(chunk.anchor, chunk.receipt.anchor),
   {
@@ -179,6 +229,39 @@ const ChunkReceiptCheck = S.makeFilter(
     message: "Chunk receipt.anchor must equal anchor.",
   }
 );
+
+const ChunkReceiptSourceCheck = S.makeFilter(
+  (chunk: typeof ChunkFields.Type) => Str.Equivalence(chunk.receipt.source.sourceRef, chunk.document),
+  {
+    identifier: $I`ChunkReceiptSourceCheck`,
+    title: "Chunk receipt source document",
+    description: "Requires the receipt source identity to name the chunk's document.",
+    message: "Chunk receipt.source.sourceRef must equal document.",
+  }
+);
+
+const ChunkIdentityCheck = S.makeFilter(
+  (chunk: typeof ChunkFields.Type) =>
+    makeChunkId(chunk).pipe(
+      Result.match({
+        onFailure: () => false,
+        onSuccess: (id) => Str.Equivalence(id, chunk.id),
+      })
+    ),
+  {
+    identifier: $I`ChunkIdentityCheck`,
+    title: "Chunk content identity",
+    description: "Requires id to hash the canonical encoded document, text digest, and anchor offsets.",
+    message: "Chunk id must match the canonical chunk preimage digest.",
+  }
+);
+
+const ChunkChecks = S.makeFilterGroup([ChunkReceiptCheck, ChunkReceiptSourceCheck, ChunkIdentityCheck], {
+  identifier: $I`ChunkChecks`,
+  title: "Chunk",
+  description: "Checks the anchor receipt, source-document binding, and canonical content identity of a chunk.",
+  message: "Chunk must have a matching receipt, source document, and content id.",
+});
 
 /**
  * Document-scoped canonical-text chunk with a verified anchor receipt.
@@ -195,7 +278,7 @@ const ChunkReceiptCheck = S.makeFilter(
  * @since 0.0.0
  */
 export class Chunk extends S.Class<Chunk>($I`Chunk`)(
-  ChunkFields.mapFields(identity).check(ChunkReceiptCheck),
+  ChunkFields.mapFields(identity).check(ChunkChecks),
   $I.annote("Chunk", {
     description: "Document-scoped chunk whose exact text anchor has a persisted verification receipt.",
   })

--- a/apps/labs/semantica/src/schema/Text.ts
+++ b/apps/labs/semantica/src/schema/Text.ts
@@ -1,0 +1,202 @@
+import { ResolvedSourceText } from "@beep/file-processing/SourceText";
+import { $SemanticaId } from "@beep/identity/packages";
+import { SourceTextExtractor, TextAnchor, TextAnchorVerificationReceipt } from "@beep/provenance";
+import { LiteralKit, NonNegativeInt } from "@beep/schema";
+import { identity, Tuple } from "effect";
+import * as S from "effect/Schema";
+import { DegradedKind } from "@/schema/Degraded";
+import { ChunkId, DocumentId } from "@/schema/Ids";
+
+const $I = $SemanticaId.create("schema/Text");
+
+class ParsedOutcome extends S.Class<ParsedOutcome>($I`ParsedOutcome`)(
+  {
+    outcome: S.tag("Parsed"),
+    document: DocumentId,
+    text: S.String,
+    extractor: SourceTextExtractor,
+  },
+  $I.annote("ParsedOutcome", {
+    description: "Successful raw-text parse with its pinned extractor identity.",
+  })
+) {}
+
+class DegradedParseOutcome extends S.Class<DegradedParseOutcome>($I`DegradedParseOutcome`)(
+  {
+    outcome: S.tag("Degraded"),
+    document: DocumentId,
+    kind: DegradedKind,
+    detail: S.NonEmptyString,
+  },
+  $I.annote("DegradedParseOutcome", {
+    description: "Typed parser degradation retained as a value.",
+  })
+) {}
+
+const ParseOutcomeKind = LiteralKit(["Parsed", "Degraded"]);
+
+/**
+ * Successful or explicitly degraded parser result.
+ *
+ * **Example** (Build a degraded parse result)
+ *
+ * ```ts
+ * import { ParseOutcome } from "@/schema/Text"
+ * import { DocumentId } from "@/schema/Ids"
+ *
+ * const result = ParseOutcome.cases.Degraded.make({
+ *   outcome: "Degraded",
+ *   document: DocumentId.make("0".repeat(64)),
+ *   kind: "invalid-utf8",
+ *   detail: "Input was not valid UTF-8."
+ * })
+ * console.log(result.kind) // "invalid-utf8"
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const ParseOutcome = ParseOutcomeKind.mapMembers(Tuple.evolve([() => ParsedOutcome, () => DegradedParseOutcome]))
+  .annotate(
+    $I.annote("ParseOutcome", {
+      description: "Parser outcome preserving either raw text or a typed degraded state.",
+    })
+  )
+  .pipe(S.toTaggedUnion("outcome"));
+
+/**
+ * Decoded parser outcome.
+ *
+ * **Example** (Annotate a parser outcome)
+ *
+ * ```ts
+ * import { ParseOutcome } from "@/schema/Text"
+ * import { DocumentId } from "@/schema/Ids"
+ * import type { ParseOutcome as ParseOutcomeValue } from "@/schema/Text"
+ *
+ * const outcome: ParseOutcomeValue = ParseOutcome.cases.Degraded.make({
+ *   outcome: "Degraded",
+ *   document: DocumentId.make("0".repeat(64)),
+ *   kind: "truncated",
+ *   detail: "Input ended early."
+ * })
+ * console.log(outcome.outcome) // "Degraded"
+ * ```
+ *
+ * @see {@link ParseOutcome} for variants.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type ParseOutcome = typeof ParseOutcome.Type;
+
+/**
+ * Canonical text reusing the file-processing resolved-source model.
+ *
+ * **Example** (Annotate canonical text)
+ *
+ * ```ts
+ * import type { CanonicalText } from "@/schema/Text"
+ *
+ * const inspect = (canonical: CanonicalText) => canonical.text
+ * console.log(typeof inspect) // "function"
+ * ```
+ *
+ * @see {@link ResolvedSourceText} for the shared schema.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type CanonicalText = ResolvedSourceText;
+
+/**
+ * Schema-derived guard for canonical resolved source text.
+ *
+ * **Example** (Reject an incomplete value)
+ *
+ * ```ts
+ * import { isCanonicalText } from "@/schema/Text"
+ *
+ * console.log(isCanonicalText({ text: "missing identity" })) // false
+ * ```
+ *
+ * @category guards
+ * @since 0.0.0
+ */
+export const isCanonicalText = S.is(ResolvedSourceText);
+
+/**
+ * Structural units produced by the deterministic C0 chunker.
+ *
+ * **Example** (Check a sentence chunk)
+ *
+ * ```ts
+ * import { ChunkKind } from "@/schema/Text"
+ *
+ * console.log(ChunkKind.is.sentence("sentence")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const ChunkKind = LiteralKit(["heading", "paragraph", "sentence"]).pipe(
+  $I.annoteSchema("ChunkKind", {
+    description: "Heading, paragraph, and sentence units emitted by the C0 chunker.",
+  })
+);
+
+/**
+ * Decoded chunk kind.
+ *
+ * **Example** (Annotate a chunk kind)
+ *
+ * ```ts
+ * import type { ChunkKind } from "@/schema/Text"
+ *
+ * const kind: ChunkKind = "sentence"
+ * console.log(kind) // "sentence"
+ * ```
+ *
+ * @see {@link ChunkKind} for literals.
+ * @category type-level
+ * @since 0.0.0
+ */
+export type ChunkKind = typeof ChunkKind.Type;
+
+const ChunkFields = S.Struct({
+  id: ChunkId,
+  document: DocumentId,
+  kind: ChunkKind,
+  ordinal: NonNegativeInt,
+  anchor: TextAnchor,
+  receipt: TextAnchorVerificationReceipt,
+});
+
+const ChunkReceiptCheck = S.makeFilter(
+  (chunk: typeof ChunkFields.Type) => S.toEquivalence(TextAnchor)(chunk.anchor, chunk.receipt.anchor),
+  {
+    identifier: $I`ChunkReceiptCheck`,
+    title: "Chunk anchor receipt",
+    description: "Requires the persisted verification receipt to contain the chunk's exact anchor.",
+    message: "Chunk receipt.anchor must equal anchor.",
+  }
+);
+
+/**
+ * Document-scoped canonical-text chunk with a verified anchor receipt.
+ *
+ * **Example** (Inspect the anchor field)
+ *
+ * ```ts
+ * import { Chunk } from "@/schema/Text"
+ *
+ * console.log(Chunk.fields.anchor !== undefined) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class Chunk extends S.Class<Chunk>($I`Chunk`)(
+  ChunkFields.mapFields(identity).check(ChunkReceiptCheck),
+  $I.annote("Chunk", {
+    description: "Document-scoped chunk whose exact text anchor has a persisted verification receipt.",
+  })
+) {}

--- a/apps/labs/semantica/test/Schema.test.ts
+++ b/apps/labs/semantica/test/Schema.test.ts
@@ -15,7 +15,7 @@ import { PosixPath } from "@beep/schema/PosixPath";
 import { UnitInterval } from "@beep/schema/UnitInterval";
 import * as BunCrypto from "@effect/platform-bun/BunCrypto";
 import { sha256 } from "@noble/hashes/sha2.js";
-import { Effect, Encoding, Equal, HashMap, Layer, Option, Result } from "effect";
+import { Effect, Encoding, Equal, HashMap, HashSet, Layer, Option, Order, Result } from "effect";
 import * as A from "effect/Array";
 import * as S from "effect/Schema";
 import * as Str from "effect/String";
@@ -26,7 +26,7 @@ import { CorpusPaperId } from "@/corpus/Manifest";
 import { F1FixtureId, FixtureDegradedKind, FixtureMediaType } from "@/fixtures/F1";
 import { DegradedKind } from "@/schema/Degraded";
 import { contentDigest, contentDigestSync, digestOmitting, digestOmittingSync, sha256TextSync } from "@/schema/Digest";
-import { Origin, SourceDocument } from "@/schema/Document";
+import { FixtureDeclaration, Origin, SourceDocument } from "@/schema/Document";
 import {
   AnchorRejected,
   DocumentUnavailable,
@@ -42,6 +42,7 @@ import {
   DocumentOutcome,
   EvalReport,
   EvalRun,
+  EvalSelection,
   MetricName,
   MetricScore,
   MetricStatus,
@@ -50,23 +51,25 @@ import {
   RequiredMetrics,
 } from "@/schema/Eval";
 import {
+  batchIdPreimage,
   ClaimBody,
   ConflictBasis,
   ConflictWitness,
+  claimIdPreimage,
   DegradedClaim,
+  declaredLosses,
   EvidenceBatch,
   EvidenceClaim,
   ExtractionLane,
   ExtractionMethod,
   ExtractOutcome,
   LossDeclaration,
+  makeBatchId,
+  makeClaimId,
   StructureRole,
 } from "@/schema/Evidence";
 import { GoldEntityLabel, GoldFile, GoldRef, GoldRelationLabel, GoldStructureLabel, GoldSubset } from "@/schema/Gold";
 import {
-  BatchId,
-  ChunkId,
-  ClaimId,
   DocumentId,
   isBatchId,
   isChunkId,
@@ -82,7 +85,7 @@ import { ModelIdentity, ProviderFamily, TaskType } from "@/schema/Model";
 import { EventBody, ProvenanceEvent } from "@/schema/Provenance";
 import { ProviderCacheEntry, ProviderCacheKey, RequestKind } from "@/schema/ProviderCache";
 import { EvalRunTelemetry } from "@/schema/Telemetry";
-import { Chunk, ChunkKind, isCanonicalText, ParseOutcome } from "@/schema/Text";
+import { Chunk, ChunkKind, chunkIdPreimage, isCanonicalText, makeChunkId, ParseOutcome } from "@/schema/Text";
 import type { DegradedKind as DegradedKindValue } from "@/schema/Degraded";
 import type { Origin as OriginValue } from "@/schema/Document";
 import type {
@@ -137,16 +140,24 @@ const canonicalDigest = (value: unknown): Sha256Hex =>
   Sha256Hex.make(Encoding.encodeHex(sha256(new TextEncoder().encode(canonicalJson(value)))));
 
 const documentId = DocumentId.make(Str.repeat(64)("1"));
-const chunkId = ChunkId.make(Str.repeat(64)("2"));
-const claimId = ClaimId.make(Str.repeat(64)("3"));
-const secondClaimId = ClaimId.make(Str.repeat(64)("4"));
-const batchId = BatchId.make(Str.repeat(64)("5"));
+const secondDocumentId = DocumentId.make(Str.repeat(64)("2"));
 const acquired = ProvenanceEventId.make(Str.repeat(64)("6"));
 
+const parsingFixtureDeclaration = FixtureDeclaration.make({
+  expectation: "parses",
+  degradedKind: Option.none(),
+});
 const fixtureOrigin = Origin.cases.Fixture.make({
   kind: "Fixture",
   fixtureId: F1FixtureId.make("md-structure"),
   relativePath: "documents/md-structure.md",
+  declared: parsingFixtureDeclaration,
+});
+const secondFixtureOrigin = Origin.cases.Fixture.make({
+  kind: "Fixture",
+  fixtureId: F1FixtureId.make("md-unicode"),
+  relativePath: "documents/md-unicode.md",
+  declared: parsingFixtureDeclaration,
 });
 const w1Origin = Origin.cases.W1Paper.make({
   kind: "W1Paper",
@@ -186,6 +197,10 @@ const otherAnchor = TextAnchor.make({
 const receipt = TextAnchorVerificationReceipt.make({ anchor, source: sourceIdentity });
 const otherReceipt = TextAnchorVerificationReceipt.make({ anchor: otherAnchor, source: sourceIdentity });
 const canonicalText = ResolvedSourceText.make({ identity: sourceIdentity, text: "Effect data" });
+const chunkId = Result.getOrThrow(makeChunkId({ document: documentId, anchor, receipt }));
+const unlistedChunkId = Result.getOrThrow(
+  makeChunkId({ document: documentId, anchor: otherAnchor, receipt: otherReceipt })
+);
 const chunk = Chunk.make({
   id: chunkId,
   document: documentId,
@@ -240,6 +255,32 @@ const entityBody = ClaimBody.cases.Entity.make({
   endChar: anchor.endChar,
   quote: anchor.quote,
 });
+const secondEntityBody = ClaimBody.cases.Entity.make({
+  kind: "Entity",
+  label: "data",
+  entityType: "concept",
+  startChar: otherAnchor.startChar,
+  endChar: otherAnchor.endChar,
+  quote: otherAnchor.quote,
+});
+const claimId = Result.getOrThrow(
+  makeClaimId({
+    document: documentId,
+    chunk: chunkId,
+    body: entityBody,
+    method: "hosted-langextract",
+    model: hostedModel,
+  })
+);
+const secondClaimId = Result.getOrThrow(
+  makeClaimId({
+    document: documentId,
+    chunk: chunkId,
+    body: secondEntityBody,
+    method: "hosted-langextract",
+    model: hostedModel,
+  })
+);
 const relationBody = ClaimBody.cases.Relation.make({
   kind: "Relation",
   predicate: "uses",
@@ -249,6 +290,15 @@ const relationBody = ClaimBody.cases.Relation.make({
   endChar: NonNegativeInt.make(6),
   quote: "Effect",
 });
+const relationClaimId = Result.getOrThrow(
+  makeClaimId({
+    document: documentId,
+    chunk: chunkId,
+    body: relationBody,
+    method: "hosted-langextract",
+    model: hostedModel,
+  })
+);
 const structureBody = ClaimBody.cases.Structure.make({
   kind: "Structure",
   role: "title",
@@ -268,11 +318,36 @@ const evidenceClaim = EvidenceClaim.make({
   cacheKey: Option.some(providerCacheKey),
   receipt,
 });
+const secondEvidenceClaim = EvidenceClaim.make({
+  id: secondClaimId,
+  document: documentId,
+  chunk: chunkId,
+  body: secondEntityBody,
+  confidence: Confidence.make(0.8),
+  method: "hosted-langextract",
+  model: hostedModel,
+  cacheKey: Option.some(providerCacheKey),
+  receipt: otherReceipt,
+});
+const relationClaim = EvidenceClaim.make({
+  id: relationClaimId,
+  document: documentId,
+  chunk: chunkId,
+  body: relationBody,
+  confidence: Confidence.make(0.7),
+  method: "hosted-langextract",
+  model: hostedModel,
+  cacheKey: Option.some(providerCacheKey),
+  receipt,
+});
 const degradedClaim = DegradedClaim.make({
   kind: "relation-unresolved",
   detail: "The relation object did not resolve to an entity claim.",
   chunk: chunkId,
 });
+const batchId = Result.getOrThrow(
+  makeBatchId({ document: documentId, method: "hosted-langextract", model: hostedModel, inputs: [chunkId] })
+);
 const evidenceBatch = EvidenceBatch.make({
   id: batchId,
   document: documentId,
@@ -283,14 +358,44 @@ const evidenceBatch = EvidenceBatch.make({
   degraded: [degradedClaim],
   lossy: [],
 });
+const relationBatch = EvidenceBatch.make({
+  ...evidenceBatch,
+  claims: [evidenceClaim, secondEvidenceClaim, relationClaim],
+  degraded: [],
+});
+const conflictEndpoints = A.sort(Order.String)([claimId, secondClaimId]);
+const conflictLeft = A.getUnsafe(conflictEndpoints, 0);
+const conflictRight = A.getUnsafe(conflictEndpoints, 1);
+const conflictBasis = "same-anchor-different-label" as const;
+const conflictWitness = ConflictWitness.make({
+  id: canonicalDigest({ left: conflictLeft, right: conflictRight, basis: conflictBasis }),
+  left: conflictLeft,
+  right: conflictRight,
+  basis: conflictBasis,
+});
 
-const paper1 = CorpusPaperId.make("000000000001");
-const paper2 = CorpusPaperId.make("000000000002");
-const paper3 = CorpusPaperId.make("000000000003");
+const goldPapers = A.map(
+  [
+    "000000000001",
+    "000000000002",
+    "000000000003",
+    "000000000004",
+    "000000000005",
+    "000000000006",
+    "000000000007",
+    "000000000008",
+    "000000000009",
+    "00000000000a",
+  ],
+  (id) => CorpusPaperId.make(id)
+);
+const paper1 = A.getUnsafe(goldPapers, 0);
+const paper2 = A.getUnsafe(goldPapers, 1);
+const paper3 = A.getUnsafe(goldPapers, 2);
 const goldSubset = GoldSubset.make({
-  structure: [paper1, paper2, paper3],
-  entity: [paper1, paper2],
-  relation: [paper1],
+  structure: goldPapers,
+  entity: A.take(goldPapers, 5),
+  relation: A.take(goldPapers, 3),
 });
 const goldRef = GoldRef.make({
   version: "gold/v1",
@@ -306,6 +411,7 @@ const runBody = {
   gold: goldRef,
   extractor: hostedModel,
   patternLane: patternModel,
+  selection: EvalSelection.make({ w1: [], f1: [fixtureOrigin.fixtureId] }),
 };
 const EvalRunBodySchema = S.Struct({
   stage: CanaryStage,
@@ -314,6 +420,7 @@ const EvalRunBodySchema = S.Struct({
   gold: GoldRef,
   extractor: ModelIdentity,
   patternLane: ModelIdentity,
+  selection: EvalSelection,
 });
 const evalRun = EvalRun.make({
   id: RunId.make(Result.getOrThrow(contentDigestSync(EvalRunBodySchema)(runBody))),
@@ -352,13 +459,18 @@ const metricScores = A.map(requiredC0, (required) =>
   })
 );
 
-const withReportDigest = (body: {
-  readonly schemaVersion: "eval-report/v1";
-  readonly run: EvalRun;
-  readonly documents: readonly [DocumentOutcome, ...Array<DocumentOutcome>];
-  readonly metrics: readonly [MetricScore, ...Array<MetricScore>];
-  readonly unexpectedDegraded: NonNegativeInt;
-}) => ({ ...body, reportDigest: canonicalDigest(body) });
+const EvalReportBodySchema = S.Struct({
+  schemaVersion: S.Literal("eval-report/v1"),
+  run: EvalRun,
+  documents: S.NonEmptyArray(DocumentOutcome),
+  metrics: S.NonEmptyArray(MetricScore),
+  unexpectedDegraded: NonNegativeInt,
+});
+
+const withReportDigest = (body: typeof EvalReportBodySchema.Type) => ({
+  ...Result.getOrThrow(S.encodeResult(EvalReportBodySchema)(body)),
+  reportDigest: Result.getOrThrow(contentDigestSync(EvalReportBodySchema)(body)),
+});
 
 const reportBody = {
   schemaVersion: "eval-report/v1" as const,
@@ -464,15 +576,7 @@ describe("C0 schema round trips", () => {
     roundTrip(EvidenceClaim, evidenceClaim);
     roundTrip(DegradedClaim, degradedClaim);
     roundTrip(EvidenceBatch, evidenceBatch);
-    roundTrip(
-      ConflictWitness,
-      ConflictWitness.make({
-        id: sha("f"),
-        left: claimId,
-        right: secondClaimId,
-        basis: "same-anchor-different-label",
-      })
-    );
+    roundTrip(ConflictWitness, conflictWitness);
     roundTrip(GoldSubset, goldSubset);
     roundTrip(GoldRef, goldRef);
     roundTrip(
@@ -632,9 +736,29 @@ describe("document and text refinements", () => {
     expect(rejects(SourceDocument, { ...sourceDocument, sha256: sha("0") })).toBe(true);
   });
 
-  it("accepts matching chunk receipts and rejects a receipt for another anchor", () => {
+  it("accepts coherent fixture declarations and rejects mismatched degraded-kind presence", () => {
+    expect(S.is(FixtureDeclaration)(parsingFixtureDeclaration)).toBe(true);
+    expect(
+      rejects(FixtureDeclaration, {
+        expectation: "parses",
+        degradedKind: "invalid-utf8",
+      })
+    ).toBe(true);
+  });
+
+  it("builds and verifies chunk content ids from the canonical encoded preimage", () => {
     expect(S.is(Chunk)(chunk)).toBe(true);
+    expect(Result.isSuccess(chunkIdPreimage(chunk))).toBe(true);
+    expect(Result.getOrThrow(makeChunkId(chunk))).toBe(chunk.id);
+    expect(rejects(Chunk, { ...chunk, id: sha("0") })).toBe(true);
+  });
+
+  it("accepts matching chunk receipts and rejects another anchor or source document", () => {
     expect(rejects(Chunk, { ...chunk, receipt: otherReceipt })).toBe(true);
+    const otherSource = SourceTextIdentity.make({ ...sourceIdentity, sourceRef: secondDocumentId });
+    const otherSourceReceipt = TextAnchorVerificationReceipt.make({ anchor, source: otherSource });
+    const otherSourceId = Result.getOrThrow(makeChunkId({ document: documentId, anchor, receipt: otherSourceReceipt }));
+    expect(rejects(Chunk, { ...chunk, id: otherSourceId, receipt: otherSourceReceipt })).toBe(true);
   });
 
   it("accepts each claim-body width and rejects each inconsistent width", () => {
@@ -679,9 +803,112 @@ describe("digest and provider-cache refinements", () => {
 });
 
 describe("evidence refinements", () => {
-  it("accepts a matching claim receipt and rejects a receipt for another anchor", () => {
+  it("builds and verifies claim ids from schema-encoded body and model preimages", () => {
     expect(S.is(EvidenceClaim)(evidenceClaim)).toBe(true);
+    expect(Result.isSuccess(claimIdPreimage(evidenceClaim))).toBe(true);
+    expect(Result.getOrThrow(makeClaimId(evidenceClaim))).toBe(evidenceClaim.id);
+    expect(rejects(EvidenceClaim, { ...evidenceClaim, id: sha("0") })).toBe(true);
+  });
+
+  it("accepts a matching claim receipt and rejects a receipt for another anchor", () => {
     expect(rejects(EvidenceClaim, { ...evidenceClaim, receipt: otherReceipt })).toBe(true);
+  });
+
+  it("builds and verifies batch ids from the ordered input preimage", () => {
+    expect(S.is(EvidenceBatch)(evidenceBatch)).toBe(true);
+    expect(Result.isSuccess(batchIdPreimage(evidenceBatch))).toBe(true);
+    expect(Result.getOrThrow(makeBatchId(evidenceBatch))).toBe(evidenceBatch.id);
+    expect(rejects(EvidenceBatch, { ...evidenceBatch, id: sha("0") })).toBe(true);
+  });
+
+  it("binds every claim and degraded claim chunk to the batch inputs", () => {
+    const unlistedClaimId = Result.getOrThrow(
+      makeClaimId({
+        document: documentId,
+        chunk: unlistedChunkId,
+        body: secondEntityBody,
+        method: "hosted-langextract",
+        model: hostedModel,
+      })
+    );
+    const unlistedClaim = EvidenceClaim.make({
+      ...secondEvidenceClaim,
+      id: unlistedClaimId,
+      chunk: unlistedChunkId,
+    });
+
+    expect(S.is(EvidenceBatch)(evidenceBatch)).toBe(true);
+    expect(rejects(EvidenceBatch, { ...evidenceBatch, claims: [unlistedClaim] })).toBe(true);
+    expect(
+      rejects(EvidenceBatch, {
+        ...evidenceBatch,
+        degraded: [{ ...degradedClaim, chunk: unlistedChunkId }],
+      })
+    ).toBe(true);
+  });
+
+  it("requires every relation endpoint to identify a same-batch entity claim", () => {
+    const externalBody = ClaimBody.cases.Entity.make({
+      ...entityBody,
+      label: "Schema",
+      quote: "Effect",
+    });
+    const externalId = Result.getOrThrow(
+      makeClaimId({
+        document: documentId,
+        chunk: chunkId,
+        body: externalBody,
+        method: "hosted-langextract",
+        model: hostedModel,
+      })
+    );
+    const unresolvedBody = ClaimBody.cases.Relation.make({ ...relationBody, object: externalId });
+    const unresolvedId = Result.getOrThrow(
+      makeClaimId({
+        document: documentId,
+        chunk: chunkId,
+        body: unresolvedBody,
+        method: "hosted-langextract",
+        model: hostedModel,
+      })
+    );
+    const unresolvedRelation = EvidenceClaim.make({ ...relationClaim, id: unresolvedId, body: unresolvedBody });
+
+    expect(S.is(EvidenceBatch)(relationBatch)).toBe(true);
+    expect(
+      rejects(EvidenceBatch, {
+        ...relationBatch,
+        claims: [evidenceClaim, secondEvidenceClaim, unresolvedRelation],
+      })
+    ).toBe(true);
+  });
+
+  it("derives exact order-insensitive loss declarations from the extraction method", () => {
+    const patternLosses = Option.getOrThrow(HashMap.get(declaredLosses, "pattern-wink"));
+    expect(
+      Equal.equals(
+        patternLosses,
+        HashSet.fromIterable<LossDeclarationValue>(["relations-not-supported", "structure-not-supported"])
+      )
+    ).toBe(true);
+
+    const patternBatchId = Result.getOrThrow(
+      makeBatchId({ document: documentId, method: "pattern-wink", model: patternModel, inputs: [chunkId] })
+    );
+    const patternBatch = EvidenceBatch.make({
+      id: patternBatchId,
+      document: documentId,
+      method: "pattern-wink",
+      model: patternModel,
+      inputs: [chunkId],
+      claims: [],
+      degraded: [],
+      lossy: ["structure-not-supported", "relations-not-supported"],
+    });
+
+    expect(S.is(EvidenceBatch)(patternBatch)).toBe(true);
+    expect(rejects(EvidenceBatch, { ...patternBatch, lossy: ["relations-not-supported"] })).toBe(true);
+    expect(rejects(EvidenceBatch, { ...evidenceBatch, lossy: ["relations-not-supported"] })).toBe(true);
   });
 
   it("accepts coherent unique claims and rejects duplicate ids or mismatched batch fields", () => {
@@ -706,6 +933,27 @@ describe("evidence refinements", () => {
       })
     ).toBe(true);
   });
+
+  it("requires conflict witnesses to use distinct ordered endpoints and their canonical digest", () => {
+    expect(S.is(ConflictWitness)(conflictWitness)).toBe(true);
+    expect(
+      rejects(ConflictWitness, {
+        id: canonicalDigest({ left: claimId, right: claimId, basis: conflictBasis }),
+        left: claimId,
+        right: claimId,
+        basis: conflictBasis,
+      })
+    ).toBe(true);
+    expect(
+      rejects(ConflictWitness, {
+        id: canonicalDigest({ left: conflictRight, right: conflictLeft, basis: conflictBasis }),
+        left: conflictRight,
+        right: conflictLeft,
+        basis: conflictBasis,
+      })
+    ).toBe(true);
+    expect(rejects(ConflictWitness, { ...conflictWitness, id: sha("0") })).toBe(true);
+  });
 });
 
 describe("provenance refinements", () => {
@@ -727,39 +975,40 @@ describe("provenance refinements", () => {
 });
 
 describe("gold refinements", () => {
-  it("accepts strict nested subsets and rejects duplicates, non-strict containment, and oversize structure", () => {
+  it("accepts exact 10/5/3 subsets and rejects smaller or larger protocol selections", () => {
     expect(S.is(GoldSubset)(goldSubset)).toBe(true);
     expect(
       rejects(GoldSubset, {
-        structure: [paper1, paper1, paper2],
-        entity: [paper1, paper2],
-        relation: [paper1],
+        structure: A.dropRight(goldPapers, 1),
+        entity: A.take(goldPapers, 5),
+        relation: A.take(goldPapers, 3),
+      })
+    ).toBe(true);
+    const paper11 = CorpusPaperId.make("00000000000b");
+    expect(
+      rejects(GoldSubset, {
+        structure: [...goldPapers, paper11],
+        entity: A.take(goldPapers, 5),
+        relation: A.take(goldPapers, 3),
+      })
+    ).toBe(true);
+  });
+
+  it("rejects duplicate ids and broken strict containment at the exact protocol sizes", () => {
+    const paper4 = A.getUnsafe(goldPapers, 3);
+    const paper11 = CorpusPaperId.make("00000000000b");
+    expect(
+      rejects(GoldSubset, {
+        structure: [...A.dropRight(goldPapers, 1), paper1],
+        entity: A.take(goldPapers, 5),
+        relation: A.take(goldPapers, 3),
       })
     ).toBe(true);
     expect(
       rejects(GoldSubset, {
-        structure: [paper1, paper2],
-        entity: [paper1, paper2],
-        relation: [paper1],
-      })
-    ).toBe(true);
-    expect(
-      rejects(GoldSubset, {
-        structure: [
-          "000000000001",
-          "000000000002",
-          "000000000003",
-          "000000000004",
-          "000000000005",
-          "000000000006",
-          "000000000007",
-          "000000000008",
-          "000000000009",
-          "00000000000a",
-          "00000000000b",
-        ],
-        entity: [paper1, paper2],
-        relation: [paper1],
+        structure: goldPapers,
+        entity: [paper1, paper2, paper3, paper4, paper11],
+        relation: [paper1, paper2, paper3],
       })
     ).toBe(true);
   });
@@ -810,6 +1059,22 @@ describe("evaluation refinements", () => {
     return { id: RunId.make(Result.getOrThrow(contentDigestSync(EvalRunBodySchema)(body))), ...body };
   };
 
+  it("accepts unique run selections and rejects duplicate W1 or F1 identities", () => {
+    expect(S.is(EvalSelection)(runBody.selection)).toBe(true);
+    expect(
+      rejects(EvalSelection, {
+        w1: [paper1, paper1],
+        f1: [fixtureOrigin.fixtureId],
+      })
+    ).toBe(true);
+    expect(
+      rejects(EvalSelection, {
+        w1: [paper1],
+        f1: [fixtureOrigin.fixtureId, fixtureOrigin.fixtureId],
+      })
+    ).toBe(true);
+  });
+
   it("accepts independent extraction and gold providers and rejects every EvalRun invariant", () => {
     expect(S.is(EvalRun)(evalRun)).toBe(true);
     const sameFamilyProposer = ModelIdentity.make({ ...proposerModel, provider: "anthropic" });
@@ -818,6 +1083,12 @@ describe("evaluation refinements", () => {
 
     const wrongTaskExtractor = ModelIdentity.make({ ...hostedModel, provider: "anthropic", taskType: "gold-proposal" });
     expect(rejects(EvalRun, runWith({ extractor: wrongTaskExtractor }))).toBe(true);
+
+    const wrongPatternProvider = ModelIdentity.make({ ...patternModel, provider: "anthropic" });
+    expect(rejects(EvalRun, runWith({ patternLane: wrongPatternProvider }))).toBe(true);
+
+    const wrongPatternTask = ModelIdentity.make({ ...patternModel, taskType: "gold-proposal" });
+    expect(rejects(EvalRun, runWith({ patternLane: wrongPatternTask }))).toBe(true);
     expect(rejects(EvalRun, { ...evalRun, id: RunId.make(Str.repeat(64)("0")) })).toBe(true);
   });
 
@@ -843,6 +1114,117 @@ describe("evaluation refinements", () => {
         support: 0,
       })
     ).toBe(false);
+    expect(
+      rejects(MetricScore, {
+        name: "rebel-end-to-end-triple-f1",
+        subset: "relation",
+        lane: "pattern",
+        status: "unsupported",
+        value: 0.5,
+        support: 1,
+      })
+    ).toBe(true);
+  });
+
+  it("accepts unique exact document coverage and rejects duplicate ids, omissions, and extras", () => {
+    const selection = EvalSelection.make({
+      w1: [],
+      f1: [fixtureOrigin.fixtureId, secondFixtureOrigin.fixtureId],
+    });
+    const run = EvalRun.make(runWith({ selection }));
+    const secondOutcome = DocumentOutcome.make({
+      ...documentOutcome,
+      document: secondDocumentId,
+      origin: secondFixtureOrigin,
+    });
+    const body: typeof EvalReportBodySchema.Type = {
+      ...reportBody,
+      run,
+      documents: [documentOutcome, secondOutcome],
+    };
+
+    expect(rejects(EvalReport, withReportDigest(body))).toBe(false);
+    expect(
+      rejects(
+        EvalReport,
+        withReportDigest({
+          ...body,
+          documents: [documentOutcome, DocumentOutcome.make({ ...secondOutcome, document: documentId })],
+        })
+      )
+    ).toBe(true);
+    expect(rejects(EvalReport, withReportDigest({ ...body, documents: [documentOutcome] }))).toBe(true);
+    expect(rejects(EvalReport, withReportDigest({ ...reportBody, documents: [documentOutcome, secondOutcome] }))).toBe(
+      true
+    );
+  });
+
+  it("derives F1 degradation arithmetic from each document origin declaration", () => {
+    const futureFixtureId = F1FixtureId.make("future-fixture");
+    const futureOrigin = Origin.cases.Fixture.make({
+      kind: "Fixture",
+      fixtureId: futureFixtureId,
+      relativePath: "documents/future-fixture.md",
+      declared: FixtureDeclaration.make({ expectation: "parses", degradedKind: Option.none() }),
+    });
+    const selection = EvalSelection.make({ w1: [], f1: [futureFixtureId] });
+    const run = EvalRun.make(runWith({ selection }));
+    const futureOutcome = DocumentOutcome.make({
+      ...documentOutcome,
+      document: secondDocumentId,
+      origin: futureOrigin,
+    });
+    const body: typeof EvalReportBodySchema.Type = { ...reportBody, run, documents: [futureOutcome] };
+
+    expect(rejects(EvalReport, withReportDigest(body))).toBe(false);
+    expect(
+      rejects(
+        EvalReport,
+        withReportDigest({
+          ...body,
+          documents: [DocumentOutcome.make({ ...futureOutcome, parse: "truncated" })],
+        })
+      )
+    ).toBe(true);
+  });
+
+  it("requires hosted relation claims for every selected relation-gold paper", () => {
+    const selection = EvalSelection.make({ w1: [paper1], f1: [fixtureOrigin.fixtureId] });
+    const run = EvalRun.make(runWith({ selection }));
+    const relationOutcome = DocumentOutcome.make({
+      ...documentOutcome,
+      document: secondDocumentId,
+      origin: w1Origin,
+      claims: {
+        ...documentOutcome.claims,
+        hosted: { ...documentOutcome.claims.hosted, relation: NonNegativeInt.make(1) },
+      },
+    });
+    const body: typeof EvalReportBodySchema.Type = {
+      ...reportBody,
+      run,
+      documents: [relationOutcome, documentOutcome],
+    };
+
+    expect(rejects(EvalReport, withReportDigest(body))).toBe(false);
+    expect(
+      rejects(
+        EvalReport,
+        withReportDigest({
+          ...body,
+          documents: [
+            DocumentOutcome.make({
+              ...relationOutcome,
+              claims: {
+                ...relationOutcome.claims,
+                hosted: { ...relationOutcome.claims.hosted, relation: NonNegativeInt.make(0) },
+              },
+            }),
+            documentOutcome,
+          ],
+        })
+      )
+    ).toBe(true);
   });
 
   it("rejects missing or duplicate metric coordinates", () => {

--- a/apps/labs/semantica/test/Schema.test.ts
+++ b/apps/labs/semantica/test/Schema.test.ts
@@ -1,0 +1,909 @@
+// @vitest-environment node
+
+import { Confidence } from "@beep/epistemic-domain";
+import { ResolvedSourceText } from "@beep/file-processing/SourceText";
+import {
+  SourceTextDigest,
+  SourceTextExtractor,
+  SourceTextIdentity,
+  TextAnchor,
+  TextAnchorVerificationReceipt,
+  VerifiedTextAnchorError,
+} from "@beep/provenance";
+import { NonNegativeInt, Sha256Hex } from "@beep/schema";
+import { PosixPath } from "@beep/schema/PosixPath";
+import { UnitInterval } from "@beep/schema/UnitInterval";
+import * as BunCrypto from "@effect/platform-bun/BunCrypto";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { Effect, Encoding, Equal, HashMap, Layer, Option, Result } from "effect";
+import * as A from "effect/Array";
+import * as S from "effect/Schema";
+import * as Str from "effect/String";
+import { FastCheck as fc } from "effect/testing";
+import { describe, expect, it } from "vitest";
+import { canonicalJson } from "@/corpus/Canonical";
+import { CorpusPaperId } from "@/corpus/Manifest";
+import { F1FixtureId, FixtureDegradedKind, FixtureMediaType } from "@/fixtures/F1";
+import { DegradedKind } from "@/schema/Degraded";
+import { contentDigest, contentDigestSync, digestOmitting, digestOmittingSync, sha256TextSync } from "@/schema/Digest";
+import { Origin, SourceDocument } from "@/schema/Document";
+import {
+  AnchorRejected,
+  DocumentUnavailable,
+  GoldUnavailable,
+  LedgerFailed,
+  ParserFailed,
+  ProviderCacheCorrupt,
+  ProviderUnavailable,
+  ReportInvalid,
+} from "@/schema/Errors";
+import {
+  CanaryStage,
+  DocumentOutcome,
+  EvalReport,
+  EvalRun,
+  MetricName,
+  MetricScore,
+  MetricStatus,
+  MetricSubset,
+  RequiredMetric,
+  RequiredMetrics,
+} from "@/schema/Eval";
+import {
+  ClaimBody,
+  ConflictBasis,
+  ConflictWitness,
+  DegradedClaim,
+  EvidenceBatch,
+  EvidenceClaim,
+  ExtractionLane,
+  ExtractionMethod,
+  ExtractOutcome,
+  LossDeclaration,
+  StructureRole,
+} from "@/schema/Evidence";
+import { GoldEntityLabel, GoldFile, GoldRef, GoldRelationLabel, GoldStructureLabel, GoldSubset } from "@/schema/Gold";
+import {
+  BatchId,
+  ChunkId,
+  ClaimId,
+  DocumentId,
+  isBatchId,
+  isChunkId,
+  isClaimId,
+  isDocumentId,
+  isProvenanceEventId,
+  isRunId,
+  ProvenanceEventId,
+  RunId,
+} from "@/schema/Ids";
+import { MediaType } from "@/schema/MediaType";
+import { ModelIdentity, ProviderFamily, TaskType } from "@/schema/Model";
+import { EventBody, ProvenanceEvent } from "@/schema/Provenance";
+import { ProviderCacheEntry, ProviderCacheKey, RequestKind } from "@/schema/ProviderCache";
+import { EvalRunTelemetry } from "@/schema/Telemetry";
+import { Chunk, ChunkKind, isCanonicalText, ParseOutcome } from "@/schema/Text";
+import type { DegradedKind as DegradedKindValue } from "@/schema/Degraded";
+import type { Origin as OriginValue } from "@/schema/Document";
+import type {
+  CanaryStage as CanaryStageValue,
+  MetricName as MetricNameValue,
+  MetricStatus as MetricStatusValue,
+  MetricSubset as MetricSubsetValue,
+} from "@/schema/Eval";
+import type {
+  ClaimBody as ClaimBodyValue,
+  ConflictBasis as ConflictBasisValue,
+  ExtractionLane as ExtractionLaneValue,
+  ExtractionMethod as ExtractionMethodValue,
+  ExtractOutcome as ExtractOutcomeValue,
+  LossDeclaration as LossDeclarationValue,
+  StructureRole as StructureRoleValue,
+} from "@/schema/Evidence";
+import type { GoldFile as GoldFileValue } from "@/schema/Gold";
+import type {
+  BatchId as BatchIdValue,
+  ChunkId as ChunkIdValue,
+  ClaimId as ClaimIdValue,
+  DocumentId as DocumentIdValue,
+  ProvenanceEventId as ProvenanceEventIdValue,
+  RunId as RunIdValue,
+} from "@/schema/Ids";
+import type { MediaType as MediaTypeValue } from "@/schema/MediaType";
+import type { ProviderFamily as ProviderFamilyValue, TaskType as TaskTypeValue } from "@/schema/Model";
+import type { EventBody as EventBodyValue } from "@/schema/Provenance";
+import type { RequestKind as RequestKindValue } from "@/schema/ProviderCache";
+import type { CanonicalText, ChunkKind as ChunkKindValue, ParseOutcome as ParseOutcomeValue } from "@/schema/Text";
+
+const provideScopedLayer =
+  <ROut, E2, RIn>(layer: Layer.Layer<ROut, E2, RIn>) =>
+  <A2, E, R>(effect: Effect.Effect<A2, E, R>): Effect.Effect<A2, E | E2, RIn | Exclude<R, ROut>> =>
+    Effect.scoped(Layer.build(layer).pipe(Effect.flatMap((context) => effect.pipe(Effect.provide(context)))));
+
+const provideBunCrypto = provideScopedLayer(BunCrypto.layer);
+
+const roundTrip = <Schema extends S.Codec<unknown>>(schema: Schema, value: Schema["Type"]): void => {
+  const encoded = Result.getOrThrow(S.encodeResult(schema)(value));
+  const decoded = Result.getOrThrow(S.decodeUnknownResult(schema)(encoded));
+
+  expect(Equal.equals(decoded, value) || S.toEquivalence(schema)(decoded, value)).toBe(true);
+};
+
+const rejects = <Schema extends S.Codec<unknown>>(schema: Schema, value: unknown): boolean =>
+  Result.isFailure(S.decodeUnknownResult(schema)(value));
+
+const sha = (digit: string): Sha256Hex => Sha256Hex.make(Str.repeat(64)(digit));
+const canonicalDigest = (value: unknown): Sha256Hex =>
+  Sha256Hex.make(Encoding.encodeHex(sha256(new TextEncoder().encode(canonicalJson(value)))));
+
+const documentId = DocumentId.make(Str.repeat(64)("1"));
+const chunkId = ChunkId.make(Str.repeat(64)("2"));
+const claimId = ClaimId.make(Str.repeat(64)("3"));
+const secondClaimId = ClaimId.make(Str.repeat(64)("4"));
+const batchId = BatchId.make(Str.repeat(64)("5"));
+const acquired = ProvenanceEventId.make(Str.repeat(64)("6"));
+
+const fixtureOrigin = Origin.cases.Fixture.make({
+  kind: "Fixture",
+  fixtureId: F1FixtureId.make("md-structure"),
+  relativePath: "documents/md-structure.md",
+});
+const w1Origin = Origin.cases.W1Paper.make({
+  kind: "W1Paper",
+  corpusId: "academia-2026-07",
+  paperId: CorpusPaperId.make("000000000001"),
+  relativePath: "000000000001.pdf",
+});
+const sourceDocument = SourceDocument.make({
+  id: documentId,
+  mediaType: "text/markdown",
+  origin: fixtureOrigin,
+  bytes: NonNegativeInt.make(6),
+  sha256: documentId,
+  acquired,
+});
+
+const extractorIdentity = SourceTextExtractor.make({ name: "identity-utf8", version: "1" });
+const sourceIdentity = SourceTextIdentity.make({
+  scopeRef: "semantica-canary",
+  sourceRef: documentId,
+  locator: PosixPath.make("documents/md-structure.md"),
+  sourceDigest: SourceTextDigest.make(`sha256:${documentId}`),
+  textDigest: SourceTextDigest.make(`sha256:${sha("7")}`),
+  extractor: extractorIdentity,
+  normalizationVersion: "raw/1",
+});
+const anchor = TextAnchor.make({
+  startChar: NonNegativeInt.make(0),
+  endChar: NonNegativeInt.make(6),
+  quote: "Effect",
+});
+const otherAnchor = TextAnchor.make({
+  startChar: NonNegativeInt.make(7),
+  endChar: NonNegativeInt.make(11),
+  quote: "data",
+});
+const receipt = TextAnchorVerificationReceipt.make({ anchor, source: sourceIdentity });
+const otherReceipt = TextAnchorVerificationReceipt.make({ anchor: otherAnchor, source: sourceIdentity });
+const canonicalText = ResolvedSourceText.make({ identity: sourceIdentity, text: "Effect data" });
+const chunk = Chunk.make({
+  id: chunkId,
+  document: documentId,
+  kind: "sentence",
+  ordinal: NonNegativeInt.make(0),
+  anchor,
+  receipt,
+});
+
+const hostedModel = ModelIdentity.make({
+  provider: "anthropic",
+  name: "claude",
+  revision: "2026-08-25",
+  artifactHash: sha("8"),
+  taskType: "extraction",
+});
+const patternModel = ModelIdentity.make({
+  provider: "wink",
+  name: "wink-nlp",
+  revision: "1",
+  artifactHash: sha("9"),
+  taskType: "extraction",
+});
+const proposerModel = ModelIdentity.make({
+  provider: "xai",
+  name: "grok",
+  revision: "2026-08-25",
+  artifactHash: sha("a"),
+  taskType: "gold-proposal",
+});
+
+const providerKey = ProviderCacheKey.make({
+  schemaVersion: "provider-cache/v1",
+  model: hostedModel,
+  requestKind: "generate-text",
+  inputDigest: sha("b"),
+});
+const providerCacheKey = Result.getOrThrow(contentDigestSync(ProviderCacheKey)(providerKey));
+const providerResponse = "grounded response";
+const providerEntry = ProviderCacheEntry.make({
+  key: providerKey,
+  cacheKey: providerCacheKey,
+  response: providerResponse,
+  responseDigest: sha256TextSync(providerResponse),
+});
+
+const entityBody = ClaimBody.cases.Entity.make({
+  kind: "Entity",
+  label: "Effect",
+  entityType: "software",
+  startChar: anchor.startChar,
+  endChar: anchor.endChar,
+  quote: anchor.quote,
+});
+const relationBody = ClaimBody.cases.Relation.make({
+  kind: "Relation",
+  predicate: "uses",
+  subject: claimId,
+  object: secondClaimId,
+  startChar: NonNegativeInt.make(0),
+  endChar: NonNegativeInt.make(6),
+  quote: "Effect",
+});
+const structureBody = ClaimBody.cases.Structure.make({
+  kind: "Structure",
+  role: "title",
+  depth: NonNegativeInt.make(0),
+  startChar: anchor.startChar,
+  endChar: anchor.endChar,
+  quote: anchor.quote,
+});
+const evidenceClaim = EvidenceClaim.make({
+  id: claimId,
+  document: documentId,
+  chunk: chunkId,
+  body: entityBody,
+  confidence: Confidence.make(0.9),
+  method: "hosted-langextract",
+  model: hostedModel,
+  cacheKey: Option.some(providerCacheKey),
+  receipt,
+});
+const degradedClaim = DegradedClaim.make({
+  kind: "relation-unresolved",
+  detail: "The relation object did not resolve to an entity claim.",
+  chunk: chunkId,
+});
+const evidenceBatch = EvidenceBatch.make({
+  id: batchId,
+  document: documentId,
+  method: "hosted-langextract",
+  model: hostedModel,
+  inputs: [chunkId],
+  claims: [evidenceClaim],
+  degraded: [degradedClaim],
+  lossy: [],
+});
+
+const paper1 = CorpusPaperId.make("000000000001");
+const paper2 = CorpusPaperId.make("000000000002");
+const paper3 = CorpusPaperId.make("000000000003");
+const goldSubset = GoldSubset.make({
+  structure: [paper1, paper2, paper3],
+  entity: [paper1, paper2],
+  relation: [paper1],
+});
+const goldRef = GoldRef.make({
+  version: "gold/v1",
+  digest: sha("c"),
+  proposer: proposerModel,
+  spotCheckedFraction: UnitInterval.make(0.5),
+  subsets: goldSubset,
+});
+const runBody = {
+  stage: "c0" as const,
+  corpusHash: sha("d"),
+  fixtureIndexDigest: sha("e"),
+  gold: goldRef,
+  extractor: hostedModel,
+  patternLane: patternModel,
+};
+const EvalRunBodySchema = S.Struct({
+  stage: CanaryStage,
+  corpusHash: Sha256Hex,
+  fixtureIndexDigest: Sha256Hex,
+  gold: GoldRef,
+  extractor: ModelIdentity,
+  patternLane: ModelIdentity,
+});
+const evalRun = EvalRun.make({
+  id: RunId.make(Result.getOrThrow(contentDigestSync(EvalRunBodySchema)(runBody))),
+  ...runBody,
+});
+const documentOutcome = DocumentOutcome.make({
+  document: documentId,
+  origin: fixtureOrigin,
+  parse: "parsed",
+  extraction: { hosted: "extracted", pattern: "extracted" },
+  chunks: NonNegativeInt.make(1),
+  claims: {
+    hosted: {
+      entity: NonNegativeInt.make(1),
+      relation: NonNegativeInt.make(0),
+      structure: NonNegativeInt.make(0),
+    },
+    pattern: {
+      entity: NonNegativeInt.make(1),
+      relation: NonNegativeInt.make(0),
+      structure: NonNegativeInt.make(0),
+    },
+  },
+  degradedClaims: NonNegativeInt.make(0),
+  anchorsVerified: NonNegativeInt.make(2),
+  anchorsFailed: NonNegativeInt.make(0),
+  cacheKeys: [providerCacheKey],
+});
+const requiredC0 = Option.getOrThrow(HashMap.get(RequiredMetrics, "c0"));
+const metricScores = A.map(requiredC0, (required) =>
+  MetricScore.make({
+    ...required,
+    status: required.lane === "pattern" && required.subset === "relation" ? "unsupported" : "scored",
+    value: UnitInterval.make(required.lane === "pattern" && required.subset === "relation" ? 0 : 1),
+    support: NonNegativeInt.make(required.lane === "pattern" && required.subset === "relation" ? 0 : 1),
+  })
+);
+
+const withReportDigest = (body: {
+  readonly schemaVersion: "eval-report/v1";
+  readonly run: EvalRun;
+  readonly documents: readonly [DocumentOutcome, ...Array<DocumentOutcome>];
+  readonly metrics: readonly [MetricScore, ...Array<MetricScore>];
+  readonly unexpectedDegraded: NonNegativeInt;
+}) => ({ ...body, reportDigest: canonicalDigest(body) });
+
+const reportBody = {
+  schemaVersion: "eval-report/v1" as const,
+  run: evalRun,
+  documents: [documentOutcome] as [DocumentOutcome],
+  metrics: metricScores as [MetricScore, ...Array<MetricScore>],
+  unexpectedDegraded: NonNegativeInt.make(0),
+};
+const evalReport = S.decodeSync(EvalReport)(withReportDigest(reportBody));
+
+describe("C0 schema exports", () => {
+  it("consumes every literal domain, branded type, guard, and type alias", () => {
+    const types = {
+      documentId: documentId as DocumentIdValue,
+      chunkId: chunkId as ChunkIdValue,
+      claimId: claimId as ClaimIdValue,
+      batchId: batchId as BatchIdValue,
+      eventId: acquired as ProvenanceEventIdValue,
+      runId: evalRun.id as RunIdValue,
+      mediaType: "text/markdown" as MediaTypeValue,
+      degradedKind: "truncated" as DegradedKindValue,
+      origin: fixtureOrigin as OriginValue,
+      parseOutcome: ParseOutcome.cases.Parsed.make({
+        outcome: "Parsed",
+        document: documentId,
+        text: "Effect data",
+        extractor: extractorIdentity,
+      }) as ParseOutcomeValue,
+      canonicalText: canonicalText as CanonicalText,
+      chunkKind: "sentence" as ChunkKindValue,
+      providerFamily: "anthropic" as ProviderFamilyValue,
+      taskType: "extraction" as TaskTypeValue,
+      requestKind: "generate-text" as RequestKindValue,
+      lane: "hosted" as ExtractionLaneValue,
+      method: "hosted-langextract" as ExtractionMethodValue,
+      structureRole: "title" as StructureRoleValue,
+      loss: "relations-not-supported" as LossDeclarationValue,
+      claimBody: entityBody as ClaimBodyValue,
+      extractOutcome: ExtractOutcome.cases.Extracted.make({
+        outcome: "Extracted",
+        batch: evidenceBatch,
+      }) as ExtractOutcomeValue,
+      conflictBasis: "same-anchor-different-label" as ConflictBasisValue,
+      eventBody: EventBody.cases.Ingested.make({ kind: "Ingested", document: documentId }) as EventBodyValue,
+      goldFile: S.decodeSync(GoldFile)({
+        version: "gold/v1",
+        paperId: paper1,
+        subset: "entity",
+        labels: [],
+        proposer: proposerModel,
+      }) as GoldFileValue,
+      stage: "c0" as CanaryStageValue,
+      metricName: "entity-span-f1" as MetricNameValue,
+      metricSubset: "entity" as MetricSubsetValue,
+      metricStatus: "scored" as MetricStatusValue,
+    };
+
+    expect(A.length(Object.keys(types))).toBe(28);
+    expect([
+      isDocumentId(documentId),
+      isChunkId(chunkId),
+      isClaimId(claimId),
+      isBatchId(batchId),
+      isProvenanceEventId(acquired),
+      isRunId(evalRun.id),
+      isCanonicalText(canonicalText),
+    ]).toEqual([true, true, true, true, true, true, true]);
+    expect(MediaType.Options).toEqual(FixtureMediaType.Options);
+    expect(ProviderFamily.is.anthropic("anthropic")).toBe(true);
+    expect(TaskType.is.extraction("extraction")).toBe(true);
+    expect(RequestKind.is["generate-text"]("generate-text")).toBe(true);
+    expect(ExtractionLane.is.hosted("hosted")).toBe(true);
+    expect(ExtractionMethod.is["pattern-wink"]("pattern-wink")).toBe(true);
+    expect(StructureRole.is.title("title")).toBe(true);
+    expect(LossDeclaration.is["structure-not-supported"]("structure-not-supported")).toBe(true);
+    expect(ConflictBasis.is["same-anchor-different-label"]("same-anchor-different-label")).toBe(true);
+    expect(ChunkKind.is.sentence("sentence")).toBe(true);
+    expect(MetricName.is["b-cubed"]("b-cubed")).toBe(true);
+    expect(MetricSubset.is.all("all")).toBe(true);
+    expect(MetricStatus.is.scored("scored")).toBe(true);
+  });
+
+  it("derives fast-check values from representative source schemas", () => {
+    fc.assert(
+      fc.property(
+        S.toArbitrary(DocumentId)(fc),
+        S.toArbitrary(DegradedKind)(fc),
+        S.toArbitrary(MetricName)(fc),
+        (id, kind, metric) => isDocumentId(id) && S.is(DegradedKind)(kind) && S.is(MetricName)(metric)
+      ),
+      { numRuns: 25 }
+    );
+  });
+});
+
+describe("C0 schema round trips", () => {
+  it("round-trips document, text, model, cache, evidence, gold, evaluation, and telemetry classes", () => {
+    roundTrip(SourceDocument, sourceDocument);
+    roundTrip(Chunk, chunk);
+    roundTrip(ModelIdentity, hostedModel);
+    roundTrip(ProviderCacheKey, providerKey);
+    roundTrip(ProviderCacheEntry, providerEntry);
+    roundTrip(EvidenceClaim, evidenceClaim);
+    roundTrip(DegradedClaim, degradedClaim);
+    roundTrip(EvidenceBatch, evidenceBatch);
+    roundTrip(
+      ConflictWitness,
+      ConflictWitness.make({
+        id: sha("f"),
+        left: claimId,
+        right: secondClaimId,
+        basis: "same-anchor-different-label",
+      })
+    );
+    roundTrip(GoldSubset, goldSubset);
+    roundTrip(GoldRef, goldRef);
+    roundTrip(
+      GoldStructureLabel,
+      GoldStructureLabel.make({
+        role: "title",
+        depth: NonNegativeInt.make(0),
+        startChar: anchor.startChar,
+        endChar: anchor.endChar,
+        quote: anchor.quote,
+        verified: true,
+      })
+    );
+    roundTrip(
+      GoldEntityLabel,
+      GoldEntityLabel.make({
+        label: "Effect",
+        entityType: "software",
+        startChar: anchor.startChar,
+        endChar: anchor.endChar,
+        quote: anchor.quote,
+        verified: true,
+      })
+    );
+    roundTrip(
+      GoldRelationLabel,
+      GoldRelationLabel.make({
+        predicate: "uses",
+        subject: "Effect",
+        object: "Schema",
+        startChar: anchor.startChar,
+        endChar: anchor.endChar,
+        quote: anchor.quote,
+        verified: false,
+      })
+    );
+    roundTrip(EvalRun, evalRun);
+    roundTrip(MetricScore, A.getUnsafe(metricScores, 0));
+    roundTrip(RequiredMetric, A.getUnsafe(requiredC0, 0));
+    roundTrip(DocumentOutcome, documentOutcome);
+    roundTrip(EvalReport, evalReport);
+
+    const telemetry = S.decodeSync(EvalRunTelemetry)({
+      schemaVersion: "eval-telemetry/v1",
+      reportDigest: evalReport.reportDigest,
+      runId: evalRun.id,
+      mode: "live",
+      startedAt: "2026-08-25T12:00:00.000Z",
+      wallClockMs: 10,
+      coldStartMs: 2,
+      p95Ms: 4,
+      rssBytes: 1_000,
+      diskGrowthBytes: 100,
+      dependencyBytes: 500,
+      modelBytes: 250,
+    });
+    roundTrip(EvalRunTelemetry, telemetry);
+  });
+
+  it("round-trips every tagged-union member", () => {
+    const parsed = ParseOutcome.cases.Parsed.make({
+      outcome: "Parsed",
+      document: documentId,
+      text: "Effect data",
+      extractor: extractorIdentity,
+    });
+    const degradedParse = ParseOutcome.cases.Degraded.make({
+      outcome: "Degraded",
+      document: documentId,
+      kind: "invalid-utf8",
+      detail: "Input was not valid UTF-8.",
+    });
+    roundTrip(Origin, fixtureOrigin);
+    roundTrip(Origin, w1Origin);
+    roundTrip(ParseOutcome, parsed);
+    roundTrip(ParseOutcome, degradedParse);
+    roundTrip(ClaimBody, entityBody);
+    roundTrip(ClaimBody, relationBody);
+    roundTrip(ClaimBody, structureBody);
+    roundTrip(ExtractOutcome, ExtractOutcome.cases.Extracted.make({ outcome: "Extracted", batch: evidenceBatch }));
+    roundTrip(
+      ExtractOutcome,
+      ExtractOutcome.cases.Degraded.make({
+        outcome: "Degraded",
+        document: documentId,
+        lane: "hosted",
+        kind: "provider-unavailable",
+        detail: "Provider cache miss.",
+      })
+    );
+
+    const eventBodies = [
+      EventBody.cases.Ingested.make({ kind: "Ingested", document: documentId }),
+      EventBody.cases.Parsed.make({
+        kind: "Parsed",
+        document: documentId,
+        outcome: "parsed",
+        extractor: extractorIdentity,
+      }),
+      EventBody.cases.Chunked.make({ kind: "Chunked", document: documentId, chunks: [chunkId] }),
+      EventBody.cases.Extracted.make({ kind: "Extracted", batch: batchId, model: hostedModel }),
+      EventBody.cases.Asserted.make({ kind: "Asserted", claims: [claimId] }),
+      EventBody.cases.Invalidated.make({ kind: "Invalidated", claim: claimId, reason: "superseded" }),
+    ];
+    A.forEach(eventBodies, (body) => roundTrip(EventBody, body));
+
+    const structureFile = S.decodeSync(GoldFile)({
+      version: "gold/v1",
+      paperId: paper1,
+      subset: "structure",
+      labels: [],
+      proposer: proposerModel,
+    });
+    const entityFile = S.decodeSync(GoldFile)({
+      version: "gold/v1",
+      paperId: paper1,
+      subset: "entity",
+      labels: [],
+      proposer: proposerModel,
+    });
+    const relationFile = S.decodeSync(GoldFile)({
+      version: "gold/v1",
+      paperId: paper1,
+      subset: "relation",
+      labels: [],
+      proposer: proposerModel,
+    });
+    roundTrip(GoldFile, structureFile);
+    roundTrip(GoldFile, entityFile);
+    roundTrip(GoldFile, relationFile);
+  });
+
+  it("round-trips every typed error", () => {
+    roundTrip(DocumentUnavailable, DocumentUnavailable.make({ message: "Document unavailable." }));
+    roundTrip(ParserFailed, ParserFailed.make({ message: "Parser failed.", kind: "extraction-failed" }));
+    roundTrip(
+      AnchorRejected,
+      AnchorRejected.make({
+        message: "Anchor rejected.",
+        cause: VerifiedTextAnchorError.fromReason("quote-mismatch"),
+      })
+    );
+    roundTrip(
+      ProviderUnavailable,
+      ProviderUnavailable.make({ message: "Provider unavailable.", offline: true, cacheKey: providerCacheKey })
+    );
+    roundTrip(ProviderCacheCorrupt, ProviderCacheCorrupt.make({ message: "Cache corrupt." }));
+    roundTrip(LedgerFailed, LedgerFailed.make({ message: "Ledger failed.", reason: "conflicting-row" }));
+    roundTrip(GoldUnavailable, GoldUnavailable.make({ message: "Gold unavailable." }));
+    roundTrip(ReportInvalid, ReportInvalid.make({ message: "Report invalid." }));
+  });
+});
+
+describe("document and text refinements", () => {
+  it("accepts matching byte identities and rejects a different sha256", () => {
+    expect(S.is(SourceDocument)(sourceDocument)).toBe(true);
+    expect(rejects(SourceDocument, { ...sourceDocument, sha256: sha("0") })).toBe(true);
+  });
+
+  it("accepts matching chunk receipts and rejects a receipt for another anchor", () => {
+    expect(S.is(Chunk)(chunk)).toBe(true);
+    expect(rejects(Chunk, { ...chunk, receipt: otherReceipt })).toBe(true);
+  });
+
+  it("accepts each claim-body width and rejects each inconsistent width", () => {
+    expect([entityBody, relationBody, structureBody].every(S.is(ClaimBody))).toBe(true);
+    expect(
+      [
+        { ...entityBody, endChar: 5 },
+        { ...relationBody, endChar: 5 },
+        { ...structureBody, endChar: 5 },
+      ].every((body) => rejects(ClaimBody, body))
+    ).toBe(true);
+  });
+});
+
+describe("digest and provider-cache refinements", () => {
+  it("keeps canonical digests stable across key insertion order and supports field omission", () =>
+    Effect.runPromise(
+      provideBunCrypto(
+        Effect.gen(function* () {
+          const Ordered = S.Struct({ a: S.Finite, b: S.Finite });
+          const ReportShape = S.Struct({ a: S.Finite, digest: S.String });
+          const left = yield* contentDigest(Ordered)({ a: 1, b: 2 });
+          const right = yield* contentDigest(Ordered)({ b: 2, a: 1 });
+          const omitted = yield* digestOmitting(ReportShape, "digest")({ a: 1, digest: "left" });
+          const omittedOther = yield* digestOmitting(ReportShape, "digest")({ a: 1, digest: "right" });
+
+          expect(left).toBe(right);
+          expect(omitted).toBe(omittedOther);
+          expect(Result.getOrThrow(contentDigestSync(Ordered)({ b: 2, a: 1 }))).toBe(left);
+          expect(Result.getOrThrow(digestOmittingSync(ReportShape, "digest")({ a: 1, digest: "ignored" }))).toBe(
+            omitted
+          );
+        })
+      )
+    ));
+
+  it("accepts both cache digests and rejects either mismatched digest", () => {
+    expect(S.is(ProviderCacheEntry)(providerEntry)).toBe(true);
+    expect(rejects(ProviderCacheEntry, { ...providerEntry, cacheKey: sha("0") })).toBe(true);
+    expect(rejects(ProviderCacheEntry, { ...providerEntry, responseDigest: sha("0") })).toBe(true);
+  });
+});
+
+describe("evidence refinements", () => {
+  it("accepts a matching claim receipt and rejects a receipt for another anchor", () => {
+    expect(S.is(EvidenceClaim)(evidenceClaim)).toBe(true);
+    expect(rejects(EvidenceClaim, { ...evidenceClaim, receipt: otherReceipt })).toBe(true);
+  });
+
+  it("accepts coherent unique claims and rejects duplicate ids or mismatched batch fields", () => {
+    expect(S.is(EvidenceBatch)(evidenceBatch)).toBe(true);
+    expect(rejects(EvidenceBatch, { ...evidenceBatch, claims: [evidenceClaim, evidenceClaim] })).toBe(true);
+    expect(
+      rejects(EvidenceBatch, {
+        ...evidenceBatch,
+        claims: [{ ...evidenceClaim, document: DocumentId.make(Str.repeat(64)("f")) }],
+      })
+    ).toBe(true);
+    expect(
+      rejects(EvidenceBatch, {
+        ...evidenceBatch,
+        claims: [{ ...evidenceClaim, method: "pattern-wink" }],
+      })
+    ).toBe(true);
+    expect(
+      rejects(EvidenceBatch, {
+        ...evidenceBatch,
+        claims: [{ ...evidenceClaim, model: patternModel }],
+      })
+    ).toBe(true);
+  });
+});
+
+describe("provenance refinements", () => {
+  const body = EventBody.cases.Ingested.make({ kind: "Ingested", document: documentId });
+  const preimage = S.Struct({ prev: S.OptionFromNullOr(ProvenanceEventId), body: EventBody });
+  const prev = Option.none<ProvenanceEventIdValue>();
+  const event = ProvenanceEvent.make({
+    id: ProvenanceEventId.make(Result.getOrThrow(contentDigestSync(preimage)({ prev, body }))),
+    prev,
+    body,
+  });
+
+  it("accepts the timestamp-free hash-chain id and rejects a wrong id", () => {
+    expect(S.is(ProvenanceEvent)(event)).toBe(true);
+    expect(rejects(ProvenanceEvent, { ...event, id: acquired })).toBe(true);
+    roundTrip(ProvenanceEvent, event);
+    expect(Object.hasOwn(S.encodeSync(ProvenanceEvent)(event), "timestamp")).toBe(false);
+  });
+});
+
+describe("gold refinements", () => {
+  it("accepts strict nested subsets and rejects duplicates, non-strict containment, and oversize structure", () => {
+    expect(S.is(GoldSubset)(goldSubset)).toBe(true);
+    expect(
+      rejects(GoldSubset, {
+        structure: [paper1, paper1, paper2],
+        entity: [paper1, paper2],
+        relation: [paper1],
+      })
+    ).toBe(true);
+    expect(
+      rejects(GoldSubset, {
+        structure: [paper1, paper2],
+        entity: [paper1, paper2],
+        relation: [paper1],
+      })
+    ).toBe(true);
+    expect(
+      rejects(GoldSubset, {
+        structure: [
+          "000000000001",
+          "000000000002",
+          "000000000003",
+          "000000000004",
+          "000000000005",
+          "000000000006",
+          "000000000007",
+          "000000000008",
+          "000000000009",
+          "00000000000a",
+          "00000000000b",
+        ],
+        entity: [paper1, paper2],
+        relation: [paper1],
+      })
+    ).toBe(true);
+  });
+
+  it("accepts gold-proposal identities and rejects extraction identities in refs and files", () => {
+    expect(S.is(GoldRef)(goldRef)).toBe(true);
+    expect(rejects(GoldRef, { ...goldRef, proposer: hostedModel })).toBe(true);
+    expect(
+      rejects(GoldFile, {
+        version: "gold/v1",
+        paperId: paper1,
+        subset: "entity",
+        labels: [],
+        proposer: hostedModel,
+      })
+    ).toBe(true);
+  });
+
+  it("accepts anchored gold labels and rejects inconsistent widths in every label family", () => {
+    const shared = {
+      startChar: anchor.startChar,
+      endChar: anchor.endChar,
+      quote: anchor.quote,
+      verified: true,
+    };
+    expect(rejects(GoldStructureLabel, { ...shared, role: "title", depth: NonNegativeInt.make(0) })).toBe(false);
+    expect(rejects(GoldEntityLabel, { ...shared, label: "Effect", entityType: "software" })).toBe(false);
+    expect(rejects(GoldRelationLabel, { ...shared, predicate: "uses", subject: "Effect", object: "Schema" })).toBe(
+      false
+    );
+    expect(rejects(GoldStructureLabel, { ...shared, endChar: 5, role: "title", depth: 0 })).toBe(true);
+    expect(rejects(GoldEntityLabel, { ...shared, endChar: 5, label: "Effect", entityType: "software" })).toBe(true);
+    expect(
+      rejects(GoldRelationLabel, {
+        ...shared,
+        endChar: 5,
+        predicate: "uses",
+        subject: "Effect",
+        object: "Schema",
+      })
+    ).toBe(true);
+  });
+});
+
+describe("evaluation refinements", () => {
+  const runWith = (overrides: Partial<typeof runBody>) => {
+    const body = { ...runBody, ...overrides };
+    return { id: RunId.make(Result.getOrThrow(contentDigestSync(EvalRunBodySchema)(body))), ...body };
+  };
+
+  it("accepts independent extraction and gold providers and rejects every EvalRun invariant", () => {
+    expect(S.is(EvalRun)(evalRun)).toBe(true);
+    const sameFamilyProposer = ModelIdentity.make({ ...proposerModel, provider: "anthropic" });
+    const sameFamilyGold = GoldRef.make({ ...goldRef, proposer: sameFamilyProposer });
+    expect(rejects(EvalRun, runWith({ gold: sameFamilyGold }))).toBe(true);
+
+    const wrongTaskExtractor = ModelIdentity.make({ ...hostedModel, provider: "anthropic", taskType: "gold-proposal" });
+    expect(rejects(EvalRun, runWith({ extractor: wrongTaskExtractor }))).toBe(true);
+    expect(rejects(EvalRun, { ...evalRun, id: RunId.make(Str.repeat(64)("0")) })).toBe(true);
+  });
+
+  it("requires support for scored metrics and allows zero support for unsupported relation metrics", () => {
+    expect(S.is(MetricScore)(A.getUnsafe(metricScores, 0))).toBe(true);
+    expect(
+      rejects(MetricScore, {
+        name: "entity-span-f1",
+        subset: "entity",
+        lane: "hosted",
+        status: "scored",
+        value: 0,
+        support: 0,
+      })
+    ).toBe(true);
+    expect(
+      rejects(MetricScore, {
+        name: "rebel-end-to-end-triple-f1",
+        subset: "relation",
+        lane: "pattern",
+        status: "unsupported",
+        value: 0,
+        support: 0,
+      })
+    ).toBe(false);
+  });
+
+  it("rejects missing or duplicate metric coordinates", () => {
+    const missingMetrics = A.drop(metricScores, 1) as [MetricScore, ...Array<MetricScore>];
+    expect(rejects(EvalReport, withReportDigest({ ...reportBody, metrics: missingMetrics }))).toBe(true);
+
+    const duplicateMetrics = Option.getOrThrow(
+      A.replace(metricScores, A.length(metricScores) - 1, A.getUnsafe(metricScores, 0))
+    ) as [MetricScore, ...Array<MetricScore>];
+    expect(rejects(EvalReport, withReportDigest({ ...reportBody, metrics: duplicateMetrics }))).toBe(true);
+  });
+
+  it("rejects unsupported hosted entries and unsupported undeclared pattern entries", () => {
+    const hostedIndex = A.findFirstIndex(metricScores, (score) => score.lane === "hosted").pipe(Option.getOrThrow);
+    const hostedUnsupported = Option.getOrThrow(
+      A.replace(
+        metricScores,
+        hostedIndex,
+        MetricScore.make({
+          ...A.getUnsafe(metricScores, hostedIndex),
+          status: "unsupported",
+          value: UnitInterval.make(0),
+          support: NonNegativeInt.make(0),
+        })
+      )
+    ) as [MetricScore, ...Array<MetricScore>];
+    expect(rejects(EvalReport, withReportDigest({ ...reportBody, metrics: hostedUnsupported }))).toBe(true);
+
+    const patternEntityIndex = A.findFirstIndex(
+      metricScores,
+      (score) => score.lane === "pattern" && score.subset === "entity"
+    ).pipe(Option.getOrThrow);
+    const undeclaredUnsupported = Option.getOrThrow(
+      A.replace(
+        metricScores,
+        patternEntityIndex,
+        MetricScore.make({
+          ...A.getUnsafe(metricScores, patternEntityIndex),
+          status: "unsupported",
+          value: UnitInterval.make(0),
+          support: NonNegativeInt.make(0),
+        })
+      )
+    ) as [MetricScore, ...Array<MetricScore>];
+    expect(rejects(EvalReport, withReportDigest({ ...reportBody, metrics: undeclaredUnsupported }))).toBe(true);
+  });
+
+  it("rejects wrong degradation arithmetic, failed anchors, and a wrong report digest", () => {
+    expect(rejects(EvalReport, withReportDigest({ ...reportBody, unexpectedDegraded: NonNegativeInt.make(1) }))).toBe(
+      true
+    );
+
+    const failedDocument = DocumentOutcome.make({ ...documentOutcome, anchorsFailed: NonNegativeInt.make(1) });
+    expect(rejects(EvalReport, withReportDigest({ ...reportBody, documents: [failedDocument] }))).toBe(true);
+    expect(rejects(EvalReport, { ...evalReport, reportDigest: sha("0") })).toBe(true);
+  });
+});
+
+describe("F1 degraded-kind subset", () => {
+  it("decodes every fixture degraded kind through the shared C0 DegradedKind", () => {
+    expect(FixtureDegradedKind.Options).toEqual(["invalid-utf8", "truncated", "extraction-failed"]);
+    expect(A.every(FixtureDegradedKind.Options, S.is(DegradedKind))).toBe(true);
+  });
+});

--- a/apps/labs/semantica/tsconfig.json
+++ b/apps/labs/semantica/tsconfig.json
@@ -30,7 +30,16 @@
   },
   "references": [
     {
+      "path": "../../../packages/epistemic/domain/tsconfig.json"
+    },
+    {
+      "path": "../../../packages/foundation/capability/file-processing/tsconfig.json"
+    },
+    {
       "path": "../../../packages/foundation/modeling/identity/tsconfig.json"
+    },
+    {
+      "path": "../../../packages/foundation/modeling/provenance/tsconfig.json"
     },
     {
       "path": "../../../packages/foundation/modeling/schema/tsconfig.json"

--- a/bun.lock
+++ b/bun.lock
@@ -66,7 +66,10 @@
       "name": "@beep/semantica",
       "version": "0.0.0",
       "dependencies": {
+        "@beep/epistemic-domain": "workspace:^",
+        "@beep/file-processing": "workspace:^",
         "@beep/identity": "workspace:^",
+        "@beep/provenance": "workspace:^",
         "@beep/schema": "workspace:^",
         "@effect/platform-bun": "catalog:",
         "@noble/hashes": "catalog:",

--- a/explorations/semantica-lab/research/OPPORTUNITIES.md
+++ b/explorations/semantica-lab/research/OPPORTUNITIES.md
@@ -69,6 +69,14 @@ ratifies.
 
 ## Friction receipts
 
+- **2026-08-25 — C0 schema verification reproduced two managed-sandbox Bun failures.** `bun install`
+  failed immediately with `EROFS accessing temporary directory`; setting `BUN_TMPDIR=/tmp` did
+  not change the result, so the lockfile could not be refreshed. The exact app proof then reached
+  `bunx --bun vitest run` but produced no worker results until interrupted; the authorized fallback
+  `node ../../../node_modules/vitest/vitest.mjs run` completed all 40 tests. Prevention: provide Bun
+  a writable effective temp/cache root in managed sessions and route lab Vitest scripts through the
+  direct Node entrypoint when Bun worker startup is known to hang.
+
 - **2026-08-25 — Git `text=auto` silently rewrote a byte-exact fixture at commit time.** The
   root `.gitattributes` normalizes every auto-detected text file, so the committed blob of the
   CRLF span-fidelity specimen `md-unicode.md` lost its `\r` bytes (sha `886330…` in the index

--- a/goals/semantica-canary/research/c0-design.md
+++ b/goals/semantica-canary/research/c0-design.md
@@ -144,7 +144,7 @@ resolution in lab code).
   `empty-text-layer`, `extraction` → `extraction-failed`, `input-limit` → `input-limit`); the
   engine boundary folds those reasons into `file-extraction-failed`, so if the translation drops
   the original reason the lab adds it to that translation in `@beep/doc-text` as cleanup-on-touch
-  (O1) before the slice — the lab never classifies by message text (**open item O-5**). An
+  (O1) before the slice — the lab never classifies by message text (**O-5, closed: the boundary keeps it**). An
   observed kind that differs from the declared one is a failed assertion, never a reason to edit
   the index.
 - Hosted lane in CI: only F1 is replayable there — its recorded `ProviderCache` entries are
@@ -157,12 +157,23 @@ resolution in lab code).
 
 ## 7. Open items (must close before the slice PR)
 
-- **O-1** `MetricName`: mine upstream #574 (T3) for the metric names; until then the LiteralKit is
-  `["structure-f1","entity-f1","relation-f1","span-fidelity"]` and the doc says so.
+- **O-1 (closed 2026-08-26)** `MetricName` = the #574 names the law table adopts
+  (`DECISIONS.md` ~414: `entity-span-f1`, `rebel-end-to-end-triple-f1`, `pairwise-f1`, `b-cubed`)
+  plus one lab-local name, `structure-span-f1` (span F1 over G-structure anchors, the entity-span
+  definition applied to structure labels), because #574 scores no document structure and S7
+  requires G-structure to be scored. `RequiredMetrics(c0)` = ten coordinates: structure-span-f1 /
+  structure, entity-span-f1 / entity, pairwise-f1 / entity, b-cubed / entity,
+  rebel-end-to-end-triple-f1 / relation, each for both lanes; the pattern lane may be
+  `unsupported` for structure and relation (its declared losses), every hosted coordinate is
+  `scored`. Span fidelity is not a metric: `anchorsFailed === 0` is a report refinement.
 - **O-2** Pattern-lane targets: the Wink custom-entity patterns used for persons/orgs/methods (pinned
   into `ModelIdentity.artifactHash` for the `wink` family).
 - **O-3** Ledger DDL v1 and the `LedgerSnapshot` read model (kept minimal: what `Evaluator` needs).
-- **O-5** Confirm whether `FileProcessingOperationError` preserves the `DocTextError.reason`; if not, the
-  cleanup-on-touch translation change lands in `@beep/doc-text` (its own PR, O1) before the slice.
+- **O-5 (closed 2026-08-26)** The boundary keeps what the mapping needs: `@beep/doc-text` translates
+  `empty-text-layer` to `file-extraction-failed` with `details.outcome === "empty-text-layer"`,
+  `input-limit` to reason `output-limit-exceeded`, and everything else to `file-extraction-failed`
+  without details. `ParserLive` therefore maps `reason === "output-limit-exceeded"` → `input-limit`,
+  `details.outcome === "empty-text-layer"` → `empty-text-layer`, otherwise → `extraction-failed`.
+  No cleanup-on-touch change is required.
 - **O-4** Hosted request budget for the slice (one LangExtract call per chunk vs per document) — start
   per document, chunks carried as `RawTextChunk`s; measure in `EvalRunTelemetry`.

--- a/standards/fallow.boundaries.generated.jsonc
+++ b/standards/fallow.boundaries.generated.jsonc
@@ -3124,12 +3124,18 @@
       {
         "from": "@beep/semantica",
         "allow": [
+          "@beep/epistemic-domain",
+          "@beep/file-processing",
           "@beep/identity",
+          "@beep/provenance",
           "@beep/schema",
           "@beep/semantica"
         ],
         "allowTypeOnly": [
+          "@beep/epistemic-domain",
+          "@beep/file-processing",
           "@beep/identity",
+          "@beep/provenance",
           "@beep/schema",
           "@beep/semantica"
         ]


### PR DESCRIPTION
## feat(semantica): define the c0 lab-local schemas (P2 PR A)

goals/semantica-canary P2, schema-first: ids, digests, media type, documents, degraded kinds,
parse/extract outcomes, chunks, ModelIdentity, provider-cache key/entry, evidence claims and
batches, timestamp-free provenance events, gold refs and label files, EvalRun/EvalReport with
the S2 refinement and the complete-metric-set law, the telemetry sidecar, and typed errors -
no services or Layers yet. Closes design open items O-1 (metric names from #574 plus the
lab-local structure-span-f1) and O-5 (doc-text keeps the degraded reason in details.outcome).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019SSLmyhoBWv8cFCV3aub4B

## chore(semantica): merge origin/main into feat/semantica-c0-schemas


## chore(semantica): sync the lab tsconfig references for the schema dependencies

## Local proof

- fallow-advisory-feedback: passed
- publish:head-install-preflight: passed
- full:pre-push: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/feat_semantica-c0-schemas-c967a8ed8aca/verdict.json

---

## Provenance

- Branch: <code>feat/semantica-c0-schemas</code>
- Harness: `codex`

<!-- yeet-provenance
{
  "schemaVersion": 1,
  "branch": "feat/semantica-c0-schemas",
  "harness": "codex"
}
-->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790311567&installation_model_id=424656&pr_number=832&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F832&signature=e38328de9d417e82c3b0682337b15b131e02c5426fee09eedfa793f4e4dd3fba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->