### PR TITLE
fix(repo-cli): serialize TS2589 quarantine reruns

### DIFF
--- a/.changeset/serial-ts2589-quarantine.md
+++ b/.changeset/serial-ts2589-quarantine.md
@@ -1,0 +1,7 @@
+---
+"@beep/repo-cli": patch
+---
+
+Run TS2589 quarantine package and lane recovery at Turbo concurrency one so the
+recovery proof does not reintroduce the same concurrent compiler pressure across
+the remaining packages.

--- a/packages/tooling/tool/cli/src/commands/Docgen/Doctest.errors.ts
+++ b/packages/tooling/tool/cli/src/commands/Docgen/Doctest.errors.ts
@@ -1,3 +1,10 @@
+/**
+ * Error models for Docgen doctest analysis and source rewriting.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
 import { $RepoCliId } from "@beep/identity/packages";
 import * as S from "effect/Schema";
 

--- a/packages/tooling/tool/cli/src/commands/Docgen/Doctest.schemas.ts
+++ b/packages/tooling/tool/cli/src/commands/Docgen/Doctest.schemas.ts
@@ -1,3 +1,10 @@
+/**
+ * Schema models for Docgen doctest discovery, assertion marking, and reports.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
 import { $RepoCliId } from "@beep/identity/packages";
 import { LiteralKit } from "@beep/schema";
 import * as S from "effect/Schema";

--- a/packages/tooling/tool/cli/src/commands/Docgen/Doctest.service.ts
+++ b/packages/tooling/tool/cli/src/commands/Docgen/Doctest.service.ts
@@ -1,3 +1,10 @@
+/**
+ * Effect service contracts for Docgen doctest analysis and source rewriting.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
 import { $RepoCliId } from "@beep/identity/packages";
 import { Context } from "effect";
 import type { Effect } from "effect";

--- a/packages/tooling/tool/cli/src/commands/Quality/internal/FlakeQuarantine.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/internal/FlakeQuarantine.ts
@@ -377,15 +377,17 @@ export const detectNoLocationTs2589Flake = (output: string): O.Option<A.NonEmpty
 const TURBO_CONCURRENCY_FLAG = "--concurrency";
 const SERIAL_TURBO_CONCURRENCY_ARG = "--concurrency=1";
 
-const acceptsDirectTurboOptions = (step: QualityTaskStep): boolean =>
-  (step.command === "bunx" &&
-    A.get(step.args, 0).pipe(O.contains("turbo")) &&
-    A.get(step.args, 1).pipe(O.contains("run"))) ||
-  (step.command === "bun" &&
-    A.get(step.args, 0).pipe(O.contains("run")) &&
-    A.get(step.args, 1).pipe(O.contains("beep")) &&
-    A.get(step.args, 2).pipe(O.contains("ci")) &&
-    A.get(step.args, 3).pipe(O.contains("lane")));
+const isDirectTurboRun = (step: QualityTaskStep): boolean =>
+  step.command === "bunx" &&
+  A.get(step.args, 0).pipe(O.contains("turbo")) &&
+  A.get(step.args, 1).pipe(O.contains("run"));
+
+const isNestedCiLane = (step: QualityTaskStep): boolean =>
+  step.command === "bun" &&
+  A.get(step.args, 0).pipe(O.contains("run")) &&
+  A.get(step.args, 1).pipe(O.contains("beep")) &&
+  A.get(step.args, 2).pipe(O.contains("ci")) &&
+  A.get(step.args, 3).pipe(O.contains("lane"));
 
 const withoutTurboConcurrencyArgs = (args: ReadonlyArray<string>): ReadonlyArray<string> =>
   A.filter(
@@ -398,10 +400,11 @@ const withoutTurboConcurrencyArgs = (args: ReadonlyArray<string>): ReadonlyArray
 
 const serialTurboRerunArgs = (step: QualityTaskStep, trailingOptions: ReadonlyArray<string>): ReadonlyArray<string> => {
   const args = withoutTurboConcurrencyArgs(step.args);
+  if (isNestedCiLane(step)) {
+    return [...args, ...trailingOptions];
+  }
   const options = [SERIAL_TURBO_CONCURRENCY_ARG, ...trailingOptions];
-  return acceptsDirectTurboOptions(step) || A.contains(args, "--")
-    ? [...args, ...options]
-    : [...args, "--", ...options];
+  return isDirectTurboRun(step) || A.contains(args, "--") ? [...args, ...options] : [...args, "--", ...options];
 };
 
 /**
@@ -409,12 +412,15 @@ const serialTurboRerunArgs = (step: QualityTaskStep, trailingOptions: ReadonlyAr
  *
  * **Details**
  *
- * Pins Turbo concurrency to one, appends an explicit package filter, and
- * preserves the lane's environment verbatim. Direct `bunx turbo run` commands
- * and nested `bun run beep ci lane` commands receive the options directly;
- * other Bun scripts receive them after `--`. Serial execution removes the
- * checker scheduling pressure that produced the no-location TS2589 before the
- * rerun is used as environmental attribution. Preserving an inherited
+ * Pins direct Turbo and root-script commands to concurrency one, appends an
+ * explicit package filter, and preserves the lane's environment verbatim.
+ * Direct `bunx turbo run` commands receive the options directly, while other
+ * Bun scripts receive them after `--`. Nested `bun run beep ci lane` commands
+ * accept the package filter but retain the selected lane's owned concurrency
+ * policy; passing a Turbo-only concurrency flag to the outer CLI would be
+ * rejected before its inner step starts. Serial execution removes the checker
+ * scheduling pressure that produced the no-location TS2589 before the rerun is
+ * used as environmental attribution. Preserving an inherited
  * `TURBO_FORCE=true` is deliberate: under a forced sweep an older successful
  * cache entry can exist at the failed task's unchanged hash, and a cache-reading
  * rerun would replay it without invoking the compiler — a vacuous green.
@@ -459,12 +465,13 @@ export const standaloneQuarantineRerunStep: {
  *
  * **Details**
  *
- * Reruns the lane with Turbo concurrency pinned to one, the quarantine policy
- * stripped (no recursive quarantine), and `TURBO_FORCE` removed. Tasks proven
- * green in the failed run replay from that run's cache, while tasks Turbo
- * skipped after the flake execute serially. This keeps the recovery proof
- * bounded without exposing the remaining packages to the concurrent compiler
- * scheduling that caused the flake.
+ * Reruns direct Turbo and root-script lanes with Turbo concurrency pinned to
+ * one, the quarantine policy stripped (no recursive quarantine), and
+ * `TURBO_FORCE` removed. A nested CI lane retains its internally owned
+ * concurrency policy. Tasks proven green in the failed run replay from that
+ * run's cache, while tasks Turbo skipped after the flake execute under the
+ * lane's bounded policy. This keeps the recovery proof bounded without
+ * reintroducing the concurrent compiler pressure that caused the flake.
  *
  * **Example** (Build lane rerun step)
  *

--- a/packages/tooling/tool/cli/src/commands/Quality/internal/FlakeQuarantine.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/internal/FlakeQuarantine.ts
@@ -33,6 +33,7 @@
 import { $RepoCliId } from "@beep/identity/packages";
 import { pipe } from "effect";
 import * as A from "effect/Array";
+import * as Eq from "effect/Equal";
 import { dual } from "effect/Function";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
@@ -373,15 +374,47 @@ export const detectNoLocationTs2589Flake = (output: string): O.Option<A.NonEmpty
   );
 };
 
+const TURBO_CONCURRENCY_FLAG = "--concurrency";
+const SERIAL_TURBO_CONCURRENCY_ARG = "--concurrency=1";
+
+const acceptsDirectTurboOptions = (step: QualityTaskStep): boolean =>
+  (step.command === "bunx" &&
+    A.get(step.args, 0).pipe(O.contains("turbo")) &&
+    A.get(step.args, 1).pipe(O.contains("run"))) ||
+  (step.command === "bun" &&
+    A.get(step.args, 0).pipe(O.contains("run")) &&
+    A.get(step.args, 1).pipe(O.contains("beep")) &&
+    A.get(step.args, 2).pipe(O.contains("ci")) &&
+    A.get(step.args, 3).pipe(O.contains("lane")));
+
+const withoutTurboConcurrencyArgs = (args: ReadonlyArray<string>): ReadonlyArray<string> =>
+  A.filter(
+    args,
+    (arg, index) =>
+      !Eq.equals(arg, TURBO_CONCURRENCY_FLAG) &&
+      !Str.startsWith(`${TURBO_CONCURRENCY_FLAG}=`)(arg) &&
+      !A.get(args, index - 1).pipe(O.contains(TURBO_CONCURRENCY_FLAG))
+  );
+
+const serialTurboRerunArgs = (step: QualityTaskStep, trailingOptions: ReadonlyArray<string>): ReadonlyArray<string> => {
+  const args = withoutTurboConcurrencyArgs(step.args);
+  const options = [SERIAL_TURBO_CONCURRENCY_ARG, ...trailingOptions];
+  return acceptsDirectTurboOptions(step) || A.contains(args, "--")
+    ? [...args, ...options]
+    : [...args, "--", ...options];
+};
+
 /**
  * Build the standalone rerun step for one quarantined Turbo task.
  *
  * **Details**
  *
- * Appends an explicit package filter and preserves the lane's environment
- * verbatim. Direct `bunx turbo run` commands and nested `bun run beep ci lane`
- * commands receive the filter as an option; other Bun scripts receive it after
- * `--`. Preserving an inherited
+ * Pins Turbo concurrency to one, appends an explicit package filter, and
+ * preserves the lane's environment verbatim. Direct `bunx turbo run` commands
+ * and nested `bun run beep ci lane` commands receive the options directly;
+ * other Bun scripts receive them after `--`. Serial execution removes the
+ * checker scheduling pressure that produced the no-location TS2589 before the
+ * rerun is used as environmental attribution. Preserving an inherited
  * `TURBO_FORCE=true` is deliberate: under a forced sweep an older successful
  * cache entry can exist at the failed task's unchanged hash, and a cache-reading
  * rerun would replay it without invoking the compiler — a vacuous green.
@@ -408,39 +441,30 @@ export const detectNoLocationTs2589Flake = (output: string): O.Option<A.NonEmpty
 export const standaloneQuarantineRerunStep: {
   (task: FlakeQuarantineTask): (step: QualityTaskStep) => QualityTaskStep;
   (step: QualityTaskStep, task: FlakeQuarantineTask): QualityTaskStep;
-} = dual(2, (step: QualityTaskStep, task: FlakeQuarantineTask): QualityTaskStep => {
-  const directTurboRun =
-    step.command === "bunx" &&
-    A.get(step.args, 0).pipe(O.contains("turbo")) &&
-    A.get(step.args, 1).pipe(O.contains("run"));
-  const nestedBeepCiLane =
-    step.command === "bun" &&
-    A.get(step.args, 0).pipe(O.contains("run")) &&
-    A.get(step.args, 1).pipe(O.contains("beep")) &&
-    A.get(step.args, 2).pipe(O.contains("ci")) &&
-    A.get(step.args, 3).pipe(O.contains("lane"));
-  return QualityTaskStep.make({
-    label: `${step.label}:flake-rerun:${task.packageName}`,
-    command: step.command,
-    args:
-      directTurboRun || nestedBeepCiLane
-        ? [...step.args, `--filter=${task.packageName}`]
-        : [...step.args, "--", `--filter=${task.packageName}`],
-    cwd: step.cwd,
-    ...optionalProp("env", O.fromUndefinedOr(step.env)),
-    ...optionalProp("useLocalEnv", O.fromUndefinedOr(step.useLocalEnv)),
-  });
-});
+} = dual(
+  2,
+  (step: QualityTaskStep, task: FlakeQuarantineTask): QualityTaskStep =>
+    QualityTaskStep.make({
+      label: `${step.label}:flake-rerun:${task.packageName}`,
+      command: step.command,
+      args: serialTurboRerunArgs(step, [`--filter=${task.packageName}`]),
+      cwd: step.cwd,
+      ...optionalProp("env", O.fromUndefinedOr(step.env)),
+      ...optionalProp("useLocalEnv", O.fromUndefinedOr(step.useLocalEnv)),
+    })
+);
 
 /**
  * Build the full lane rerun step that arbitrates a quarantine attempt.
  *
  * **Details**
  *
- * Reruns the identical lane with the quarantine policy stripped (no recursive
- * quarantine) and `TURBO_FORCE` removed so tasks proven green in the failed
- * run replay from the cache that run wrote, while tasks Turbo skipped after
- * the flake actually execute.
+ * Reruns the lane with Turbo concurrency pinned to one, the quarantine policy
+ * stripped (no recursive quarantine), and `TURBO_FORCE` removed. Tasks proven
+ * green in the failed run replay from that run's cache, while tasks Turbo
+ * skipped after the flake execute serially. This keeps the recovery proof
+ * bounded without exposing the remaining packages to the concurrent compiler
+ * scheduling that caused the flake.
  *
  * **Example** (Build lane rerun step)
  *
@@ -460,7 +484,7 @@ export const laneQuarantineRerunStep = (step: QualityTaskStep): QualityTaskStep 
   QualityTaskStep.make({
     label: `${step.label}:flake-lane-rerun`,
     command: step.command,
-    args: step.args,
+    args: serialTurboRerunArgs(step, A.empty()),
     cwd: step.cwd,
     env: { ...(step.env ?? {}), TURBO_FORCE: undefined },
     ...optionalProp("useLocalEnv", O.fromUndefinedOr(step.useLocalEnv)),

--- a/packages/tooling/tool/cli/test/flake-quarantine.test.ts
+++ b/packages/tooling/tool/cli/test/flake-quarantine.test.ts
@@ -160,7 +160,7 @@ describe("quarantine rerun steps", () => {
     expect(rerun.useLocalEnv).toBe(true);
   });
 
-  it("passes the package filter to a nested beep CI lane instead of its child passthrough", () => {
+  it("passes only the supported package filter to a nested beep CI lane", () => {
     const nestedCiLane = QualityTaskStep.make({
       label: "quality:check",
       command: "bun",
@@ -180,10 +180,24 @@ describe("quarantine rerun steps", () => {
       "--base",
       "origin/main",
       "--summarize",
-      "--concurrency=1",
       "--filter=@beep/box",
     ]);
+    expect(rerun.args).not.toContain("--concurrency=1");
     expect(rerun.args).not.toContain("--");
+  });
+
+  it("retains a nested CI lane's owned concurrency policy for its full rerun", () => {
+    const nestedCiLane = QualityTaskStep.make({
+      label: "quality:check",
+      command: "bun",
+      args: ["run", "beep", "ci", "lane", "check", "--affected", "--base", "origin/main", "--summarize"],
+      cwd: "/repo",
+      flakeQuarantine: "ts2589-no-location",
+    });
+    const rerun = laneQuarantineRerunStep(nestedCiLane);
+
+    expect(rerun.args).toEqual(nestedCiLane.args);
+    expect(rerun.args).not.toContain("--concurrency=1");
   });
 
   it("keeps an inherited TURBO_FORCE on the standalone rerun so cache replay cannot green it", () => {

--- a/packages/tooling/tool/cli/test/flake-quarantine.test.ts
+++ b/packages/tooling/tool/cli/test/flake-quarantine.test.ts
@@ -139,7 +139,7 @@ describe("quarantine rerun steps", () => {
   it("builds the standalone package rerun with the lane environment preserved", () => {
     const rerun = standaloneQuarantineRerunStep(laneStep, task);
     expect(rerun.label).toBe("quality:build:flake-rerun:@beep/box");
-    expect(rerun.args).toEqual(["run", "build", "--", "--filter=@beep/box"]);
+    expect(rerun.args).toEqual(["run", "build", "--", "--concurrency=1", "--filter=@beep/box"]);
     expect(rerun.cwd).toBe("/repo");
     expect(rerun.env).toBeUndefined();
     expect(rerun.flakeQuarantine).toBeUndefined();
@@ -156,7 +156,7 @@ describe("quarantine rerun steps", () => {
     });
     const rerun = standaloneQuarantineRerunStep(directTurboLane, task);
 
-    expect(rerun.args).toEqual(["turbo", "run", "build", "--concurrency=3", "--filter=@beep/box"]);
+    expect(rerun.args).toEqual(["turbo", "run", "build", "--concurrency=1", "--filter=@beep/box"]);
     expect(rerun.useLocalEnv).toBe(true);
   });
 
@@ -180,6 +180,7 @@ describe("quarantine rerun steps", () => {
       "--base",
       "origin/main",
       "--summarize",
+      "--concurrency=1",
       "--filter=@beep/box",
     ]);
     expect(rerun.args).not.toContain("--");
@@ -191,10 +192,10 @@ describe("quarantine rerun steps", () => {
     expect(rerun.env).toEqual({ TURBO_FORCE: "true" });
   });
 
-  it("builds the lane rerun with the policy stripped and TURBO_FORCE removed for cache resume", () => {
+  it("builds a serial lane rerun with the policy stripped and TURBO_FORCE removed for cache resume", () => {
     const rerun = laneQuarantineRerunStep(laneStep);
     expect(rerun.label).toBe("quality:build:flake-lane-rerun");
-    expect(rerun.args).toEqual(["run", "build"]);
+    expect(rerun.args).toEqual(["run", "build", "--", "--concurrency=1"]);
     expect(rerun.env).toEqual({ TURBO_FORCE: undefined });
     expect(rerun.flakeQuarantine).toBeUndefined();
   });
@@ -203,6 +204,18 @@ describe("quarantine rerun steps", () => {
     const rerun = laneQuarantineRerunStep(QualityTaskStep.make({ ...laneStep, useLocalEnv: true }));
 
     expect(rerun.useLocalEnv).toBe(true);
+  });
+
+  it("replaces split-form Turbo concurrency without leaving its value behind", () => {
+    const rerun = laneQuarantineRerunStep(
+      QualityTaskStep.make({
+        ...laneStep,
+        command: "bunx",
+        args: ["turbo", "run", "build", "--concurrency", "8", "--force"],
+      })
+    );
+
+    expect(rerun.args).toEqual(["turbo", "run", "build", "--force", "--concurrency=1"]);
   });
 });
 


### PR DESCRIPTION
## fix(repo-cli): serialize TS2589 quarantine reruns

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/fix_ts2589-serial-quarantine-31c912a869f2/verdict.json

---

## Provenance

- Branch: <code>fix/ts2589-serial-quarantine</code>
- Harness: `codex`

<!-- yeet-provenance
{
  "schemaVersion": 1,
  "branch": "fix/ts2589-serial-quarantine",
  "harness": "codex"
}
-->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790315812&installation_model_id=424656&pr_number=834&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F834&signature=0b8e5bb44d5a216d2867c7f618bf453c23cd0163c1b6328160901740a55ff625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->