### PR TITLE
docs(explorations): ratify the lejeune-bolt align round and move the packet to shape

### DIFF
--- a/explorations/ATLAS.md
+++ b/explorations/ATLAS.md
@@ -39,18 +39,15 @@ The lego pieces already built. Authoritative inventories (link, never copy):
 
 ### Active
 
-- [`lejeune-bolt-agentic-demo`](./lejeune-bolt-agentic-demo/README.md) — align
-  (2026-08-25): lunch pitch next week to LeJeune Bolt (Burnsville MN structural
+- [`lejeune-bolt-agentic-demo`](./lejeune-bolt-agentic-demo/README.md) — shape
+  (2026-08-26): lunch pitch next week to LeJeune Bolt (Burnsville MN structural
   fastener distributor; stadium/bridge/TNA work) whose veterans are retiring.
   Six research lanes synthesized; operator-ratified thesis: Option C — a
-  disposable the proposed `lejeune-bolt-workbench` lab (under `apps/labs/`) ("LeJeune Knowledge Desk")
-  composing beep bricks, deployed to the tailnet only, running a fixed 30-minute
-  scenario over the public site corpus + synthetic Office records. Top three
-  use cases: RFQ email → reviewed quote request with exact spans; cited
-  specification clarification (advisory, drafts RFI); veteran temporal memory
-  (reviewed claims with validity/supersession). Approval-gated PO draft is the
-  closing beat; service-as-software pilot is the ask. 11 PROPOSED align
-  questions await Benjamin's grill.
+  disposable version of the proposed `lejeune-bolt-workbench` lab (under `apps/labs/`), working
+  title "LeJeune Knowledge Desk," composing beep bricks, deployed to the tailnet only, and
+  running a fixed 30-minute scenario over the public site corpus plus synthetic Office records.
+  Align completed with Benjamin. Next: should we graduate this exploration to a `goals/` packet
+  and build the lab within the five-day appetite?
 - [`protocol-as-value`](./protocol-as-value/README.md) — shape
   (2026-08-23): Mepuka-thread synthesis packet. Research: novelty claim
   (digest-named global protocol type + projections + journal-audited

--- a/explorations/ATLAS.md
+++ b/explorations/ATLAS.md
@@ -46,8 +46,8 @@ The lego pieces already built. Authoritative inventories (link, never copy):
   disposable version of the proposed `lejeune-bolt-workbench` lab (under `apps/labs/`), working
   title "LeJeune Knowledge Desk," composing beep bricks, deployed to the tailnet only, and
   running a fixed 30-minute scenario over the public site corpus plus synthetic Office records.
-  Align completed with Benjamin. Next: should we graduate this exploration to a `goals/` packet
-  and build the lab within the five-day appetite?
+  Align completed with Benjamin (17 decisions ratified). Next: shape review of the brief;
+  graduation follows decompose.
 - [`protocol-as-value`](./protocol-as-value/README.md) — shape
   (2026-08-23): Mepuka-thread synthesis packet. Research: novelty claim
   (digest-named global protocol type + projections + journal-audited

--- a/explorations/lejeune-bolt-agentic-demo/BRIEF.md
+++ b/explorations/lejeune-bolt-agentic-demo/BRIEF.md
@@ -1,6 +1,6 @@
 # LeJeune Knowledge Desk brief
 
-**DRAFT — pending Benjamin's align round**
+**DRAFT — ready for shape review**
 
 ## Problem
 

--- a/explorations/lejeune-bolt-agentic-demo/DECISIONS.md
+++ b/explorations/lejeune-bolt-agentic-demo/DECISIONS.md
@@ -2,15 +2,13 @@
 
 Date: 2026-08-25
 
-Benjamin was unavailable for the align round. The operator-ratified entries below are pinned,
-but still await Benjamin's confirmation. Every other entry is a recommendation, not a settled
-decision.
+Benjamin completed the align round on 2026-08-26. Every entry below is ratified.
 
-## Ratified by operator, pending Benjamin's confirmation
+## Ratified by operator and confirmed by Benjamin
 
 ### 2026-08-25 — Demo architecture
 
-**Status:** ratified by operator, pending Benjamin's confirmation
+**Status:** ratified 2026-08-25; confirmed by Benjamin 2026-08-26
 
 **Question:** Which demo architecture should carry the lunch scenario?
 
@@ -29,7 +27,7 @@ Semantica's ingest, extract, and serve commands still stop at `StageNotImplement
 
 ### 2026-08-25 — Lunch use cases and closing beat
 
-**Status:** ratified by operator, pending Benjamin's confirmation
+**Status:** ratified 2026-08-25; confirmed by Benjamin 2026-08-26
 
 **Question:** Which use cases define the lunch story?
 
@@ -49,7 +47,7 @@ candidates, not part of the lunch promise.
 
 ### 2026-08-25 — Deployment boundary
 
-**Status:** ratified by operator, pending Benjamin's confirmation
+**Status:** ratified 2026-08-25; confirmed by Benjamin 2026-08-26
 
 **Question:** Where should the lunch build run?
 
@@ -66,7 +64,7 @@ endpoint and a cloud-only runtime are rejected.
 
 ### 2026-08-25 — Lunch data boundary
 
-**Status:** ratified by operator, pending Benjamin's confirmation
+**Status:** ratified 2026-08-25; confirmed by Benjamin 2026-08-26
 
 **Question:** What data may the lunch demo use?
 
@@ -85,7 +83,7 @@ scraped supplier data are rejected for this demo.
 
 ### 2026-08-25 — Engagement framing
 
-**Status:** ratified by operator, pending Benjamin's confirmation
+**Status:** ratified 2026-08-25; confirmed by Benjamin 2026-08-26
 
 **Question:** What commercial story should the demo support?
 
@@ -102,7 +100,7 @@ consulting pitch, and claim of a finished SaaS product are rejected.
 
 ### 2026-08-25 — Appetite and definition of done
 
-**Status:** ratified by operator, pending Benjamin's confirmation
+**Status:** ratified 2026-08-25; confirmed by Benjamin 2026-08-26
 
 **Question:** How much work is authorized before lunch?
 
@@ -117,16 +115,16 @@ ontology in five days. Those options are rejected from the lunch scope.
 [recommended five-day cut](./research/04-in-repo-capability-inventory.md#recommended-five-day-cut),
 [Option C recommendation](./research/08-demo-options.md#recommendation).
 
-## Proposed for Benjamin's align round
+## Ratified in Benjamin's 2026-08-26 align round
 
 ### 2026-08-25 — License the TypeScript port for component reuse?
 
-**Status:** PROPOSED
+**Status:** RATIFIED 2026-08-26 (align round)
 
 **Question:** License the TypeScript port under MIT or Apache-2.0 so its workbench components can
 be reused?
 
-**Recommended answer:** Yes. Prefer Apache-2.0 to match the relevant upstream TrustGraph
+**Answer:** Yes. Prefer Apache-2.0 to match the relevant upstream TrustGraph
 repositories and retain the license and attribution record at the port root.
 
 **Reasoning:** The port has useful workbench routes, but its root license is unverified. Until
@@ -139,11 +137,11 @@ dependency; leaving the license absent and treating the port as reusable.
 
 ### 2026-08-25 — Confirm the lab slug and working product name?
 
-**Status:** PROPOSED
+**Status:** RATIFIED 2026-08-26 (align round)
 
 **Question:** Confirm the proposed `lejeune-bolt-workbench` lab (under `apps/labs/`) and "LeJeune Knowledge Desk"?
 
-**Recommended answer:** Yes. Keep the package slug descriptive and disposable. Use the product
+**Answer:** Yes. Keep the package slug descriptive and disposable. Use the product
 name only on the demo surface, with beep branding and no copied third-party marks.
 
 **Reasoning:** A small branded app keeps the RFQ, evidence, graph, review, and memory change on
@@ -155,11 +153,11 @@ a production LeJeune product; carrying TrustGraph marks into the demo.
 
 ### 2026-08-25 — Which two RFQ layouts should the demo fix?
 
-**Status:** PROPOSED
+**Status:** RATIFIED 2026-08-26 (align round)
 
 **Question:** Which two RFQ layouts should the deterministic fixture set support?
 
-**Recommended answer:** Fix one Outlook body table with an attached Excel takeoff, and one prose
+**Answer:** Fix one Outlook body table with an attached Excel takeoff, and one prose
 email with an attached PDF schedule. Both should split relevant facts across messages and leave
 at least one field missing.
 
@@ -174,12 +172,12 @@ layouts in the first slice; OCR-heavy drawings in the lunch path.
 
 ### 2026-08-25 — Ask for one anonymized RFQ before lunch?
 
-**Status:** PROPOSED
+**Status:** RATIFIED 2026-08-26 (align round)
 
 **Question:** Should Benjamin ask the LeJeune sales and logistics contact for one anonymized real
 RFQ before lunch?
 
-**Recommended answer:** Yes, with explicit permission, only to check whether the two synthetic
+**Answer:** Yes, with explicit permission, only to check whether the two synthetic
 layouts feel real. Keep it outside the repo and the lunch bundle. The demo remains public plus
 synthetic even if the sample arrives.
 
@@ -193,13 +191,14 @@ asking for a mailbox export before consent and pilot terms exist.
 
 ### 2026-08-25 — Which model-provider posture should the demo use?
 
-**Status:** PROPOSED
+**Status:** RATIFIED 2026-08-26 (align round)
 
 **Question:** Should the demo use a local model, a hosted provider, or both?
 
-**Recommended answer:** Use an already configured hosted provider for extraction and reasoning
-over public and synthetic content. Keep a fixed local replay of successful outputs as the fully
-offline fallback.
+**Answer:** Use the already API-key-wired `@beep/anthropic` hosted driver for extraction and
+reasoning over public and synthetic content. If it fails proving, keep the `openai-compat`,
+`venice-ai`, and `xai` drivers as fallback candidates. Keep a fixed local replay of successful
+outputs as the fully offline fallback.
 
 **Reasoning:** Hosted providers are allowed for this data boundary. The repo has several model
 adapters, but lane 04 did not verify a live provider. Local-only inference would add hardware and
@@ -213,14 +212,16 @@ LeJeune correspondence; a demo that fails when the provider is unavailable.
 
 ### 2026-08-25 — Freeze which ontology and rule-check slice?
 
-**Status:** PROPOSED
+**Status:** RATIFIED 2026-08-26 (align round)
 
 **Question:** What ontology and specification rules should freeze on day one?
 
-**Recommended answer:** Use the 12 shared-contract classes: `ProductVariant`, `Component`,
+**Answer:** Use the 12 shared-contract classes: `ProductVariant`, `Component`,
 `Standard`, `Finish`, `Tool`, `SupplierOffer`, `Project`, `RFQ`, `QuoteLine`, `LotCertificate`,
 `Approval`, and `ExpertClaim`. Fix three rule checks: matched assemblies, DTI strength matching,
-and the A490 hot-dip-galvanizing refusal.
+and the A490 hot-dip-galvanizing refusal. Keep the twelve class schemas and three rule checks
+lab-local in the proposed `lejeune-bolt-workbench` lab (under `apps/labs/`) until an explicit
+shared promotion. Nothing is promoted to shared or foundation now.
 
 **Reasoning:** These classes cover the 30-minute scenario. The three rules create visible,
 cited refusals without pretending to encode complete ASTM, RCSC, or AISC practice.
@@ -232,11 +233,11 @@ rules that cannot open a governing source and revision.
 
 ### 2026-08-25 — What deletion date governs the lab and corpus?
 
-**Status:** PROPOSED
+**Status:** RATIFIED 2026-08-26 (align round)
 
 **Question:** What date should trigger lab disposition and demo-corpus deletion?
 
-**Recommended answer:** Set 2026-09-30 as the delete-or-promote review date. Delete the mutable
+**Answer:** Set 2026-09-30 as the delete-or-promote review date. Delete the mutable
 demo corpus then unless a consented pilot authorizes a new retention term. Keep authored packet
 history and source ledgers.
 
@@ -250,11 +251,11 @@ pilot without a new authorization.
 
 ### 2026-08-25 — Who reviews veteran-memory claims in a pilot?
 
-**Status:** PROPOSED
+**Status:** RATIFIED 2026-08-26 (align round)
 
 **Question:** Which roles should adjudicate a veteran correction before the system reuses it?
 
-**Recommended answer:** Require the source veteran, an active successor, and the appropriate
+**Answer:** Require the source veteran, an active successor, and the appropriate
 technical or commercial authority for the claim. Record the reviewer, valid-from date,
 superseded claim, scope, and source.
 
@@ -268,11 +269,11 @@ product scope; indefinite validity.
 
 ### 2026-08-25 — How should the draft-only PO closing beat look?
 
-**Status:** PROPOSED
+**Status:** RATIFIED 2026-08-26 (align round)
 
 **Question:** How literal should the supplier PO draft look while preserving the no-write rule?
 
-**Recommended answer:** Show a neutral supplier-offer comparison, a PO draft, policy and evidence
+**Answer:** Show a neutral supplier-offer comparison, a PO draft, policy and evidence
 checks, approve/edit/reject, and a clearly labeled non-executing receipt. Do not mimic a live
 supplier portal or imply submission.
 
@@ -287,11 +288,11 @@ state.
 
 ### 2026-08-25 — What is the paid pilot's first scope and success measure?
 
-**Status:** PROPOSED
+**Status:** RATIFIED 2026-08-26 (align round)
 
 **Question:** What bounded pilot should the lunch ask permission to start?
 
-**Recommended answer:** Offer a two- to four-week pilot around one consenting mailbox or PST and
+**Answer:** Offer a two- to four-week pilot around one consenting mailbox or PST and
 one RFQ class. Measure time to reviewed draft, citation coverage, accepted line matches, rep
 edits, missing-field catches, and reuse of reviewed corrections.
 
@@ -307,11 +308,11 @@ demo applause rather than review outcomes.
 
 ### 2026-08-25 — What pricing shape should the pilot use?
 
-**Status:** PROPOSED
+**Status:** RATIFIED 2026-08-26 (align round)
 
 **Question:** How should the first paid engagement be priced?
 
-**Recommended answer:** Quote a fixed-fee discovery and pilot with named data, workflow, and
+**Answer:** Quote a fixed-fee discovery and pilot with named data, workflow, and
 measurement boundaries. Price any managed continuation after the baseline shows review volume
 and accepted-draft performance. Do not use per-seat pricing.
 
@@ -323,3 +324,20 @@ or a defensible outcome price before discovery.
 
 **Rejected options:** A SaaS seat subscription; open-ended time and materials with no acceptance
 measures; outcome pricing based on an unmeasured baseline.
+
+### 2026-08-26 — Corpus refresh moves to the operator browser lane
+
+**Status:** ratified 2026-08-26 (operator)
+
+**Answer:** While the site's bot filter answers the honest crawler identity with an HTTP 202
+captcha challenge, the sanctioned corpus-refresh path is the operator's own signed-in Chrome
+session driven by the Codex extension. `ops/mine-site.ts` stays stop-at-preflight by design.
+Browser captures land machine-local under dated browser-run directories with an index and never
+enter the repo. The boundary is unchanged: public pages only, no forms, no logins, and polite
+pacing.
+
+**Rationale:** An operator browsing their own browser is ordinary access, not crawler disguise.
+The crawler boundary in [`research/08-demo-options.md`](./research/08-demo-options.md) is
+untouched.
+
+**Rejected options:** Changing the crawler identity; solving captchas programmatically.

--- a/explorations/lejeune-bolt-agentic-demo/MAP.md
+++ b/explorations/lejeune-bolt-agentic-demo/MAP.md
@@ -1,9 +1,10 @@
 # LeJeune Knowledge Desk map
 
-**DRAFT — pending Benjamin's align round**
+**DRAFT — align ratified 2026-08-26; awaiting shape review**
 
-Later-stage artifacts are pre-seeded for review. The manifest remains at `align` until Benjamin
-closes or defers the proposed decisions in [`DECISIONS.md`](./DECISIONS.md).
+Benjamin closed the align round on 2026-08-26: every entry in
+[`DECISIONS.md`](./DECISIONS.md) is ratified and the manifest stage is `shape`. This map stays
+a draft until the brief passes shape review and decompose begins.
 
 ## Candidate goal packets
 
@@ -92,9 +93,9 @@ packet, as required by the exploration graduation contract.
 
 ## Sequencing
 
-1. **Freeze decisions, fixtures, ontology, and rule checks.** Benjamin's align round chooses the
-   proposed details without reopening the operator-ratified Option C, lunch boundary, or five-day
-   appetite.
+1. **Freeze decisions, fixtures, ontology, and rule checks.** Done 2026-08-26: the align round
+   ratified every proposed detail without reopening the operator-ratified Option C, lunch
+   boundary, or five-day appetite ([`DECISIONS.md`](./DECISIONS.md)).
 2. **Build `lejeune-demo-corpus-and-ontology`.** The deterministic bundle is the shared contract
    for extraction, retrieval, citations, spec checks, synthetic offers, and veteran correction.
    It gives the UI stable data and keeps provider or network failures out of the critical path.
@@ -148,8 +149,8 @@ may narrow the day-two upper bound from three layouts to two.
 
 ## Open risks inherited from the brief
 
-- **Align remains open.** All proposed choices in `DECISIONS.md` still need Benjamin's answer or
-  an explicit deferral.
+- **Align is closed.** Every choice in `DECISIONS.md` was ratified on 2026-08-26; reopening one
+  requires a new dated entry, not an edit.
 - **Five days leave little recovery margin.** New schemas, fixtures, UI, review behavior, and
   packaging must stay within the fixed scenario.
   [Option C risks](./research/08-demo-options.md#risks-2).

--- a/explorations/lejeune-bolt-agentic-demo/README.md
+++ b/explorations/lejeune-bolt-agentic-demo/README.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Stage: `align`
+Stage: `shape`
 Status: `active`
 
 Source: [`ops/manifest.json`](./ops/manifest.json)
@@ -16,15 +16,14 @@ foundations, then offer a measured service-as-software pilot.
 
 ## Next Open Question
 
-Should Benjamin license the TypeScript port under MIT or Apache-2.0 so its workbench components
-can be reused? The remaining questions stay queued in [`ops/manifest.json`](./ops/manifest.json)
-and [`DECISIONS.md`](./DECISIONS.md#proposed-for-benjamins-align-round).
+Should we graduate this exploration to a `goals/` packet and build the proposed
+`lejeune-bolt-workbench` lab (under `apps/labs/`) within the five-day appetite?
 
 ## Read This First
 
 1. [`ops/manifest.json`](./ops/manifest.json) - authoritative stage and open-question frontier.
-2. [`DECISIONS.md`](./DECISIONS.md) - pinned operator calls and 11 proposed align questions.
-3. [`BRIEF.md`](./BRIEF.md) - pre-seeded Shape Up pitch, pending align.
+2. [`DECISIONS.md`](./DECISIONS.md) - confirmed operator calls and ratified align decisions.
+3. [`BRIEF.md`](./BRIEF.md) - pre-seeded Shape Up pitch, ready for shape review.
 4. [`MAP.md`](./MAP.md) - pre-seeded candidate goals and first vertical slice.
 5. [`RESEARCH.md`](./RESEARCH.md) - cited synthesis and constraints.
 6. [`research/07-use-case-evaluation.md`](./research/07-use-case-evaluation.md) - ranked cases and
@@ -37,13 +36,14 @@ and [`DECISIONS.md`](./DECISIONS.md#proposed-for-benjamins-align-round).
 
 - 2026-08-25: packet opened from the lunch conversation; capture landed with both Mystic Lake photos; research fan-out launched (site mining, social/X, fastener-distribution process, in-repo bricks, open-source references).
 - 2026-08-25: six research lanes synthesized into the stage-1 research artifact, ranked use-case
-  evaluation, demo architecture comparison, and complete source ledger; packet remains at
-  research pending align decisions.
+  evaluation, demo architecture comparison, and complete source ledger; align was the next
+  stage.
 - 2026-08-25: advanced to align. Pinned the operator's Option C, top-three use cases, tailnet and
-  data boundaries, service-as-software framing, and five-day appetite pending Benjamin's
-  confirmation; pre-seeded `BRIEF.md` and `MAP.md`; left 11 proposed questions for his align
-  round.
+  data boundaries, service-as-software framing, and five-day appetite; pre-seeded `BRIEF.md` and
+  `MAP.md`; left 11 questions for his align round.
 - 2026-08-26: review closeout — honest-identity TypeScript miner replaced the shell
   script (17 bot threads answered), fallow ignore for packet `ops/**`, and three
   machine-local path tokens reworded in CAPTURE/DECISIONS/MAP so the knowledge-refs
   gate sees no live host paths (CAPTURE content otherwise untouched).
+- 2026-08-26: align round completed with Benjamin; 13 decisions ratified, including the two
+  2026-08-25 pins; browser-lane corpus-refresh decision recorded.

--- a/explorations/lejeune-bolt-agentic-demo/README.md
+++ b/explorations/lejeune-bolt-agentic-demo/README.md
@@ -16,8 +16,8 @@ foundations, then offer a measured service-as-software pilot.
 
 ## Next Open Question
 
-Should we graduate this exploration to a `goals/` packet and build the proposed
-`lejeune-bolt-workbench` lab (under `apps/labs/`) within the five-day appetite?
+Does [`BRIEF.md`](./BRIEF.md) hold as shaped — problem, appetite, sketch, rabbit holes,
+no-gos — or what changes before decompose? Graduation comes after decompose per the pipeline.
 
 ## Read This First
 
@@ -45,5 +45,6 @@ Should we graduate this exploration to a `goals/` packet and build the proposed
   script (17 bot threads answered), fallow ignore for packet `ops/**`, and three
   machine-local path tokens reworded in CAPTURE/DECISIONS/MAP so the knowledge-refs
   gate sees no live host paths (CAPTURE content otherwise untouched).
-- 2026-08-26: align round completed with Benjamin; 13 decisions ratified, including the two
-  2026-08-25 pins; browser-lane corpus-refresh decision recorded.
+- 2026-08-26: align round completed with Benjamin; 17 decisions ratified — the six 2026-08-25
+  operator pins confirmed plus the eleven align answers — and the browser-lane corpus-refresh
+  decision recorded.

--- a/explorations/lejeune-bolt-agentic-demo/ops/manifest.json
+++ b/explorations/lejeune-bolt-agentic-demo/ops/manifest.json
@@ -6,7 +6,7 @@
     "status": "active",
     "stage": "shape",
     "openQuestions": [
-      "Should we graduate this exploration to a `goals/` packet and build the proposed `lejeune-bolt-workbench` lab (under `apps/labs/`) within the five-day appetite?"
+      "Does BRIEF.md hold as shaped (problem, appetite, sketch, rabbit holes, no-gos), or what changes before decompose?"
     ],
     "sources": ["research/SOURCES.md"],
     "links": {

--- a/explorations/lejeune-bolt-agentic-demo/ops/manifest.json
+++ b/explorations/lejeune-bolt-agentic-demo/ops/manifest.json
@@ -4,19 +4,9 @@
     "slug": "lejeune-bolt-agentic-demo",
     "title": "LeJeune Bolt Agentic Demo",
     "status": "active",
-    "stage": "align",
+    "stage": "shape",
     "openQuestions": [
-      "License the TypeScript port for component reuse?",
-      "Confirm the lab slug and working product name?",
-      "Which two RFQ layouts should the demo fix?",
-      "Ask for one anonymized RFQ before lunch?",
-      "Which model-provider posture should the demo use?",
-      "Freeze which ontology and rule-check slice?",
-      "What deletion date governs the lab and corpus?",
-      "Who reviews veteran-memory claims in a pilot?",
-      "How should the draft-only PO closing beat look?",
-      "What is the paid pilot's first scope and success measure?",
-      "What pricing shape should the pilot use?"
+      "Should we graduate this exploration to a `goals/` packet and build the proposed `lejeune-bolt-workbench` lab (under `apps/labs/`) within the five-day appetite?"
     ],
     "sources": ["research/SOURCES.md"],
     "links": {
@@ -25,6 +15,6 @@
       "supersededBy": null
     },
     "created": "2026-08-25",
-    "updated": "2026-08-25"
+    "updated": "2026-08-26"
   }
 }


### PR DESCRIPTION
## Summary

Records Benjamin's completed align round (2026-08-26, `/grill-with-docs` session) for
`explorations/lejeune-bolt-agentic-demo` and moves the packet from `align` to `shape`.

- The two 2026-08-25 operator pins are **confirmed**: Option C demo architecture (disposable
  `lejeune-bolt-workbench` lab under `apps/labs/`, TrustGraph port as licensed component donor /
  escape hatch only) and the three-case lunch story closing on the approval-gated,
  non-executing PO draft.
- All **eleven proposed questions ratified** as recommended, with two concretizations:
  - hosted provider = the already API-key-wired `@beep/anthropic` driver (openai-compat /
    venice-ai / xai as fallback candidates) plus a fixed local replay for offline;
  - the twelve ontology classes + three rule checks stay **lab-local** until an explicit shared
    promotion.
- New operator decision: while the site's bot filter answers the honest crawler identity with a
  202 captcha challenge, corpus refresh runs through the operator's own signed-in Chrome
  (Codex extension lane); `ops/mine-site.ts` keeps its stop-at-preflight behavior. A 12-page
  browser-lane capture landed machine-local on 2026-08-26 (no captcha appears in a real
  browser session).
- Manifest frontier collapses to the graduation question; README, Trail, and `ATLAS.md` synced.

## Verification

- `bun run beep knowledge refs --check` — 0 gated observations
- `bun run beep knowledge semantic-delta` — 0 introduced
- `jq . ops/manifest.json` / `git diff --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/836"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790325857&installation_model_id=424656&pr_number=836&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F836&signature=bff17c6b4e74860034cb4c7c55f90ad662d4cf4e21868eafca5b4472f0d3b5c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->