### PR TITLE
docs(doctest): mark capability and primitive examples for the runtime lane

### DIFF
--- a/.changeset/doctest-mark-capability.md
+++ b/.changeset/doctest-mark-capability.md
@@ -1,0 +1,15 @@
+---
+"@beep/api-transport": patch
+"@beep/chalk": patch
+"@beep/colors": patch
+"@beep/file-processing": patch
+"@beep/langextract": patch
+"@beep/mcp-kit": patch
+"@beep/nlp-processing": patch
+"@beep/observability": patch
+"@beep/semantic-web": patch
+"@beep/data": patch
+"@beep/types": patch
+---
+
+Mark capability and primitive documentation examples for runtime doctest coverage.

--- a/packages/foundation/capability/api-transport/src/Transport.ts
+++ b/packages/foundation/capability/api-transport/src/Transport.ts
@@ -335,7 +335,8 @@ export class ApiTransportOptions extends S.Class<ApiTransportOptions>($I`ApiTran
  *   return yield* readSnapshot(transport)
  * }).pipe(Effect.provide(RateLimiter.layerStoreMemory))
  *
- * void program
+ * const snapshot = await Effect.runPromise(program)
+ * snapshot._tag // => "None"
  * ```
  *
  * @category models
@@ -373,7 +374,8 @@ export interface ApiTransport {
  *   return transport.transformClient
  * }).pipe(Effect.provide(RateLimiter.layerStoreMemory))
  *
- * void program
+ * const transformClient = await Effect.runPromise(program)
+ * typeof transformClient // => "function"
  * ```
  *
  * @category constructors

--- a/packages/foundation/capability/api-transport/src/Transport.ts
+++ b/packages/foundation/capability/api-transport/src/Transport.ts
@@ -319,7 +319,7 @@ export class ApiTransportOptions extends S.Class<ApiTransportOptions>($I`ApiTran
  *
  * **Example** (Read rate-limit from transport)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Read rate-limit from transport"
  * import { Effect } from "effect"
  * import * as RateLimiter from "effect/unstable/persistence/RateLimiter"
  * import { ApiAuth, type ApiTransport, makeApiTransport } from "@beep/api-transport"
@@ -359,7 +359,7 @@ export interface ApiTransport {
  *
  * **Example** (Build transport transformClient)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Build transport transformClient"
  * import { Effect } from "effect"
  * import * as RateLimiter from "effect/unstable/persistence/RateLimiter"
  * import { ApiAuth, makeApiTransport } from "@beep/api-transport"

--- a/packages/foundation/capability/chalk/src/Chalk.browser.ts
+++ b/packages/foundation/capability/chalk/src/Chalk.browser.ts
@@ -10,7 +10,7 @@
  *
  * **Example** (Check browser color support)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check browser color support"
  * import chalk, { Chalk, supportsColor } from "@beep/chalk/Chalk.browser"
  *
  * if (supportsColor !== false) {

--- a/packages/foundation/capability/colors/src/Colors.browser.ts
+++ b/packages/foundation/capability/colors/src/Colors.browser.ts
@@ -69,7 +69,7 @@ export const isColorSupported = false;
  * **Example** (supportsColor always false)
  *
  * ```ts import.meta.vitest name="supportsColor always false"
- * import { supportsColor } from "@beep/colors"
+ * import { supportsColor } from "@beep/colors/Colors.browser"
  *
  * supportsColor() // => false
  * ```

--- a/packages/foundation/capability/colors/src/Colors.browser.ts
+++ b/packages/foundation/capability/colors/src/Colors.browser.ts
@@ -27,12 +27,12 @@ const identity: FormatterType = String;
  *
  * **Example** (Browser-safe bold formatting)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Browser-safe bold formatting"
  * import { Colors, createColors } from "@beep/colors"
  *
  * const colors = createColors(false)
  * const rendered = colors.bold("hello")
- * console.log(rendered) // "hello"
+ * rendered // => "hello"
  * ```
  *
  * @category models
@@ -52,10 +52,10 @@ export class Colors extends S.Class<Colors>($I`Colors`)(
  *
  * **Example** (Check isColorSupported type)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Check isColorSupported type"
  * import { isColorSupported } from "@beep/colors"
  *
- * console.log(typeof isColorSupported) // "boolean"
+ * typeof isColorSupported // => "boolean"
  * ```
  *
  * @category utilities
@@ -68,10 +68,10 @@ export const isColorSupported = false;
  *
  * **Example** (supportsColor always false)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="supportsColor always false"
  * import { supportsColor } from "@beep/colors"
  *
- * console.log(supportsColor()) // false
+ * supportsColor() // => false
  * ```
  *
  * @returns Always `false` in browser-safe builds.
@@ -153,11 +153,11 @@ export const createColors = (_enabled?: undefined | boolean): Colors =>
  *
  * **Example** (Default green string output)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Default green string output"
  * import colors from "@beep/colors"
  *
  * const rendered = colors.green("ok")
- * console.log(typeof rendered) // "string"
+ * typeof rendered // => "string"
  * ```
  *
  * @category utilities
@@ -170,11 +170,11 @@ const colors = createColors();
  *
  * **Example** (Use String as Formatter)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Use String as Formatter"
  * import { type Formatter } from "@beep/colors"
  *
  * const fmt: Formatter = String
- * console.log(fmt(42)) // "42"
+ * fmt(42) // => "42"
  * ```
  *
  * @category models

--- a/packages/foundation/capability/colors/src/Colors.ts
+++ b/packages/foundation/capability/colors/src/Colors.ts
@@ -401,6 +401,7 @@ export const createColors = (enabled: boolean = isColorSupported): Colors => {
  * import colors from "@beep/colors"
  *
  * const rendered = colors.cyan("beep")
+ * typeof rendered // => "string"
  * ```
  *
  * @category utilities

--- a/packages/foundation/capability/colors/src/Colors.ts
+++ b/packages/foundation/capability/colors/src/Colors.ts
@@ -19,13 +19,13 @@
  *
  * **Example** (Disabled color formatters)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Disabled color formatters"
  * import { createColors } from "@beep/colors"
  *
  * const plain = createColors(false)
  * const rendered = plain.red("warning")
  *
- * console.log(rendered) // "warning"
+ * rendered // => "warning"
  * ```
  *
  * @packageDocumentation
@@ -182,13 +182,13 @@ const replaceClose = (text: string, close: string, replace: string, index: numbe
  *
  * **Example** (Format number with cyan)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Format number with cyan"
  * import { createColors, type Formatter } from "@beep/colors"
  *
  * const formatter: Formatter = createColors(true).cyan
  * const rendered = formatter(42)
  *
- * console.log(rendered) // "\u001b[36m42\u001b[39m"
+ * rendered // => "\u001b[36m42\u001b[39m"
  * ```
  *
  * @category models
@@ -235,14 +235,14 @@ const formatter =
  *
  * **Example** (Detect forced color support)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Detect forced color support"
  * import { supportsColor } from "@beep/colors"
  *
  * const enabled = supportsColor({
  *   env: { FORCE_COLOR: "1" },
  * })
  *
- * console.log(enabled) // true
+ * enabled // => true
  * ```
  *
  * @param processLike - The process-like runtime metadata used for color capability detection.
@@ -257,10 +257,10 @@ export const supportsColor = ProcessLike.supportsColor;
  *
  * **Example** (Check runtime color support type)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Check runtime color support type"
  * import { isColorSupported } from "@beep/colors"
  *
- * console.log(typeof isColorSupported) // "boolean"
+ * typeof isColorSupported // => "boolean"
  * ```
  *
  * @category utilities
@@ -278,13 +278,13 @@ export const isColorSupported = supportsColor();
  *
  * **Example** (Verify Colors instance type)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Verify Colors instance type"
  * import { Colors, createColors } from "@beep/colors"
  *
  * const colors = createColors(true)
  * const isColorsInstance = colors instanceof Colors
  *
- * console.log(isColorsInstance) // true
+ * isColorsInstance // => true
  * ```
  *
  * @category models
@@ -325,13 +325,13 @@ export class Colors extends S.Class<Colors>($I`Colors`)(
  *
  * **Example** (Create disabled formatter set)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Create disabled formatter set"
  * import { createColors } from "@beep/colors"
  *
  * const colors = createColors(false)
  * const rendered = colors.bold(colors.red("offline"))
  *
- * console.log(rendered) // "offline"
+ * rendered // => "offline"
  * ```
  *
  * @param enabled - Whether the returned formatter set should emit ANSI escapes.
@@ -397,7 +397,7 @@ export const createColors = (enabled: boolean = isColorSupported): Colors => {
  *
  * **Example** (Use default cyan formatter)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Use default cyan formatter"
  * import colors from "@beep/colors"
  *
  * const rendered = colors.cyan("beep")

--- a/packages/foundation/capability/file-processing/src/Artifact/Artifact.schema.ts
+++ b/packages/foundation/capability/file-processing/src/Artifact/Artifact.schema.ts
@@ -65,14 +65,14 @@ const ArtifactName = S.Union([
  *
  * **Example** (Decode ArtifactId from string)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode ArtifactId from string"
  * import { ArtifactId } from "@beep/file-processing/Artifact"
  * import * as S from "effect/Schema"
  *
  * const id = S.decodeUnknownSync(ArtifactId)(
  *   "artifact:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
  * )
- * console.log(id.startsWith("artifact:")) // true
+ * id.startsWith("artifact:") // => true
  * ```
  *
  * @category schemas
@@ -95,14 +95,14 @@ export const ArtifactId = S.TemplateLiteral(["artifact:", Sha256Hex]).pipe(
  *
  * **Example** (Annotate decoded ArtifactId type)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Annotate decoded ArtifactId type"
  * import { ArtifactId } from "@beep/file-processing/Artifact"
  * import * as S from "effect/Schema"
  *
  * const id: ArtifactId = S.decodeUnknownSync(ArtifactId)(
  *   "artifact:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
  * )
- * console.log(id.startsWith("artifact:")) // true
+ * id.startsWith("artifact:") // => true
  * ```
  *
  * @category models
@@ -115,14 +115,14 @@ export type ArtifactId = typeof ArtifactId.Type;
  *
  * **Example** (Decode OperationId from string)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode OperationId from string"
  * import { OperationId } from "@beep/file-processing/Artifact"
  * import * as S from "effect/Schema"
  *
  * const id = S.decodeUnknownSync(OperationId)(
  *   "operation:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
  * )
- * console.log(id.startsWith("operation:")) // true
+ * id.startsWith("operation:") // => true
  * ```
  *
  * @category schemas
@@ -145,14 +145,14 @@ export const OperationId = S.TemplateLiteral(["operation:", Sha256Hex]).pipe(
  *
  * **Example** (Annotate decoded OperationId type)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Annotate decoded OperationId type"
  * import { OperationId } from "@beep/file-processing/Artifact"
  * import * as S from "effect/Schema"
  *
  * const id: OperationId = S.decodeUnknownSync(OperationId)(
  *   "operation:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
  * )
- * console.log(id.startsWith("operation:")) // true
+ * id.startsWith("operation:") // => true
  * ```
  *
  * @category models
@@ -165,14 +165,14 @@ export type OperationId = typeof OperationId.Type;
  *
  * **Example** (Decode ContentDigest from string)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode ContentDigest from string"
  * import { ContentDigest } from "@beep/file-processing/Artifact"
  * import * as S from "effect/Schema"
  *
  * const digest = S.decodeUnknownSync(ContentDigest)(
  *   "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
  * )
- * console.log(digest.slice(0, 7)) // "sha256:"
+ * digest.slice(0, 7) // => "sha256:"
  * ```
  *
  * @category schemas
@@ -195,14 +195,14 @@ export const ContentDigest = S.TemplateLiteral(["sha256:", Sha256Hex]).pipe(
  *
  * **Example** (Annotate decoded ContentDigest type)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Annotate decoded ContentDigest type"
  * import { ContentDigest } from "@beep/file-processing/Artifact"
  * import * as S from "effect/Schema"
  *
  * const digest: ContentDigest = S.decodeUnknownSync(ContentDigest)(
  *   "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
  * )
- * console.log(digest.slice(0, 7)) // "sha256:"
+ * digest.slice(0, 7) // => "sha256:"
  * ```
  *
  * @category models
@@ -215,10 +215,10 @@ export type ContentDigest = typeof ContentDigest.Type;
  *
  * **Example** (Check locator kind options)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check locator kind options"
  * import { ArtifactLocatorKind } from "@beep/file-processing/Artifact"
  *
- * console.log(ArtifactLocatorKind.Options.includes("memory")) // true
+ * ArtifactLocatorKind.Options.includes("memory") // => true
  * ```
  *
  * @category schemas
@@ -235,11 +235,11 @@ export const ArtifactLocatorKind = LiteralKit(["file", "synthetic", "memory"]).p
  *
  * **Example** (Narrow memory locator kind)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Narrow memory locator kind"
  * import { ArtifactLocatorKind } from "@beep/file-processing/Artifact"
  *
  * const kind: ArtifactLocatorKind = "memory"
- * console.log(ArtifactLocatorKind.is.memory(kind)) // true
+ * ArtifactLocatorKind.is.memory(kind) // => true
  * ```
  *
  * @category models
@@ -252,7 +252,7 @@ export type ArtifactLocatorKind = typeof ArtifactLocatorKind.Type;
  *
  * **Example** (Create synthetic artifact locator)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Create synthetic artifact locator"
  * import { ArtifactLocator } from "@beep/file-processing/Artifact"
  * import { PosixPath } from "@beep/schema/PosixPath"
  * import { Effect } from "effect"
@@ -263,7 +263,7 @@ export type ArtifactLocatorKind = typeof ArtifactLocatorKind.Type;
  *   return ArtifactLocator.make({ kind: "synthetic", value }).kind
  * })
  *
- * Effect.runPromise(program).then(console.log) // "synthetic"
+ * await Effect.runPromise(program) // => "synthetic"
  * ```
  *
  * @category models
@@ -284,7 +284,7 @@ export class ArtifactLocator extends S.Class<ArtifactLocator>($I`ArtifactLocator
  *
  * **Example** (Construct SourceArtifact instance)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Construct SourceArtifact instance"
  * import { ArtifactId, ArtifactLocator, ContentDigest, SourceArtifact } from "@beep/file-processing/Artifact"
  * import { NonNegativeInt } from "@beep/schema"
  * import { PosixPath } from "@beep/schema/PosixPath"
@@ -308,7 +308,7 @@ export class ArtifactLocator extends S.Class<ArtifactLocator>($I`ArtifactLocator
  *   }).extension
  * })
  *
- * Effect.runPromise(program).then(console.log) // "md"
+ * await Effect.runPromise(program) // => "md"
  * ```
  *
  * @category models
@@ -337,7 +337,7 @@ export class SourceArtifact extends S.Class<SourceArtifact>($I`SourceArtifact`)(
  *
  * **Example** (Construct ArtifactReference instance)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Construct ArtifactReference instance"
  * import { ArtifactId, ArtifactReference } from "@beep/file-processing/Artifact"
  * import { NonNegativeInt } from "@beep/schema"
  * import { PosixPath } from "@beep/schema/PosixPath"
@@ -355,7 +355,7 @@ export class SourceArtifact extends S.Class<SourceArtifact>($I`SourceArtifact`)(
  *   }).relativePath
  * })
  *
- * Effect.runPromise(program).then(console.log) // "text/README.txt"
+ * await Effect.runPromise(program) // => "text/README.txt"
  * ```
  *
  * @category models

--- a/packages/foundation/capability/file-processing/src/Extraction/Extraction.manifest.ts
+++ b/packages/foundation/capability/file-processing/src/Extraction/Extraction.manifest.ts
@@ -31,7 +31,7 @@ type JsonEncodeEffect<Input> = {
  *
  * **Example** (Make succeeded source record)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make succeeded source record"
  * import { ArtifactId, ContentDigest, OperationId } from "@beep/file-processing/Artifact"
  * import { SucceededSourceProcessingRecord } from "@beep/file-processing/Extraction"
  * import { NonNegativeInt } from "@beep/schema"
@@ -59,7 +59,7 @@ type JsonEncodeEffect<Input> = {
  *   }).status
  * })
  *
- * Effect.runPromise(program).then(console.log) // "succeeded"
+ * await Effect.runPromise(program) // => "succeeded"
  * ```
  *
  * @category models
@@ -89,7 +89,7 @@ export class SucceededSourceProcessingRecord extends S.Class<SucceededSourceProc
  *
  * **Example** (Make skipped source record)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make skipped source record"
  * import { ArtifactId, ContentDigest, OperationId } from "@beep/file-processing/Artifact"
  * import { SkippedSourceProcessingRecord } from "@beep/file-processing/Extraction"
  * import { NonNegativeInt } from "@beep/schema"
@@ -116,7 +116,7 @@ export class SucceededSourceProcessingRecord extends S.Class<SucceededSourceProc
  *   }).skipReason
  * })
  *
- * Effect.runPromise(program).then(console.log) // "format-out-of-scope"
+ * await Effect.runPromise(program) // => "format-out-of-scope"
  * ```
  *
  * @category models
@@ -146,7 +146,7 @@ export class SkippedSourceProcessingRecord extends S.Class<SkippedSourceProcessi
  *
  * **Example** (Make failed source record)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make failed source record"
  * import { ArtifactId, ContentDigest, OperationId } from "@beep/file-processing/Artifact"
  * import { FailedSourceProcessingRecord } from "@beep/file-processing/Extraction"
  * import { NonNegativeInt } from "@beep/schema"
@@ -171,7 +171,7 @@ export class SkippedSourceProcessingRecord extends S.Class<SkippedSourceProcessi
  *   }).status
  * })
  *
- * Effect.runPromise(program).then(console.log) // "failed"
+ * await Effect.runPromise(program) // => "failed"
  * ```
  *
  * @category models
@@ -248,7 +248,7 @@ export const SourceProcessingRecord = S.Union([
  *
  * **Example** (Type source processing record)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Type source processing record"
  * import { SourceProcessingRecord } from "@beep/file-processing/Extraction"
  * import { Effect } from "effect"
  * import * as S from "effect/Schema"
@@ -266,7 +266,7 @@ export const SourceProcessingRecord = S.Union([
  *   return record.status
  * })
  *
- * Effect.runPromise(program).then(console.log) // "succeeded"
+ * await Effect.runPromise(program) // => "succeeded"
  * ```
  *
  * @category models
@@ -279,14 +279,14 @@ export type SourceProcessingRecord = typeof SourceProcessingRecord.Type;
  *
  * **Example** (Decode failure reason value)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode failure reason value"
  * import { FileProcessingFailureReason } from "@beep/file-processing/Extraction"
  * import { Effect } from "effect"
  * import * as S from "effect/Schema"
  *
  * const program = S.decodeUnknownEffect(FileProcessingFailureReason)("format-out-of-scope")
  *
- * Effect.runPromise(program).then(console.log) // "format-out-of-scope"
+ * await Effect.runPromise(program) // => "format-out-of-scope"
  * ```
  *
  * @category schemas
@@ -304,7 +304,7 @@ export const FileProcessingFailureReason = S.Union([FileProcessingOperationError
  *
  * **Example** (Type failure reason value)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Type failure reason value"
  * import { FileProcessingFailureReason } from "@beep/file-processing/Extraction"
  * import { Effect } from "effect"
  * import * as S from "effect/Schema"
@@ -316,7 +316,7 @@ export const FileProcessingFailureReason = S.Union([FileProcessingOperationError
  *   return reason
  * })
  *
- * Effect.runPromise(program).then(console.log) // "format-out-of-scope"
+ * await Effect.runPromise(program) // => "format-out-of-scope"
  * ```
  *
  * @category models
@@ -373,7 +373,7 @@ export class SkippedFileProcessingFailureRecord extends S.Class<SkippedFileProce
  *
  * **Example** (Make failed failure record)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make failed failure record"
  * import { ArtifactId, OperationId } from "@beep/file-processing/Artifact"
  * import { FailedFileProcessingFailureRecord } from "@beep/file-processing/Extraction"
  * import { PosixPath } from "@beep/schema/PosixPath"
@@ -396,7 +396,7 @@ export class SkippedFileProcessingFailureRecord extends S.Class<SkippedFileProce
  *   }).reason
  * })
  *
- * Effect.runPromise(program).then(console.log) // "unsupported-file-format"
+ * await Effect.runPromise(program) // => "unsupported-file-format"
  * ```
  *
  * @category models
@@ -465,7 +465,7 @@ export const FileProcessingFailureRecord = S.Union([
  *
  * **Example** (Type failure record)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Type failure record"
  * import { FileProcessingFailureRecord } from "@beep/file-processing/Extraction"
  * import { Effect } from "effect"
  * import * as S from "effect/Schema"
@@ -483,7 +483,7 @@ export const FileProcessingFailureRecord = S.Union([
  *   return record.status
  * })
  *
- * Effect.runPromise(program).then(console.log) // "failed"
+ * await Effect.runPromise(program) // => "failed"
  * ```
  *
  * @category models

--- a/packages/foundation/capability/file-processing/src/Extraction/Extraction.schema.ts
+++ b/packages/foundation/capability/file-processing/src/Extraction/Extraction.schema.ts
@@ -29,10 +29,10 @@ class TextSpanBase extends S.Class<TextSpanBase>($I`TextSpan`)(
  *
  * **Example** (Check skipped status option)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check skipped status option"
  * import { SourceProcessingStatus } from "@beep/file-processing/Extraction"
  *
- * console.log(SourceProcessingStatus.Options.includes("skipped")) // true
+ * SourceProcessingStatus.Options.includes("skipped") // => true
  * ```
  *
  * @category schemas
@@ -49,11 +49,11 @@ export const SourceProcessingStatus = LiteralKit(["succeeded", "skipped", "faile
  *
  * **Example** (Type succeeded status value)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Type succeeded status value"
  * import { SourceProcessingStatus } from "@beep/file-processing/Extraction"
  *
  * const status: SourceProcessingStatus = "succeeded"
- * console.log(SourceProcessingStatus.is.succeeded(status)) // true
+ * SourceProcessingStatus.is.succeeded(status) // => true
  * ```
  *
  * @category models
@@ -101,12 +101,12 @@ export class TextArtifactReference extends S.Class<TextArtifactReference>($I`Tex
  *
  * **Example** (Make text span value)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make text span value"
  * import { TextSpan } from "@beep/file-processing/Extraction"
  * import { NonNegativeInt } from "@beep/schema"
  *
  * const span = TextSpan.make({ endOffset: NonNegativeInt.make(5), startOffset: NonNegativeInt.make(0), text: "hello" })
- * console.log(span.text) // "hello"
+ * span.text // => "hello"
  * ```
  *
  * @category models
@@ -126,12 +126,12 @@ export const TextSpan = TextSpanBase.check(
  *
  * **Example** (Type text span value)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Type text span value"
  * import { TextSpan } from "@beep/file-processing/Extraction"
  * import { NonNegativeInt } from "@beep/schema"
  *
  * const span: TextSpan = TextSpan.make({ endOffset: NonNegativeInt.make(5), startOffset: NonNegativeInt.make(0), text: "hello" })
- * console.log(span.text) // "hello"
+ * span.text // => "hello"
  * ```
  *
  * @category models
@@ -224,7 +224,7 @@ export class ArchiveExportResult extends S.Class<ArchiveExportResult>($I`Archive
  *
  * **Example** (Make extracted process result)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make extracted process result"
  * import { ArtifactId, OperationId } from "@beep/file-processing/Artifact"
  * import { ExtractedProcessFileResult, ExtractionResult } from "@beep/file-processing/Extraction"
  * import { Effect } from "effect"
@@ -254,7 +254,7 @@ export class ArchiveExportResult extends S.Class<ArchiveExportResult>($I`Archive
  *   }).resultKind
  * })
  *
- * Effect.runPromise(program).then(console.log) // "extracted"
+ * await Effect.runPromise(program) // => "extracted"
  * ```
  *
  * @category models
@@ -280,7 +280,7 @@ export class ExtractedProcessFileResult extends S.Class<ExtractedProcessFileResu
  *
  * **Example** (Make archive export process result)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make archive export process result"
  * import { ArtifactId, OperationId } from "@beep/file-processing/Artifact"
  * import { ArchiveExportProcessFileResult, ArchiveExportResult } from "@beep/file-processing/Extraction"
  * import { Effect } from "effect"
@@ -308,7 +308,7 @@ export class ExtractedProcessFileResult extends S.Class<ExtractedProcessFileResu
  *   }).resultKind
  * })
  *
- * Effect.runPromise(program).then(console.log) // "archive-exported"
+ * await Effect.runPromise(program) // => "archive-exported"
  * ```
  *
  * @category models
@@ -336,7 +336,7 @@ export class ArchiveExportProcessFileResult extends S.Class<ArchiveExportProcess
  *
  * **Example** (Make skipped process result)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make skipped process result"
  * import { ArtifactId, OperationId } from "@beep/file-processing/Artifact"
  * import { SkippedProcessFileResult } from "@beep/file-processing/Extraction"
  * import { Effect } from "effect"
@@ -358,7 +358,7 @@ export class ArchiveExportProcessFileResult extends S.Class<ArchiveExportProcess
  *   return result.skipReason
  * })
  *
- * Effect.runPromise(program).then(console.log) // "format-out-of-scope"
+ * await Effect.runPromise(program) // => "format-out-of-scope"
  * ```
  *
  * @category models
@@ -428,7 +428,7 @@ export const ProcessFileResult = S.Union([
  *
  * **Example** (Type process file result)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Type process file result"
  * import { ProcessFileResult } from "@beep/file-processing/Extraction"
  * import { Effect } from "effect"
  * import * as S from "effect/Schema"
@@ -446,7 +446,7 @@ export const ProcessFileResult = S.Union([
  *   return result.resultKind
  * })
  *
- * Effect.runPromise(program).then(console.log) // "skipped"
+ * await Effect.runPromise(program) // => "skipped"
  * ```
  *
  * @category models

--- a/packages/foundation/capability/file-processing/src/Operation/Operation.errors.ts
+++ b/packages/foundation/capability/file-processing/src/Operation/Operation.errors.ts
@@ -18,10 +18,10 @@ const $I = $FileProcessingId.create("Operation");
  *
  * **Example** (Check reason options membership)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check reason options membership"
  * import { FileProcessingOperationErrorReason } from "@beep/file-processing/Operation"
  *
- * console.log(FileProcessingOperationErrorReason.Options.includes("engine-unavailable")) // true
+ * FileProcessingOperationErrorReason.Options.includes("engine-unavailable") // => true
  * ```
  *
  * @category errors
@@ -47,11 +47,11 @@ export const FileProcessingOperationErrorReason = LiteralKit([
  *
  * **Example** (Type and refine reason)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Type and refine reason"
  * import { FileProcessingOperationErrorReason } from "@beep/file-processing/Operation"
  *
  * const reason: FileProcessingOperationErrorReason = "engine-unavailable"
- * console.log(FileProcessingOperationErrorReason.is["engine-unavailable"](reason)) // true
+ * FileProcessingOperationErrorReason.is["engine-unavailable"](reason) // => true
  * ```
  *
  * @category errors

--- a/packages/foundation/capability/file-processing/src/PathSafety/PathSafety.errors.ts
+++ b/packages/foundation/capability/file-processing/src/PathSafety/PathSafety.errors.ts
@@ -47,11 +47,11 @@ export const PathSafetyViolationReason = LiteralKit([
  *
  * **Example** (Check escapes-root reason type)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check escapes-root reason type"
  * import { PathSafetyViolationReason } from "@beep/file-processing/PathSafety"
  *
  * const reason: PathSafetyViolationReason = "escapes-root"
- * console.log(PathSafetyViolationReason.is["escapes-root"](reason)) // true
+ * PathSafetyViolationReason.is["escapes-root"](reason) // => true
  * ```
  *
  * @category errors
@@ -69,7 +69,7 @@ export type PathSafetyViolationReason = typeof PathSafetyViolationReason.Type;
  *
  * **Example** (Create escapesRoot error)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Create escapesRoot error"
  * import { PathSafetyError } from "@beep/file-processing/PathSafety"
  *
  * const error = PathSafetyError.escapesRoot({
@@ -77,7 +77,7 @@ export type PathSafetyViolationReason = typeof PathSafetyViolationReason.Type;
  *   candidate: "../etc/passwd",
  *   resolved: "/etc/passwd"
  * })
- * console.log(error.reason) // "escapes-root"
+ * error.reason // => "escapes-root"
  * ```
  *
  * @category errors

--- a/packages/foundation/capability/file-processing/src/PathSafety/PathSafety.policy.ts
+++ b/packages/foundation/capability/file-processing/src/PathSafety/PathSafety.policy.ts
@@ -51,12 +51,12 @@ const segmentsOf: (normalized: string) => ReadonlyArray<string> = flow(Str.split
  *
  * **Example** (Compare contained absolute paths)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Compare contained absolute paths"
  * import { isPathWithinRoot } from "@beep/file-processing/PathSafety"
  *
- * console.log(isPathWithinRoot("/srv/data", "/srv/data/file.txt")) // true
- * console.log(isPathWithinRoot("/srv/data", "/srv/data-evil")) // false
- * console.log(isPathWithinRoot("/srv/data", "/etc/passwd")) // false
+ * isPathWithinRoot("/srv/data", "/srv/data/file.txt") // => true
+ * isPathWithinRoot("/srv/data", "/srv/data-evil") // => false
+ * isPathWithinRoot("/srv/data", "/etc/passwd") // => false
  * ```
  *
  * @category predicates
@@ -95,15 +95,15 @@ export const isPathWithinRoot: {
  *
  * **Example** (Validate contained resolved path)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Validate contained resolved path"
  * import { validateResolvedPath } from "@beep/file-processing/PathSafety"
  * import { Result } from "effect"
  *
  * const ok = validateResolvedPath({ root: "/srv/data", candidate: "/srv/data/a.txt" })
- * console.log(Result.isSuccess(ok)) // true
+ * Result.isSuccess(ok) // => true
  *
  * const bad = validateResolvedPath({ root: "/srv/data", candidate: "/etc/passwd" })
- * console.log(Result.isFailure(bad)) // true
+ * Result.isFailure(bad) // => true
  * ```
  *
  * @category validation

--- a/packages/foundation/capability/file-processing/src/Service/FileProcessing.service.ts
+++ b/packages/foundation/capability/file-processing/src/Service/FileProcessing.service.ts
@@ -54,13 +54,13 @@ export type FileProcessingEngineShape = {
  *
  * **Example** (Service method type keys)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Service method type keys"
  * import type { FileProcessingServiceShape } from "@beep/file-processing/Service"
  *
  * type ServiceMethod = keyof FileProcessingServiceShape
  * const method: ServiceMethod = "process"
  *
- * console.log(method) // "process"
+ * method // => "process"
  * ```
  *
  * @category services
@@ -93,7 +93,7 @@ export type FileProcessingServiceShape = {
  *   Effect.provide(BunCrypto.layer)
  * )
  *
- * Effect.runPromise(program).then(console.log) // "function"
+ * await Effect.runPromise(program) // => "function"
  * ```
  *
  * @category services

--- a/packages/foundation/capability/file-processing/src/Service/FileProcessing.service.ts
+++ b/packages/foundation/capability/file-processing/src/Service/FileProcessing.service.ts
@@ -80,7 +80,7 @@ export type FileProcessingServiceShape = {
  *
  * **Example** (Provide service with layer)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Provide service with layer"
  * import * as BunCrypto from "@effect/platform-bun/BunCrypto"
  * import { FileProcessingService } from "@beep/file-processing/Service"
  * import { makeFileProcessingServiceLayer } from "@beep/file-processing/Service"

--- a/packages/foundation/capability/file-processing/src/SourceText/SourceText.errors.ts
+++ b/packages/foundation/capability/file-processing/src/SourceText/SourceText.errors.ts
@@ -17,10 +17,10 @@ const $I = $FileProcessingId.create("SourceText");
  *
  * **Example** (Check reason membership)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check reason membership"
  * import { SourceTextResolverErrorReason } from "@beep/file-processing/SourceText"
  *
- * console.log(SourceTextResolverErrorReason.is["source-digest-mismatch"]("source-digest-mismatch")) // true
+ * SourceTextResolverErrorReason.is["source-digest-mismatch"]("source-digest-mismatch") // => true
  * ```
  *
  * @category schemas
@@ -64,11 +64,11 @@ export type SourceTextResolverErrorReason = typeof SourceTextResolverErrorReason
  *
  * **Example** (Create source-unavailable error)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Create source-unavailable error"
  * import { SourceTextResolverError } from "@beep/file-processing/SourceText"
  *
  * const error = SourceTextResolverError.new("source-unavailable", "The source file could not be read.")
- * console.log(error.reason) // "source-unavailable"
+ * error.reason // => "source-unavailable"
  * ```
  *
  * @category errors
@@ -90,11 +90,11 @@ export class SourceTextResolverError extends S.TaggedError<SourceTextResolverErr
    *
    * **Example** (Create page-out-of-range error)
    *
-   * ```ts
+   * ```ts import.meta.vitest name="Create page-out-of-range error"
    * import { SourceTextResolverError } from "@beep/file-processing/SourceText"
    *
    * const error = SourceTextResolverError.new("page-out-of-range", "Page 2 does not exist.")
-   * console.log(error._tag) // "SourceTextResolverError"
+   * error._tag // => "SourceTextResolverError"
    * ```
    *
    * @category constructors

--- a/packages/foundation/capability/file-processing/src/SourceText/SourceText.paging.ts
+++ b/packages/foundation/capability/file-processing/src/SourceText/SourceText.paging.ts
@@ -98,6 +98,8 @@ const sourceTextPageFromBounds = Effect.fn("SourceText.pageFromBounds")(function
  *
  * const loadFirstPage = (source: ResolvedSourceText) =>
  *   Effect.runPromise(pageSourceText(source, NonNegativeInt.make(0)))
+ *
+ * typeof loadFirstPage // => "function"
  * ```
  *
  * @effects Performs deterministic in-memory paging only. It does not read or
@@ -137,6 +139,8 @@ export const pageSourceText = Effect.fn("SourceText.pageSourceText")(function* (
  *   Effect.runPromise(
  *     pageSourceTextContainingOffset(source, NonNegativeInt.make(offset))
  *   )
+ *
+ * typeof loadPageContaining // => "function"
  * ```
  *
  * @effects Searches deterministic in-memory page bounds only. It does not read

--- a/packages/foundation/capability/file-processing/src/SourceText/SourceText.paging.ts
+++ b/packages/foundation/capability/file-processing/src/SourceText/SourceText.paging.ts
@@ -90,7 +90,7 @@ const sourceTextPageFromBounds = Effect.fn("SourceText.pageFromBounds")(function
  *
  * **Example** (Load first page)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Load first page"
  * import type { ResolvedSourceText } from "@beep/file-processing/SourceText"
  * import { pageSourceText } from "@beep/file-processing/SourceText"
  * import { NonNegativeInt } from "@beep/schema"
@@ -125,7 +125,7 @@ export const pageSourceText = Effect.fn("SourceText.pageSourceText")(function* (
  *
  * **Example** (Load page for offset)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Load page for offset"
  * import {
  *   pageSourceTextContainingOffset
  * } from "@beep/file-processing/SourceText"

--- a/packages/foundation/capability/file-processing/src/SourceText/SourceText.schema.ts
+++ b/packages/foundation/capability/file-processing/src/SourceText/SourceText.schema.ts
@@ -24,12 +24,12 @@ const $I = $FileProcessingId.create("SourceText");
  *
  * **Example** (Compute nominal page count)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Compute nominal page count"
  * import { SOURCE_TEXT_PAGE_CODE_UNITS } from "@beep/file-processing/SourceText"
  *
  * const sourceCodeUnits = SOURCE_TEXT_PAGE_CODE_UNITS * 2 + 1
  * const nominalPageCount = Math.ceil(sourceCodeUnits / SOURCE_TEXT_PAGE_CODE_UNITS)
- * console.log(nominalPageCount) // 3
+ * nominalPageCount // => 3
  * ```
  *
  * @category constants
@@ -40,9 +40,9 @@ export const SOURCE_TEXT_PAGE_CODE_UNITS = 65_536;
 /**
  * Stable extractor name for canonical UTF-8 text and Markdown sources.
  *
- * **Example** (Build extractor identity string)
+ * **Example** (Build extractor name identity string)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Build extractor name identity string"
  * import {
  *   UTF8_SOURCE_TEXT_EXTRACTOR_NAME,
  *   UTF8_SOURCE_TEXT_EXTRACTOR_VERSION
@@ -50,7 +50,7 @@ export const SOURCE_TEXT_PAGE_CODE_UNITS = 65_536;
  *
  * const extractorIdentity =
  *   `${UTF8_SOURCE_TEXT_EXTRACTOR_NAME}@${UTF8_SOURCE_TEXT_EXTRACTOR_VERSION}`
- * console.log(extractorIdentity) // "utf8@1"
+ * extractorIdentity // => "utf8@1"
  * ```
  *
  * @category constants
@@ -61,9 +61,9 @@ export const UTF8_SOURCE_TEXT_EXTRACTOR_NAME = "utf8";
 /**
  * Version of the strict UTF-8 decoding contract used for source text.
  *
- * **Example** (Build extractor identity string)
+ * **Example** (Build extractor version identity string)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Build extractor version identity string"
  * import {
  *   UTF8_SOURCE_TEXT_EXTRACTOR_NAME,
  *   UTF8_SOURCE_TEXT_EXTRACTOR_VERSION
@@ -71,7 +71,7 @@ export const UTF8_SOURCE_TEXT_EXTRACTOR_NAME = "utf8";
  *
  * const extractorIdentity =
  *   `${UTF8_SOURCE_TEXT_EXTRACTOR_NAME}@${UTF8_SOURCE_TEXT_EXTRACTOR_VERSION}`
- * console.log(extractorIdentity) // "utf8@1"
+ * extractorIdentity // => "utf8@1"
  * ```
  *
  * @category constants

--- a/packages/foundation/capability/file-processing/src/Strategy/Strategy.schema.ts
+++ b/packages/foundation/capability/file-processing/src/Strategy/Strategy.schema.ts
@@ -18,10 +18,10 @@ const $I = $FileProcessingId.create("Strategy");
  *
  * **Example** (Check process option included)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check process option included"
  * import { FileProcessingOperationKind } from "@beep/file-processing/Strategy"
  *
- * console.log(FileProcessingOperationKind.Options.includes("process")) // true
+ * FileProcessingOperationKind.Options.includes("process") // => true
  * ```
  *
  * @category schemas
@@ -38,11 +38,11 @@ export const FileProcessingOperationKind = LiteralKit(["detect", "extract", "exp
  *
  * **Example** (Type process kind guard)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Type process kind guard"
  * import { FileProcessingOperationKind } from "@beep/file-processing/Strategy"
  *
  * const kind: FileProcessingOperationKind = "process"
- * console.log(FileProcessingOperationKind.is.process(kind)) // true
+ * FileProcessingOperationKind.is.process(kind) // => true
  * ```
  *
  * @category models
@@ -55,10 +55,10 @@ export type FileProcessingOperationKind = typeof FileProcessingOperationKind.Typ
  *
  * **Example** (Check tika option included)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check tika option included"
  * import { FileProcessingEngineFamily } from "@beep/file-processing/Strategy"
  *
- * console.log(FileProcessingEngineFamily.Options.includes("tika")) // true
+ * FileProcessingEngineFamily.Options.includes("tika") // => true
  * ```
  *
  * @category schemas
@@ -75,11 +75,11 @@ export const FileProcessingEngineFamily = LiteralKit(["auto", "tika", "libpff", 
  *
  * **Example** (Type tika engine guard)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Type tika engine guard"
  * import { FileProcessingEngineFamily } from "@beep/file-processing/Strategy"
  *
  * const engine: FileProcessingEngineFamily = "tika"
- * console.log(FileProcessingEngineFamily.is.tika(engine)) // true
+ * FileProcessingEngineFamily.is.tika(engine) // => true
  * ```
  *
  * @category models
@@ -92,10 +92,10 @@ export type FileProcessingEngineFamily = typeof FileProcessingEngineFamily.Type;
  *
  * **Example** (Check pdf-text-layer option)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check pdf-text-layer option"
  * import { FileFormatFamily } from "@beep/file-processing/Strategy"
  *
- * console.log(FileFormatFamily.Options.includes("pdf-text-layer")) // true
+ * FileFormatFamily.Options.includes("pdf-text-layer") // => true
  * ```
  *
  * @category schemas
@@ -147,11 +147,11 @@ export const FileFormatFamily = LiteralKit([
  *
  * **Example** (Type format family guard)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Type format family guard"
  * import { FileFormatFamily } from "@beep/file-processing/Strategy"
  *
  * const format: FileFormatFamily = "pdf-text-layer"
- * console.log(FileFormatFamily.is["pdf-text-layer"](format)) // true
+ * FileFormatFamily.is["pdf-text-layer"](format) // => true
  * ```
  *
  * @category models
@@ -164,10 +164,10 @@ export type FileFormatFamily = typeof FileFormatFamily.Type;
  *
  * **Example** (Check export-children option)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check export-children option"
  * import { FileProcessingCapability } from "@beep/file-processing/Strategy"
  *
- * console.log(FileProcessingCapability.Options.includes("export-children")) // true
+ * FileProcessingCapability.Options.includes("export-children") // => true
  * ```
  *
  * @category schemas
@@ -189,11 +189,11 @@ export const FileProcessingCapability = LiteralKit([
  *
  * **Example** (Type capability guard)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Type capability guard"
  * import { FileProcessingCapability } from "@beep/file-processing/Strategy"
  *
  * const capability: FileProcessingCapability = "export-children"
- * console.log(FileProcessingCapability.is["export-children"](capability)) // true
+ * FileProcessingCapability.is["export-children"](capability) // => true
  * ```
  *
  * @category models
@@ -206,10 +206,10 @@ export type FileProcessingCapability = typeof FileProcessingCapability.Type;
  *
  * **Example** (Check deferred disposition option)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check deferred disposition option"
  * import { FileProcessingSupportDisposition } from "@beep/file-processing/Strategy"
  *
- * console.log(FileProcessingSupportDisposition.Options.includes("deferred")) // true
+ * FileProcessingSupportDisposition.Options.includes("deferred") // => true
  * ```
  *
  * @category schemas
@@ -226,11 +226,11 @@ export const FileProcessingSupportDisposition = LiteralKit(["supported", "deferr
  *
  * **Example** (Type deferred disposition guard)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Type deferred disposition guard"
  * import { FileProcessingSupportDisposition } from "@beep/file-processing/Strategy"
  *
  * const disposition: FileProcessingSupportDisposition = "deferred"
- * console.log(FileProcessingSupportDisposition.is.deferred(disposition)) // true
+ * FileProcessingSupportDisposition.is.deferred(disposition) // => true
  * ```
  *
  * @category models
@@ -243,10 +243,10 @@ export type FileProcessingSupportDisposition = typeof FileProcessingSupportDispo
  *
  * **Example** (Check skip reason option)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check skip reason option"
  * import { FileProcessingSkipReason } from "@beep/file-processing/Strategy"
  *
- * console.log(FileProcessingSkipReason.Options.includes("operation-not-required")) // true
+ * FileProcessingSkipReason.Options.includes("operation-not-required") // => true
  * ```
  *
  * @category schemas
@@ -272,11 +272,11 @@ export const FileProcessingSkipReason = LiteralKit([
  *
  * **Example** (Type skip reason guard)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Type skip reason guard"
  * import { FileProcessingSkipReason } from "@beep/file-processing/Strategy"
  *
  * const reason: FileProcessingSkipReason = "operation-not-required"
- * console.log(FileProcessingSkipReason.is["operation-not-required"](reason)) // true
+ * FileProcessingSkipReason.is["operation-not-required"](reason) // => true
  * ```
  *
  * @category models
@@ -313,7 +313,7 @@ export class StrategyPreference extends S.Class<StrategyPreference>($I`StrategyP
  *
  * **Example** (Make supported selected strategy)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make supported selected strategy"
  * import { SupportedSelectedStrategy } from "@beep/file-processing/Strategy"
  *
  * const strategy = SupportedSelectedStrategy.make({
@@ -323,7 +323,7 @@ export class StrategyPreference extends S.Class<StrategyPreference>($I`StrategyP
  *   operationKind: "extract"
  * })
  *
- * console.log(strategy.disposition) // "supported"
+ * strategy.disposition // => "supported"
  * ```
  *
  * @category models
@@ -346,7 +346,7 @@ export class SupportedSelectedStrategy extends S.Class<SupportedSelectedStrategy
  *
  * **Example** (Make deferred selected strategy)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make deferred selected strategy"
  * import { DeferredSelectedStrategy } from "@beep/file-processing/Strategy"
  *
  * const strategy = DeferredSelectedStrategy.make({
@@ -357,7 +357,7 @@ export class SupportedSelectedStrategy extends S.Class<SupportedSelectedStrategy
  *   skipReason: "engine-unavailable"
  * })
  *
- * console.log(strategy.skipReason) // "engine-unavailable"
+ * strategy.skipReason // => "engine-unavailable"
  * ```
  *
  * @category models
@@ -381,7 +381,7 @@ export class DeferredSelectedStrategy extends S.Class<DeferredSelectedStrategy>(
  *
  * **Example** (Make unsupported selected strategy)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make unsupported selected strategy"
  * import { UnsupportedSelectedStrategy } from "@beep/file-processing/Strategy"
  *
  * const strategy = UnsupportedSelectedStrategy.make({
@@ -392,7 +392,7 @@ export class DeferredSelectedStrategy extends S.Class<DeferredSelectedStrategy>(
  *   skipReason: "format-out-of-scope"
  * })
  *
- * console.log(strategy.format) // "xls"
+ * strategy.format // => "xls"
  * ```
  *
  * @category models
@@ -452,7 +452,7 @@ export const SelectedStrategy = S.Union([
  *
  * **Example** (Typed decode selected strategy)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Typed decode selected strategy"
  * import { SelectedStrategy } from "@beep/file-processing/Strategy"
  * import { Effect } from "effect"
  * import * as S from "effect/Schema"
@@ -468,7 +468,7 @@ export const SelectedStrategy = S.Union([
  *   return strategy.disposition
  * })
  *
- * Effect.runPromise(program).then(console.log) // "deferred"
+ * await Effect.runPromise(program) // => "deferred"
  * ```
  *
  * @category models
@@ -481,7 +481,7 @@ export type SelectedStrategy = typeof SelectedStrategy.Type;
  *
  * **Example** (Make engine descriptor)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make engine descriptor"
  * import { FileProcessingEngineDescriptor } from "@beep/file-processing/Strategy"
  *
  * const descriptor = FileProcessingEngineDescriptor.make({
@@ -492,7 +492,7 @@ export type SelectedStrategy = typeof SelectedStrategy.Type;
  *   version: "2.9.0"
  * })
  *
- * console.log(descriptor.supportedFormats.includes("docx")) // true
+ * descriptor.supportedFormats.includes("docx") // => true
  * ```
  *
  * @category models
@@ -536,11 +536,11 @@ export class FileProcessingEngineDescriptor extends S.Class<FileProcessingEngine
  *
  * **Example** (Classify known unknown extensions)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Classify known unknown extensions"
  * import { classifyFormatFromExtension } from "@beep/file-processing/Strategy"
  *
- * console.log(classifyFormatFromExtension("docx")) // "docx"
- * console.log(classifyFormatFromExtension("zip")) // "unknown"
+ * classifyFormatFromExtension("docx") // => "docx"
+ * classifyFormatFromExtension("zip") // => "unknown"
  * ```
  *
  * @category utilities

--- a/packages/foundation/capability/file-processing/src/test.ts
+++ b/packages/foundation/capability/file-processing/src/test.ts
@@ -33,10 +33,10 @@ import type * as Crypto from "effect/Crypto";
  *
  * **Example** (Verify PST format support)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Verify PST format support"
  * import { TestFileProcessingEngineDescriptor } from "@beep/file-processing/test"
  *
- * console.log(TestFileProcessingEngineDescriptor.supportedFormats.includes("pst")) // true
+ * TestFileProcessingEngineDescriptor.supportedFormats.includes("pst") // => true
  * ```
  *
  * @category fixtures
@@ -58,7 +58,7 @@ const testIdentifierHex = "3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d
  *
  * **Example** (Decode synthetic identifiers)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode synthetic identifiers"
  * import { decodeTestOperationIdentifiers } from "@beep/file-processing/test"
  * import { Effect } from "effect"
  *
@@ -67,7 +67,7 @@ const testIdentifierHex = "3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d
  *   return identifiers.digest.startsWith("sha256:")
  * })
  *
- * Effect.runPromise(program).then(console.log) // true
+ * await Effect.runPromise(program) // => true
  * ```
  *
  * @effects Decodes the fixed synthetic identifiers through the exported schemas and can fail with `SchemaError` if the fixture constants drift.
@@ -122,10 +122,10 @@ const deriveTestChildArtifactId = (
  *
  * **Example** (Log engine descriptor name)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Log engine descriptor name"
  * import { TestFileProcessingEngine } from "@beep/file-processing/test"
  *
- * console.log(TestFileProcessingEngine.descriptor.engine) // "test"
+ * TestFileProcessingEngine.descriptor.engine // => "test"
  * ```
  *
  * @category fixtures

--- a/packages/foundation/capability/langextract/src/Alignment/Alignment.behavior.ts
+++ b/packages/foundation/capability/langextract/src/Alignment/Alignment.behavior.ts
@@ -34,11 +34,11 @@ const candidateFields = (candidate: ExtractionCandidate) => ({
  *
  * **Example** (Span from a matched slice)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Span from a matched slice"
  * import { spanFromMatch } from "@beep/langextract/Alignment"
  * import { NonNegativeInt } from "@beep/schema"
  *
- * console.log(spanFromMatch([NonNegativeInt.make(4), "Lovelace"]).end) // 12
+ * spanFromMatch([NonNegativeInt.make(4), "Lovelace"]).end // => 12
  * ```
  *
  * @category mapping

--- a/packages/foundation/capability/langextract/src/Alignment/Alignment.config.ts
+++ b/packages/foundation/capability/langextract/src/Alignment/Alignment.config.ts
@@ -13,10 +13,10 @@ import { NonNegativeInt } from "@beep/schema/Int";
  *
  * **Example** (Log the default threshold)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Log the default threshold"
  * import { DEFAULT_FUZZY_THRESHOLD } from "@beep/langextract/Alignment"
  *
- * console.log(DEFAULT_FUZZY_THRESHOLD) // 0.82
+ * DEFAULT_FUZZY_THRESHOLD // => 0.82
  * ```
  *
  * @category constants
@@ -37,10 +37,10 @@ export const DEFAULT_FUZZY_THRESHOLD = UnitInterval.make(0.82);
  *
  * **Example** (Log the fuzzy source bound)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Log the fuzzy source bound"
  * import { MAX_FUZZY_SOURCE_LENGTH } from "@beep/langextract/Alignment"
  *
- * console.log(MAX_FUZZY_SOURCE_LENGTH) // 100000
+ * MAX_FUZZY_SOURCE_LENGTH // => 100000
  * ```
  *
  * @category constants
@@ -58,10 +58,10 @@ export const MAX_FUZZY_SOURCE_LENGTH = 100_000;
  *
  * **Example** (Log the fuzzy query bound)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Log the fuzzy query bound"
  * import { MAX_FUZZY_QUERY_LENGTH } from "@beep/langextract/Alignment"
  *
- * console.log(MAX_FUZZY_QUERY_LENGTH) // 4096
+ * MAX_FUZZY_QUERY_LENGTH // => 4096
  * ```
  *
  * @category constants
@@ -80,10 +80,10 @@ export const MAX_FUZZY_QUERY_LENGTH = 4_096;
  *
  * **Example** (Log the default extraction cap)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Log the default extraction cap"
  * import { DEFAULT_MAX_EXTRACTIONS } from "@beep/langextract/Alignment"
  *
- * console.log(DEFAULT_MAX_EXTRACTIONS) // 256
+ * DEFAULT_MAX_EXTRACTIONS // => 256
  * ```
  *
  * @category constants

--- a/packages/foundation/capability/langextract/src/Alignment/Alignment.model.ts
+++ b/packages/foundation/capability/langextract/src/Alignment/Alignment.model.ts
@@ -34,10 +34,10 @@ const $I = $LangExtractId.create("Alignment");
  *
  * **Example** (Check aligned status membership)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check aligned status membership"
  * import { AlignedStatus } from "@beep/langextract/Alignment"
  *
- * console.log(AlignedStatus.is.match_exact("match_exact")) // true
+ * AlignedStatus.is.match_exact("match_exact") // => true
  * ```
  *
  * @category schemas
@@ -214,11 +214,11 @@ export declare namespace AlignedMatch {
  *
  * **Example** (Construct an alignment source)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Construct an alignment source"
  * import { AlignmentSource } from "@beep/langextract/Alignment"
  *
  * const source = AlignmentSource.make({ sourceText: "Ada Lovelace wrote notes." })
- * console.log(source.fuzzyThreshold) // 0.82
+ * source.fuzzyThreshold // => 0.82
  * ```
  *
  * @category models

--- a/packages/foundation/capability/langextract/src/Extraction/Extraction.config.ts
+++ b/packages/foundation/capability/langextract/src/Extraction/Extraction.config.ts
@@ -16,10 +16,10 @@
  *
  * **Example** (Log the request text bound)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Log the request text bound"
  * import { MAX_REQUEST_TEXT_LENGTH } from "@beep/langextract/Extraction"
  *
- * console.log(MAX_REQUEST_TEXT_LENGTH) // 1000000
+ * MAX_REQUEST_TEXT_LENGTH // => 1000000
  * ```
  *
  * @category constants
@@ -32,10 +32,10 @@ export const MAX_REQUEST_TEXT_LENGTH = 1_000_000;
  *
  * **Example** (Log the candidate text bound)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Log the candidate text bound"
  * import { MAX_CANDIDATE_TEXT_LENGTH } from "@beep/langextract/Extraction"
  *
- * console.log(MAX_CANDIDATE_TEXT_LENGTH) // 4096
+ * MAX_CANDIDATE_TEXT_LENGTH // => 4096
  * ```
  *
  * @category constants
@@ -48,10 +48,10 @@ export const MAX_CANDIDATE_TEXT_LENGTH = 4_096;
  *
  * **Example** (Log the candidate attribute bound)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Log the candidate attribute bound"
  * import { MAX_CANDIDATE_ATTRIBUTES } from "@beep/langextract/Extraction"
  *
- * console.log(MAX_CANDIDATE_ATTRIBUTES) // 64
+ * MAX_CANDIDATE_ATTRIBUTES // => 64
  * ```
  *
  * @category constants
@@ -64,10 +64,10 @@ export const MAX_CANDIDATE_ATTRIBUTES = 64;
  *
  * **Example** (Log the request example bound)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Log the request example bound"
  * import { MAX_REQUEST_EXAMPLES } from "@beep/langextract/Extraction"
  *
- * console.log(MAX_REQUEST_EXAMPLES) // 64
+ * MAX_REQUEST_EXAMPLES // => 64
  * ```
  *
  * @category constants
@@ -80,10 +80,10 @@ export const MAX_REQUEST_EXAMPLES = 64;
  *
  * **Example** (Log candidate limit constant)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Log candidate limit constant"
  * import { MAX_EXTRACTION_CANDIDATES } from "@beep/langextract/Extraction"
  *
- * console.log(MAX_EXTRACTION_CANDIDATES) // 1024
+ * MAX_EXTRACTION_CANDIDATES // => 1024
  * ```
  *
  * @category constants

--- a/packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.behavior.ts
+++ b/packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.behavior.ts
@@ -207,10 +207,10 @@ const normalizeWithRawOffsets = (source: string): NormalizedTextWithRawOffsets =
  *
  * **Example** (Normalize locator candidate text)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Normalize locator candidate text"
  * import { normalizeTextLocator } from "@beep/langextract/VerifiedSpan"
  *
- * console.log(normalizeTextLocator("“ofﬁce”\nrecord")) // "\"office\" record"
+ * normalizeTextLocator("“ofﬁce”\nrecord") // => "\"office\" record"
  * ```
  *
  * @category normalization

--- a/packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.config.ts
+++ b/packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.config.ts
@@ -10,10 +10,10 @@
  *
  * **Example** (Log normalization version constant)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Log normalization version constant"
  * import { VERIFIED_SPAN_NORMALIZATION_VERSION } from "@beep/langextract/VerifiedSpan"
  *
- * console.log(VERIFIED_SPAN_NORMALIZATION_VERSION) // "1"
+ * VERIFIED_SPAN_NORMALIZATION_VERSION // => "1"
  * ```
  *
  * @category constants
@@ -31,10 +31,10 @@ export const VERIFIED_SPAN_NORMALIZATION_VERSION = "1";
  *
  * **Example** (Log the source text bound)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Log the source text bound"
  * import { MAX_SOURCE_TEXT_LENGTH } from "@beep/langextract/VerifiedSpan"
  *
- * console.log(MAX_SOURCE_TEXT_LENGTH) // 1000000
+ * MAX_SOURCE_TEXT_LENGTH // => 1000000
  * ```
  *
  * @category constants
@@ -52,10 +52,10 @@ export const MAX_SOURCE_TEXT_LENGTH = 1_000_000;
  *
  * **Example** (Log the locator bound)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Log the locator bound"
  * import { MAX_LOCATOR_LENGTH } from "@beep/langextract/VerifiedSpan"
  *
- * console.log(MAX_LOCATOR_LENGTH) // 4096
+ * MAX_LOCATOR_LENGTH // => 4096
  * ```
  *
  * @category constants

--- a/packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.errors.ts
+++ b/packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.errors.ts
@@ -16,10 +16,10 @@ const $I = $LangExtractId.create("VerifiedSpan");
  *
  * **Example** (Check error reason membership)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check error reason membership"
  * import { VerifiedSpanErrorReason } from "@beep/langextract/VerifiedSpan"
  *
- * console.log(VerifiedSpanErrorReason.is.ambiguous("ambiguous")) // true
+ * VerifiedSpanErrorReason.is.ambiguous("ambiguous") // => true
  * ```
  *
  * @category errors
@@ -60,10 +60,10 @@ export type VerifiedSpanErrorReason = typeof VerifiedSpanErrorReason.Type;
  *
  * **Example** (Create error from reason)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Create error from reason"
  * import { VerifiedSpanError } from "@beep/langextract/VerifiedSpan"
  *
- * console.log(VerifiedSpanError.fromReason("ambiguous").reason) // "ambiguous"
+ * VerifiedSpanError.fromReason("ambiguous").reason // => "ambiguous"
  * ```
  *
  * @category errors

--- a/packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.model.ts
+++ b/packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.model.ts
@@ -16,10 +16,10 @@ const $I = $LangExtractId.create("VerifiedSpan");
  *
  * **Example** (Check offset unit membership)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check offset unit membership"
  * import { TextOffsetUnit } from "@beep/langextract/VerifiedSpan"
  *
- * console.log(TextOffsetUnit.is["utf16-code-unit"]("utf16-code-unit")) // true
+ * TextOffsetUnit.is["utf16-code-unit"]("utf16-code-unit") // => true
  * ```
  *
  * @category schemas
@@ -165,7 +165,7 @@ const Utf16TextRangeInvariant = Utf16TextRangeStruct.mapFields(identity)
  *
  * **Example** (Create UTF-16 text range)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Create UTF-16 text range"
  * import { Utf16TextRange } from "@beep/langextract/VerifiedSpan"
  * import { NonNegativeInt } from "@beep/schema"
  *
@@ -173,7 +173,7 @@ const Utf16TextRangeInvariant = Utf16TextRangeStruct.mapFields(identity)
  *   startChar: NonNegativeInt.make(1),
  *   endChar: NonNegativeInt.make(3),
  * })
- * console.log(range.endChar) // 3
+ * range.endChar // => 3
  * ```
  *
  * @category models

--- a/packages/foundation/capability/mcp-kit/src/SanitizedSpan.ts
+++ b/packages/foundation/capability/mcp-kit/src/SanitizedSpan.ts
@@ -163,7 +163,7 @@ export const sanitizeTracerAttributes: {
  * import { withSanitizedToolSpan } from "@beep/mcp-kit"
  *
  * const program = withSanitizedToolSpan(Effect.annotateCurrentSpan({ parameters: { secret: "x" } }), "mcp.tool.call")
- * Effect.runSync(program)
+ * Effect.runSync(program) // => undefined
  * ```
  *
  * @category combinators

--- a/packages/foundation/capability/mcp-kit/src/SanitizedSpan.ts
+++ b/packages/foundation/capability/mcp-kit/src/SanitizedSpan.ts
@@ -158,7 +158,7 @@ export const sanitizeTracerAttributes: {
  *
  * **Example** (Run under sanitized span)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Run under sanitized span"
  * import { Effect } from "effect"
  * import { withSanitizedToolSpan } from "@beep/mcp-kit"
  *

--- a/packages/foundation/capability/nlp-processing/src/Backend/Composition.ts
+++ b/packages/foundation/capability/nlp-processing/src/Backend/Composition.ts
@@ -89,7 +89,7 @@ const cachedGet = <A, E, R>(
  *
  * **Example** (Primary secondary fallback composition)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Primary secondary fallback composition"
  * import { Effect } from "effect"
  * import { withFallback } from "@beep/nlp-processing/Backend/Composition"
  * import { notSupported } from "@beep/nlp-processing/Backend/NLPBackend"
@@ -118,7 +118,7 @@ const cachedGet = <A, E, R>(
  *   extractRelations: () => Effect.succeed([])
  * }
  * const secondary: NLPBackendShape = { ...primary, name: "secondary", tokenize: (text) => Effect.succeed([text]) }
- * console.log(withFallback(primary, secondary).name) // "primary+secondary"
+ * withFallback(primary, secondary).name // => "primary+secondary"
  * ```
  *
  * @category combinators
@@ -202,13 +202,13 @@ export const withFallback: {
  *
  * **Example** (Caching options capacity TTL)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Caching options capacity TTL"
  * import { Duration } from "effect"
  * import { PosInt } from "@beep/schema"
  * import type { CachingOptions } from "@beep/nlp-processing/Backend/Composition"
  *
  * const options: CachingOptions = { capacity: PosInt.make(64), timeToLive: Duration.minutes(5) }
- * console.log(options.capacity) // 64
+ * options.capacity // => 64
  * ```
  *
  * @category models
@@ -235,7 +235,7 @@ export class CachingOptions extends S.Class<CachingOptions>($I`CachingOptions`)(
  *
  * **Example** (Memoized backend tokenize cache)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Memoized backend tokenize cache"
  * import { Effect } from "effect"
  * import { PosInt } from "@beep/schema"
  * import { withCaching } from "@beep/nlp-processing/Backend/Composition"
@@ -265,7 +265,7 @@ export class CachingOptions extends S.Class<CachingOptions>($I`CachingOptions`)(
  * const program = Effect.flatMap(withCaching(backend, { capacity: PosInt.make(16) }), (cached) =>
  *   cached.tokenize("typed effects")
  * )
- * Effect.runPromise(program).then(console.log) // ["typed", "effects"]
+ * await Effect.runPromise(program) // => ["typed", "effects"]
  * ```
  *
  * @effects Allocates per-operation `effect/Cache` instances when the wrapper

--- a/packages/foundation/capability/nlp-processing/src/Backend/NLPBackend.ts
+++ b/packages/foundation/capability/nlp-processing/src/Backend/NLPBackend.ts
@@ -47,7 +47,7 @@ const isBackendOperationErrorDataFirst = (args: IArguments): boolean => args.len
  *
  * **Example** (Create unsupported backend error)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Create unsupported backend error"
  * import { BackendNotSupported } from "@beep/nlp-processing/Backend/NLPBackend"
  *
  * const error = BackendNotSupported.make({
@@ -55,7 +55,7 @@ const isBackendOperationErrorDataFirst = (args: IArguments): boolean => args.len
  *   operation: "parseDependencies",
  *   message: "Dependency parsing is unavailable"
  * })
- * console.log(error._tag) // "BackendNotSupported"
+ * error._tag // => "BackendNotSupported"
  * ```
  *
  * @category errors
@@ -91,7 +91,7 @@ export class BackendNotSupported extends S.TaggedError<BackendNotSupported>($I`B
  *
  * **Example** (Create backend init error)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Create backend init error"
  * import { BackendInitError } from "@beep/nlp-processing/Backend/NLPBackend"
  *
  * const error = BackendInitError.make({
@@ -99,7 +99,7 @@ export class BackendNotSupported extends S.TaggedError<BackendNotSupported>($I`B
  *   cause: new Error("model load failed"),
  *   message: "Backend wink-nlp failed to initialize"
  * })
- * console.log(error.backend) // "wink-nlp"
+ * error.backend // => "wink-nlp"
  * ```
  *
  * @category errors
@@ -135,7 +135,7 @@ export class BackendInitError extends S.TaggedError<BackendInitError>($I`Backend
  *
  * **Example** (Create operation failure error)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Create operation failure error"
  * import { BackendOperationError } from "@beep/nlp-processing/Backend/NLPBackend"
  *
  * const error = BackendOperationError.make({
@@ -144,7 +144,7 @@ export class BackendInitError extends S.TaggedError<BackendInitError>($I`Backend
  *   cause: new Error("tokenizer failed"),
  *   message: "Backend wink-nlp operation posTag failed"
  * })
- * console.log(error.operation) // "posTag"
+ * error.operation // => "posTag"
  * ```
  *
  * @category errors
@@ -185,11 +185,11 @@ export class BackendOperationError extends S.TaggedError<BackendOperationError>(
  *
  * **Example** (Check union membership)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check union membership"
  * import { notSupported, NLPBackendError } from "@beep/nlp-processing/Backend/NLPBackend"
  *
  * const error = notSupported("minimal", "ner")
- * console.log(NLPBackendError.is(error)) // true
+ * NLPBackendError.is(error) // => true
  * ```
  *
  * @category errors
@@ -225,7 +225,7 @@ export type NLPBackendError = typeof NLPBackendError.Type;
  *
  * **Example** (Declare capability bitmap)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Declare capability bitmap"
  * import type { BackendCapabilities } from "@beep/nlp-processing/Backend/NLPBackend"
  *
  * const capabilities: BackendCapabilities = {
@@ -239,7 +239,7 @@ export type NLPBackendError = typeof NLPBackendError.Type;
  *   sentencization: true,
  *   tokenization: true
  * }
- * console.log(capabilities.tokenization) // true
+ * capabilities.tokenization // => true
  * ```
  *
  * @category models
@@ -301,7 +301,7 @@ export class BackendCapabilities extends S.Class<BackendCapabilities>($I`Backend
  *
  * **Example** (Implement minimal backend shape)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Implement minimal backend shape"
  * import { Effect } from "effect"
  * import type { NLPBackendShape } from "@beep/nlp-processing/Backend/NLPBackend"
  *
@@ -326,7 +326,7 @@ export class BackendCapabilities extends S.Class<BackendCapabilities>($I`Backend
  *   parseDependencies: () => Effect.succeed([]),
  *   extractRelations: () => Effect.succeed([])
  * }
- * console.log(backend.name) // "minimal"
+ * backend.name // => "minimal"
  * ```
  *
  * @category models
@@ -376,7 +376,7 @@ export class NLPBackend extends Context.Service<NLPBackend, NLPBackendShape>()($
  *
  * **Example** (Check single capability support)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check single capability support"
  * import { Effect } from "effect"
  * import { supportsCapability } from "@beep/nlp-processing/Backend/NLPBackend"
  * import type { NLPBackendShape } from "@beep/nlp-processing/Backend/NLPBackend"
@@ -402,7 +402,7 @@ export class NLPBackend extends Context.Service<NLPBackend, NLPBackendShape>()($
  *   parseDependencies: () => Effect.succeed([]),
  *   extractRelations: () => Effect.succeed([])
  * }
- * console.log(supportsCapability(backend, "tokenization")) // true
+ * supportsCapability(backend, "tokenization") // => true
  * ```
  *
  * @category utilities
@@ -421,7 +421,7 @@ export const supportsCapability: {
  *
  * **Example** (List supported capability keys)
  *
- * ```ts
+ * ```ts import.meta.vitest name="List supported capability keys"
  * import { Effect } from "effect"
  * import { getSupportedCapabilities } from "@beep/nlp-processing/Backend/NLPBackend"
  * import type { NLPBackendShape } from "@beep/nlp-processing/Backend/NLPBackend"
@@ -447,7 +447,7 @@ export const supportsCapability: {
  *   parseDependencies: () => Effect.succeed([]),
  *   extractRelations: () => Effect.succeed([])
  * }
- * console.log(getSupportedCapabilities(backend)) // ["tokenization"]
+ * getSupportedCapabilities(backend) // => ["sentencization", "tokenization"]
  * ```
  *
  * @category utilities
@@ -470,15 +470,15 @@ export const getSupportedCapabilities = (backend: NLPBackendShape): ReadonlyArra
  *
  * **Example** (Build not-supported failure)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Build not-supported failure"
  * import { pipe } from "effect"
  * import { notSupported } from "@beep/nlp-processing/Backend/NLPBackend"
  *
  * const error = notSupported("minimal", "dependencyParsing")
  * const custom = pipe("minimal", notSupported("dependencyParsing", { message: "No parser bundled" }))
  *
- * console.log(error.message.includes("dependencyParsing")) // true
- * console.log(custom.message) // "No parser bundled"
+ * error.message.includes("dependencyParsing") // => true
+ * custom.message // => "No parser bundled"
  * ```
  *
  * @category constructors
@@ -498,11 +498,11 @@ export const notSupported: {
  *
  * **Example** (Build init error from cause)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Build init error from cause"
  * import { initError } from "@beep/nlp-processing/Backend/NLPBackend"
  *
  * const error = initError("wink-nlp", new Error("missing model"))
- * console.log(error.backend) // "wink-nlp"
+ * error.backend // => "wink-nlp"
  * ```
  *
  * @category constructors
@@ -515,11 +515,11 @@ export const initError: typeof BackendInitError.fromCause = BackendInitError.fro
  *
  * **Example** (Build operation error from cause)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Build operation error from cause"
  * import { operationError } from "@beep/nlp-processing/Backend/NLPBackend"
  *
  * const error = operationError("wink-nlp", "tokenize", new Error("bad input"))
- * console.log(error.operation) // "tokenize"
+ * error.operation // => "tokenize"
  * ```
  *
  * @category constructors

--- a/packages/foundation/capability/nlp-processing/src/Core/Tokenization.ts
+++ b/packages/foundation/capability/nlp-processing/src/Core/Tokenization.ts
@@ -27,14 +27,14 @@ type TokenizationShape = {
  *
  * **Example** (Make tokenization error)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make tokenization error"
  * import { TokenizationError } from "@beep/nlp-processing/Core/Tokenization"
  *
  * const error = TokenizationError.make({
  *   operation: "tokenize",
  *   cause: new Error("tokenizer unavailable")
  * })
- * console.log(error.operation) // "tokenize"
+ * error.operation // => "tokenize"
  * ```
  *
  * @category errors
@@ -148,7 +148,7 @@ export const sentences = Effect.fn("Nlp.Core.Tokenization.sentences")(function* 
  *
  * **Example** (Build document with mock)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Build document with mock"
  * import { Chunk, Effect } from "effect"
  * import * as O from "effect/Option"
  * import { Document, DocumentId } from "@beep/nlp/Core/Document"
@@ -171,7 +171,7 @@ export const sentences = Effect.fn("Nlp.Core.Tokenization.sentences")(function* 
  *   Effect.provideService(tokenizeToDocument("Effect works.", "doc-001"), Tokenization, service),
  *   (document) => document.id
  * )
- * Effect.runPromise(program).then(console.log) // "doc-001"
+ * await Effect.runPromise(program) // => "doc-001"
  * ```
  *
  * @effects Requires a {@link Tokenization} service and executes that service's
@@ -192,7 +192,7 @@ export const tokenizeToDocument = Effect.fn("Nlp.Core.Tokenization.tokenizeToDoc
  *
  * **Example** (Count tokens with mock)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Count tokens with mock"
  * import { Chunk, Effect } from "effect"
  * import * as O from "effect/Option"
  * import { Document, DocumentId } from "@beep/nlp/Core/Document"
@@ -212,7 +212,7 @@ export const tokenizeToDocument = Effect.fn("Nlp.Core.Tokenization.tokenizeToDoc
  *   tokenCount: (text) => Effect.succeed(text.split(" ").length)
  * })
  * const program = Effect.provideService(tokenCount("typed effects"), Tokenization, service)
- * Effect.runPromise(program).then(console.log) // 2
+ * await Effect.runPromise(program) // => 2
  * ```
  *
  * @effects Requires a {@link Tokenization} service and executes that service's

--- a/packages/foundation/capability/nlp-processing/src/Graph/AnnotatedTextGraph.ts
+++ b/packages/foundation/capability/nlp-processing/src/Graph/AnnotatedTextGraph.ts
@@ -54,7 +54,7 @@ const $I = $NlpProcessingId.create("Graph/AnnotatedTextGraph");
  *
  * **Example** (Create TextNode as AnnotatedNode)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Create TextNode as AnnotatedNode"
  * import { TextNode } from "@beep/nlp/Graph/Schema"
  * import type { AnnotatedNode } from "@beep/nlp-processing/Graph/AnnotatedTextGraph"
  *
@@ -64,7 +64,7 @@ const $I = $NlpProcessingId.create("Graph/AnnotatedTextGraph");
  *   timestamp: 0
  * })
  *
- * console.log(node.type) // "sentence"
+ * node.type // => "sentence"
  * ```
  *
  * @category models
@@ -82,7 +82,7 @@ export const AnnotatedNode = S.Union([TextNode, POSNode, EntityNode, LemmaNode, 
  *
  * **Example** (Validate POSNode with Schema)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Validate POSNode with Schema"
  * import { POSNode } from "@beep/nlp/Graph/Schema"
  * import type { AnnotatedNode } from "@beep/nlp-processing/Graph/AnnotatedTextGraph"
  * import * as S from "effect/Schema"
@@ -94,7 +94,7 @@ export const AnnotatedNode = S.Union([TextNode, POSNode, EntityNode, LemmaNode, 
  *   timestamp: 0
  * })
  *
- * console.log(S.is(POSNode)(node)) // true
+ * S.is(POSNode)(node) // => true
  * ```
  *
  * @category models
@@ -107,12 +107,12 @@ export type AnnotatedNode = typeof AnnotatedNode.Type;
  *
  * **Example** (Check node is TextNode)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check node is TextNode"
  * import { isTextNode } from "@beep/nlp-processing/Graph/AnnotatedTextGraph"
  * import { TextNode } from "@beep/nlp/Graph/Schema"
  *
  * const node = TextNode.make({ text: "Hello.", type: "sentence", timestamp: 0 })
- * console.log(isTextNode(node)) // true
+ * isTextNode(node) // => true
  * ```
  *
  * @param node - The annotated node to refine.
@@ -127,12 +127,12 @@ export const isTextNode: (node: AnnotatedNode) => node is TextNode = S.is(TextNo
  *
  * **Example** (Check node is POSNode)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check node is POSNode"
  * import { isPOSNode } from "@beep/nlp-processing/Graph/AnnotatedTextGraph"
  * import { POSNode } from "@beep/nlp/Graph/Schema"
  *
  * const node = POSNode.make({ text: "runs", tag: "VBZ", position: 0, timestamp: 0 })
- * console.log(isPOSNode(node)) // true
+ * isPOSNode(node) // => true
  * ```
  *
  * @param node - The annotated node to refine.
@@ -147,7 +147,7 @@ export const isPOSNode: (node: AnnotatedNode) => node is POSNode = S.is(POSNode)
  *
  * **Example** (Check node is EntityNode)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check node is EntityNode"
  * import { isEntityNode } from "@beep/nlp-processing/Graph/AnnotatedTextGraph"
  * import { EntityNode } from "@beep/nlp/Graph/Schema"
  *
@@ -158,7 +158,7 @@ export const isPOSNode: (node: AnnotatedNode) => node is POSNode = S.is(POSNode)
  *   timestamp: 0
  * })
  *
- * console.log(isEntityNode(node)) // true
+ * isEntityNode(node) // => true
  * ```
  *
  * @param node - The annotated node to refine.
@@ -173,12 +173,12 @@ export const isEntityNode: (node: AnnotatedNode) => node is EntityNode = S.is(En
  *
  * **Example** (Check node is LemmaNode)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check node is LemmaNode"
  * import { isLemmaNode } from "@beep/nlp-processing/Graph/AnnotatedTextGraph"
  * import { LemmaNode } from "@beep/nlp/Graph/Schema"
  *
  * const node = LemmaNode.make({ token: "running", lemma: "run", position: 0, timestamp: 0 })
- * console.log(isLemmaNode(node)) // true
+ * isLemmaNode(node) // => true
  * ```
  *
  * @category refinements
@@ -191,7 +191,7 @@ export const isLemmaNode: (node: AnnotatedNode) => node is LemmaNode = S.is(Lemm
  *
  * **Example** (Check node is DependencyNode)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check node is DependencyNode"
  * import { isDependencyNode } from "@beep/nlp-processing/Graph/AnnotatedTextGraph"
  * import { DependencyNode } from "@beep/nlp/Graph/Schema"
  *
@@ -203,7 +203,7 @@ export const isLemmaNode: (node: AnnotatedNode) => node is LemmaNode = S.is(Lemm
  *   timestamp: 0
  * })
  *
- * console.log(isDependencyNode(node)) // true
+ * isDependencyNode(node) // => true
  * ```
  *
  * @category refinements
@@ -216,7 +216,7 @@ export const isDependencyNode: (node: AnnotatedNode) => node is DependencyNode =
  *
  * **Example** (Check node is RelationNode)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check node is RelationNode"
  * import { isRelationNode } from "@beep/nlp-processing/Graph/AnnotatedTextGraph"
  * import { RelationNode } from "@beep/nlp/Graph/Schema"
  *
@@ -227,7 +227,7 @@ export const isDependencyNode: (node: AnnotatedNode) => node is DependencyNode =
  *   timestamp: 0
  * })
  *
- * console.log(isRelationNode(node)) // true
+ * isRelationNode(node) // => true
  * ```
  *
  * @category refinements
@@ -244,11 +244,11 @@ export const isRelationNode: (node: AnnotatedNode) => node is RelationNode = S.i
  *
  * **Example** (Empty graph node count)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Empty graph node count"
  * import { empty, nodeCount, type AnnotatedTextGraph } from "@beep/nlp-processing/Graph/AnnotatedTextGraph"
  *
  * const graph: AnnotatedTextGraph = empty()
- * console.log(nodeCount(graph)) // 0
+ * nodeCount(graph) // => 0
  * ```
  *
  * @category models
@@ -297,10 +297,10 @@ const makeTextNode = (fields: {
  *
  * **Example** (Create empty annotated graph)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Create empty annotated graph"
  * import { empty, nodeCount } from "@beep/nlp-processing/Graph/AnnotatedTextGraph"
  *
- * console.log(nodeCount(empty())) // 0
+ * nodeCount(empty()) // => 0
  * ```
  *
  * @category constructors
@@ -347,7 +347,7 @@ class AnnotationOptions extends S.Class<AnnotationOptions>($I`AnnotationOptions`
  *
  * **Example** (Build graph from document)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Build graph from document"
  * import { Effect } from "effect"
  * import { NLPBackend } from "@beep/nlp-processing/Backend/NLPBackend"
  * import { fromDocumentAnnotated } from "@beep/nlp-processing/Graph/AnnotatedTextGraph"
@@ -377,7 +377,7 @@ class AnnotationOptions extends S.Class<AnnotationOptions>($I`AnnotationOptions`
  *   })
  * )
  *
- * console.log(nodeCount(graph)) // 2
+ * nodeCount(graph) // => 2
  * ```
  *
  * @effects Reads the `NLPBackend` service for sentence and annotation data and reads the Effect `Clock` while creating structural text nodes.
@@ -665,10 +665,10 @@ const entriesWhere: {
  *
  * **Example** (Get POS nodes from empty)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Get POS nodes from empty"
  * import { empty, getPOSNodes } from "@beep/nlp-processing/Graph/AnnotatedTextGraph"
  *
- * console.log(getPOSNodes(empty()).length) // 0
+ * getPOSNodes(empty()).length // => 0
  * ```
  *
  * @category getters
@@ -686,10 +686,10 @@ export const getPOSNodes = (
  *
  * **Example** (Get entity nodes from empty)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Get entity nodes from empty"
  * import { empty, getEntityNodes } from "@beep/nlp-processing/Graph/AnnotatedTextGraph"
  *
- * console.log(getEntityNodes(empty()).length) // 0
+ * getEntityNodes(empty()).length // => 0
  * ```
  *
  * @category getters
@@ -707,10 +707,10 @@ export const getEntityNodes = (
  *
  * **Example** (Get lemma nodes from empty)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Get lemma nodes from empty"
  * import { empty, getLemmaNodes } from "@beep/nlp-processing/Graph/AnnotatedTextGraph"
  *
- * console.log(getLemmaNodes(empty()).length) // 0
+ * getLemmaNodes(empty()).length // => 0
  * ```
  *
  * @category getters
@@ -728,10 +728,10 @@ export const getLemmaNodes = (
  *
  * **Example** (Get text nodes from empty)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Get text nodes from empty"
  * import { empty, getTextNodes } from "@beep/nlp-processing/Graph/AnnotatedTextGraph"
  *
- * console.log(getTextNodes(empty()).length) // 0
+ * getTextNodes(empty()).length // => 0
  * ```
  *
  * @category getters
@@ -749,10 +749,10 @@ export const getTextNodes = (
  *
  * **Example** (Filter empty graph by ORG)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Filter empty graph by ORG"
  * import { empty, filterEntitiesByType } from "@beep/nlp-processing/Graph/AnnotatedTextGraph"
  *
- * console.log(filterEntitiesByType(empty(), "ORG").length) // 0
+ * filterEntitiesByType(empty(), "ORG").length // => 0
  * ```
  *
  * @category getters
@@ -775,10 +775,10 @@ export const filterEntitiesByType: {
  *
  * **Example** (Filter empty graph by NNP)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Filter empty graph by NNP"
  * import { empty, filterByPOSTag } from "@beep/nlp-processing/Graph/AnnotatedTextGraph"
  *
- * console.log(filterByPOSTag(empty(), "NNP").length) // 0
+ * filterByPOSTag(empty(), "NNP").length // => 0
  * ```
  *
  * @category getters
@@ -801,10 +801,10 @@ export const filterByPOSTag: {
  *
  * **Example** (Count entity nodes in empty)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Count entity nodes in empty"
  * import { countNodesByType, empty } from "@beep/nlp-processing/Graph/AnnotatedTextGraph"
  *
- * console.log(countNodesByType(empty()).entity) // 0
+ * countNodesByType(empty()).entity // => 0
  * ```
  *
  * @category getters
@@ -837,10 +837,10 @@ export const countNodesByType = (graph: AnnotatedTextGraph): Record<string, numb
  *
  * **Example** (Collect nodes from empty)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Collect nodes from empty"
  * import { empty, toArray } from "@beep/nlp-processing/Graph/AnnotatedTextGraph"
  *
- * console.log(toArray(empty()).length) // 0
+ * toArray(empty()).length // => 0
  * ```
  *
  * @category getters
@@ -854,10 +854,10 @@ export const toArray = (graph: AnnotatedTextGraph): ReadonlyArray<AnnotatedNode>
  *
  * **Example** (Count nodes in empty graph)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Count nodes in empty graph"
  * import { empty, nodeCount } from "@beep/nlp-processing/Graph/AnnotatedTextGraph"
  *
- * console.log(nodeCount(empty())) // 0
+ * nodeCount(empty()) // => 0
  * ```
  *
  * @category getters
@@ -870,10 +870,10 @@ export const nodeCount = (graph: AnnotatedTextGraph): number => Graph.nodeCount(
  *
  * **Example** (Get roots of empty graph)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Get roots of empty graph"
  * import { empty, getRoots } from "@beep/nlp-processing/Graph/AnnotatedTextGraph"
  *
- * console.log(getRoots(empty()).length) // 0
+ * getRoots(empty()).length // => 0
  * ```
  *
  * @category getters

--- a/packages/foundation/capability/nlp-processing/src/Graph/EffectGraph.ts
+++ b/packages/foundation/capability/nlp-processing/src/Graph/EffectGraph.ts
@@ -44,11 +44,11 @@ const $I = $NlpProcessingId.create("Graph/EffectGraph");
  *
  * **Example** (Making a branded NodeId)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Making a branded NodeId"
  * import { NodeId } from "@beep/nlp-processing/Graph/EffectGraph"
  *
  * const nodeId = NodeId.make("node-example")
- * console.log(nodeId.startsWith("node-")) // true
+ * nodeId.startsWith("node-") // => true
  * ```
  *
  * @category models
@@ -84,12 +84,12 @@ export type NodeId = typeof NodeId.Type;
  *
  * **Example** (Generating a fresh NodeId)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Generating a fresh NodeId"
  * import { Effect } from "effect"
  * import { generateNodeId } from "@beep/nlp-processing/Graph/EffectGraph"
  *
  * const program = Effect.map(generateNodeId, (id) => id.startsWith("node-"))
- * console.log(Effect.runSync(program)) // true
+ * Effect.runSync(program) // => true
  * ```
  *
  * @effects Reads the Effect `Clock` and random service to include timestamp and entropy in the generated id.
@@ -107,11 +107,11 @@ export const generateNodeId: Effect.Effect<NodeId> = Effect.gen(function* () {
  *
  * **Example** (Creating NodeNotFoundError)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Creating NodeNotFoundError"
  * import { NodeId, NodeNotFoundError } from "@beep/nlp-processing/Graph/EffectGraph"
  *
  * const error = NodeNotFoundError.make({ nodeId: NodeId.make("node-missing") })
- * console.log(error._tag) // "NodeNotFoundError"
+ * error._tag // => "NodeNotFoundError"
  * ```
  *
  * @category errors
@@ -132,7 +132,7 @@ export class NodeNotFoundError extends S.TaggedError<NodeNotFoundError>($I`NodeN
  *
  * **Example** (Building NodeMetadata values)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Building NodeMetadata values"
  * import { NonNegativeInt } from "@beep/schema"
  * import { NodeMetadata } from "@beep/nlp-processing/Graph/EffectGraph"
  * import * as O from "effect/Option"
@@ -143,7 +143,7 @@ export class NodeNotFoundError extends S.TaggedError<NodeNotFoundError>($I`NodeN
  *   timestamp: 0
  * })
  *
- * console.log(metadata.depth) // 0
+ * metadata.depth // => 0
  * ```
  *
  * @category models
@@ -194,11 +194,11 @@ export interface GraphNode<A> {
  *
  * **Example** (Making a GraphEdge)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Making a GraphEdge"
  * import { GraphEdge } from "@beep/nlp-processing/Graph/EffectGraph"
  *
  * const edge = GraphEdge.make({ relation: "child" })
- * console.log(edge.relation) // "child"
+ * edge.relation // => "child"
  * ```
  *
  * @category models
@@ -249,12 +249,12 @@ export interface EffectGraph<A> {
  *
  * **Example** (Creating node with makeNode)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Creating node with makeNode"
  * import { Effect } from "effect"
  * import { makeNode } from "@beep/nlp-processing/Graph/EffectGraph"
  *
  * const node = Effect.runSync(makeNode("hello"))
- * console.log(node.data) // "hello"
+ * node.data // => "hello"
  * ```
  *
  * @category constructors
@@ -315,12 +315,12 @@ export const empty = <A>(): EffectGraph<A> => ({
  *
  * **Example** (Creating a singleton graph)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Creating a singleton graph"
  * import { Effect } from "effect"
  * import { singleton, size } from "@beep/nlp-processing/Graph/EffectGraph"
  *
  * const graph = Effect.runSync(singleton("root"))
- * console.log(size(graph)) // 1
+ * size(graph) // => 1
  * ```
  *
  * @effects Generates a root node via `makeNode`, which reads the Effect `Clock` and random service for metadata and id fields.
@@ -417,7 +417,7 @@ export const addNode: {
  *
  * **Example** (Looking up node by id)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Looking up node by id"
  * import { Effect } from "effect"
  * import { getNode, getRoots, singleton } from "@beep/nlp-processing/Graph/EffectGraph"
  * import * as O from "effect/Option"
@@ -427,7 +427,7 @@ export const addNode: {
  *   return O.isSome(getNode(graph, root.id))
  * })
  *
- * console.log(Effect.runSync(program)) // true
+ * Effect.runSync(program) // => true
  * ```
  *
  * @category getters
@@ -447,7 +447,7 @@ export const getNode: {
  *
  * **Example** (Reading direct child nodes)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Reading direct child nodes"
  * import { Effect } from "effect"
  * import { getChildren, getRoots, singleton } from "@beep/nlp-processing/Graph/EffectGraph"
  *
@@ -456,7 +456,7 @@ export const getNode: {
  *   return getChildren(graph, root.id).length
  * })
  *
- * console.log(Effect.runSync(program)) // 0
+ * Effect.runSync(program) // => 0
  * ```
  *
  * @category getters
@@ -480,12 +480,12 @@ export const getChildren: {
  *
  * **Example** (Getting root nodes)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Getting root nodes"
  * import { Effect } from "effect"
  * import { getRoots, singleton } from "@beep/nlp-processing/Graph/EffectGraph"
  *
  * const program = Effect.map(singleton("root"), (graph) => getRoots(graph).length)
- * console.log(Effect.runSync(program)) // 1
+ * Effect.runSync(program) // => 1
  * ```
  *
  * @category getters
@@ -652,7 +652,7 @@ export const ana: {
  *
  * **Example** (Mapping node payload values)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Mapping node payload values"
  * import { Effect } from "effect"
  * import { map, singleton, toArray } from "@beep/nlp-processing/Graph/EffectGraph"
  *
@@ -660,7 +660,7 @@ export const ana: {
  *   toArray(map(graph, (text) => text.length))[0].data
  * )
  *
- * console.log(Effect.runSync(program)) // 4
+ * Effect.runSync(program) // => 4
  * ```
  *
  * @category mapping
@@ -709,12 +709,12 @@ export const map: {
  *
  * **Example** (Collecting nodes as array)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Collecting nodes as array"
  * import { Effect } from "effect"
  * import { singleton, toArray } from "@beep/nlp-processing/Graph/EffectGraph"
  *
  * const program = Effect.map(singleton("root"), (graph) => toArray(graph).length)
- * console.log(Effect.runSync(program)) // 1
+ * Effect.runSync(program) // => 1
  * ```
  *
  * @category getters
@@ -749,12 +749,12 @@ export const size = <A>(graph: EffectGraph<A>): number => Graph.nodeCount(graph.
  *
  * **Example** (Rendering graph as tree)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Rendering graph as tree"
  * import { Effect } from "effect"
  * import { show, singleton } from "@beep/nlp-processing/Graph/EffectGraph"
  *
  * const program = Effect.map(singleton("root"), show((text) => text))
- * console.log(Effect.runSync(program)) // "[root] root"
+ * Effect.runSync(program) // => "[root] root"
  * ```
  *
  * @category formatting

--- a/packages/foundation/capability/nlp-processing/src/Graph/GraphOperations/Catalog.ts
+++ b/packages/foundation/capability/nlp-processing/src/Graph/GraphOperations/Catalog.ts
@@ -42,10 +42,10 @@ import type { DependencyNode, EntityNode, LemmaNode, POSNode, RelationNode } fro
  *
  * **Example** (Log sentencize category)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Log sentencize category"
  * import { sentencize } from "@beep/nlp-processing/Graph/GraphOperations/Catalog"
  *
- * console.log(sentencize.category) // "expansion"
+ * sentencize.category // => "expansion"
  * ```
  *
  * @category use-cases
@@ -72,10 +72,10 @@ export const sentencize: Op.GraphOperation<string, string, Backend.NLPBackend, B
  *
  * **Example** (Log tokenize category)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Log tokenize category"
  * import { tokenize } from "@beep/nlp-processing/Graph/GraphOperations/Catalog"
  *
- * console.log(tokenize.category) // "expansion"
+ * tokenize.category // => "expansion"
  * ```
  *
  * @category use-cases
@@ -103,10 +103,10 @@ export const tokenize: Op.GraphOperation<string, string, Backend.NLPBackend, Bac
  *
  * **Example** (Log posTag name)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Log posTag name"
  * import { posTag } from "@beep/nlp-processing/Graph/GraphOperations/Catalog"
  *
- * console.log(posTag.name) // "posTag"
+ * posTag.name // => "posTag"
  * ```
  *
  * @category use-cases
@@ -133,10 +133,10 @@ export const posTag: Op.GraphOperation<string, POSNode, Backend.NLPBackend, Back
  *
  * **Example** (Log lemmatize name)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Log lemmatize name"
  * import { lemmatize } from "@beep/nlp-processing/Graph/GraphOperations/Catalog"
  *
- * console.log(lemmatize.name) // "lemmatize"
+ * lemmatize.name // => "lemmatize"
  * ```
  *
  * @category use-cases
@@ -162,10 +162,10 @@ export const lemmatize: Op.GraphOperation<string, LemmaNode, Backend.NLPBackend,
  *
  * **Example** (Log extractEntities name)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Log extractEntities name"
  * import { extractEntities } from "@beep/nlp-processing/Graph/GraphOperations/Catalog"
  *
- * console.log(extractEntities.name) // "extractEntities"
+ * extractEntities.name // => "extractEntities"
  * ```
  *
  * @category use-cases
@@ -193,10 +193,10 @@ export const extractEntities: Op.GraphOperation<string, EntityNode, Backend.NLPB
  *
  * **Example** (Log parseDependencies name)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Log parseDependencies name"
  * import { parseDependencies } from "@beep/nlp-processing/Graph/GraphOperations/Catalog"
  *
- * console.log(parseDependencies.name) // "parseDependencies"
+ * parseDependencies.name // => "parseDependencies"
  * ```
  *
  * @category use-cases
@@ -225,10 +225,10 @@ export const parseDependencies: Op.GraphOperation<string, DependencyNode, Backen
  *
  * **Example** (Log extractRelations name)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Log extractRelations name"
  * import { extractRelations } from "@beep/nlp-processing/Graph/GraphOperations/Catalog"
  *
- * console.log(extractRelations.name) // "extractRelations"
+ * extractRelations.name // => "extractRelations"
  * ```
  *
  * @category use-cases
@@ -251,10 +251,10 @@ export const extractRelations: Op.GraphOperation<string, RelationNode, Backend.N
  *
  * **Example** (Log toLowerCase category)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Log toLowerCase category"
  * import { toLowerCase } from "@beep/nlp-processing/Graph/GraphOperations/Catalog"
  *
- * console.log(toLowerCase.category) // "transformation"
+ * toLowerCase.category // => "transformation"
  * ```
  *
  * @category use-cases
@@ -271,10 +271,10 @@ export const toLowerCase: Op.GraphOperation<string, string> = Op.transform({
  *
  * **Example** (Log toUpperCase category)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Log toUpperCase category"
  * import { toUpperCase } from "@beep/nlp-processing/Graph/GraphOperations/Catalog"
  *
- * console.log(toUpperCase.category) // "transformation"
+ * toUpperCase.category // => "transformation"
  * ```
  *
  * @category use-cases
@@ -291,10 +291,10 @@ export const toUpperCase: Op.GraphOperation<string, string> = Op.transform({
  *
  * **Example** (Log trim category)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Log trim category"
  * import { trim } from "@beep/nlp-processing/Graph/GraphOperations/Catalog"
  *
- * console.log(trim.category) // "transformation"
+ * trim.category // => "transformation"
  * ```
  *
  * @category use-cases
@@ -316,10 +316,10 @@ export const trim: Op.GraphOperation<string, string> = Op.transform({
  *
  * **Example** (Log tokenize operation name)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Log tokenize operation name"
  * import { StandardOperations } from "@beep/nlp-processing/Graph/GraphOperations/Catalog"
  *
- * console.log(StandardOperations.tokenize.name) // "tokenize"
+ * StandardOperations.tokenize.name // => "tokenize"
  * ```
  *
  * @category constants
@@ -343,10 +343,10 @@ export const StandardOperations = {
  *
  * **Example** (Check tokenize name listed)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check tokenize name listed"
  * import { getOperationNames } from "@beep/nlp-processing/Graph/GraphOperations/Catalog"
  *
- * console.log(getOperationNames().includes("tokenize")) // true
+ * getOperationNames().includes("tokenize") // => true
  * ```
  *
  * @category constants

--- a/packages/foundation/capability/nlp-processing/src/Graph/GraphOperations/Errors.ts
+++ b/packages/foundation/capability/nlp-processing/src/Graph/GraphOperations/Errors.ts
@@ -22,7 +22,7 @@ const $I = $NlpProcessingId.create("Graph/GraphOperations/Errors");
  *
  * **Example** (Construct ValidationError instance)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Construct ValidationError instance"
  * import { NodeId } from "@beep/nlp-processing/Graph/EffectGraph"
  * import { ValidationError } from "@beep/nlp-processing/Graph/GraphOperations/Errors"
  *
@@ -32,7 +32,7 @@ const $I = $NlpProcessingId.create("Graph/GraphOperations/Errors");
  *   errors: ["Node text is empty"]
  * })
  *
- * console.log(error._tag) // "ValidationError"
+ * error._tag // => "ValidationError"
  * ```
  *
  * @category errors
@@ -55,7 +55,7 @@ export class ValidationError extends S.TaggedError<ValidationError>($I`Validatio
  *
  * **Example** (Construct TimeoutError instance)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Construct TimeoutError instance"
  * import { NodeId } from "@beep/nlp-processing/Graph/EffectGraph"
  * import { TimeoutError } from "@beep/nlp-processing/Graph/GraphOperations/Errors"
  *
@@ -65,7 +65,7 @@ export class ValidationError extends S.TaggedError<ValidationError>($I`Validatio
  *   timeoutMs: 1_000
  * })
  *
- * console.log(error.timeoutMs) // 1000
+ * error.timeoutMs // => 1000
  * ```
  *
  * @category errors
@@ -94,7 +94,7 @@ export class TimeoutError extends S.TaggedError<TimeoutError>($I`TimeoutError`)(
  *
  * **Example** (Construct OperationError instance)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Construct OperationError instance"
  * import { NodeId } from "@beep/nlp-processing/Graph/EffectGraph"
  * import { OperationError } from "@beep/nlp-processing/Graph/GraphOperations/Errors"
  *
@@ -104,7 +104,7 @@ export class TimeoutError extends S.TaggedError<TimeoutError>($I`TimeoutError`)(
  *   cause: new Error("backend defect")
  * })
  *
- * console.log(error.operationName) // "posTag"
+ * error.operationName // => "posTag"
  * ```
  *
  * @category errors
@@ -127,7 +127,7 @@ export class OperationError extends S.TaggedError<OperationError>($I`OperationEr
  *
  * **Example** (Construct GraphError instance)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Construct GraphError instance"
  * import { NodeId } from "@beep/nlp-processing/Graph/EffectGraph"
  * import { GraphError } from "@beep/nlp-processing/Graph/GraphOperations/Errors"
  * import * as O from "effect/Option"
@@ -137,7 +137,7 @@ export class OperationError extends S.TaggedError<OperationError>($I`OperationEr
  *   nodeId: O.some(NodeId.make("node-root"))
  * })
  *
- * console.log(error.message) // "Expected at least one leaf node"
+ * error.message // => "Expected at least one leaf node"
  * ```
  *
  * @category errors
@@ -164,7 +164,7 @@ export class GraphError extends S.TaggedError<GraphError>($I`GraphError`)(
  *
  * **Example** (Construct StorageError instance)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Construct StorageError instance"
  * import { StorageError } from "@beep/nlp-processing/Graph/GraphOperations/Errors"
  *
  * const error = StorageError.make({
@@ -172,7 +172,7 @@ export class GraphError extends S.TaggedError<GraphError>($I`GraphError`)(
  *   cause: new Error("cache unavailable")
  * })
  *
- * console.log(error.operation) // "retrieve"
+ * error.operation // => "retrieve"
  * ```
  *
  * @category errors
@@ -194,7 +194,7 @@ export class StorageError extends S.TaggedError<StorageError>($I`StorageError`)(
  *
  * **Example** (Construct ExecutionError instance)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Construct ExecutionError instance"
  * import { ExecutionError } from "@beep/nlp-processing/Graph/GraphOperations/Errors"
  * import * as O from "effect/Option"
  *
@@ -203,7 +203,7 @@ export class StorageError extends S.TaggedError<StorageError>($I`StorageError`)(
  *   message: "Storage retrieve failed"
  * })
  *
- * console.log(error.message) // "Storage retrieve failed"
+ * error.message // => "Storage retrieve failed"
  * ```
  *
  * @category errors
@@ -231,13 +231,13 @@ export class ExecutionError extends S.TaggedError<ExecutionError>($I`ExecutionEr
  *
  * **Example** (Check GraphOperationError membership)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check GraphOperationError membership"
  * import { GraphError, GraphOperationError } from "@beep/nlp-processing/Graph/GraphOperations/Errors"
  * import * as O from "effect/Option"
  * import * as S from "effect/Schema"
  *
  * const error = GraphError.make({ message: "Missing root", nodeId: O.none() })
- * console.log(S.is(GraphOperationError)(error)) // true
+ * S.is(GraphOperationError)(error) // => true
  * ```
  *
  * @category errors
@@ -262,13 +262,13 @@ export const GraphOperationError = S.Union([
  *
  * **Example** (Assign GraphOperationError type)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Assign GraphOperationError type"
  * import type { GraphOperationError } from "@beep/nlp-processing/Graph/GraphOperations/Errors"
  * import { GraphError } from "@beep/nlp-processing/Graph/GraphOperations/Errors"
  * import * as O from "effect/Option"
  *
  * const error: GraphOperationError = GraphError.make({ message: "Missing root", nodeId: O.none() })
- * console.log(error._tag) // "GraphError"
+ * error._tag // => "GraphError"
  * ```
  *
  * @category errors

--- a/packages/foundation/capability/nlp-processing/src/Graph/GraphOperations/Operation.ts
+++ b/packages/foundation/capability/nlp-processing/src/Graph/GraphOperations/Operation.ts
@@ -127,7 +127,7 @@ export const make = <A, B, R = never, E = never>(config: {
  *
  * **Example** (Pure duplicate expansion)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Pure duplicate expansion"
  * import { pure } from "@beep/nlp-processing/Graph/GraphOperations/Operation"
  *
  * const duplicate = pure({
@@ -137,7 +137,7 @@ export const make = <A, B, R = never, E = never>(config: {
  *   f: (text: string) => [text, text]
  * })
  *
- * console.log(duplicate.category) // "expansion"
+ * duplicate.category // => "expansion"
  * ```
  *
  * @category constructors
@@ -166,7 +166,7 @@ export const pure = <A, B>(config: {
  *
  * **Example** (Lowercase transform operation)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Lowercase transform operation"
  * import { transform } from "@beep/nlp-processing/Graph/GraphOperations/Operation"
  *
  * const normalize = transform({
@@ -175,7 +175,7 @@ export const pure = <A, B>(config: {
  *   f: (text: string) => text.toLowerCase()
  * })
  *
- * console.log(normalize.category) // "transformation"
+ * normalize.category // => "transformation"
  * ```
  *
  * @category constructors
@@ -204,7 +204,7 @@ export const transform = <A, B>(config: {
  *
  * **Example** (Split words expansion)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Split words expansion"
  * import { expand } from "@beep/nlp-processing/Graph/GraphOperations/Operation"
  *
  * const splitWords = expand({
@@ -213,7 +213,7 @@ export const transform = <A, B>(config: {
  *   f: (text: string) => text.split(/\s+/).filter((token) => token.length > 0)
  * })
  *
- * console.log(splitWords.category) // "expansion"
+ * splitWords.category // => "expansion"
  * ```
  *
  * @category constructors
@@ -236,7 +236,7 @@ export const expand = <A, B>(config: {
  *
  * **Example** (Filter non-empty leaves)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Filter non-empty leaves"
  * import { filter } from "@beep/nlp-processing/Graph/GraphOperations/Operation"
  *
  * const nonEmpty = filter({
@@ -245,7 +245,7 @@ export const expand = <A, B>(config: {
  *   predicate: (text: string) => text.trim().length > 0
  * })
  *
- * console.log(nonEmpty.category) // "filtering"
+ * nonEmpty.category // => "filtering"
  * ```
  *
  * @category constructors
@@ -300,11 +300,11 @@ export const identity = <A>(): GraphOperation<A, A> =>
  *
  * **Example** (Map text to lengths)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Map text to lengths"
  * import { map } from "@beep/nlp-processing/Graph/GraphOperations/Operation"
  *
  * const lengths = map((text: string) => text.length)
- * console.log(lengths.category) // "transformation"
+ * lengths.category // => "transformation"
  * ```
  *
  * @category combinators
@@ -318,11 +318,11 @@ export const map = <A, B>(f: (a: A) => B): GraphOperation<A, B> =>
  *
  * **Example** (FlatMap into characters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="FlatMap into characters"
  * import { flatMap } from "@beep/nlp-processing/Graph/GraphOperations/Operation"
  *
  * const characters = flatMap((text: string) => text.split(""))
- * console.log(characters.category) // "expansion"
+ * characters.category // => "expansion"
  * ```
  *
  * @category combinators
@@ -340,11 +340,11 @@ export const flatMap = <A, B>(f: (a: A) => ReadonlyArray<B>): GraphOperation<A, 
  *
  * **Example** (Read mapped operation category)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Read mapped operation category"
  * import { getCategory, map } from "@beep/nlp-processing/Graph/GraphOperations/Operation"
  *
  * const category = getCategory(map((text: string) => text.length))
- * console.log(category) // "transformation"
+ * category // => "transformation"
  * ```
  *
  * @category getters

--- a/packages/foundation/capability/nlp-processing/src/Graph/GraphOperations/ResultStore.ts
+++ b/packages/foundation/capability/nlp-processing/src/Graph/GraphOperations/ResultStore.ts
@@ -95,14 +95,14 @@ export class AnyOperationResult extends S.Class<AnyOperationResult>($I`AnyOperat
  *
  * **Example** (Create and stringify key)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Create and stringify key"
  * import { NodeId } from "@beep/nlp-processing/Graph/EffectGraph"
  * import { ResultKey } from "@beep/nlp-processing/Graph/GraphOperations/ResultStore"
  *
  * const nodeId = NodeId.make("node-example")
  * const key = ResultKey.new("tokenize", nodeId)
  *
- * console.log(ResultKey.toString(key)) // "tokenize:node-example"
+ * ResultKey.toString(key) // => "tokenize:node-example"
  * ```
  *
  * @category models
@@ -163,7 +163,7 @@ export class StoredResult extends S.Class<StoredResult>($I`StoredResult`)(
  *
  * **Example** (Build empty cache stats)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Build empty cache stats"
  * import { NonNegativeInt } from "@beep/schema"
  * import { CacheStats } from "@beep/nlp-processing/Graph/GraphOperations/ResultStore"
  * import * as O from "effect/Option"
@@ -175,7 +175,7 @@ export class StoredResult extends S.Class<StoredResult>($I`StoredResult`)(
  *   newestEntry: O.none()
  * })
  *
- * console.log(emptyStats.size) // 0
+ * emptyStats.size // => 0
  * ```
  *
  * @category models
@@ -344,7 +344,7 @@ const makeResultStore = Effect.gen(function* () {
  *
  * **Example** (Provide live store layer)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Provide live store layer"
  * import { Effect } from "effect"
  * import { ResultStoreLive } from "@beep/nlp-processing/Graph/GraphOperations/ResultStore"
  * import { ResultStore } from "@beep/nlp-processing/Graph/GraphOperations/ResultStore"
@@ -369,7 +369,7 @@ export const ResultStoreLive: Layer.Layer<ResultStore> = Layer.effect(ResultStor
  *
  * **Example** (Assert empty test store)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Assert empty test store"
  * import { Effect } from "effect"
  * import { ResultStoreTest } from "@beep/nlp-processing/Graph/GraphOperations/ResultStore"
  * import { ResultStore } from "@beep/nlp-processing/Graph/GraphOperations/ResultStore"

--- a/packages/foundation/capability/nlp-processing/src/Graph/GraphOperations/Types.ts
+++ b/packages/foundation/capability/nlp-processing/src/Graph/GraphOperations/Types.ts
@@ -79,11 +79,11 @@ export const MAX_PARALLEL_CONCURRENCY = 64;
  *
  * **Example** (Create parallel execution strategy)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Create parallel execution strategy"
  * import { ExecutionStrategy } from "@beep/nlp-processing/Graph/GraphOperations/Types"
  *
  * const strategy = ExecutionStrategy.Parallel(4)
- * console.log(strategy.concurrency) // 4
+ * strategy.concurrency // => 4
  * ```
  *
  * @category models
@@ -117,11 +117,11 @@ export const ExecutionStrategy = S.TaggedUnion({
  *
  * **Example** (Annotate sequential strategy type)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Annotate sequential strategy type"
  * import { ExecutionStrategy } from "@beep/nlp-processing/Graph/GraphOperations/Types"
  *
  * const strategy: ExecutionStrategy = ExecutionStrategy.Sequential
- * console.log(strategy._tag) // "Sequential"
+ * strategy._tag // => "Sequential"
  * ```
  *
  * @category models
@@ -144,7 +144,7 @@ export type ExecutionStrategy = typeof ExecutionStrategy.Type;
  *
  * **Example** (Combine empty metrics monoid)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Combine empty metrics monoid"
  * import { NonNegativeInt } from "@beep/schema"
  * import { ExecutionMetrics } from "@beep/nlp-processing/Graph/GraphOperations/Types"
  *
@@ -153,7 +153,7 @@ export type ExecutionStrategy = typeof ExecutionStrategy.Type;
  *   ExecutionMetrics.make({ ...ExecutionMetrics.empty(), nodesProcessed: NonNegativeInt.make(2) })
  * )
  *
- * console.log(combined.nodesProcessed) // 2
+ * combined.nodesProcessed // => 2
  * ```
  *
  * @category models
@@ -211,10 +211,10 @@ export class ExecutionMetrics extends S.Class<ExecutionMetrics>($I`ExecutionMetr
  *
  * **Example** (Check O(n) complexity tag)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check O(n) complexity tag"
  * import { Complexity } from "@beep/nlp-processing/Graph/GraphOperations/Types"
  *
- * console.log(Complexity.is["O(n)"]("O(n)")) // true
+ * Complexity.is["O(n)"]("O(n)") // => true
  * ```
  *
  * @category models
@@ -248,7 +248,7 @@ export type Complexity = typeof Complexity.Type;
  *
  * **Example** (Make constant operation cost)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make constant operation cost"
  * import { Duration } from "effect"
  * import { ConstantOperationCost } from "@beep/nlp-processing/Graph/GraphOperations/Types"
  *
@@ -259,7 +259,7 @@ export type Complexity = typeof Complexity.Type;
  *   tokenCost: 0
  * })
  *
- * console.log(cost.complexity) // "O(1)"
+ * cost.complexity // => "O(1)"
  * ```
  *
  * @category models
@@ -288,7 +288,7 @@ export class ConstantOperationCost extends S.Class<ConstantOperationCost>($I`Con
  *
  * **Example** (Make linear operation cost)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make linear operation cost"
  * import { Duration } from "effect"
  * import { LinearOperationCost } from "@beep/nlp-processing/Graph/GraphOperations/Types"
  *
@@ -299,7 +299,7 @@ export class ConstantOperationCost extends S.Class<ConstantOperationCost>($I`Con
  *   tokenCost: 4
  * })
  *
- * console.log(cost.tokenCost) // 4
+ * cost.tokenCost // => 4
  * ```
  *
  * @category models
@@ -328,7 +328,7 @@ export class LinearOperationCost extends S.Class<LinearOperationCost>($I`LinearO
  *
  * **Example** (Make linearithmic operation cost)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make linearithmic operation cost"
  * import { Duration } from "effect"
  * import { LinearithmicOperationCost } from "@beep/nlp-processing/Graph/GraphOperations/Types"
  *
@@ -339,7 +339,7 @@ export class LinearOperationCost extends S.Class<LinearOperationCost>($I`LinearO
  *   tokenCost: 0
  * })
  *
- * console.log(cost.memoryCost) // 256
+ * cost.memoryCost // => 256
  * ```
  *
  * @category models
@@ -368,7 +368,7 @@ export class LinearithmicOperationCost extends S.Class<LinearithmicOperationCost
  *
  * **Example** (Make quadratic operation cost)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make quadratic operation cost"
  * import { Duration } from "effect"
  * import { QuadraticOperationCost } from "@beep/nlp-processing/Graph/GraphOperations/Types"
  *
@@ -379,7 +379,7 @@ export class LinearithmicOperationCost extends S.Class<LinearithmicOperationCost
  *   tokenCost: 0
  * })
  *
- * console.log(cost.complexity) // "O(n^2)"
+ * cost.complexity // => "O(n^2)"
  * ```
  *
  * @category models
@@ -414,7 +414,7 @@ export class QuadraticOperationCost extends S.Class<QuadraticOperationCost>($I`Q
  *
  * **Example** (Scale linear cost by leaves)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Scale linear cost by leaves"
  * import { Duration } from "effect"
  * import { OperationCost } from "@beep/nlp-processing/Graph/GraphOperations/Types"
  *
@@ -424,7 +424,7 @@ export class QuadraticOperationCost extends S.Class<QuadraticOperationCost>($I`Q
  *   tokenCost: 1
  * })
  *
- * console.log(OperationCost.scale(cost, 3).memoryCost) // 30
+ * OperationCost.scale(cost, 3).memoryCost // => 30
  * ```
  *
  * @category models
@@ -478,7 +478,7 @@ export const OperationCost = Complexity.mapMembers(
  *
  * **Example** (Type constant operation cost)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Type constant operation cost"
  * import { Duration } from "effect"
  * import { OperationCost } from "@beep/nlp-processing/Graph/GraphOperations/Types"
  *
@@ -488,7 +488,7 @@ export const OperationCost = Complexity.mapMembers(
  *   tokenCost: 0,
  * })
  *
- * console.log(cost.complexity) // "O(1)"
+ * cost.complexity // => "O(1)"
  * ```
  *
  * @category models
@@ -510,7 +510,7 @@ export type OperationCost = typeof OperationCost.Type;
  *
  * **Example** (Attach non-blocking validation warnings)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Attach non-blocking validation warnings"
  * import { ValidationResult } from "@beep/nlp-processing/Graph/GraphOperations/Types"
  *
  * const result = ValidationResult.withWarnings(
@@ -518,7 +518,7 @@ export type OperationCost = typeof OperationCost.Type;
  *   ["No leaf nodes to process"]
  * )
  *
- * console.log(result.warnings.length) // 1
+ * result.warnings.length // => 1
  * ```
  *
  * @category models
@@ -566,10 +566,10 @@ export class ValidationResult extends S.Class<ValidationResult>($I`ValidationRes
  *
  * **Example** (Check expansion category tag)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check expansion category tag"
  * import { OperationCategory } from "@beep/nlp-processing/Graph/GraphOperations/Types"
  *
- * console.log(OperationCategory.is.expansion("expansion")) // true
+ * OperationCategory.is.expansion("expansion") // => true
  * ```
  *
  * @category models
@@ -623,11 +623,11 @@ export type OperationCategory = typeof OperationCategory.Type;
  *
  * **Example** (Build parallel execution options)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Build parallel execution options"
  * import { ExecutionOptions } from "@beep/nlp-processing/Graph/GraphOperations/Types"
  *
  * const options = ExecutionOptions.parallel(8)
- * console.log(options.strategy._tag) // "Parallel"
+ * options.strategy._tag // => "Parallel"
  * ```
  *
  * @category models
@@ -704,12 +704,12 @@ export type ExecutionId = typeof ExecutionId.Type;
  *
  * **Example** (Generate fresh execution id)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Generate fresh execution id"
  * import { Effect } from "effect"
  * import { generateExecutionId } from "@beep/nlp-processing/Graph/GraphOperations/Types"
  *
  * const program = Effect.map(generateExecutionId, (id) => id.startsWith("exec-"))
- * console.log(Effect.runSync(program)) // true
+ * Effect.runSync(program) // => true
  * ```
  *
  * @effects Reads the Effect `Clock` and random service to include timestamp and entropy in the generated id.
@@ -763,7 +763,7 @@ export interface OperationResult<B, E> {
  *
  * **Example** (Stamp result with clock time)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Stamp result with clock time"
  * import { Effect } from "effect"
  * import { ExecutionId, ExecutionMetrics, makeOperationResult } from "@beep/nlp-processing/Graph/GraphOperations/Types"
  *
@@ -774,7 +774,7 @@ export interface OperationResult<B, E> {
  *   metrics: ExecutionMetrics.empty()
  * })
  *
- * console.log(Effect.runSync(program).newNodes.length) // 0
+ * Effect.runSync(program).newNodes.length // => 0
  * ```
  *
  * @category constructors

--- a/packages/foundation/capability/nlp-processing/src/Graph/TextGraph.ts
+++ b/packages/foundation/capability/nlp-processing/src/Graph/TextGraph.ts
@@ -35,11 +35,11 @@ const $I = $NlpProcessingId.create("Graph/TextGraph");
  *
  * **Example** (Empty graph node count)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Empty graph node count"
  * import { empty, nodeCount, type TextGraph } from "@beep/nlp-processing/Graph/TextGraph"
  *
  * const graph: TextGraph = empty()
- * console.log(nodeCount(graph)) // 0
+ * nodeCount(graph) // => 0
  * ```
  *
  * @category models
@@ -69,11 +69,11 @@ export type MutableTextGraph = Graph.MutableDirectedGraph<TextNode, TextEdge>;
  *
  * **Example** (Make GraphCycleError instance)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make GraphCycleError instance"
  * import { GraphCycleError } from "@beep/nlp-processing/Graph/TextGraph"
  *
  * const error = GraphCycleError.make({ parentIndex: 0 })
- * console.log(error._tag) // "GraphCycleError"
+ * error._tag // => "GraphCycleError"
  * ```
  *
  * @category errors
@@ -112,10 +112,10 @@ const makeTextNode = (fields: {
  *
  * **Example** (Empty graph zero nodes)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Empty graph zero nodes"
  * import { empty, nodeCount } from "@beep/nlp-processing/Graph/TextGraph"
  *
- * console.log(nodeCount(empty())) // 0
+ * nodeCount(empty()) // => 0
  * ```
  *
  * @category constructors
@@ -128,12 +128,12 @@ export const empty = (): TextGraph => Graph.directed<TextNode, TextEdge>();
  *
  * **Example** (Create singleton document graph)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Create singleton document graph"
  * import { Effect } from "effect"
  * import { nodeCount, singleton } from "@beep/nlp-processing/Graph/TextGraph"
  *
  * const graph = Effect.runSync(singleton("Hello.", "document"))
- * console.log(nodeCount(graph)) // 1
+ * nodeCount(graph) // => 1
  * ```
  *
  * @effects Builds the root text node through `makeTextNode`, which reads the Effect `Clock` for the node timestamp.
@@ -163,7 +163,7 @@ export const singleton: {
  *
  * **Example** (Document with sentence children)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Document with sentence children"
  * import { Chunk, Effect } from "effect"
  * import * as O from "effect/Option"
  * import { Document as NLPDocument, DocumentId } from "@beep/nlp/Core/Document"
@@ -203,7 +203,7 @@ export const singleton: {
  *   })
  * )
  *
- * console.log(nodeCount(graph)) // 3
+ * nodeCount(graph) // => 3
  * ```
  *
  * @effects Reads the `Tokenization` service to split the document into sentences and reads the Effect `Clock` while creating graph nodes.
@@ -256,7 +256,7 @@ export const fromDocument = Effect.fn("fromDocument")(function* (
  *
  * **Example** (Add child under root)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Add child under root"
  * import { Effect } from "effect"
  * import { addChildren, getRoots, nodeCount, singleton } from "@beep/nlp-processing/Graph/TextGraph"
  * import { TextNode } from "@beep/nlp/Graph/Schema"
@@ -275,7 +275,7 @@ export const fromDocument = Effect.fn("fromDocument")(function* (
  *   })
  * )
  *
- * console.log(nodeCount(Effect.runSync(program))) // 2
+ * nodeCount(Effect.runSync(program)) // => 2
  * ```
  *
  * @category combinators
@@ -331,7 +331,7 @@ export const addChildren: {
  *
  * **Example** (Tokenize sentence into tokens)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Tokenize sentence into tokens"
  * import { Chunk, Effect } from "effect"
  * import * as O from "effect/Option"
  * import { Document as NLPDocument, DocumentId } from "@beep/nlp/Core/Document"
@@ -380,7 +380,7 @@ export const addChildren: {
  *   })
  * )
  *
- * console.log(nodeCount(graph)) // 3
+ * nodeCount(graph) // => 3
  * ```
  *
  * @effects Reads the `Tokenization` service for sentence tokens and reads the Effect `Clock` while adding token nodes.
@@ -480,14 +480,14 @@ const rebuild = (
  *
  * **Example** (Map nodes to uppercase)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Map nodes to uppercase"
  * import { Effect } from "effect"
  * import { mapNodes, singleton, toArray } from "@beep/nlp-processing/Graph/TextGraph"
  *
  * const graph = Effect.runSync(singleton("Hello.", "document"))
  * const mapped = mapNodes(graph, (node) => ({ ...node, text: node.text.toUpperCase() }))
  *
- * console.log(toArray(mapped)[0]?.text) // "HELLO."
+ * toArray(mapped)[0]?.text // => "HELLO."
  * ```
  *
  * @category mapping
@@ -503,12 +503,12 @@ export const mapNodes: {
  *
  * **Example** (Filter nodes by type)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Filter nodes by type"
  * import { Effect } from "effect"
  * import { filterNodes, nodeCount, singleton } from "@beep/nlp-processing/Graph/TextGraph"
  *
  * const graph = Effect.runSync(singleton("Hello.", "document"))
- * console.log(nodeCount(filterNodes(graph, (node) => node.type === "document"))) // 1
+ * nodeCount(filterNodes(graph, (node) => node.type === "document")) // => 1
  * ```
  *
  * @category filtering
@@ -538,12 +538,12 @@ const isTraversalDataFirst = (args: IArguments): boolean =>
  *
  * **Example** (Depth-first walk values)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Depth-first walk values"
  * import { Effect, Graph } from "effect"
  * import { dfs, singleton } from "@beep/nlp-processing/Graph/TextGraph"
  *
  * const graph = Effect.runSync(singleton("Hello.", "document"))
- * console.log(Array.from(Graph.values(dfs(graph))).length) // 1
+ * Array.from(Graph.values(dfs(graph, [0]))).length // => 1
  * ```
  *
  * @category sequencing
@@ -563,12 +563,12 @@ export const dfs: {
  *
  * **Example** (Breadth-first walk values)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Breadth-first walk values"
  * import { Effect, Graph } from "effect"
  * import { bfs, singleton } from "@beep/nlp-processing/Graph/TextGraph"
  *
  * const graph = Effect.runSync(singleton("Hello.", "document"))
- * console.log(Array.from(Graph.values(bfs(graph))).length) // 1
+ * Array.from(Graph.values(bfs(graph, [0]))).length // => 1
  * ```
  *
  * @category sequencing
@@ -588,12 +588,12 @@ export const bfs: {
  *
  * **Example** (Topological walk values)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Topological walk values"
  * import { Effect, Graph } from "effect"
  * import { singleton, topo } from "@beep/nlp-processing/Graph/TextGraph"
  *
  * const graph = Effect.runSync(singleton("Hello.", "document"))
- * console.log(Array.from(Graph.values(topo(graph))).length) // 1
+ * Array.from(Graph.values(topo(graph))).length // => 1
  * ```
  *
  * @category sequencing
@@ -606,11 +606,11 @@ export const topo = (graph: TextGraph): Graph.NodeWalker<TextNode> => Graph.topo
  *
  * **Example** (Collect nodes into array)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Collect nodes into array"
  * import { Effect } from "effect"
  * import { singleton, toArray } from "@beep/nlp-processing/Graph/TextGraph"
  *
- * console.log(toArray(Effect.runSync(singleton("Hello.", "document"))).length) // 1
+ * toArray(Effect.runSync(singleton("Hello.", "document"))).length // => 1
  * ```
  *
  * @category getters
@@ -628,10 +628,10 @@ export const toArray = (graph: TextGraph): ReadonlyArray<TextNode> =>
  *
  * **Example** (Count nodes in empty)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Count nodes in empty"
  * import { empty, nodeCount } from "@beep/nlp-processing/Graph/TextGraph"
  *
- * console.log(nodeCount(empty())) // 0
+ * nodeCount(empty()) // => 0
  * ```
  *
  * @category getters
@@ -644,10 +644,10 @@ export const nodeCount = (graph: TextGraph): number => Graph.nodeCount(graph);
  *
  * **Example** (Count edges in empty)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Count edges in empty"
  * import { empty, edgeCount } from "@beep/nlp-processing/Graph/TextGraph"
  *
- * console.log(edgeCount(empty())) // 0
+ * edgeCount(empty()) // => 0
  * ```
  *
  * @category getters
@@ -660,12 +660,12 @@ export const edgeCount = (graph: TextGraph): number => Graph.edgeCount(graph);
  *
  * **Example** (Find nodes by document type)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Find nodes by document type"
  * import { Effect } from "effect"
  * import { findNodesByType, singleton } from "@beep/nlp-processing/Graph/TextGraph"
  *
  * const graph = Effect.runSync(singleton("Hello.", "document"))
- * console.log(findNodesByType(graph, "document").length) // 1
+ * findNodesByType(graph, "document").length // => 1
  * ```
  *
  * @category getters
@@ -685,11 +685,11 @@ export const findNodesByType: {
  *
  * **Example** (Get roots of singleton)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Get roots of singleton"
  * import { Effect } from "effect"
  * import { getRoots, singleton } from "@beep/nlp-processing/Graph/TextGraph"
  *
- * console.log(getRoots(Effect.runSync(singleton("Hello.", "document"))).length) // 1
+ * getRoots(Effect.runSync(singleton("Hello.", "document"))).length // => 1
  * ```
  *
  * @category getters
@@ -703,11 +703,11 @@ export const getRoots = (graph: TextGraph): ReadonlyArray<Graph.NodeIndex> =>
  *
  * **Example** (Get leaves of singleton)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Get leaves of singleton"
  * import { Effect } from "effect"
  * import { getLeaves, singleton } from "@beep/nlp-processing/Graph/TextGraph"
  *
- * console.log(getLeaves(Effect.runSync(singleton("Hello.", "document"))).length) // 1
+ * getLeaves(Effect.runSync(singleton("Hello.", "document"))).length // => 1
  * ```
  *
  * @category getters
@@ -721,7 +721,7 @@ export const getLeaves = (graph: TextGraph): ReadonlyArray<Graph.NodeIndex> =>
  *
  * **Example** (Children of document root)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Children of document root"
  * import { Effect } from "effect"
  * import { getChildren, getRoots, singleton } from "@beep/nlp-processing/Graph/TextGraph"
  * import * as A from "effect/Array"
@@ -733,7 +733,7 @@ export const getLeaves = (graph: TextGraph): ReadonlyArray<Graph.NodeIndex> =>
  *   onSome: (root) => getChildren(graph, root).length
  * })
  *
- * console.log(childCount) // 0
+ * childCount // => 0
  * ```
  *
  * @category getters
@@ -756,10 +756,10 @@ export const getChildren: {
  *
  * **Example** (Export empty to GraphViz)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Export empty to GraphViz"
  * import { empty, toGraphViz } from "@beep/nlp-processing/Graph/TextGraph"
  *
- * console.log(toGraphViz(empty()).includes("TextProcessingGraph")) // true
+ * toGraphViz(empty()).includes("TextProcessingGraph") // => true
  * ```
  *
  * @category formatting
@@ -777,10 +777,10 @@ export const toGraphViz = (graph: TextGraph): string =>
  *
  * **Example** (Export empty to Mermaid)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Export empty to Mermaid"
  * import { empty, toMermaid } from "@beep/nlp-processing/Graph/TextGraph"
  *
- * console.log(toMermaid(empty()).includes("graph")) // true
+ * toMermaid(empty()) // => "flowchart TB"
  * ```
  *
  * @category formatting
@@ -813,11 +813,11 @@ export const toMermaid = (graph: TextGraph): string =>
  *
  * **Example** (Show singleton tree string)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Show singleton tree string"
  * import { Effect } from "effect"
  * import { show, singleton } from "@beep/nlp-processing/Graph/TextGraph"
  *
- * console.log(show(Effect.runSync(singleton("Hello.", "document")))) // "[node] document: Hello."
+ * show(Effect.runSync(singleton("Hello.", "document"))) // => "[node] document: Hello."
  * ```
  *
  * @category formatting
@@ -847,10 +847,10 @@ export const show = (graph: TextGraph): string => {
  *
  * **Example** (Check empty graph acyclic)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check empty graph acyclic"
  * import { empty, isAcyclic } from "@beep/nlp-processing/Graph/TextGraph"
  *
- * console.log(isAcyclic(empty())) // true
+ * isAcyclic(empty()) // => true
  * ```
  *
  * @category utilities
@@ -863,10 +863,10 @@ export const isAcyclic = (graph: TextGraph): boolean => Graph.isAcyclic(graph);
  *
  * **Example** (SCCs of empty graph)
  *
- * ```ts
+ * ```ts import.meta.vitest name="SCCs of empty graph"
  * import { empty, stronglyConnectedComponents } from "@beep/nlp-processing/Graph/TextGraph"
  *
- * console.log(stronglyConnectedComponents(empty()).length) // 0
+ * stronglyConnectedComponents(empty()).length // => 0
  * ```
  *
  * @category utilities

--- a/packages/foundation/capability/nlp-processing/src/Graph/TypeClass.ts
+++ b/packages/foundation/capability/nlp-processing/src/Graph/TypeClass.ts
@@ -100,11 +100,11 @@ export const makeOperation: {
  *
  * **Example** (Build a pure splitting operation)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Build a pure splitting operation"
  * import { pureOperation } from "@beep/nlp-processing/Graph/TypeClass"
  *
  * const split = pureOperation("split", (text: string) => text.split(" "))
- * console.log(split.name) // "split"
+ * split.name // => "split"
  * ```
  *
  * @category constructors
@@ -182,7 +182,7 @@ export const identityOperation = <A>(): TextOperation<A, A> =>
  *
  * **Example** (Compose operations)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Compose operations"
  * import { composeOperations, mapOperation } from "@beep/nlp-processing/Graph/TypeClass"
  *
  * const trimThenLength = composeOperations(
@@ -190,7 +190,7 @@ export const identityOperation = <A>(): TextOperation<A, A> =>
  *   mapOperation("length", (text: string) => text.length)
  * )
  *
- * console.log(trimThenLength.name) // "trim -> length"
+ * trimThenLength.name // => "trim -> length"
  * ```
  *
  * @category combinators
@@ -284,7 +284,7 @@ const getLeafNodes = <A>(graph: EffectGraph<A>): ReadonlyArray<GraphNode<A>> =>
  *
  * **Example** (Execute an operation)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Execute an operation"
  * import { Effect } from "effect"
  * import { singleton, size } from "@beep/nlp-processing/Graph/EffectGraph"
  * import { executeOperation, mapOperation } from "@beep/nlp-processing/Graph/TypeClass"
@@ -294,7 +294,7 @@ const getLeafNodes = <A>(graph: EffectGraph<A>): ReadonlyArray<GraphNode<A>> =>
  *   executeOperation(mapOperation("length", (text: string) => text.length))
  * )
  *
- * console.log(size(Effect.runSync(program))) // 2
+ * size(Effect.runSync(program)) // => 2
  * ```
  *
  * @category combinators
@@ -328,7 +328,7 @@ export const executeOperation: {
  *
  * **Example** (Execute operations)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Execute operations"
  * import { Effect } from "effect"
  * import { singleton, size } from "@beep/nlp-processing/Graph/EffectGraph"
  * import { executeOperations, mapOperation } from "@beep/nlp-processing/Graph/TypeClass"
@@ -338,7 +338,7 @@ export const executeOperation: {
  *   mapOperation("length", (value: unknown) => String(value).length)
  * ])
  *
- * console.log(size(Effect.runSync(program))) // 2
+ * size(Effect.runSync(program)) // => 2
  * ```
  *
  * @category combinators
@@ -459,11 +459,11 @@ export const makeAdjunction: {
  *
  * **Example** (Map text to its length)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Map text to its length"
  * import { mapOperation } from "@beep/nlp-processing/Graph/TypeClass"
  *
  * const operation = mapOperation("length", (text: string) => text.length)
- * console.log(operation.name) // "length"
+ * operation.name // => "length"
  * ```
  *
  * @category combinators
@@ -479,11 +479,11 @@ export const mapOperation: {
  *
  * **Example** (Filter an operation)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Filter an operation"
  * import { filterOperation } from "@beep/nlp-processing/Graph/TypeClass"
  *
  * const operation = filterOperation("non-empty", (text: string) => text.length > 0)
- * console.log(operation.name) // "non-empty"
+ * operation.name // => "non-empty"
  * ```
  *
  * @category combinators
@@ -503,11 +503,11 @@ export const filterOperation: {
  *
  * **Example** (Expand text into words)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Expand text into words"
  * import { flatMapOperation } from "@beep/nlp-processing/Graph/TypeClass"
  *
  * const operation = flatMapOperation("words", (text: string) => text.split(" "))
- * console.log(operation.name) // "words"
+ * operation.name // => "words"
  * ```
  *
  * @category combinators
@@ -523,12 +523,12 @@ export const flatMapOperation: {
  *
  * **Example** (Collect a data)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Collect a data"
  * import { Effect } from "effect"
  * import { singleton } from "@beep/nlp-processing/Graph/EffectGraph"
  * import { collectData } from "@beep/nlp-processing/Graph/TypeClass"
  *
- * console.log(collectData(Effect.runSync(singleton("root")))) // ["root"]
+ * collectData(Effect.runSync(singleton("root"))) // => ["root"]
  * ```
  *
  * @category getters
@@ -541,12 +541,12 @@ export const collectData = <A>(graph: EffectGraph<A>): ReadonlyArray<A> => A.map
  *
  * **Example** (Measure a singleton graph's depth)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Measure a singleton graph's depth"
  * import { Effect } from "effect"
  * import { singleton } from "@beep/nlp-processing/Graph/EffectGraph"
  * import { depth } from "@beep/nlp-processing/Graph/TypeClass"
  *
- * console.log(depth(Effect.runSync(singleton("root")))) // 0
+ * depth(Effect.runSync(singleton("root"))) // => 0
  * ```
  *
  * @category getters
@@ -628,11 +628,11 @@ const makeEffectfulMapBody =
  *
  * **Example** (Compose a map onto an operation)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Compose a map onto an operation"
  * import { map, mapOperation } from "@beep/nlp-processing/Graph/TypeClass"
  *
  * const operation = map(mapOperation("trim", (text: string) => text.trim()), (text) => text.length)
- * console.log(operation.name) // "trim |> map"
+ * operation.name // => "trim |> map"
  * ```
  *
  * @category mapping
@@ -659,7 +659,7 @@ export const map: {
  *
  * **Example** (Sequence an effectful step)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Sequence an effectful step"
  * import { Effect } from "effect"
  * import { flatMap, mapOperation } from "@beep/nlp-processing/Graph/TypeClass"
  *
@@ -668,7 +668,7 @@ export const map: {
  *   (text) => Effect.succeed(text.length)
  * )
  *
- * console.log(operation.name) // "trim |> flatMap"
+ * operation.name // => "trim |> flatMap"
  * ```
  *
  * @category mapping
@@ -685,14 +685,14 @@ export const flatMap: EffectfulMapOperationSignature = dual(2, makeEffectfulMapB
  *
  * **Example** (Apply lifted functions to values)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Apply lifted functions to values"
  * import { ap, mapOperation, pureOperation } from "@beep/nlp-processing/Graph/TypeClass"
  *
  * const functions = pureOperation("fn", () => [(text: string) => text.length])
  * const values = mapOperation("trim", (text: string) => text.trim())
  * const operation = ap(functions, values)
  *
- * console.log(operation.name) // "ap(fn, trim)"
+ * operation.name // => "ap(fn, trim)"
  * ```
  *
  * @category combinators
@@ -759,7 +759,7 @@ export const pure = <A, B>(value: B): TextOperation<A, B> =>
  *
  * **Example** (Chain two operations)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Chain two operations"
  * import { chain, mapOperation } from "@beep/nlp-processing/Graph/TypeClass"
  *
  * const operation = chain(
@@ -767,7 +767,7 @@ export const pure = <A, B>(value: B): TextOperation<A, B> =>
  *   (text) => mapOperation("length", () => text.length)
  * )
  *
- * console.log(operation.name) // "trim >>= chain"
+ * operation.name // => "trim >>= chain"
  * ```
  *
  * @category combinators
@@ -805,7 +805,7 @@ export const chain: {
  *
  * **Example** (Flatten a nested operation)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Flatten a nested operation"
  * import { flatten, mapOperation } from "@beep/nlp-processing/Graph/TypeClass"
  *
  * const operation = flatten(
@@ -813,7 +813,7 @@ export const chain: {
  *   (text) => mapOperation("length", () => text.length)
  * )
  *
- * console.log(operation.name) // "trim >>= chain"
+ * operation.name // => "trim >>= chain"
  * ```
  *
  * @category combinators
@@ -844,7 +844,7 @@ export const flatten: {
  *
  * **Example** (Fall back to an alternative operation)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Fall back to an alternative operation"
  * import { alt, mapOperation } from "@beep/nlp-processing/Graph/TypeClass"
  *
  * const operation = alt(
@@ -852,7 +852,7 @@ export const flatten: {
  *   mapOperation("upper", (text: string) => text.toUpperCase())
  * )
  *
- * console.log(operation.name) // "alt(lower, upper)"
+ * operation.name // => "alt(lower, upper)"
  * ```
  *
  * @category combinators
@@ -909,7 +909,7 @@ export const empty = <A, B>(): TextOperation<A, B> =>
  *
  * **Example** (Traverse with an effectful step)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Traverse with an effectful step"
  * import { Effect } from "effect"
  * import { mapOperation, traverse } from "@beep/nlp-processing/Graph/TypeClass"
  *
@@ -918,7 +918,7 @@ export const empty = <A, B>(): TextOperation<A, B> =>
  *   (text) => Effect.succeed(text.length)
  * )
  *
- * console.log(operation.name) // "trim |> traverse"
+ * operation.name // => "trim |> traverse"
  * ```
  *
  * @category combinators
@@ -935,11 +935,11 @@ export const traverse: EffectfulMapOperationSignature = dual(2, makeEffectfulMap
  *
  * **Example** (Replicate an operation twice)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Replicate an operation twice"
  * import { mapOperation, replicate } from "@beep/nlp-processing/Graph/TypeClass"
  *
  * const operation = replicate(mapOperation("length", (text: string) => text.length), 2)
- * console.log(operation.name) // "replicate(length, 2)"
+ * operation.name // => "replicate(length, 2)"
  * ```
  *
  * @category combinators
@@ -969,7 +969,7 @@ export const replicate: {
  *
  * **Example** (Run an operation under a predicate)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Run an operation under a predicate"
  * import { mapOperation, when } from "@beep/nlp-processing/Graph/TypeClass"
  *
  * const operation = when(
@@ -977,7 +977,7 @@ export const replicate: {
  *   mapOperation("length", (text: string) => text.length)
  * )
  *
- * console.log(operation.name) // "when(length)"
+ * operation.name // => "when(length)"
  * ```
  *
  * @category combinators
@@ -999,7 +999,7 @@ export const when: {
  *
  * **Example** (Skip an operation under a predicate)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Skip an operation under a predicate"
  * import { mapOperation, unless } from "@beep/nlp-processing/Graph/TypeClass"
  *
  * const operation = unless(
@@ -1007,7 +1007,7 @@ export const when: {
  *   mapOperation("length", (text: string) => text.length)
  * )
  *
- * console.log(operation.name) // "when(length)"
+ * operation.name // => "when(length)"
  * ```
  *
  * @category combinators

--- a/packages/foundation/capability/nlp-processing/src/NLPService.ts
+++ b/packages/foundation/capability/nlp-processing/src/NLPService.ts
@@ -184,7 +184,7 @@ export const layer = <E, R>(backendLayer: Layer.Layer<Backend.NLPBackend, E, R>)
  *
  * **Example** (Process text with stub service)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Process text with stub service"
  * import { Effect } from "effect"
  * import { empty, nodeCount } from "@beep/nlp-processing/Graph/AnnotatedTextGraph"
  * import { NLPService, processText } from "@beep/nlp-processing/NLPService"
@@ -222,7 +222,7 @@ export const layer = <E, R>(backendLayer: Layer.Layer<Backend.NLPBackend, E, R>)
  *   Effect.provideService(processText("Effect models typed failure."), NLPService, service),
  *   nodeCount
  * )
- * Effect.runPromise(program).then(console.log) // 0
+ * await Effect.runPromise(program) // => 0
  * ```
  *
  * @effects Requires an {@link NLPService} in context and executes the

--- a/packages/foundation/capability/nlp-processing/src/Tools/Analyze.ts
+++ b/packages/foundation/capability/nlp-processing/src/Tools/Analyze.ts
@@ -36,7 +36,7 @@ class AnalyzeParameters extends S.Class<AnalyzeParameters>($I`AnalyzeParameters`
  *
  * **Example** (Decode parameters schema)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode parameters schema"
  * import * as S from "effect/Schema"
  * import { Analyze } from "@beep/nlp-processing/Tools/Analyze"
  *

--- a/packages/foundation/capability/nlp-processing/src/Tools/BagOfWords.ts
+++ b/packages/foundation/capability/nlp-processing/src/Tools/BagOfWords.ts
@@ -47,7 +47,7 @@ class BagOfWordsSuccess extends S.Class<BagOfWordsSuccess>($I`BagOfWordsSuccess`
  *
  * **Example** (Decode parameters schema)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode parameters schema"
  * import * as S from "effect/Schema"
  * import { BagOfWords } from "@beep/nlp-processing/Tools/BagOfWords"
  *

--- a/packages/foundation/capability/nlp-processing/src/Tools/BowCosineSimilarity.ts
+++ b/packages/foundation/capability/nlp-processing/src/Tools/BowCosineSimilarity.ts
@@ -55,7 +55,7 @@ class BowCosineSimilaritySuccess extends S.Class<BowCosineSimilaritySuccess>($I`
  *
  * **Example** (Decode parameters schema)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode parameters schema"
  * import * as S from "effect/Schema"
  * import { BowCosineSimilarity } from "@beep/nlp-processing/Tools/BowCosineSimilarity"
  *

--- a/packages/foundation/capability/nlp-processing/src/Tools/ChunkBySentences.ts
+++ b/packages/foundation/capability/nlp-processing/src/Tools/ChunkBySentences.ts
@@ -52,7 +52,7 @@ class ChunkBySentencesSuccess extends S.Class<ChunkBySentencesSuccess>($I`ChunkB
  *
  * **Example** (Decode parameters schema)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode parameters schema"
  * import * as S from "effect/Schema"
  * import { ChunkBySentences } from "@beep/nlp-processing/Tools/ChunkBySentences"
  *

--- a/packages/foundation/capability/nlp-processing/src/Tools/CorpusStats.ts
+++ b/packages/foundation/capability/nlp-processing/src/Tools/CorpusStats.ts
@@ -44,7 +44,7 @@ class CorpusStatsParameters extends S.Class<CorpusStatsParameters>($I`CorpusStat
  *
  * **Example** (Decode parameters schema)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode parameters schema"
  * import * as S from "effect/Schema"
  * import { CorpusStats } from "@beep/nlp-processing/Tools/CorpusStats"
  *

--- a/packages/foundation/capability/nlp-processing/src/Tools/CreateCorpus.ts
+++ b/packages/foundation/capability/nlp-processing/src/Tools/CreateCorpus.ts
@@ -60,7 +60,7 @@ class CreateCorpusParameters extends S.Class<CreateCorpusParameters>($I`CreateCo
  *
  * **Example** (Decode CreateCorpus parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode CreateCorpus parameters"
  * import * as S from "effect/Schema"
  * import { CreateCorpus } from "@beep/nlp-processing/Tools/CreateCorpus"
  *

--- a/packages/foundation/capability/nlp-processing/src/Tools/DeleteCorpus.ts
+++ b/packages/foundation/capability/nlp-processing/src/Tools/DeleteCorpus.ts
@@ -44,7 +44,7 @@ class DeleteCorpusSuccess extends S.Class<DeleteCorpusSuccess>($I`DeleteCorpusSu
  *
  * **Example** (Decode DeleteCorpus parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode DeleteCorpus parameters"
  * import * as S from "effect/Schema"
  * import { DeleteCorpus } from "@beep/nlp-processing/Tools/DeleteCorpus"
  *

--- a/packages/foundation/capability/nlp-processing/src/Tools/DocumentStats.ts
+++ b/packages/foundation/capability/nlp-processing/src/Tools/DocumentStats.ts
@@ -36,7 +36,7 @@ class DocumentStatsParameters extends S.Class<DocumentStatsParameters>($I`Docume
  *
  * **Example** (Decode parameters schema)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode parameters schema"
  * import * as S from "effect/Schema"
  * import { DocumentStats } from "@beep/nlp-processing/Tools/DocumentStats"
  *

--- a/packages/foundation/capability/nlp-processing/src/Tools/ExtractEntities.ts
+++ b/packages/foundation/capability/nlp-processing/src/Tools/ExtractEntities.ts
@@ -63,7 +63,7 @@ class ExtractEntitiesSuccess extends S.Class<ExtractEntitiesSuccess>($I`ExtractE
  *
  * **Example** (Decode ExtractEntities parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode ExtractEntities parameters"
  * import * as S from "effect/Schema"
  * import { ExtractEntities } from "@beep/nlp-processing/Tools/ExtractEntities"
  *

--- a/packages/foundation/capability/nlp-processing/src/Tools/ExtractKeywords.ts
+++ b/packages/foundation/capability/nlp-processing/src/Tools/ExtractKeywords.ts
@@ -50,7 +50,7 @@ class ExtractKeywordsSuccess extends S.Class<ExtractKeywordsSuccess>($I`ExtractK
  *
  * **Example** (Decode parameters schema)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode parameters schema"
  * import * as S from "effect/Schema"
  * import { ExtractKeywords } from "@beep/nlp-processing/Tools/ExtractKeywords"
  *

--- a/packages/foundation/capability/nlp-processing/src/Tools/LearnCorpus.ts
+++ b/packages/foundation/capability/nlp-processing/src/Tools/LearnCorpus.ts
@@ -65,7 +65,7 @@ class LearnCorpusSuccess extends S.Class<LearnCorpusSuccess>($I`LearnCorpusSucce
  *
  * **Example** (Decode LearnCorpus parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode LearnCorpus parameters"
  * import * as S from "effect/Schema"
  * import { LearnCorpus } from "@beep/nlp-processing/Tools/LearnCorpus"
  *

--- a/packages/foundation/capability/nlp-processing/src/Tools/LearnCustomEntities.ts
+++ b/packages/foundation/capability/nlp-processing/src/Tools/LearnCustomEntities.ts
@@ -83,7 +83,7 @@ class LearnCustomEntitiesSuccess extends S.Class<LearnCustomEntitiesSuccess>($I`
  *
  * **Example** (Decode custom entity parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode custom entity parameters"
  * import * as S from "effect/Schema"
  * import { LearnCustomEntities } from "@beep/nlp-processing/Tools/LearnCustomEntities"
  *

--- a/packages/foundation/capability/nlp-processing/src/Tools/NGrams.ts
+++ b/packages/foundation/capability/nlp-processing/src/Tools/NGrams.ts
@@ -70,7 +70,7 @@ class NGramsSuccess extends S.Class<NGramsSuccess>($I`NGramsSuccess`)(
  *
  * **Example** (Decode bag n-gram parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode bag n-gram parameters"
  * import * as S from "effect/Schema"
  * import { NGrams } from "@beep/nlp-processing/Tools/NGrams"
  *

--- a/packages/foundation/capability/nlp-processing/src/Tools/Paragraphize.ts
+++ b/packages/foundation/capability/nlp-processing/src/Tools/Paragraphize.ts
@@ -46,7 +46,7 @@ class ParagraphizeSuccess extends S.Class<ParagraphizeSuccess>($I`ParagraphizeSu
  *
  * **Example** (Decode parameters schema)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode parameters schema"
  * import * as S from "effect/Schema"
  * import { Paragraphize } from "@beep/nlp-processing/Tools/Paragraphize"
  *

--- a/packages/foundation/capability/nlp-processing/src/Tools/PhoneticMatch.ts
+++ b/packages/foundation/capability/nlp-processing/src/Tools/PhoneticMatch.ts
@@ -46,7 +46,7 @@ class PhoneticMatchParameters extends S.Class<PhoneticMatchParameters>($I`Phonet
  *
  * **Example** (Decode soundex match parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode soundex match parameters"
  * import * as S from "effect/Schema"
  * import { PhoneticMatch } from "@beep/nlp-processing/Tools/PhoneticMatch"
  *

--- a/packages/foundation/capability/nlp-processing/src/Tools/QueryCorpus.ts
+++ b/packages/foundation/capability/nlp-processing/src/Tools/QueryCorpus.ts
@@ -70,7 +70,7 @@ class QueryCorpusSuccess extends S.Class<QueryCorpusSuccess>($I`QueryCorpusSucce
  *
  * **Example** (Decode QueryCorpus parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode QueryCorpus parameters"
  * import * as S from "effect/Schema"
  * import { QueryCorpus } from "@beep/nlp-processing/Tools/QueryCorpus"
  *

--- a/packages/foundation/capability/nlp-processing/src/Tools/RankByRelevance.ts
+++ b/packages/foundation/capability/nlp-processing/src/Tools/RankByRelevance.ts
@@ -60,7 +60,7 @@ class RankByRelevanceSuccess extends S.Class<RankByRelevanceSuccess>($I`RankByRe
  *
  * **Example** (Decode ranking parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode ranking parameters"
  * import * as S from "effect/Schema"
  * import { RankByRelevance } from "@beep/nlp-processing/Tools/RankByRelevance"
  *

--- a/packages/foundation/capability/nlp-processing/src/Tools/RemoveStopWords.ts
+++ b/packages/foundation/capability/nlp-processing/src/Tools/RemoveStopWords.ts
@@ -47,7 +47,7 @@ class RemoveStopWordsSuccess extends S.Class<RemoveStopWordsSuccess>($I`RemoveSt
  *
  * **Example** (Decode parameters schema)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode parameters schema"
  * import * as S from "effect/Schema"
  * import { RemoveStopWords } from "@beep/nlp-processing/Tools/RemoveStopWords"
  *

--- a/packages/foundation/capability/nlp-processing/src/Tools/Sentences.ts
+++ b/packages/foundation/capability/nlp-processing/src/Tools/Sentences.ts
@@ -46,7 +46,7 @@ class SentencesSuccess extends S.Class<SentencesSuccess>($I`SentencesSuccess`)(
  *
  * **Example** (Decode parameters schema)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode parameters schema"
  * import * as S from "effect/Schema"
  * import { Sentences } from "@beep/nlp-processing/Tools/Sentences"
  *

--- a/packages/foundation/capability/nlp-processing/src/Tools/Stem.ts
+++ b/packages/foundation/capability/nlp-processing/src/Tools/Stem.ts
@@ -46,7 +46,7 @@ class StemSuccess extends S.Class<StemSuccess>($I`StemSuccess`)(
  *
  * **Example** (Decode Stem parametersSchema)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode Stem parametersSchema"
  * import * as S from "effect/Schema"
  * import { Stem } from "@beep/nlp-processing/Tools/Stem"
  *

--- a/packages/foundation/capability/nlp-processing/src/Tools/TextSimilarity.ts
+++ b/packages/foundation/capability/nlp-processing/src/Tools/TextSimilarity.ts
@@ -55,7 +55,7 @@ class TextSimilaritySuccess extends S.Class<TextSimilaritySuccess>($I`TextSimila
  *
  * **Example** (Decode similarity parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode similarity parameters"
  * import * as S from "effect/Schema"
  * import { TextSimilarity } from "@beep/nlp-processing/Tools/TextSimilarity"
  *

--- a/packages/foundation/capability/nlp-processing/src/Tools/Tokenize.ts
+++ b/packages/foundation/capability/nlp-processing/src/Tools/Tokenize.ts
@@ -47,7 +47,7 @@ class TokenizeSuccess extends S.Class<TokenizeSuccess>($I`TokenizeSuccess`)(
  *
  * **Example** (Decode tokenize parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode tokenize parameters"
  * import * as S from "effect/Schema"
  * import { Tokenize } from "@beep/nlp-processing/Tools/Tokenize"
  *

--- a/packages/foundation/capability/nlp-processing/src/Tools/ToolExport.ts
+++ b/packages/foundation/capability/nlp-processing/src/Tools/ToolExport.ts
@@ -88,7 +88,7 @@ const parameterNamesForTool = (tool: NlpTool): ReadonlyArray<string> => {
  *
  * **Example** (Recover from ExportedToolError)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Recover from ExportedToolError"
  * import { Effect } from "effect"
  * import { ExportedToolError } from "@beep/nlp-processing/Tools/ToolExport"
  *
@@ -403,7 +403,7 @@ const exportToolsEffect: Effect.Effect<
  *
  * **Example** (List exported tool names)
  *
- * ```ts
+ * ```ts import.meta.vitest name="List exported tool names"
  * import { Effect } from "effect"
  * import { exportTools } from "@beep/nlp-processing/Tools/ToolExport"
  * import { WinkNlpToolkitLive } from "@beep/wink"

--- a/packages/foundation/capability/nlp-processing/src/Tools/TransformText.ts
+++ b/packages/foundation/capability/nlp-processing/src/Tools/TransformText.ts
@@ -80,7 +80,7 @@ class TransformTextSuccess extends S.Class<TransformTextSuccess>($I`TransformTex
  *
  * **Example** (Decode transform parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode transform parameters"
  * import * as S from "effect/Schema"
  * import { TransformText } from "@beep/nlp-processing/Tools/TransformText"
  *

--- a/packages/foundation/capability/nlp-processing/src/Tools/TverskySimilarity.ts
+++ b/packages/foundation/capability/nlp-processing/src/Tools/TverskySimilarity.ts
@@ -68,7 +68,7 @@ class TverskySimilaritySuccess extends S.Class<TverskySimilaritySuccess>($I`Tver
  *
  * **Example** (Decode Tversky parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode Tversky parameters"
  * import * as S from "effect/Schema"
  * import { TverskySimilarity } from "@beep/nlp-processing/Tools/TverskySimilarity"
  *

--- a/packages/foundation/capability/nlp-processing/src/Tools/WordCount.ts
+++ b/packages/foundation/capability/nlp-processing/src/Tools/WordCount.ts
@@ -46,7 +46,7 @@ class WordCountSuccess extends S.Class<WordCountSuccess>($I`WordCountSuccess`)(
  *
  * **Example** (Decode WordCount parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode WordCount parameters"
  * import * as S from "effect/Schema"
  * import { WordCount } from "@beep/nlp-processing/Tools/WordCount"
  *

--- a/packages/foundation/capability/nlp-processing/src/Tools/_schemas.ts
+++ b/packages/foundation/capability/nlp-processing/src/Tools/_schemas.ts
@@ -29,10 +29,10 @@ const AiEntitySourceKit = LiteralKit(["builtin", "custom"]).annotate(
  *
  * **Example** (Validating soundex membership)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Validating soundex membership"
  * import { AiPhoneticAlgorithmKit } from "@beep/nlp-processing/Tools/_schemas"
  *
- * console.log(AiPhoneticAlgorithmKit.is.soundex("soundex")) // true
+ * AiPhoneticAlgorithmKit.is.soundex("soundex") // => true
  * ```
  *
  * @category schemas
@@ -73,10 +73,10 @@ const AiEntitySource = AiEntitySourceKit.pipe(
  *
  * **Example** (Validating phonetize membership)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Validating phonetize membership"
  * import { AiPhoneticAlgorithm } from "@beep/nlp-processing/Tools/_schemas"
  *
- * console.log(AiPhoneticAlgorithm.is.phonetize("phonetize")) // true
+ * AiPhoneticAlgorithm.is.phonetize("phonetize") // => true
  * ```
  *
  * @category schemas
@@ -99,7 +99,7 @@ export const AiPhoneticAlgorithm = AiPhoneticAlgorithmKit.pipe(
  *
  * **Example** (Decoding an annotated token)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decoding an annotated token"
  * import * as S from "effect/Schema"
  * import { AiToken } from "@beep/nlp-processing/Tools/_schemas"
  *
@@ -149,7 +149,7 @@ export class AiToken extends S.Class<AiToken>($I`AiToken`)(
  *
  * **Example** (Decoding composite analysis)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decoding composite analysis"
  * import * as S from "effect/Schema"
  * import { AiAnalysis } from "@beep/nlp-processing/Tools/_schemas"
  *
@@ -203,7 +203,7 @@ export class AiAnalysis extends S.Class<AiAnalysis>($I`AiAnalysis`)(
  *
  * **Example** (Decoding a sentence)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decoding a sentence"
  * import * as S from "effect/Schema"
  * import { AiSentence } from "@beep/nlp-processing/Tools/_schemas"
  *
@@ -244,7 +244,7 @@ export class AiSentence extends S.Class<AiSentence>($I`AiSentence`)(
  *
  * **Example** (Decoding a keyword score)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decoding a keyword score"
  * import * as S from "effect/Schema"
  * import { AiKeyword } from "@beep/nlp-processing/Tools/_schemas"
  *
@@ -279,7 +279,7 @@ export class AiKeyword extends S.Class<AiKeyword>($I`AiKeyword`)(
  *
  * **Example** (Decoding document statistics)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decoding document statistics"
  * import * as S from "effect/Schema"
  * import { AiDocumentStats } from "@beep/nlp-processing/Tools/_schemas"
  *
@@ -318,7 +318,7 @@ export class AiDocumentStats extends S.Class<AiDocumentStats>($I`AiDocumentStats
  *
  * **Example** (Decoding a sentence chunk)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decoding a sentence chunk"
  * import * as S from "effect/Schema"
  * import { AiSentenceChunk } from "@beep/nlp-processing/Tools/_schemas"
  *
@@ -359,7 +359,7 @@ export class AiSentenceChunk extends S.Class<AiSentenceChunk>($I`AiSentenceChunk
  *
  * **Example** (Decoding ranked text)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decoding ranked text"
  * import * as S from "effect/Schema"
  * import { AiRankedText } from "@beep/nlp-processing/Tools/_schemas"
  *
@@ -394,7 +394,7 @@ export class AiRankedText extends S.Class<AiRankedText>($I`AiRankedText`)(
  *
  * **Example** (Decoding a named entity)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decoding a named entity"
  * import * as S from "effect/Schema"
  * import { AiEntity } from "@beep/nlp-processing/Tools/_schemas"
  *
@@ -439,7 +439,7 @@ export class AiEntity extends S.Class<AiEntity>($I`AiEntity`)(
  *
  * **Example** (Decoding an n-gram)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decoding an n-gram"
  * import * as S from "effect/Schema"
  * import { AiNGram } from "@beep/nlp-processing/Tools/_schemas"
  *
@@ -474,7 +474,7 @@ export class AiNGram extends S.Class<AiNGram>($I`AiNGram`)(
  *
  * **Example** (Decoding phonetic match)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decoding phonetic match"
  * import * as S from "effect/Schema"
  * import { AiPhoneticMatch } from "@beep/nlp-processing/Tools/_schemas"
  *
@@ -557,7 +557,7 @@ export class AiToolError extends S.Class<AiToolError>($I`AiToolError`)(
  *
  * **Example** (Decoding BM25 configuration)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decoding BM25 configuration"
  * import * as S from "effect/Schema"
  * import { AiCorpusConfig } from "@beep/nlp-processing/Tools/_schemas"
  *
@@ -596,7 +596,7 @@ export class AiCorpusConfig extends S.Class<AiCorpusConfig>($I`AiCorpusConfig`)(
  *
  * **Example** (Decoding corpus summary)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decoding corpus summary"
  * import * as S from "effect/Schema"
  * import { AiCorpusSummary } from "@beep/nlp-processing/Tools/_schemas"
  *
@@ -637,7 +637,7 @@ export class AiCorpusSummary extends S.Class<AiCorpusSummary>($I`AiCorpusSummary
  *
  * **Example** (Decoding ranked document)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decoding ranked document"
  * import * as S from "effect/Schema"
  * import { AiCorpusRankedDocument } from "@beep/nlp-processing/Tools/_schemas"
  *
@@ -675,7 +675,7 @@ export class AiCorpusRankedDocument extends S.Class<AiCorpusRankedDocument>($I`A
  *
  * **Example** (Decoding an IDF entry)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decoding an IDF entry"
  * import * as S from "effect/Schema"
  * import { AiCorpusIdf } from "@beep/nlp-processing/Tools/_schemas"
  *
@@ -710,7 +710,7 @@ export class AiCorpusIdf extends S.Class<AiCorpusIdf>($I`AiCorpusIdf`)(
  *
  * **Example** (Decoding matrix dimensions)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decoding matrix dimensions"
  * import * as S from "effect/Schema"
  * import { AiCorpusMatrixShape } from "@beep/nlp-processing/Tools/_schemas"
  *
@@ -745,7 +745,7 @@ export class AiCorpusMatrixShape extends S.Class<AiCorpusMatrixShape>($I`AiCorpu
  *
  * **Example** (Decoding corpus statistics)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decoding corpus statistics"
  * import * as S from "effect/Schema"
  * import { AiCorpusStats } from "@beep/nlp-processing/Tools/_schemas"
  *

--- a/packages/foundation/capability/nlp-processing/src/Tools/index.ts
+++ b/packages/foundation/capability/nlp-processing/src/Tools/index.ts
@@ -57,7 +57,7 @@ import { WordCount as WordCountSource } from "./WordCount.ts";
  *
  * **Example** (Decode composite analysis schema)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode composite analysis schema"
  * import * as S from "effect/Schema"
  * import { AiAnalysis } from "@beep/nlp-processing/Tools"
  *
@@ -82,7 +82,7 @@ export const AiAnalysis = AiAnalysisSource;
  *
  * **Example** (Decode BM25 corpus config)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode BM25 corpus config"
  * import * as S from "effect/Schema"
  * import { AiCorpusConfig } from "@beep/nlp-processing/Tools"
  *
@@ -105,7 +105,7 @@ export const AiCorpusConfig = AiCorpusConfigSource;
  *
  * **Example** (Decode corpus IDF entry)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode corpus IDF entry"
  * import * as S from "effect/Schema"
  * import { AiCorpusIdf } from "@beep/nlp-processing/Tools"
  *
@@ -126,7 +126,7 @@ export const AiCorpusIdf = AiCorpusIdfSource;
  *
  * **Example** (Decode matrix dimensions)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode matrix dimensions"
  * import * as S from "effect/Schema"
  * import { AiCorpusMatrixShape } from "@beep/nlp-processing/Tools"
  *
@@ -147,7 +147,7 @@ export const AiCorpusMatrixShape = AiCorpusMatrixShapeSource;
  *
  * **Example** (Decode ranked corpus document)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode ranked corpus document"
  * import * as S from "effect/Schema"
  * import { AiCorpusRankedDocument } from "@beep/nlp-processing/Tools"
  *
@@ -170,7 +170,7 @@ export const AiCorpusRankedDocument = AiCorpusRankedDocumentSource;
  *
  * **Example** (Decode corpus diagnostic stats)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode corpus diagnostic stats"
  * import * as S from "effect/Schema"
  * import { AiCorpusStats } from "@beep/nlp-processing/Tools"
  *
@@ -195,7 +195,7 @@ export const AiCorpusStats = AiCorpusStatsSource;
  *
  * **Example** (Decode managed corpus summary)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode managed corpus summary"
  * import * as S from "effect/Schema"
  * import { AiCorpusSummary } from "@beep/nlp-processing/Tools"
  *
@@ -219,7 +219,7 @@ export const AiCorpusSummary = AiCorpusSummarySource;
  *
  * **Example** (Decode document-level stats)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode document-level stats"
  * import * as S from "effect/Schema"
  * import { AiDocumentStats } from "@beep/nlp-processing/Tools"
  *
@@ -242,7 +242,7 @@ export const AiDocumentStats = AiDocumentStatsSource;
  *
  * **Example** (Decode named entity result)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode named entity result"
  * import * as S from "effect/Schema"
  * import { AiEntity } from "@beep/nlp-processing/Tools"
  *
@@ -268,7 +268,7 @@ export const AiEntity = AiEntitySource;
  *
  * **Example** (Decode ranked keyword)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode ranked keyword"
  * import * as S from "effect/Schema"
  * import { AiKeyword } from "@beep/nlp-processing/Tools"
  *
@@ -289,7 +289,7 @@ export const AiKeyword = AiKeywordSource;
  *
  * **Example** (Decode frequency n-gram)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode frequency n-gram"
  * import * as S from "effect/Schema"
  * import { AiNGram } from "@beep/nlp-processing/Tools"
  *
@@ -310,7 +310,7 @@ export const AiNGram = AiNGramSource;
  *
  * **Example** (Decode phonetic match result)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode phonetic match result"
  * import * as S from "effect/Schema"
  * import { AiPhoneticMatch } from "@beep/nlp-processing/Tools"
  *
@@ -334,7 +334,7 @@ export const AiPhoneticMatch = AiPhoneticMatchSource;
  *
  * **Example** (Decode ranked text candidate)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode ranked text candidate"
  * import * as S from "effect/Schema"
  * import { AiRankedText } from "@beep/nlp-processing/Tools"
  *
@@ -355,7 +355,7 @@ export const AiRankedText = AiRankedTextSource;
  *
  * **Example** (Decode sentence result)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode sentence result"
  * import * as S from "effect/Schema"
  * import { AiSentence } from "@beep/nlp-processing/Tools"
  *
@@ -379,7 +379,7 @@ export const AiSentence = AiSentenceSource;
  *
  * **Example** (Decode sentence-aligned chunk)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode sentence-aligned chunk"
  * import * as S from "effect/Schema"
  * import { AiSentenceChunk } from "@beep/nlp-processing/Tools"
  *
@@ -427,7 +427,7 @@ export const AiToolError = AiToolErrorSource;
  *
  * **Example** (Decode annotated token)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode annotated token"
  * import * as S from "effect/Schema"
  * import { AiToken } from "@beep/nlp-processing/Tools"
  *
@@ -454,7 +454,7 @@ export const AiToken = AiTokenSource;
  *
  * **Example** (Decode Analyze parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode Analyze parameters"
  * import * as S from "effect/Schema"
  * import { Analyze } from "@beep/nlp-processing/Tools"
  *
@@ -474,7 +474,7 @@ export const Analyze = AnalyzeSource;
  *
  * **Example** (Decode BagOfWords parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode BagOfWords parameters"
  * import * as S from "effect/Schema"
  * import { BagOfWords } from "@beep/nlp-processing/Tools"
  *
@@ -494,7 +494,7 @@ export const BagOfWords = BagOfWordsSource;
  *
  * **Example** (Decode cosine similarity parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode cosine similarity parameters"
  * import * as S from "effect/Schema"
  * import { BowCosineSimilarity } from "@beep/nlp-processing/Tools"
  *
@@ -515,7 +515,7 @@ export const BowCosineSimilarity = BowCosineSimilaritySource;
  *
  * **Example** (Decode sentence chunk parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode sentence chunk parameters"
  * import * as S from "effect/Schema"
  * import { ChunkBySentences } from "@beep/nlp-processing/Tools"
  *
@@ -536,7 +536,7 @@ export const ChunkBySentences = ChunkBySentencesSource;
  *
  * **Example** (Decode corpus stats parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode corpus stats parameters"
  * import * as S from "effect/Schema"
  * import { CorpusStats } from "@beep/nlp-processing/Tools"
  *
@@ -559,7 +559,7 @@ export const CorpusStats = CorpusStatsSource;
  *
  * **Example** (Decode create corpus parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode create corpus parameters"
  * import * as S from "effect/Schema"
  * import { CreateCorpus } from "@beep/nlp-processing/Tools"
  *
@@ -580,7 +580,7 @@ export const CreateCorpus: typeof CreateCorpusSource = CreateCorpusSource;
  *
  * **Example** (Decode delete corpus parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode delete corpus parameters"
  * import * as S from "effect/Schema"
  * import { DeleteCorpus } from "@beep/nlp-processing/Tools"
  *
@@ -600,7 +600,7 @@ export const DeleteCorpus = DeleteCorpusSource;
  *
  * **Example** (Decode document stats parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode document stats parameters"
  * import * as S from "effect/Schema"
  * import { DocumentStats } from "@beep/nlp-processing/Tools"
  *
@@ -620,7 +620,7 @@ export const DocumentStats = DocumentStatsSource;
  *
  * **Example** (Decode entity extraction parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode entity extraction parameters"
  * import * as S from "effect/Schema"
  * import { ExtractEntities } from "@beep/nlp-processing/Tools"
  *
@@ -641,7 +641,7 @@ export const ExtractEntities = ExtractEntitiesSource;
  *
  * **Example** (Decode keyword extraction parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode keyword extraction parameters"
  * import * as S from "effect/Schema"
  * import { ExtractKeywords } from "@beep/nlp-processing/Tools"
  *
@@ -662,7 +662,7 @@ export const ExtractKeywords = ExtractKeywordsSource;
  *
  * **Example** (Decode learn corpus parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode learn corpus parameters"
  * import * as S from "effect/Schema"
  * import { LearnCorpus } from "@beep/nlp-processing/Tools"
  *
@@ -684,7 +684,7 @@ export const LearnCorpus = LearnCorpusSource;
  *
  * **Example** (Decode custom entity learning)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode custom entity learning"
  * import * as S from "effect/Schema"
  * import { LearnCustomEntities } from "@beep/nlp-processing/Tools"
  *
@@ -706,7 +706,7 @@ export const LearnCustomEntities = LearnCustomEntitiesSource;
  *
  * **Example** (Decode n-gram extraction parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode n-gram extraction parameters"
  * import * as S from "effect/Schema"
  * import { NGrams } from "@beep/nlp-processing/Tools"
  *
@@ -729,7 +729,7 @@ export const NGrams = NGramsSource;
  *
  * **Example** (Decode paragraphize parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode paragraphize parameters"
  * import * as S from "effect/Schema"
  * import { Paragraphize } from "@beep/nlp-processing/Tools"
  *
@@ -749,7 +749,7 @@ export const Paragraphize = ParagraphizeSource;
  *
  * **Example** (Decode phonetic match parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode phonetic match parameters"
  * import * as S from "effect/Schema"
  * import { PhoneticMatch } from "@beep/nlp-processing/Tools"
  *
@@ -772,7 +772,7 @@ export const PhoneticMatch = PhoneticMatchSource;
  *
  * **Example** (Decode query corpus parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode query corpus parameters"
  * import * as S from "effect/Schema"
  * import { QueryCorpus } from "@beep/nlp-processing/Tools"
  *
@@ -795,7 +795,7 @@ export const QueryCorpus = QueryCorpusSource;
  *
  * **Example** (Decode relevance ranking parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode relevance ranking parameters"
  * import * as S from "effect/Schema"
  * import { RankByRelevance } from "@beep/nlp-processing/Tools"
  *
@@ -817,7 +817,7 @@ export const RankByRelevance = RankByRelevanceSource;
  *
  * **Example** (Decode stop-word removal parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode stop-word removal parameters"
  * import * as S from "effect/Schema"
  * import { RemoveStopWords } from "@beep/nlp-processing/Tools"
  *
@@ -837,7 +837,7 @@ export const RemoveStopWords = RemoveStopWordsSource;
  *
  * **Example** (Decode sentence segmentation parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode sentence segmentation parameters"
  * import * as S from "effect/Schema"
  * import { Sentences } from "@beep/nlp-processing/Tools"
  *
@@ -857,7 +857,7 @@ export const Sentences = SentencesSource;
  *
  * **Example** (Decode stemming parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode stemming parameters"
  * import * as S from "effect/Schema"
  * import { Stem } from "@beep/nlp-processing/Tools"
  *
@@ -877,7 +877,7 @@ export const Stem = StemSource;
  *
  * **Example** (Decode text similarity parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode text similarity parameters"
  * import * as S from "effect/Schema"
  * import { TextSimilarity } from "@beep/nlp-processing/Tools"
  *
@@ -898,7 +898,7 @@ export const TextSimilarity = TextSimilaritySource;
  *
  * **Example** (Decode tokenize parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode tokenize parameters"
  * import * as S from "effect/Schema"
  * import { Tokenize } from "@beep/nlp-processing/Tools"
  *
@@ -918,7 +918,7 @@ export const Tokenize = TokenizeSource;
  *
  * **Example** (Decode text transform parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode text transform parameters"
  * import * as S from "effect/Schema"
  * import { TransformText } from "@beep/nlp-processing/Tools"
  *
@@ -939,7 +939,7 @@ export const TransformText = TransformTextSource;
  *
  * **Example** (Decode Tversky similarity parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode Tversky similarity parameters"
  * import * as S from "effect/Schema"
  * import { TverskySimilarity } from "@beep/nlp-processing/Tools"
  *
@@ -962,7 +962,7 @@ export const TverskySimilarity = TverskySimilaritySource;
  *
  * **Example** (Decode word count parameters)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode word count parameters"
  * import * as S from "effect/Schema"
  * import { WordCount } from "@beep/nlp-processing/Tools"
  *
@@ -1021,7 +1021,7 @@ export const NlpTools: typeof NlpToolsSource = NlpToolsSource;
  *
  * **Example** (Export toolkit tool names)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Export toolkit tool names"
  * import { Effect } from "effect"
  * import { exportTools } from "@beep/nlp-processing/Tools"
  *

--- a/packages/foundation/capability/observability/src/CauseDiagnostics.ts
+++ b/packages/foundation/capability/observability/src/CauseDiagnostics.ts
@@ -9,7 +9,7 @@
  *
  * **Example** (Classify and summarize cause)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Classify and summarize cause"
  * import { Cause } from "effect"
  * import { classifyCause, summarizeCause } from "@beep/observability"
  *
@@ -17,8 +17,8 @@
  * const classification = classifyCause(cause)
  * const summary = summarizeCause(cause)
  *
- * console.log(classification) // "failure"
- * console.log(summary.primaryMessage) // "boom"
+ * classification // => "failure"
+ * summary.primaryMessage // => "boom"
  * ```
  *
  * @packageDocumentation
@@ -42,15 +42,15 @@ const $I = $ObservabilityId.create("CauseDiagnostics");
  *
  * One of `"empty"`, `"failure"`, `"defect"`, `"interrupted"`, or `"mixed"`.
  *
- * **Example** (Classify empty failure defect)
+ * **Example** (Classify causes for schema values)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Classify causes for schema values"
  * import { Cause } from "effect"
  * import { classifyCause } from "@beep/observability"
  *
- * console.log(classifyCause(Cause.empty)) // "empty"
- * console.log(classifyCause(Cause.fail("err"))) // "failure"
- * console.log(classifyCause(Cause.die("bug"))) // "defect"
+ * classifyCause(Cause.empty) // => "empty"
+ * classifyCause(Cause.fail("err")) // => "failure"
+ * classifyCause(Cause.die("bug")) // => "defect"
  * ```
  *
  * @category models
@@ -84,12 +84,12 @@ export type CauseClassification = typeof CauseClassification.Type;
  *
  * **Example** (Read success exit outcome)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Read success exit outcome"
  * import { Exit } from "effect"
  * import { summarizeExit } from "@beep/observability"
  *
  * const outcome = summarizeExit(Exit.succeed("ok")).outcome
- * console.log(outcome) // "success"
+ * outcome // => "success"
  * ```
  *
  * @category models
@@ -123,11 +123,11 @@ export type ExitOutcome = typeof ExitOutcome.Type;
  *
  * **Example** (Make cause fingerprint value)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Make cause fingerprint value"
  * import { CauseFingerprint } from "@beep/observability"
  *
  * const fp = CauseFingerprint.make({ value: "failure:fail:1:error:boom" })
- * console.log(fp.value) // "failure:fail:1:error:boom"
+ * fp.value // => "failure:fail:1:error:boom"
  * ```
  *
  * @category models
@@ -147,15 +147,15 @@ export class CauseFingerprint extends S.Class<CauseFingerprint>($I`CauseFingerpr
  *
  * **Example** (Summarize cause field counts)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Summarize cause field counts"
  * import { Cause } from "effect"
  * import { summarizeCause } from "@beep/observability"
  *
  * const summary = summarizeCause(Cause.fail(new Error("timeout")))
  *
- * console.log(summary.classification) // "failure"
- * console.log(summary.errorCount) // 1
- * console.log(summary.defectCount) // 0
+ * summary.classification // => "failure"
+ * summary.errorCount // => 1
+ * summary.defectCount // => 0
  * ```
  *
  * @category models
@@ -205,18 +205,18 @@ export type CauseSummary = typeof CauseSummary.Type;
 /**
  * Transport-safe summary of an exit with outcome, classification, and fingerprint.
  *
- * **Example** (Summarize success and failure)
+ * **Example** (Build success and failure summaries)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Build success and failure summaries"
  * import { Exit, Cause } from "effect"
  * import { summarizeExit } from "@beep/observability"
  *
  * const success = summarizeExit(Exit.succeed(42))
- * console.log(success.outcome) // "success"
+ * success.outcome // => "success"
  *
  * const failure = summarizeExit(Exit.fail(new Error("oops")))
- * console.log(failure.outcome) // "failure"
- * console.log(failure.classification) // "failure"
+ * failure.outcome // => "failure"
+ * failure.classification // => "failure"
  * ```
  *
  * @category models
@@ -257,14 +257,14 @@ const ObservedExitSummaryTagged = CauseClassification.toTaggedUnion("classificat
  *
  * **Example** (Decode observed exit summary)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Decode observed exit summary"
  * import { Exit } from "effect"
  * import * as S from "effect/Schema"
  * import { ObservedExitSummary, summarizeExit } from "@beep/observability"
  *
  * const summary = summarizeExit(Exit.fail(new Error("boom")))
  * const decoded = S.decodeUnknownSync(ObservedExitSummary)(summary)
- * console.log(decoded.outcome) // "failure"
+ * decoded.outcome // => "failure"
  * ```
  *
  * @category models
@@ -407,15 +407,15 @@ const classifyReasonCounts = flow(
  * Returns `"empty"` for empty causes, `"mixed"` when multiple reason kinds are
  * present, or the single kind (`"failure"`, `"defect"`, `"interrupted"`) otherwise.
  *
- * **Example** (Classify empty failure defect)
+ * **Example** (Classify causes by reason makeup)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Classify causes by reason makeup"
  * import { Cause } from "effect"
  * import { classifyCause } from "@beep/observability"
  *
- * console.log(classifyCause(Cause.empty)) // "empty"
- * console.log(classifyCause(Cause.fail("err"))) // "failure"
- * console.log(classifyCause(Cause.die("bug"))) // "defect"
+ * classifyCause(Cause.empty) // => "empty"
+ * classifyCause(Cause.fail("err")) // => "failure"
+ * classifyCause(Cause.die("bug")) // => "defect"
  * ```
  *
  * @category diagnostics
@@ -433,12 +433,12 @@ export const classifyCause = flow(summarizeReasonCounts, classifyReasonCounts);
  *
  * **Example** (Fingerprint failed cause)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Fingerprint failed cause"
  * import { Cause } from "effect"
  * import { fingerprintCause } from "@beep/observability"
  *
  * const fp = fingerprintCause(Cause.fail(new Error("connection refused")))
- * console.log(fp.value) // "failure:fail:1:error:connection refused"
+ * fp.value // => "failure:fail:1:error:connection refused"
  * ```
  *
  * @category diagnostics
@@ -455,15 +455,15 @@ export const fingerprintCause = (cause: Cause.Cause<unknown>): CauseFingerprint 
  *
  * **Example** (Summarize failed cause fields)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Summarize failed cause fields"
  * import { Cause } from "effect"
  * import { summarizeCause } from "@beep/observability"
  *
  * const summary = summarizeCause(Cause.fail(new Error("timeout")))
  *
- * console.log(summary.classification) // "failure"
- * console.log(summary.errorCount) // 1
- * console.log(summary.primaryMessage) // "timeout"
+ * summary.classification // => "failure"
+ * summary.errorCount // => 1
+ * summary.primaryMessage // => "timeout"
  * ```
  *
  * @category diagnostics
@@ -504,17 +504,17 @@ export const summarizeCause = (cause: Cause.Cause<unknown>): CauseSummary => {
  * For successful exits the outcome is `"success"` with an empty classification.
  * For failed exits the cause is analyzed via {@link summarizeCause}.
  *
- * **Example** (Summarize success and failure)
+ * **Example** (Summarize success and failed exits)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Summarize success and failed exits"
  * import { Exit } from "effect"
  * import { summarizeExit } from "@beep/observability"
  *
  * const ok = summarizeExit(Exit.succeed("done"))
- * console.log(ok.outcome) // "success"
+ * ok.outcome // => "success"
  *
  * const err = summarizeExit(Exit.fail(new Error("oops")))
- * console.log(err.outcome) // "failure"
+ * err.outcome // => "failure"
  * ```
  *
  * @category diagnostics

--- a/packages/foundation/capability/observability/src/CauseRedaction.ts
+++ b/packages/foundation/capability/observability/src/CauseRedaction.ts
@@ -18,15 +18,15 @@
  *
  * **Example** (Redact cause for safe logs)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Redact cause for safe logs"
  * import { Cause } from "effect"
  * import { redactCause } from "@beep/observability"
  *
  * const cause = Cause.fail(new Error("connect ECONNREFUSED token=sk-EXAMPLEKEY00"))
  * const safe = redactCause(cause)
  *
- * console.log(safe.tag) // "failure"
- * console.log(safe.message) // "connect ECONNREFUSED token=[REDACTED]"
+ * safe.tag // => "failure"
+ * safe.message // => "connect ECONNREFUSED token=[REDACTED]"
  * ```
  *
  * @packageDocumentation
@@ -54,11 +54,11 @@ const decodeNonNegativeInt = (input: number): NonNegativeInt =>
  *
  * **Example** (Check redaction placeholder presence)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Check redaction placeholder presence"
  * import { REDACTION_PLACEHOLDER, sanitizeSensitiveText } from "@beep/observability"
  *
  * const sanitized = sanitizeSensitiveText("Authorization: Bearer sk-EXAMPLEKEY00")
- * console.log(sanitized.includes(REDACTION_PLACEHOLDER)) // true
+ * sanitized.includes(REDACTION_PLACEHOLDER) // => true
  * ```
  *
  * @category constants
@@ -71,7 +71,7 @@ export const REDACTION_PLACEHOLDER = "[REDACTED]" as const;
  *
  * **Example** (Use default message limit)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Use default message limit"
  * import { NonNegativeInt } from "@beep/schema"
  * import * as S from "effect/Schema"
  * import { DEFAULT_MESSAGE_LIMIT, RedactCauseOptions } from "@beep/observability"
@@ -79,7 +79,7 @@ export const REDACTION_PLACEHOLDER = "[REDACTED]" as const;
  * const options = RedactCauseOptions.make({
  *   messageLimit: S.decodeUnknownSync(NonNegativeInt)(DEFAULT_MESSAGE_LIMIT)
  * })
- * console.log(options.messageLimit) // 256
+ * options.messageLimit // => 256
  * ```
  *
  * @category constants
@@ -92,7 +92,7 @@ export const DEFAULT_MESSAGE_LIMIT = 256 as const;
  *
  * **Example** (Use default detail limit)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Use default detail limit"
  * import { NonNegativeInt } from "@beep/schema"
  * import * as S from "effect/Schema"
  * import { DEFAULT_DETAIL_LIMIT, RedactCauseOptions } from "@beep/observability"
@@ -100,7 +100,7 @@ export const DEFAULT_MESSAGE_LIMIT = 256 as const;
  * const options = RedactCauseOptions.make({
  *   detailLimit: S.decodeUnknownSync(NonNegativeInt)(DEFAULT_DETAIL_LIMIT)
  * })
- * console.log(options.detailLimit) // 2048
+ * options.detailLimit // => 2048
  * ```
  *
  * @category constants
@@ -115,11 +115,11 @@ export const DEFAULT_DETAIL_LIMIT = 2048 as const;
  *
  * **Example** (List redaction channel values)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="List redaction channel values"
  * import { RedactionChannel } from "@beep/observability"
  *
- * console.log(RedactionChannel.Enum.client) // "client"
- * console.log(RedactionChannel.Enum.diagnostic) // "diagnostic"
+ * RedactionChannel.Enum.client // => "client"
+ * RedactionChannel.Enum.diagnostic // => "diagnostic"
  * ```
  *
  * @category models
@@ -241,13 +241,13 @@ export const redactString: {
  *
  * **Example** (Inspect redacted cause fields)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Inspect redacted cause fields"
  * import { Cause } from "effect"
  * import { redactCause } from "@beep/observability"
  *
  * const redacted = redactCause(Cause.fail(new Error("token=sk-EXAMPLEKEY00")))
- * console.log(redacted.tag) // "failure"
- * console.log(redacted.message) // "token=[REDACTED]"
+ * redacted.tag // => "failure"
+ * redacted.message // => "token=[REDACTED]"
  * ```
  *
  * @category models
@@ -281,11 +281,11 @@ export class RedactedCause extends S.Class<RedactedCause>($I`RedactedCause`)(
  *
  * **Example** (Make client channel options)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Make client channel options"
  * import { RedactCauseOptions } from "@beep/observability"
  *
  * const options = RedactCauseOptions.make({ channel: "client" })
- * console.log(options.channel) // "client"
+ * options.channel // => "client"
  * ```
  *
  * @category models
@@ -334,13 +334,13 @@ const detailForChannel = (summary: CauseSummary, options: RedactCauseOptions): O
  *
  * **Example** (Redact summarized cause)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Redact summarized cause"
  * import { Cause } from "effect"
  * import { redactCauseSummary, summarizeCause } from "@beep/observability"
  *
  * const summary = summarizeCause(Cause.fail(new Error("boom")))
  * const safe = redactCauseSummary(summary)
- * console.log(safe.tag) // "failure"
+ * safe.tag // => "failure"
  * ```
  *
  * @category utilities
@@ -373,13 +373,13 @@ const redactCauseSummaryImpl = (summary: CauseSummary, options: RedactCauseOptio
  *
  * **Example** (Redact cause summary safely)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Redact cause summary safely"
  * import { Cause } from "effect"
  * import { redactCauseSummary, summarizeCause } from "@beep/observability"
  *
  * const summary = summarizeCause(Cause.fail(new Error("boom")))
  * const safe = redactCauseSummary(summary)
- * console.log(safe.tag) // "failure"
+ * safe.tag // => "failure"
  * ```
  *
  * @category utilities
@@ -464,12 +464,12 @@ export const redactCauseForClient = (input: unknown): RedactedCause =>
  *
  * **Example** (Make redacted cause error)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Make redacted cause error"
  * import { Cause } from "effect"
  * import { RedactedCauseError, redactCause } from "@beep/observability"
  *
  * const error = RedactedCauseError.make({ redacted: redactCause(Cause.fail("boom")) })
- * console.log(error._tag) // "RedactedCauseError"
+ * error._tag // => "RedactedCauseError"
  * ```
  *
  * @category error-handling
@@ -497,13 +497,13 @@ export class RedactedCauseError extends S.TaggedError<RedactedCauseError>($I`Red
  *
  * **Example** (Redact cause inside Effect)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Redact cause inside Effect"
  * import { Cause, Effect } from "effect"
  * import { redactCauseEffect } from "@beep/observability"
  *
  * const safe = Effect.runSync(redactCauseEffect(Cause.fail(new Error("boom"))))
  *
- * console.log(safe.tag) // "failure"
+ * safe.tag // => "failure"
  * ```
  *
  * @effects Annotates the active span with the sanitized cause tag and fingerprint while keeping raw messages out of telemetry.
@@ -530,10 +530,10 @@ export const redactCauseEffect: {
  *
  * **Example** (Read log level enum value)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Read log level enum value"
  * import { RedactedCauseLogLevel } from "@beep/observability"
  *
- * console.log(RedactedCauseLogLevel.Enum.Warn) // "Warn"
+ * RedactedCauseLogLevel.Enum.Warn // => "Warn"
  * ```
  *
  * @category models
@@ -567,11 +567,11 @@ export type RedactedCauseLogLevel = typeof RedactedCauseLogLevel.Type;
  *
  * **Example** (Make log options defaults)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Make log options defaults"
  * import { LogRedactedCauseOptions } from "@beep/observability"
  *
  * const options = LogRedactedCauseOptions.make({ message: "request failed" })
- * console.log(options.level) // "Error"
+ * options.level // => "Error"
  * ```
  *
  * @category models

--- a/packages/foundation/capability/observability/src/CoreConfig.ts
+++ b/packages/foundation/capability/observability/src/CoreConfig.ts
@@ -26,7 +26,7 @@ const ObservabilityCoreConfigFields = {
  *
  * **Example** (Creating a core config)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Creating a core config"
  * import { ObservabilityCoreConfig } from "@beep/observability"
  *
  * const config: ObservabilityCoreConfig = {
@@ -36,7 +36,7 @@ const ObservabilityCoreConfigFields = {
  *   minLogLevel: "Info"
  * }
  *
- * console.log(config.serviceName) // "todox-web"
+ * config.serviceName // => "todox-web"
  * ```
  *
  * @category models

--- a/packages/foundation/capability/observability/src/HttpError.ts
+++ b/packages/foundation/capability/observability/src/HttpError.ts
@@ -443,11 +443,11 @@ export class GatewayTimeoutError extends S.TaggedError<GatewayTimeoutError>($I`G
  *
  * **Example** (Make BadRequestError helper)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Make BadRequestError helper"
  * import { makeBadRequestError } from "@beep/observability"
  *
  * const error = makeBadRequestError("missing required field 'email'")
- * console.log(error.status) // 400
+ * error.status // => 400
  * ```
  *
  * @category error-handling
@@ -463,11 +463,11 @@ export const makeBadRequestError: StatusErrorConstructor<BadRequestError> = dual
  *
  * **Example** (Make UnauthorizedError helper)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Make UnauthorizedError helper"
  * import { makeUnauthorizedError } from "@beep/observability"
  *
  * const error = makeUnauthorizedError("token expired")
- * console.log(error.status) // 401
+ * error.status // => 401
  * ```
  *
  * @category error-handling
@@ -483,11 +483,11 @@ export const makeUnauthorizedError: StatusErrorConstructor<UnauthorizedError> = 
  *
  * **Example** (Make ForbiddenError helper)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Make ForbiddenError helper"
  * import { makeForbiddenError } from "@beep/observability"
  *
  * const error = makeForbiddenError("insufficient permissions")
- * console.log(error.status) // 403
+ * error.status // => 403
  * ```
  *
  * @category error-handling
@@ -503,11 +503,11 @@ export const makeForbiddenError: StatusErrorConstructor<ForbiddenError> = dual(
  *
  * **Example** (Make NotFoundError helper)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Make NotFoundError helper"
  * import { makeNotFoundError } from "@beep/observability"
  *
  * const error = makeNotFoundError("resource missing")
- * console.log(error.status) // 404
+ * error.status // => 404
  * ```
  *
  * @category error-handling
@@ -523,11 +523,11 @@ export const makeNotFoundError: StatusErrorConstructor<NotFoundError> = dual(
  *
  * **Example** (Make ConflictError helper)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Make ConflictError helper"
  * import { makeConflictError } from "@beep/observability"
  *
  * const error = makeConflictError("duplicate key")
- * console.log(error.status) // 409
+ * error.status // => 409
  * ```
  *
  * @category error-handling
@@ -543,11 +543,11 @@ export const makeConflictError: StatusErrorConstructor<ConflictError> = dual(
  *
  * **Example** (Make UnprocessableEntityError helper)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Make UnprocessableEntityError helper"
  * import { makeUnprocessableEntityError } from "@beep/observability"
  *
  * const error = makeUnprocessableEntityError("schema mismatch")
- * console.log(error.status) // 422
+ * error.status // => 422
  * ```
  *
  * @category error-handling
@@ -563,11 +563,11 @@ export const makeUnprocessableEntityError: StatusErrorConstructor<UnprocessableE
  *
  * **Example** (Make TooManyRequestsError helper)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Make TooManyRequestsError helper"
  * import { makeTooManyRequestsError } from "@beep/observability"
  *
  * const error = makeTooManyRequestsError("rate limit hit")
- * console.log(error.status) // 429
+ * error.status // => 429
  * ```
  *
  * @category error-handling
@@ -583,11 +583,11 @@ export const makeTooManyRequestsError: StatusErrorConstructor<TooManyRequestsErr
  *
  * **Example** (Make InternalServerError helper)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Make InternalServerError helper"
  * import { makeInternalServerError } from "@beep/observability"
  *
  * const error = makeInternalServerError("unexpected failure")
- * console.log(error.status) // 500
+ * error.status // => 500
  * ```
  *
  * @category error-handling
@@ -603,11 +603,11 @@ export const makeInternalServerError: StatusErrorConstructor<InternalServerError
  *
  * **Example** (Make BadGatewayError helper)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Make BadGatewayError helper"
  * import { makeBadGatewayError } from "@beep/observability"
  *
  * const error = makeBadGatewayError("upstream unreachable")
- * console.log(error.status) // 502
+ * error.status // => 502
  * ```
  *
  * @category error-handling
@@ -623,11 +623,11 @@ export const makeBadGatewayError: StatusErrorConstructor<BadGatewayError> = dual
  *
  * **Example** (Make ServiceUnavailableError helper)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Make ServiceUnavailableError helper"
  * import { makeServiceUnavailableError } from "@beep/observability"
  *
  * const error = makeServiceUnavailableError("service down for maintenance")
- * console.log(error.status) // 503
+ * error.status // => 503
  * ```
  *
  * @category error-handling
@@ -643,11 +643,11 @@ export const makeServiceUnavailableError: StatusErrorConstructor<ServiceUnavaila
  *
  * **Example** (Make GatewayTimeoutError helper)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Make GatewayTimeoutError helper"
  * import { makeGatewayTimeoutError } from "@beep/observability"
  *
  * const error = makeGatewayTimeoutError("upstream timed out")
- * console.log(error.status) // 504
+ * error.status // => 504
  * ```
  *
  * @category error-handling

--- a/packages/foundation/capability/observability/src/Logging.ts
+++ b/packages/foundation/capability/observability/src/Logging.ts
@@ -79,11 +79,11 @@ export type LogFormat = typeof LogFormat.Type;
  *
  * **Example** (Forest theme pretty config)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Forest theme pretty config"
  * import { PrettyLoggerConfig } from "@beep/observability"
  *
  * const config = PrettyLoggerConfig.make({ theme: "forest", bannerMode: "off" })
- * console.log(config.theme)// "forest"
+ * config.theme // => "forest"
  * ```
  *
  * @category models
@@ -117,11 +117,11 @@ export type PrettyLogTheme = typeof PrettyLogTheme.Type;
  *
  * **Example** (Startup banner mode config)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Startup banner mode config"
  * import { PrettyLoggerConfig } from "@beep/observability"
  *
  * const config = PrettyLoggerConfig.make({ theme: "ocean", bannerMode: "startup" })
- * console.log(config.bannerMode)// "startup"
+ * config.bannerMode // => "startup"
  * ```
  *
  * @category models
@@ -155,7 +155,7 @@ export type BannerMode = typeof BannerMode.Type;
  *
  * **Example** (Pretty logger theme config)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Pretty logger theme config"
  * import { PrettyLoggerConfig } from "@beep/observability"
  *
  * const config = PrettyLoggerConfig.make({
@@ -163,7 +163,7 @@ export type BannerMode = typeof BannerMode.Type;
  *   bannerMode: "off",
  * })
  *
- * console.log(config.theme)// "forest"
+ * config.theme // => "forest"
  * ```
  *
  * @category models
@@ -184,7 +184,7 @@ export class PrettyLoggerConfig extends S.Class<PrettyLoggerConfig>($I`PrettyLog
  *
  * **Example** (Structured logging config)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Structured logging config"
  * import { LoggingConfig } from "@beep/observability"
  *
  * const config = LoggingConfig.make({
@@ -192,7 +192,7 @@ export class PrettyLoggerConfig extends S.Class<PrettyLoggerConfig>($I`PrettyLog
  *   minLogLevel: "Info",
  * })
  *
- * console.log(config.format)// "structured"
+ * config.format // => "structured"
  * ```
  *
  * @category models

--- a/packages/foundation/capability/observability/src/Metric.ts
+++ b/packages/foundation/capability/observability/src/Metric.ts
@@ -138,13 +138,13 @@ const incrementOutcomeCounter = (outcome: PhaseOutcome, options: ObserveWorkflow
  *
  * **Example** (Map status codes to classes)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Map status codes to classes"
  * import { statusClass } from "@beep/observability"
  *
- * console.log(statusClass(200)) // "2xx"
- * console.log(statusClass(404)) // "4xx"
- * console.log(statusClass(503)) // "5xx"
- * console.log(statusClass(999)) // "unknown"
+ * statusClass(200) // => "2xx"
+ * statusClass(404) // => "4xx"
+ * statusClass(503) // => "5xx"
+ * statusClass(999) // => "unknown"
  * ```
  *
  * @category utilities

--- a/packages/foundation/capability/observability/src/Observed.ts
+++ b/packages/foundation/capability/observability/src/Observed.ts
@@ -8,14 +8,14 @@
  *
  * **Example** (Decode ObservedCause from fail)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Decode ObservedCause from fail"
  * import { Cause } from "effect"
  * import * as S from "effect/Schema"
  * import { ObservedCause } from "@beep/observability"
  *
  * const decodeCause = S.decodeUnknownSync(ObservedCause)
  * const observed = decodeCause(Cause.fail(new Error("boom")))
- * console.log(Cause.pretty(observed).includes("boom")) // true
+ * Cause.pretty(observed).includes("boom") // => true
  * ```
  *
  * @packageDocumentation
@@ -32,13 +32,13 @@ const $I = $ObservabilityId.create("Observed");
  *
  * **Example** (Decode message-only error)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Decode message-only error"
  * import * as S from "effect/Schema"
  * import { ObservedError } from "@beep/observability"
  *
  * const decode = S.decodeUnknownSync(ObservedError)
- * const err = decode({ message: "boom" })
- * console.log(err.message) // "boom"
+ * const err = decode(new Error("boom"))
+ * err.message // => "boom"
  * ```
  *
  * @category models
@@ -72,13 +72,13 @@ export type ObservedError = typeof ObservedError.Type;
  *
  * **Example** (Decode error preserving stack)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Decode error preserving stack"
  * import * as S from "effect/Schema"
  * import { ObservedErrorWithStack } from "@beep/observability"
  *
  * const decode = S.decodeUnknownSync(ObservedErrorWithStack)
  * const err = decode(new Error("boom"))
- * console.log(err.message) // "boom"
+ * err.message // => "boom"
  * ```
  *
  * @category models
@@ -192,7 +192,7 @@ export type ObservedDefectWithStack = typeof ObservedDefectWithStack.Type;
  *
  * **Example** (Decode Cause failure reasons)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Decode Cause failure reasons"
  * import { Cause } from "effect"
  * import * as A from "effect/Array"
  * import * as S from "effect/Schema"
@@ -200,7 +200,7 @@ export type ObservedDefectWithStack = typeof ObservedDefectWithStack.Type;
  *
  * const decodeReason = S.decodeUnknownSync(ObservedCauseReason)
  * const decoded = A.map(Cause.fail(new Error("boom")).reasons, (reason) => decodeReason(reason))
- * console.log(decoded.length) // 1
+ * decoded.length // => 1
  * ```
  *
  * @category models
@@ -234,13 +234,13 @@ export type ObservedCauseReason = typeof ObservedCauseReason.Type;
  *
  * **Example** (Decode full Effect cause)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Decode full Effect cause"
  * import { Cause } from "effect"
  * import * as S from "effect/Schema"
  * import { ObservedCause } from "@beep/observability"
  *
  * const observed = S.decodeUnknownSync(ObservedCause)(Cause.fail(new Error("boom")))
- * console.log(Cause.pretty(observed).includes("boom")) // true
+ * Cause.pretty(observed).includes("boom") // => true
  * ```
  *
  * @category models
@@ -275,13 +275,13 @@ export type ObservedCause = typeof ObservedCause.Type;
  *
  * **Example** (Decode failed Exit value)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Decode failed Exit value"
  * import { Exit } from "effect"
  * import * as S from "effect/Schema"
  * import { ObservedExit } from "@beep/observability"
  *
  * const observed = S.decodeUnknownSync(ObservedExit)(Exit.fail(new Error("boom")))
- * console.log(observed._tag) // "Failure"
+ * observed._tag // => "Failure"
  * ```
  *
  * @category models

--- a/packages/foundation/capability/observability/src/PhaseProfiler.ts
+++ b/packages/foundation/capability/observability/src/PhaseProfiler.ts
@@ -53,7 +53,7 @@ const isProfilePhaseDataFirst = (args: IArguments): boolean => args.length >= 2 
  *
  * **Example** (Return completed outcome)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Return completed outcome"
  * import { PhaseOutcome, profilePhase } from "@beep/observability"
  * import { Effect } from "effect"
  *
@@ -61,7 +61,7 @@ const isProfilePhaseDataFirst = (args: IArguments): boolean => args.length >= 2 
  *   phase: "startup"
  * })
  * const outcome = Effect.runSync(program)
- * console.log(outcome) // "completed"
+ * outcome // => "completed"
  * ```
  *
  * @category models
@@ -95,7 +95,7 @@ export type PhaseOutcome = typeof PhaseOutcome.Type;
  *
  * **Example** (Construct a PhaseProfile)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Construct a PhaseProfile"
  * import { NonNegativeInt } from "@beep/schema"
  * import * as S from "effect/Schema"
  * import { PhaseProfile } from "@beep/observability"
@@ -108,8 +108,8 @@ export type PhaseOutcome = typeof PhaseOutcome.Type;
  *   phase: "startup"
  * })
  *
- * console.log(profile.phase) // "startup"
- * console.log(profile.outcome) // "completed"
+ * profile.phase // => "startup"
+ * profile.outcome // => "completed"
  * ```
  *
  * @category models

--- a/packages/foundation/capability/observability/src/experimental/server/DevToolsRelay.ts
+++ b/packages/foundation/capability/observability/src/experimental/server/DevToolsRelay.ts
@@ -23,7 +23,7 @@ const maxSpanEvents = 200;
  *
  * **Example** (Make zero-count snapshot)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Make zero-count snapshot"
  * import { NonNegativeInt } from "@beep/schema"
  * import * as S from "effect/Schema"
  * import { DevToolsSnapshot } from "@beep/observability/experimental/server"
@@ -35,7 +35,7 @@ const maxSpanEvents = 200;
  *   spanCount: count,
  *   spanEventCount: count
  * })
- * console.log(snapshot.spanCount) // 0
+ * snapshot.spanCount // => 0
  * ```
  *
  * @category models

--- a/packages/foundation/capability/observability/src/experimental/server/OtlpPacketLab.ts
+++ b/packages/foundation/capability/observability/src/experimental/server/OtlpPacketLab.ts
@@ -22,11 +22,11 @@ const textDecoder = new TextDecoder();
  *
  * **Example** (Enum traces kind value)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Enum traces kind value"
  * import { OtlpPacketKind } from "@beep/observability/experimental/server"
  *
  * const kind: OtlpPacketKind = OtlpPacketKind.Enum.traces
- * console.log(kind) // "traces"
+ * kind // => "traces"
  * ```
  *
  * @category models
@@ -60,11 +60,11 @@ export type OtlpPacketKind = typeof OtlpPacketKind.Type;
  *
  * **Example** (Enum json encoding value)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Enum json encoding value"
  * import { OtlpPacketEncoding } from "@beep/observability/experimental/server"
  *
  * const encoding: OtlpPacketEncoding = OtlpPacketEncoding.Enum.json
- * console.log(encoding) // "json"
+ * encoding // => "json"
  * ```
  *
  * @category models
@@ -98,7 +98,7 @@ export type OtlpPacketEncoding = typeof OtlpPacketEncoding.Type;
  *
  * **Example** (Make packet with fields)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Make packet with fields"
  * import { NonNegativeInt } from "@beep/schema"
  * import * as S from "effect/Schema"
  * import { OtlpPacket } from "@beep/observability/experimental/server"
@@ -112,7 +112,7 @@ export type OtlpPacketEncoding = typeof OtlpPacketEncoding.Type;
  *   preview: "{}",
  *   size: zero
  * })
- * console.log(packet.kind) // "traces"
+ * packet.kind // => "traces"
  * ```
  *
  * @category models

--- a/packages/foundation/capability/observability/src/index.ts
+++ b/packages/foundation/capability/observability/src/index.ts
@@ -8,7 +8,7 @@
  *
  * **Example** (Classify cause with logger)
  *
- * ```typescript
+ * ```ts
  * import { Cause, Effect } from "effect"
  * import { classifyCause, layerConsoleLogger } from "@beep/observability"
  *
@@ -30,11 +30,11 @@
  *
  * **Example** (Import package version)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Import package version"
  * import { VERSION } from "@beep/observability"
  *
  * const version: string = VERSION
- * console.log(version) // "0.0.3"
+ * version // => "0.0.3"
  * ```
  *
  * @category configuration

--- a/packages/foundation/capability/observability/src/server/HttpApiTelemetry.ts
+++ b/packages/foundation/capability/observability/src/server/HttpApiTelemetry.ts
@@ -279,7 +279,7 @@ const annotateHttpApiOutcome = Effect.fn("annotateHttpApiOutcome")(function* (
  *
  * **Example** (Descriptor from HttpApi metadata)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Descriptor from HttpApi metadata"
  * import * as S from "effect/Schema"
  * import { makeHttpApiTelemetryDescriptor } from "@beep/observability/server"
  * import { HttpApiEndpoint, HttpApiGroup, HttpApiSchema } from "effect/unstable/httpapi"
@@ -289,7 +289,7 @@ const annotateHttpApiOutcome = Effect.fn("annotateHttpApiOutcome")(function* (
  *   success: S.Struct({ id: S.String }).pipe(HttpApiSchema.status(201))
  * })
  * const descriptor = makeHttpApiTelemetryDescriptor("TodoApi", group, endpoint)
- * console.log(descriptor.successStatus) // 201
+ * descriptor.successStatus // => 201
  * ```
  *
  * @category observability
@@ -603,7 +603,7 @@ export const layerHttpApiTelemetryMiddleware = (
  *
  * **Example** (Observe handler with annotations)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Observe handler with annotations"
  * import { Effect } from "effect"
  * import { NonNegativeInt } from "@beep/schema"
  * import * as S from "effect/Schema"
@@ -625,7 +625,7 @@ export const layerHttpApiTelemetryMiddleware = (
  * const metrics = makeHttpApiMetrics("todox_api")
  * const handler = Effect.succeed({ status: 200 })
  * const observed = observeHttpApiHandler(handler, { descriptor, metrics })
- * console.log(Effect.runSync(observed).status) // 200
+ * Effect.runSync(observed).status // => 200
  * ```
  *
  * @category observability

--- a/packages/foundation/capability/observability/src/web/Config.ts
+++ b/packages/foundation/capability/observability/src/web/Config.ts
@@ -15,7 +15,7 @@ const $I = $ObservabilityId.create("web/Config");
  *
  * **Example** (Creating browser observability config)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Creating browser observability config"
  * import { WebObservabilityConfig } from "@beep/observability/web"
  *
  * const config = WebObservabilityConfig.make({
@@ -26,7 +26,7 @@ const $I = $ObservabilityId.create("web/Config");
  *   resourceAttributes: {},
  * })
  *
- * console.log(config.serviceName) // "todox-web"
+ * config.serviceName // => "todox-web"
  * ```
  *
  * @category models
@@ -50,7 +50,7 @@ export class WebObservabilityConfig extends S.Class<WebObservabilityConfig>($I`W
  *
  * **Example** (Converting config to resource)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Converting config to resource"
  * import { WebObservabilityConfig, toWebResource } from "@beep/observability/web"
  *
  * const config = WebObservabilityConfig.make({
@@ -62,7 +62,7 @@ export class WebObservabilityConfig extends S.Class<WebObservabilityConfig>($I`W
  * })
  *
  * const resource = toWebResource(config)
- * console.log(resource.serviceName) // "todox-web"
+ * resource.serviceName // => "todox-web"
  * ```
  *
  * @category observability

--- a/packages/foundation/capability/semantic-web/src/identity/IdentityRdfBinding.ts
+++ b/packages/foundation/capability/semantic-web/src/identity/IdentityRdfBinding.ts
@@ -127,11 +127,11 @@ export const DefaultIdentityRdfBinding: IdentityRdfBinding = IdentityRdfBinding.
  *
  * **Example** (Identify an unmapped fiber)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Identify an unmapped fiber"
  * import { IdentityFiberPathError } from "@beep/semantic-web"
  *
  * const error = IdentityFiberPathError.make({ fiber: "label" })
- * console.log(error._tag) // "IdentityFiberPathError"
+ * error._tag // => "IdentityFiberPathError"
  * ```
  *
  * @category errors
@@ -150,14 +150,14 @@ export class IdentityFiberPathError extends S.TaggedError<IdentityFiberPathError
  *
  * **Example** (Inspect an invalid entry IRI)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Inspect an invalid entry IRI"
  * import { IdentityEntryIriError } from "@beep/semantic-web"
  *
  * const error = IdentityEntryIriError.make({
  *   identity: "@beep/example/Invalid",
  *   iri: "not an iri"
  * })
- * console.log(error.iri) // "not an iri"
+ * error.iri // => "not an iri"
  * ```
  *
  * @category errors
@@ -382,12 +382,12 @@ const decodeSubject = Effect.fn("IdentityRdfBinding.decodeSubject")(function* (
  *
  * **Example** (Encode an empty registry dataset)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Encode an empty registry dataset"
  * import { DefaultIdentityRdfBinding, entriesToDataset } from "@beep/semantic-web"
  * import { Effect } from "effect"
  *
  * const dataset = await Effect.runPromise(entriesToDataset(DefaultIdentityRdfBinding)([]))
- * console.log(dataset.quads.length) // 0
+ * dataset.quads.length // => 0
  * ```
  *
  * @category encoding
@@ -436,13 +436,13 @@ export const entriesToDataset = (binding: IdentityRdfBinding) =>
  *
  * **Example** (Decode an empty registry dataset)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode an empty registry dataset"
  * import { DefaultIdentityRdfBinding, datasetToEntries } from "@beep/semantic-web"
  * import { makeDataset } from "@beep/rdf/Rdf"
  * import { Effect } from "effect"
  *
  * const entries = await Effect.runPromise(datasetToEntries(DefaultIdentityRdfBinding)(makeDataset([])))
- * console.log(entries.length) // 0
+ * entries.length // => 0
  * ```
  *
  * @category decoding

--- a/packages/foundation/capability/semantic-web/src/identity/IdentityShaclProjection.ts
+++ b/packages/foundation/capability/semantic-web/src/identity/IdentityShaclProjection.ts
@@ -77,11 +77,11 @@ const addressPropertyShapes = (path: NamedNode, value: string): ReadonlyArray<Sh
  *
  * **Example** (Require a label fiber)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Require a label fiber"
  * import { IdentityShapePolicy } from "@beep/semantic-web"
  *
  * const policy = IdentityShapePolicy.make({ requiredFibers: ["label"] })
- * console.log(policy.requiredFibers) // ["label"]
+ * policy.requiredFibers // => ["label"]
  * ```
  *
  * @category policies
@@ -105,7 +105,7 @@ export class IdentityShapePolicy extends S.Class<IdentityShapePolicy>($I`Identit
  *
  * **Example** (Project no identity entries)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Project no identity entries"
  * import {
  *   DefaultIdentityRdfBinding,
  *   IdentityShapePolicy,
@@ -119,7 +119,7 @@ export class IdentityShapePolicy extends S.Class<IdentityShapePolicy>($I`Identit
  *     IdentityShapePolicy.make({ requiredFibers: [] })
  *   )([])
  * )
- * console.log(shapes.length) // 0
+ * shapes.length // => 0
  * ```
  *
  * @category projections

--- a/packages/foundation/primitive/data/src/Blockchain.ts
+++ b/packages/foundation/primitive/data/src/Blockchain.ts
@@ -10,7 +10,7 @@
  *
  * **Example** (Access network ticker values)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Access network ticker values"
  * import { Blockchain } from "@beep/data"
  *
  * const ethTicker = Blockchain.Networks.Ethereum.ticker

--- a/packages/foundation/primitive/data/src/Calendar.ts
+++ b/packages/foundation/primitive/data/src/Calendar.ts
@@ -21,7 +21,7 @@ import * as internal from "./internal/data/calendar/index.ts";
  *
  * **Example** (Assign lowercase month name)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Assign lowercase month name"
  * import type { MonthName } from "@beep/data/Calendar"
  *
  * const month: MonthName = "january"
@@ -38,7 +38,7 @@ export type MonthName = (typeof internal.MonthNameValues)[number];
  *
  * **Example** (Assign capitalized month name)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Assign capitalized month name"
  * import type { FormalMonthName } from "@beep/data/Calendar"
  *
  * const month: FormalMonthName = "January"
@@ -55,7 +55,7 @@ export type FormalMonthName = (typeof internal.FormalMonthNameValues)[number];
  *
  * **Example** (Assign month number literals)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Assign month number literals"
  * import type { MonthNumber } from "@beep/data/Calendar"
  *
  * const jan: MonthNumber = 1
@@ -73,7 +73,7 @@ export type MonthNumber = (typeof internal.MonthNumberValues)[number];
  *
  * **Example** (Assign ISO month code)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Assign ISO month code"
  * import type { MonthISO } from "@beep/data/Calendar"
  *
  * const jan: MonthISO = "01"
@@ -90,7 +90,7 @@ export type MonthISO = (typeof internal.MonthISOValues)[number];
  *
  * **Example** (Assign lowercase weekday name)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Assign lowercase weekday name"
  * import type { WeekName } from "@beep/data/Calendar"
  *
  * const day: WeekName = "monday"
@@ -107,7 +107,7 @@ export type WeekName = (typeof internal.Weekday.WeekNameValues)[number];
  *
  * **Example** (Assign capitalized weekday name)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Assign capitalized weekday name"
  * import type { FormalWeekName } from "@beep/data/Calendar"
  *
  * const day: FormalWeekName = "Monday"
@@ -128,7 +128,7 @@ export type FormalWeekName = (typeof internal.Weekday.FormalWeekNameValues)[numb
  *
  * **Example** (Read ordered month names)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Read ordered month names"
  * import { MonthNameValues } from "@beep/data/Calendar"
  *
  * console.assert(MonthNameValues[0] === "january" && MonthNameValues[11] === "december")
@@ -144,7 +144,7 @@ export const MonthNameValues: typeof internal.MonthNameValues = internal.MonthNa
  *
  * **Example** (Read formal month names)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Read formal month names"
  * import { FormalMonthNameValues } from "@beep/data/Calendar"
  *
  * console.assert(FormalMonthNameValues[0] === "January")
@@ -160,7 +160,7 @@ export const FormalMonthNameValues: typeof internal.FormalMonthNameValues = inte
  *
  * **Example** (Read ordered month numbers)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Read ordered month numbers"
  * import { MonthNumberValues } from "@beep/data/Calendar"
  *
  * console.assert(MonthNumberValues[0] === 1 && MonthNumberValues[11] === 12)
@@ -176,7 +176,7 @@ export const MonthNumberValues: typeof internal.MonthNumberValues = internal.Mon
  *
  * **Example** (Read ISO month codes)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Read ISO month codes"
  * import { MonthISOValues } from "@beep/data/Calendar"
  *
  * console.assert(MonthISOValues[0] === "01" && MonthISOValues[11] === "12")
@@ -192,7 +192,7 @@ export const MonthISOValues: typeof internal.MonthISOValues = internal.MonthISOV
  *
  * **Example** (Read ordered weekday names)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Read ordered weekday names"
  * import { WeekNameValues } from "@beep/data/Calendar"
  *
  * console.assert(WeekNameValues[0] === "sunday" && WeekNameValues[1] === "monday")
@@ -208,7 +208,7 @@ export const WeekNameValues: typeof internal.Weekday.WeekNameValues = internal.W
  *
  * **Example** (Read formal weekday names)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Read formal weekday names"
  * import { FormalWeekNameValues } from "@beep/data/Calendar"
  *
  * console.assert(FormalWeekNameValues[0] === "Sunday" && FormalWeekNameValues[1] === "Monday")

--- a/packages/foundation/primitive/data/src/CurrencyCodes.ts
+++ b/packages/foundation/primitive/data/src/CurrencyCodes.ts
@@ -22,7 +22,7 @@ import * as internal from "./generated/iso4217.ts";
  *
  * **Example** (USD currency entry lookup)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="USD currency entry lookup"
  * import { CurrencyCodeDataByCode, type CurrencyCodeData } from "@beep/data/CurrencyCodes"
  *
  * const usd: CurrencyCodeData = CurrencyCodeDataByCode.USD
@@ -39,7 +39,7 @@ export type CurrencyCodeData = (typeof internal.CurrencyCodeDataValues)[number];
  *
  * **Example** (Assign USD and EUR codes)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Assign USD and EUR codes"
  * import type { CurrencyCode } from "@beep/data/CurrencyCodes"
  *
  * const usd: CurrencyCode = "USD"
@@ -57,7 +57,7 @@ export type CurrencyCode = CurrencyCodeData["code"];
  *
  * **Example** (Access dataset source metadata)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Access dataset source metadata"
  * import { CurrencyCodeDataMetadata } from "@beep/data/CurrencyCodes"
  * import type { CurrencyCodeDataMetadata as CurrencyCodeDataMetadataShape } from "@beep/data/CurrencyCodes"
  *
@@ -87,7 +87,7 @@ export type CurrencyCodeDataMetadata = typeof internal.CurrencyCodeDataMetadata;
  *
  * **Example** (Find USD in currency array)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Find USD in currency array"
  * import { CurrencyCodeDataValues } from "@beep/data/CurrencyCodes"
  *
  * const usd = CurrencyCodeDataValues.find((entry) => entry.code === "USD")
@@ -104,7 +104,7 @@ export const CurrencyCodeDataValues: typeof internal.CurrencyCodeDataValues = in
  *
  * **Example** (Check published date value)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Check published date value"
  * import { CurrencyCodeDataMetadata } from "@beep/data/CurrencyCodes"
  *
  * console.assert(CurrencyCodeDataMetadata.published === "2026-01-01")
@@ -120,7 +120,7 @@ export const CurrencyCodeDataMetadata: typeof internal.CurrencyCodeDataMetadata 
  *
  * **Example** (Assert published date string)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Assert published date string"
  * import { CurrencyCodeDataPublished } from "@beep/data/CurrencyCodes"
  *
  * console.assert(CurrencyCodeDataPublished === "2026-01-01")
@@ -136,7 +136,7 @@ export const CurrencyCodeDataPublished: typeof internal.CurrencyCodeDataPublishe
  *
  * **Example** (Verify source URL path)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Verify source URL path"
  * import { CurrencyCodeDataSourceUrl } from "@beep/data/CurrencyCodes"
  *
  * console.assert(CurrencyCodeDataSourceUrl.includes("list-one.xml"))
@@ -152,7 +152,7 @@ export const CurrencyCodeDataSourceUrl: typeof internal.CurrencyCodeDataSourceUr
  *
  * **Example** (Check SHA-256 digest length)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Check SHA-256 digest length"
  * import { CurrencyCodeDataSourceSha256 } from "@beep/data/CurrencyCodes"
  *
  * console.assert(CurrencyCodeDataSourceSha256.length === 64)
@@ -169,7 +169,7 @@ export const CurrencyCodeDataSourceSha256: typeof internal.CurrencyCodeDataSourc
  *
  * **Example** (Lookup EUR decimal digits)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Lookup EUR decimal digits"
  * import { CurrencyCodeDataByCode } from "@beep/data/CurrencyCodes"
  *
  * console.assert(CurrencyCodeDataByCode.EUR.digits === 2)
@@ -185,7 +185,7 @@ export const CurrencyCodeDataByCode: typeof internal.CurrencyCodeDataByCode = in
  *
  * **Example** (Check USD code is included)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Check USD code is included"
  * import { CurrencyCodeDataCodeValues } from "@beep/data/CurrencyCodes"
  *
  * console.assert(CurrencyCodeDataCodeValues.includes("USD"))
@@ -202,7 +202,7 @@ export const CurrencyCodeDataCodeValues: typeof internal.CurrencyCodeDataCodeVal
  *
  * **Example** (Lookup USD currency name)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Lookup USD currency name"
  * import { CurrencyCodeDataNameByCode } from "@beep/data/CurrencyCodes"
  *
  * console.assert(CurrencyCodeDataNameByCode.USD === "US Dollar")
@@ -219,7 +219,7 @@ export const CurrencyCodeDataNameByCode: typeof internal.CurrencyCodeDataNameByC
  *
  * **Example** (Find USD code-name pair)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Find USD code-name pair"
  * import { CurrencyCodeDataCodeNamePairs } from "@beep/data/CurrencyCodes"
  *
  * const usd = CurrencyCodeDataCodeNamePairs.find(([code]) => code === "USD")

--- a/packages/foundation/primitive/data/src/KeyboardShortcuts.ts
+++ b/packages/foundation/primitive/data/src/KeyboardShortcuts.ts
@@ -21,7 +21,7 @@ import * as internal from "./internal/data/keyboard-shortcuts.ts";
  *
  * **Example** (Assign macos platform value)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Assign macos platform value"
  * import type { KeyboardShortcutPlatform } from "@beep/data/KeyboardShortcuts"
  *
  * const platform: KeyboardShortcutPlatform = "macos"
@@ -38,7 +38,7 @@ export type KeyboardShortcutPlatform = (typeof internal.KeyboardShortcutPlatform
  *
  * **Example** (Assign app scope value)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Assign app scope value"
  * import type { KeyboardShortcutScope } from "@beep/data/KeyboardShortcuts"
  *
  * const scope: KeyboardShortcutScope = "app"
@@ -55,7 +55,7 @@ export type KeyboardShortcutScope = (typeof internal.KeyboardShortcutScopeValues
  *
  * **Example** (Assign supported status value)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Assign supported status value"
  * import type { KeyboardShortcutRuntimeSupport } from "@beep/data/KeyboardShortcuts"
  *
  * const support: KeyboardShortcutRuntimeSupport = "supported"
@@ -72,7 +72,7 @@ export type KeyboardShortcutRuntimeSupport = (typeof internal.KeyboardShortcutRu
  *
  * **Example** (Assign clipboard category value)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Assign clipboard category value"
  * import type { KeyboardShortcutCategory } from "@beep/data/KeyboardShortcuts"
  *
  * const category: KeyboardShortcutCategory = "clipboard"
@@ -89,7 +89,7 @@ export type KeyboardShortcutCategory = (typeof internal.KeyboardShortcutCategory
  *
  * **Example** (Read first source publisher)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Read first source publisher"
  * import { KeyboardShortcutSourceValues, type KeyboardShortcutSource } from "@beep/data/KeyboardShortcuts"
  *
  * const source = KeyboardShortcutSourceValues[0] satisfies KeyboardShortcutSource
@@ -106,7 +106,7 @@ export type KeyboardShortcutSource = (typeof internal.KeyboardShortcutSourceValu
  *
  * **Example** (Assign Apple source id)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Assign Apple source id"
  * import type { KeyboardShortcutSourceId } from "@beep/data/KeyboardShortcuts"
  *
  * const sourceId: KeyboardShortcutSourceId = "appleMacKeyboardShortcuts"
@@ -123,7 +123,7 @@ export type KeyboardShortcutSourceId = KeyboardShortcutSource["id"];
  *
  * **Example** (Assign copy command name)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Assign copy command name"
  * import type { KeyboardShortcutCommandName } from "@beep/data/KeyboardShortcuts"
  *
  * const name: KeyboardShortcutCommandName = "copy"
@@ -140,7 +140,7 @@ export type KeyboardShortcutCommandName = (typeof internal.KeyboardShortcutComma
  *
  * **Example** (Assign Copy command label)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Assign Copy command label"
  * import type { KeyboardShortcutCommandLabel } from "@beep/data/KeyboardShortcuts"
  *
  * const label: KeyboardShortcutCommandLabel = "Copy"
@@ -157,7 +157,7 @@ export type KeyboardShortcutCommandLabel = (typeof internal.KeyboardShortcutComm
  *
  * **Example** (Find copy chord values)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Find copy chord values"
  * import { KeyboardShortcutDataValues, type KeyboardShortcutChordData } from "@beep/data/KeyboardShortcuts"
  *
  * const copy = KeyboardShortcutDataValues.find((shortcut) => shortcut.name === "copy")
@@ -178,7 +178,7 @@ export type KeyboardShortcutChordData = (typeof internal.KeyboardShortcutDataVal
  *
  * **Example** (Assign Meta+C shortcut value)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Assign Meta+C shortcut value"
  * import type { KeyboardShortcutValue } from "@beep/data/KeyboardShortcuts"
  *
  * const shortcut: KeyboardShortcutValue = "Meta+C"
@@ -195,7 +195,7 @@ export type KeyboardShortcutValue = KeyboardShortcutChordData["value"];
  *
  * **Example** (Assign ⌘C display literal)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Assign ⌘C display literal"
  * import type { KeyboardShortcutDisplay } from "@beep/data/KeyboardShortcuts"
  *
  * const display: KeyboardShortcutDisplay = "⌘C"
@@ -212,7 +212,7 @@ export type KeyboardShortcutDisplay = KeyboardShortcutChordData["display"];
  *
  * **Example** (Assign Cmd+C accelerator)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Assign Cmd+C accelerator"
  * import type { KeyboardShortcutTauriAccelerator } from "@beep/data/KeyboardShortcuts"
  *
  * const accelerator: KeyboardShortcutTauriAccelerator = "Cmd+C"
@@ -232,7 +232,7 @@ export type KeyboardShortcutTauriAccelerator = Extract<
  *
  * **Example** (Type copy shortcut entry)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Type copy shortcut entry"
  * import { KeyboardShortcutDataValues, type KeyboardShortcutData } from "@beep/data/KeyboardShortcuts"
  *
  * const copy = KeyboardShortcutDataValues.find((shortcut) => shortcut.name === "copy")
@@ -258,7 +258,7 @@ export type KeyboardShortcutData = (typeof internal.KeyboardShortcutDataValues)[
  *
  * **Example** (Check macos platform included)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Check macos platform included"
  * import { KeyboardShortcutPlatformValues } from "@beep/data/KeyboardShortcuts"
  *
  * console.assert(KeyboardShortcutPlatformValues.includes("macos"))
@@ -275,7 +275,7 @@ export const KeyboardShortcutPlatformValues: typeof internal.KeyboardShortcutPla
  *
  * **Example** (Check app scope included)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Check app scope included"
  * import { KeyboardShortcutScopeValues } from "@beep/data/KeyboardShortcuts"
  *
  * console.assert(KeyboardShortcutScopeValues.includes("app"))
@@ -292,7 +292,7 @@ export const KeyboardShortcutScopeValues: typeof internal.KeyboardShortcutScopeV
  *
  * **Example** (Check supported status included)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Check supported status included"
  * import { KeyboardShortcutRuntimeSupportValues } from "@beep/data/KeyboardShortcuts"
  *
  * console.assert(KeyboardShortcutRuntimeSupportValues.includes("supported"))
@@ -309,7 +309,7 @@ export const KeyboardShortcutRuntimeSupportValues: typeof internal.KeyboardShort
  *
  * **Example** (Check clipboard category included)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Check clipboard category included"
  * import { KeyboardShortcutCategoryValues } from "@beep/data/KeyboardShortcuts"
  *
  * console.assert(KeyboardShortcutCategoryValues.includes("clipboard"))
@@ -326,7 +326,7 @@ export const KeyboardShortcutCategoryValues: typeof internal.KeyboardShortcutCat
  *
  * **Example** (Find Apple Support source)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Find Apple Support source"
  * import { KeyboardShortcutSourceValues } from "@beep/data/KeyboardShortcuts"
  *
  * const appleSupport = KeyboardShortcutSourceValues.find((source) => source.publisher === "Apple Support")
@@ -344,7 +344,7 @@ export const KeyboardShortcutSourceValues: typeof internal.KeyboardShortcutSourc
  *
  * **Example** (Check copy name included)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Check copy name included"
  * import { KeyboardShortcutCommandNameValues } from "@beep/data/KeyboardShortcuts"
  *
  * console.assert(KeyboardShortcutCommandNameValues.includes("copy"))
@@ -361,7 +361,7 @@ export const KeyboardShortcutCommandNameValues: typeof internal.KeyboardShortcut
  *
  * **Example** (Check Copy label included)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Check Copy label included"
  * import { KeyboardShortcutCommandLabelValues } from "@beep/data/KeyboardShortcuts"
  *
  * console.assert(KeyboardShortcutCommandLabelValues.includes("Copy"))
@@ -378,7 +378,7 @@ export const KeyboardShortcutCommandLabelValues: typeof internal.KeyboardShortcu
  *
  * **Example** (Find macOS copy shortcut)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Find macOS copy shortcut"
  * import { MacOSKeyboardShortcutDataValues } from "@beep/data/KeyboardShortcuts"
  *
  * const copy = MacOSKeyboardShortcutDataValues.find((shortcut) => shortcut.name === "copy")
@@ -396,7 +396,7 @@ export const MacOSKeyboardShortcutDataValues: typeof internal.MacOSKeyboardShort
  *
  * **Example** (Find Windows copy shortcut)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Find Windows copy shortcut"
  * import { WindowsKeyboardShortcutDataValues } from "@beep/data/KeyboardShortcuts"
  *
  * const copy = WindowsKeyboardShortcutDataValues.find((shortcut) => shortcut.name === "copy")
@@ -414,7 +414,7 @@ export const WindowsKeyboardShortcutDataValues: typeof internal.WindowsKeyboardS
  *
  * **Example** (Find Linux copy shortcut)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Find Linux copy shortcut"
  * import { LinuxKeyboardShortcutDataValues } from "@beep/data/KeyboardShortcuts"
  *
  * const copy = LinuxKeyboardShortcutDataValues.find((shortcut) => shortcut.name === "copy")
@@ -432,7 +432,7 @@ export const LinuxKeyboardShortcutDataValues: typeof internal.LinuxKeyboardShort
  *
  * **Example** (Find GNOME activities shortcut)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Find GNOME activities shortcut"
  * import { LinuxGnomeKeyboardShortcutDataValues } from "@beep/data/KeyboardShortcuts"
  *
  * const activities = LinuxGnomeKeyboardShortcutDataValues.find((shortcut) => shortcut.name === "activitiesOverview")
@@ -450,7 +450,7 @@ export const LinuxGnomeKeyboardShortcutDataValues: typeof internal.LinuxGnomeKey
  *
  * **Example** (Find KDE showDesktop shortcut)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Find KDE showDesktop shortcut"
  * import { LinuxKdePlasmaKeyboardShortcutDataValues } from "@beep/data/KeyboardShortcuts"
  *
  * const showDesktop = LinuxKdePlasmaKeyboardShortcutDataValues.find((shortcut) => shortcut.name === "showDesktop")
@@ -468,7 +468,7 @@ export const LinuxKdePlasmaKeyboardShortcutDataValues: typeof internal.LinuxKdeP
  *
  * **Example** (Find macOS copy display)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Find macOS copy display"
  * import { KeyboardShortcutDataValues } from "@beep/data/KeyboardShortcuts"
  *
  * const copy = KeyboardShortcutDataValues.find((shortcut) => shortcut.name === "copy" && shortcut.platform === "macos")

--- a/packages/foundation/primitive/data/src/MimeTypes.ts
+++ b/packages/foundation/primitive/data/src/MimeTypes.ts
@@ -21,9 +21,9 @@ import * as internal from "./internal/data/mime-types/index.ts";
  *
  * Each member is a full MIME type string such as `"application/json"` or `"image/png"`.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Use MIME type union)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Use MIME type union"
  * import type { MimeType } from "@beep/data/MimeTypes"
  *
  * const contentType: MimeType = "application/json"
@@ -38,9 +38,9 @@ export type MimeType = internal.MimeType;
 /**
  * Union of official IANA media type strings from the generated registry data.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Use official MIME type union)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Use official MIME type union"
  * import type { OfficialMimeType } from "@beep/data/MimeTypes"
  *
  * const contentType: OfficialMimeType = "application/json"
@@ -55,9 +55,9 @@ export type OfficialMimeType = (typeof official.OfficialMimeTypeDataTypeValues)[
 /**
  * Union of official IANA `application/*` media type strings.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Use application MIME type union)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Use application MIME type union"
  * import type { ApplicationMimeType } from "@beep/data/MimeTypes"
  *
  * const contentType: ApplicationMimeType = "application/json"
@@ -72,9 +72,9 @@ export type ApplicationMimeType = (typeof official.ApplicationMimeTypeValues)[nu
 /**
  * Union of official IANA `audio/*` media type strings.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Use audio MIME type union)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Use audio MIME type union"
  * import type { AudioMimeType } from "@beep/data/MimeTypes"
  *
  * const contentType: AudioMimeType = "audio/mpeg"
@@ -89,9 +89,9 @@ export type AudioMimeType = (typeof official.AudioMimeTypeValues)[number];
 /**
  * Union of official IANA `image/*` media type strings.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Use image MIME type union)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Use image MIME type union"
  * import type { ImageMimeType } from "@beep/data/MimeTypes"
  *
  * const contentType: ImageMimeType = "image/png"
@@ -106,9 +106,9 @@ export type ImageMimeType = (typeof official.ImageMimeTypeValues)[number];
 /**
  * Union of official IANA `text/*` media type strings.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Use text MIME type union)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Use text MIME type union"
  * import type { TextMimeType } from "@beep/data/MimeTypes"
  *
  * const contentType: TextMimeType = "text/plain"
@@ -123,9 +123,9 @@ export type TextMimeType = (typeof official.TextMimeTypeValues)[number];
 /**
  * Union of official IANA `video/*` media type strings.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Use video MIME type union)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Use video MIME type union"
  * import type { VideoMimeType } from "@beep/data/MimeTypes"
  *
  * const contentType: VideoMimeType = "video/mp4"
@@ -140,9 +140,9 @@ export type VideoMimeType = (typeof official.VideoMimeTypeValues)[number];
 /**
  * Union of official IANA media type strings outside the primary top-level categories.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Use miscellaneous MIME type union)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Use miscellaneous MIME type union"
  * import type { MiscMimeType } from "@beep/data/MimeTypes"
  *
  * const contentType: MiscMimeType = "font/woff2"
@@ -157,9 +157,9 @@ export type MiscMimeType = (typeof official.MiscMimeTypeValues)[number];
 /**
  * A single official IANA media type registry entry.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Inspect official MIME type data)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Inspect official MIME type data"
  * import { OfficialMimeTypeDataByType, type OfficialMimeTypeData } from "@beep/data/MimeTypes"
  *
  * const json: OfficialMimeTypeData = OfficialMimeTypeDataByType["application/json"]
@@ -177,9 +177,9 @@ export type OfficialMimeTypeData = (typeof official.OfficialMimeTypeDataValues)[
  *
  * Each member is a bare extension like `"json"`, `"html"`, or `"png"`.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Use file extension union)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Use file extension union"
  * import type { FileExtension } from "@beep/data/MimeTypes"
  *
  * const ext: FileExtension = "json"
@@ -204,9 +204,9 @@ type MimeTypeDefinition = {
  * Record of `application/*` MIME type definitions sourced from IANA, Apache,
  * and Nginx registries.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Use application MIME records)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Use application MIME records"
  * import { application } from "@beep/data/MimeTypes"
  *
  * console.assert(application["application/json"].extensions.includes("json"))
@@ -221,9 +221,9 @@ export const application: typeof internal.application = internal.application;
  * Record of `audio/*` MIME type definitions sourced from IANA, Apache,
  * and Nginx registries.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Use audio MIME records)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Use audio MIME records"
  * import { audio } from "@beep/data/MimeTypes"
  *
  * console.assert(audio["audio/mpeg"].extensions.includes("mp3"))
@@ -238,9 +238,9 @@ export const audio: typeof internal.audio = internal.audio;
  * Record of `image/*` MIME type definitions sourced from IANA, Apache,
  * and Nginx registries.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Use image MIME records)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Use image MIME records"
  * import { image } from "@beep/data/MimeTypes"
  *
  * console.assert(image["image/png"].extensions.includes("png"))
@@ -255,9 +255,9 @@ export const image: typeof internal.image = internal.image;
  * Record of miscellaneous MIME type definitions covering chemical, font,
  * message, model, and x-conference types.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Use miscellaneous MIME records)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Use miscellaneous MIME records"
  * import { misc } from "@beep/data/MimeTypes"
  *
  * console.assert(misc["font/woff2"].extensions.includes("woff2"))
@@ -272,9 +272,9 @@ export const misc: typeof internal.misc = internal.misc;
  * Record of `text/*` MIME type definitions sourced from IANA, Apache,
  * and Nginx registries.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Use text MIME records)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Use text MIME records"
  * import { text } from "@beep/data/MimeTypes"
  *
  * console.assert(text["text/html"].extensions.includes("html"))
@@ -289,9 +289,9 @@ export const text: typeof internal.text = internal.text;
  * Record of `video/*` MIME type definitions sourced from IANA, Apache,
  * and Nginx registries.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Use video MIME records)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Use video MIME records"
  * import { video } from "@beep/data/MimeTypes"
  *
  * console.assert(video["video/mp4"].extensions.includes("mp4"))
@@ -312,9 +312,9 @@ export const video: typeof internal.video = internal.video;
  *
  * This is the raw merged data object that backs the `mimeTypes` typed record.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Use extension-to-MIME map)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Use extension-to-MIME map"
  * import { mimes } from "@beep/data/MimeTypes"
  *
  * console.assert(mimes["text/css"].extensions.includes("css"))
@@ -330,9 +330,9 @@ export const mimes: typeof internal.mimes = internal.mimes;
  * file extensions. The source indicates where the MIME type definition
  * originated (`"iana"`, `"apache"`, or `"nginx"`).
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Use MIME-to-extension map)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Use MIME-to-extension map"
  * import { mimeTypes } from "@beep/data/MimeTypes"
  *
  * const json = mimeTypes["application/json"]
@@ -347,9 +347,9 @@ export const mimeTypes: Record<MimeType, MimeTypeDefinition> = internal.mimeType
 /**
  * Stable source metadata for the generated official IANA media type registry.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Inspect MIME registry metadata)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Inspect MIME registry metadata"
  * import { OfficialMimeTypeDataMetadata, OfficialMimeTypeDataUpdated } from "@beep/data/MimeTypes"
  *
  * console.assert(OfficialMimeTypeDataMetadata.updated === OfficialMimeTypeDataUpdated)
@@ -364,9 +364,9 @@ export const OfficialMimeTypeDataMetadata: typeof official.OfficialMimeTypeDataM
 /**
  * Last updated date reported by the official IANA media type registry.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Read MIME registry update date)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Read MIME registry update date"
  * import { OfficialMimeTypeDataUpdated } from "@beep/data/MimeTypes"
  *
  * console.assert(OfficialMimeTypeDataUpdated.length === "YYYY-MM-DD".length)
@@ -381,9 +381,9 @@ export const OfficialMimeTypeDataUpdated: typeof official.OfficialMimeTypeDataUp
 /**
  * Official IANA media type registry source URL.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Read MIME registry source URL)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Read MIME registry source URL"
  * import { OfficialMimeTypeDataSourceUrl } from "@beep/data/MimeTypes"
  *
  * console.assert(OfficialMimeTypeDataSourceUrl.endsWith("media-types.xml"))
@@ -398,9 +398,9 @@ export const OfficialMimeTypeDataSourceUrl: typeof official.OfficialMimeTypeData
 /**
  * SHA-256 digest of the official source payload used for the generated dataset.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Read MIME registry source digest)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Read MIME registry source digest"
  * import { OfficialMimeTypeDataSourceSha256 } from "@beep/data/MimeTypes"
  *
  * console.assert(OfficialMimeTypeDataSourceSha256.length === 64)
@@ -415,9 +415,9 @@ export const OfficialMimeTypeDataSourceSha256: typeof official.OfficialMimeTypeD
 /**
  * Official IANA media type registry entries.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Inspect MIME registry values)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Inspect MIME registry values"
  * import { OfficialMimeTypeDataValues } from "@beep/data/MimeTypes"
  *
  * const json = OfficialMimeTypeDataValues.find((entry) => entry.type === "application/json")
@@ -433,9 +433,9 @@ export const OfficialMimeTypeDataValues: typeof official.OfficialMimeTypeDataVal
 /**
  * Official IANA media type registry entries keyed by full media type.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Look up an official MIME type)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Look up an official MIME type"
  * import { OfficialMimeTypeDataByType } from "@beep/data/MimeTypes"
  *
  * console.assert(OfficialMimeTypeDataByType["application/json"].name === "json")
@@ -450,9 +450,9 @@ export const OfficialMimeTypeDataByType: typeof official.OfficialMimeTypeDataByT
 /**
  * Official IANA media type literal values.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Inspect official MIME type values)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Inspect official MIME type values"
  * import { OfficialMimeTypeDataTypeValues } from "@beep/data/MimeTypes"
  *
  * console.assert(OfficialMimeTypeDataTypeValues.includes("application/json"))
@@ -467,9 +467,9 @@ export const OfficialMimeTypeDataTypeValues: typeof official.OfficialMimeTypeDat
 /**
  * Official IANA `application/*` media type literal values.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Inspect application MIME type values)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Inspect application MIME type values"
  * import { ApplicationMimeTypeValues } from "@beep/data/MimeTypes"
  *
  * console.assert(ApplicationMimeTypeValues.includes("application/json"))
@@ -483,9 +483,9 @@ export const ApplicationMimeTypeValues: typeof official.ApplicationMimeTypeValue
 /**
  * Official IANA `audio/*` media type literal values.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Inspect audio MIME type values)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Inspect audio MIME type values"
  * import { AudioMimeTypeValues } from "@beep/data/MimeTypes"
  *
  * console.assert(AudioMimeTypeValues.includes("audio/mpeg"))
@@ -499,9 +499,9 @@ export const AudioMimeTypeValues: typeof official.AudioMimeTypeValues = official
 /**
  * Official IANA `image/*` media type literal values.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Inspect image MIME type values)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Inspect image MIME type values"
  * import { ImageMimeTypeValues } from "@beep/data/MimeTypes"
  *
  * console.assert(ImageMimeTypeValues.includes("image/png"))
@@ -515,9 +515,9 @@ export const ImageMimeTypeValues: typeof official.ImageMimeTypeValues = official
 /**
  * Official IANA `text/*` media type literal values.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Inspect text MIME type values)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Inspect text MIME type values"
  * import { TextMimeTypeValues } from "@beep/data/MimeTypes"
  *
  * console.assert(TextMimeTypeValues.includes("text/plain"))
@@ -531,9 +531,9 @@ export const TextMimeTypeValues: typeof official.TextMimeTypeValues = official.T
 /**
  * Official IANA `video/*` media type literal values.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Inspect video MIME type values)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Inspect video MIME type values"
  * import { VideoMimeTypeValues } from "@beep/data/MimeTypes"
  *
  * console.assert(VideoMimeTypeValues.includes("video/mp4"))
@@ -547,9 +547,9 @@ export const VideoMimeTypeValues: typeof official.VideoMimeTypeValues = official
 /**
  * Official IANA media type literal values outside the primary top-level categories.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Inspect miscellaneous MIME type values)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Inspect miscellaneous MIME type values"
  * import { MiscMimeTypeValues } from "@beep/data/MimeTypes"
  *
  * console.assert(MiscMimeTypeValues.includes("font/woff2"))
@@ -563,9 +563,9 @@ export const MiscMimeTypeValues: typeof official.MiscMimeTypeValues = official.M
 /**
  * Official IANA media type entries grouped for schema category helpers.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Group MIME types by top level)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Group MIME types by top level"
  * import { OfficialMimeTypeDataByTopLevel } from "@beep/data/MimeTypes"
  *
  * console.assert(OfficialMimeTypeDataByTopLevel.application["application/json"].name === "json")
@@ -589,9 +589,9 @@ export const OfficialMimeTypeDataByTopLevel: typeof official.OfficialMimeTypeDat
  * Lazily populates the internal lookup tables on first call; subsequent
  * calls return the same cached object.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Get MIME types for an extension)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Get MIME types for an extension"
  * import { getTypes } from "@beep/data/MimeTypes"
  *
  * const types = getTypes()
@@ -610,9 +610,9 @@ export const getTypes: () => Record<FileExtension, MimeType> = internal.getTypes
  * Lazily populates the internal lookup tables on first call; subsequent
  * calls return the same cached object.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Get extensions for a MIME type)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Get extensions for a MIME type"
  * import { getExtensions } from "@beep/data/MimeTypes"
  *
  * const extensions = getExtensions()
@@ -635,9 +635,9 @@ export const getExtensions: () => Record<MimeType, FileExtension[]> = internal.g
  * full file path (`"path/to/file.json"`). The lookup is case-insensitive.
  * Returns the matching MIME type string, or `false` if no match is found.
  *
- * **Example** (Use MIME type registry data)
+ * **Example** (Look up a MIME type by extension)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Look up a MIME type by extension"
  * import { lookup } from "@beep/data/MimeTypes"
  *
  * console.assert(lookup("json") === "application/json")

--- a/packages/foundation/primitive/data/src/Territories.ts
+++ b/packages/foundation/primitive/data/src/Territories.ts
@@ -12,7 +12,7 @@ import * as internal from "./generated/cldr-territories.ts";
  *
  * **Example** (Lookup US territory entry)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Lookup US territory entry"
  * import { TerritoryDataByCode, type TerritoryData } from "@beep/data/Territories"
  *
  * const unitedStates: TerritoryData = TerritoryDataByCode.US
@@ -29,7 +29,7 @@ export type TerritoryData = (typeof internal.TerritoryDataValues)[number];
  *
  * **Example** (Assign US territory code)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Assign US territory code"
  * import type { TerritoryCode } from "@beep/data/Territories"
  *
  * const code: TerritoryCode = "US"
@@ -46,7 +46,7 @@ export type TerritoryCode = TerritoryData["code"];
  *
  * **Example** (Assign United States name)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Assign United States name"
  * import type { TerritoryName } from "@beep/data/Territories"
  *
  * const name: TerritoryName = "United States"
@@ -63,7 +63,7 @@ export type TerritoryName = TerritoryData["name"];
  *
  * **Example** (Lookup Americas continent entry)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Lookup Americas continent entry"
  * import { ContinentDataByCode, type ContinentData } from "@beep/data/Territories"
  *
  * const americas: ContinentData = ContinentDataByCode["019"]
@@ -80,7 +80,7 @@ export type ContinentData = (typeof internal.ContinentDataValues)[number];
  *
  * **Example** (Assign Americas continent code)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Assign Americas continent code"
  * import type { ContinentCode } from "@beep/data/Territories"
  *
  * const code: ContinentCode = "019"
@@ -97,7 +97,7 @@ export type ContinentCode = ContinentData["code"];
  *
  * **Example** (Assign Americas continent name)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Assign Americas continent name"
  * import type { ContinentName } from "@beep/data/Territories"
  *
  * const name: ContinentName = "Americas"
@@ -114,7 +114,7 @@ export type ContinentName = ContinentData["name"];
  *
  * **Example** (Check territory release tag)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Check territory release tag"
  * import { TerritoryDataMetadata } from "@beep/data/Territories"
  *
  * console.assert(TerritoryDataMetadata.releaseTag === "48.2.0")
@@ -130,7 +130,7 @@ export const TerritoryDataMetadata: typeof internal.TerritoryDataMetadata = inte
  *
  * **Example** (Assert CLDR release tag)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Assert CLDR release tag"
  * import { TerritoryDataReleaseTag } from "@beep/data/Territories"
  *
  * console.assert(TerritoryDataReleaseTag === "48.2.0")
@@ -146,7 +146,7 @@ export const TerritoryDataReleaseTag: typeof internal.TerritoryDataReleaseTag = 
  *
  * **Example** (Find US in territory list)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Find US in territory list"
  * import { TerritoryDataValues } from "@beep/data/Territories"
  *
  * const unitedStates = TerritoryDataValues.find((entry) => entry.code === "US")
@@ -163,7 +163,7 @@ export const TerritoryDataValues: typeof internal.TerritoryDataValues = internal
  *
  * **Example** (Access US by territory code)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Access US by territory code"
  * import { TerritoryDataByCode } from "@beep/data/Territories"
  *
  * console.assert(TerritoryDataByCode.US.name === "United States")
@@ -179,7 +179,7 @@ export const TerritoryDataByCode: typeof internal.TerritoryDataByCode = internal
  *
  * **Example** (Check US code is included)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Check US code is included"
  * import { TerritoryCodeValues } from "@beep/data/Territories"
  *
  * console.assert(TerritoryCodeValues.includes("US"))
@@ -195,7 +195,7 @@ export const TerritoryCodeValues: typeof internal.TerritoryCodeValues = internal
  *
  * **Example** (Map US code to name)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Map US code to name"
  * import { TerritoryDataNameByCode } from "@beep/data/Territories"
  *
  * console.assert(TerritoryDataNameByCode.US === "United States")
@@ -211,7 +211,7 @@ export const TerritoryDataNameByCode: typeof internal.TerritoryDataNameByCode = 
  *
  * **Example** (Find US code-name pair)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Find US code-name pair"
  * import { TerritoryDataCodeNamePairs } from "@beep/data/Territories"
  *
  * const unitedStates = TerritoryDataCodeNamePairs.find(([code]) => code === "US")
@@ -229,7 +229,7 @@ export const TerritoryDataCodeNamePairs: typeof internal.TerritoryDataCodeNamePa
  *
  * **Example** (Find Americas in continent list)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Find Americas in continent list"
  * import { ContinentDataValues } from "@beep/data/Territories"
  *
  * const americas = ContinentDataValues.find((entry) => entry.code === "019")
@@ -246,7 +246,7 @@ export const ContinentDataValues: typeof internal.ContinentDataValues = internal
  *
  * **Example** (Access Americas by region code)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Access Americas by region code"
  * import { ContinentDataByCode } from "@beep/data/Territories"
  *
  * console.assert(ContinentDataByCode["019"].name === "Americas")
@@ -262,7 +262,7 @@ export const ContinentDataByCode: typeof internal.ContinentDataByCode = internal
  *
  * **Example** (Check 019 code is included)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Check 019 code is included"
  * import { ContinentCodeValues } from "@beep/data/Territories"
  *
  * console.assert(ContinentCodeValues.includes("019"))
@@ -278,7 +278,7 @@ export const ContinentCodeValues: typeof internal.ContinentCodeValues = internal
  *
  * **Example** (Map 019 code to name)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Map 019 code to name"
  * import { ContinentDataNameByCode } from "@beep/data/Territories"
  *
  * console.assert(ContinentDataNameByCode["019"] === "Americas")
@@ -294,7 +294,7 @@ export const ContinentDataNameByCode: typeof internal.ContinentDataNameByCode = 
  *
  * **Example** (Find Americas code-name pair)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Find Americas code-name pair"
  * import { ContinentDataCodeNamePairs } from "@beep/data/Territories"
  *
  * const americas = ContinentDataCodeNamePairs.find(([code]) => code === "019")

--- a/packages/foundation/primitive/data/src/Timezones.ts
+++ b/packages/foundation/primitive/data/src/Timezones.ts
@@ -22,7 +22,7 @@ import * as internal from "./generated/iana-timezones.ts";
  *
  * **Example** (Type a timezone identifier)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Type a timezone identifier"
  * import type { TimezoneName } from "@beep/data/Timezones"
  *
  * const tz: TimezoneName = "America/New_York"
@@ -39,7 +39,7 @@ export type TimezoneName = (typeof internal.TimezoneNameValues)[number];
  *
  * **Example** (Reference a generated timezone entry)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Reference a generated timezone entry"
  * import { TimezoneDataByName, type TimezoneData } from "@beep/data/Timezones"
  *
  * const utc: TimezoneData = TimezoneDataByName.UTC
@@ -63,7 +63,7 @@ export type TimezoneData = (typeof internal.TimezoneDataValues)[number];
  *
  * **Example** (Check a known identifier is present)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check a known identifier is present"
  * import { TimezoneNameValues } from "@beep/data/Timezones"
  *
  * console.assert(TimezoneNameValues.includes("UTC"))
@@ -79,7 +79,7 @@ export const TimezoneNameValues: typeof internal.TimezoneNameValues = internal.T
  *
  * **Example** (Read the tzdb metadata)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Read the tzdb metadata"
  * import { TimezoneDataMetadata } from "@beep/data/Timezones"
  *
  * console.assert(TimezoneDataMetadata.version === "2026c")
@@ -95,7 +95,7 @@ export const TimezoneDataMetadata: typeof internal.TimezoneDataMetadata = intern
  *
  * **Example** (Read the tzdb version)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Read the tzdb version"
  * import { TimezoneDataVersion } from "@beep/data/Timezones"
  *
  * console.assert(TimezoneDataVersion === "2026c")
@@ -111,7 +111,7 @@ export const TimezoneDataVersion: typeof internal.TimezoneDataVersion = internal
  *
  * **Example** (Inspect the source URL)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Inspect the source URL"
  * import { TimezoneDataSourceUrl } from "@beep/data/Timezones"
  *
  * console.assert(TimezoneDataSourceUrl.endsWith("tzdata-latest.tar.gz"))
@@ -127,7 +127,7 @@ export const TimezoneDataSourceUrl: typeof internal.TimezoneDataSourceUrl = inte
  *
  * **Example** (Inspect the source digest)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Inspect the source digest"
  * import { TimezoneDataSourceSha256 } from "@beep/data/Timezones"
  *
  * console.assert(TimezoneDataSourceSha256.length === 64)
@@ -143,7 +143,7 @@ export const TimezoneDataSourceSha256: typeof internal.TimezoneDataSourceSha256 
  *
  * **Example** (Find the UTC entry)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Find the UTC entry"
  * import { TimezoneDataValues } from "@beep/data/Timezones"
  *
  * const utc = TimezoneDataValues.find((entry) => entry.name === "UTC")
@@ -160,7 +160,7 @@ export const TimezoneDataValues: typeof internal.TimezoneDataValues = internal.T
  *
  * **Example** (Look up a timezone by name)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Look up a timezone by name"
  * import { TimezoneDataByName } from "@beep/data/Timezones"
  *
  * console.assert(TimezoneDataByName["America/New_York"].name === "America/New_York")

--- a/packages/foundation/primitive/data/src/index.ts
+++ b/packages/foundation/primitive/data/src/index.ts
@@ -14,7 +14,7 @@
  *
  * **Example** (Ethereum network ticker)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Ethereum network ticker"
  * import { Blockchain } from "@beep/data"
  *
  * console.assert(Blockchain.Networks.Ethereum.ticker === "ETH")
@@ -29,7 +29,7 @@ export * as Blockchain from "./Blockchain.ts";
  *
  * **Example** (ISO month value lookup)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="ISO month value lookup"
  * import { Calendar } from "@beep/data"
  *
  * console.assert(Calendar.MonthISOValues[0] === "01")
@@ -44,7 +44,7 @@ export * as Calendar from "./Calendar.ts";
  *
  * **Example** (USD currency name lookup)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="USD currency name lookup"
  * import { CurrencyCodes } from "@beep/data"
  *
  * console.assert(CurrencyCodes.CurrencyCodeDataByCode.USD.currency === "US Dollar")
@@ -59,7 +59,7 @@ export * as CurrencyCodes from "./CurrencyCodes.ts";
  *
  * **Example** (Find copy keyboard shortcut)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Find copy keyboard shortcut"
  * import { KeyboardShortcuts } from "@beep/data"
  *
  * const hasCopyShortcut = KeyboardShortcuts.KeyboardShortcutDataValues.some(
@@ -78,7 +78,7 @@ export * as KeyboardShortcuts from "./KeyboardShortcuts.ts";
  *
  * **Example** (Lookup JSON MIME type)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Lookup JSON MIME type"
  * import { MimeTypesData } from "@beep/data"
  *
  * console.assert(MimeTypesData.lookup("asset.json") === "application/json")
@@ -93,7 +93,7 @@ export * as MimeTypesData from "./MimeTypes.ts";
  *
  * **Example** (US territory name lookup)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="US territory name lookup"
  * import { Territories } from "@beep/data"
  *
  * console.assert(Territories.TerritoryDataByCode.US.name === "United States")
@@ -108,7 +108,7 @@ export * as Territories from "./Territories.ts";
  *
  * **Example** (UTC timezone name lookup)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="UTC timezone name lookup"
  * import { Timezones } from "@beep/data"
  *
  * console.assert(Timezones.TimezoneDataByName.UTC.name === "UTC")

--- a/packages/foundation/primitive/data/src/internal/data/mime-types/application.ts
+++ b/packages/foundation/primitive/data/src/internal/data/mime-types/application.ts
@@ -14,11 +14,10 @@
  *
  * **Example** (Lookup application/json entry)
  *
- * ```typescript
- * import { application } from "@beep/data/mime-types/application"
+ * ```ts import.meta.vitest name="Lookup application/json entry"
+ * import { application } from "@beep/data/MimeTypes"
  *
- * application["application/json"]
- * // { source: "iana", charset: "UTF-8", extensions: ["json", "map"] }
+ * application["application/json"].charset // => "UTF-8"
  * ```
  *
  * @category models

--- a/packages/foundation/primitive/data/src/internal/data/mime-types/audio.ts
+++ b/packages/foundation/primitive/data/src/internal/data/mime-types/audio.ts
@@ -14,11 +14,10 @@
  *
  * **Example** (Lookup audio/mpeg entry)
  *
- * ```typescript
- * import { audio } from "@beep/data/mime-types/audio"
+ * ```ts import.meta.vitest name="Lookup audio/mpeg entry"
+ * import { audio } from "@beep/data/MimeTypes"
  *
- * audio["audio/mpeg"]
- * // { source: "iana", extensions: ["mpga", "mp2", "mp2a", "mp3", "m2a", "m3a"] }
+ * audio["audio/mpeg"].extensions.includes("mp3") // => true
  * ```
  *
  * @category models

--- a/packages/foundation/primitive/data/src/internal/data/mime-types/image.ts
+++ b/packages/foundation/primitive/data/src/internal/data/mime-types/image.ts
@@ -14,11 +14,10 @@
  *
  * **Example** (Lookup image/png entry)
  *
- * ```typescript
- * import { image } from "@beep/data/mime-types/image"
+ * ```ts import.meta.vitest name="Lookup image/png entry"
+ * import { image } from "@beep/data/MimeTypes"
  *
- * image["image/png"]
- * // { source: "iana", extensions: ["png"] }
+ * image["image/png"].extensions.includes("png") // => true
  * ```
  *
  * @category models

--- a/packages/foundation/primitive/data/src/internal/data/mime-types/index.ts
+++ b/packages/foundation/primitive/data/src/internal/data/mime-types/index.ts
@@ -85,11 +85,10 @@ export const video = _video;
  *
  * **Example** (Access CSS MIME definition)
  *
- * ```typescript
- * import { mimes } from "@beep/data"
+ * ```ts import.meta.vitest name="Access CSS MIME definition"
+ * import { mimes } from "@beep/data/MimeTypes"
  *
- * mimes["text/css"]
- * // { source: "iana", charset: "UTF-8", extensions: ["css"] }
+ * mimes["text/css"].charset // => "UTF-8"
  * ```
  *
  * @category configuration
@@ -113,7 +112,7 @@ export const mimes = {
  *
  * **Example** (Assign JSON content type)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Assign JSON content type"
  * import type { MimeType } from "@beep/data"
  *
  * const contentType: MimeType = "application/json"
@@ -134,7 +133,7 @@ export type MimeType = keyof typeof mimes;
  *
  * **Example** (Assign JSON file extension)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Assign JSON file extension"
  * import type { FileExtension } from "@beep/data"
  *
  * const ext: FileExtension = "json"
@@ -152,11 +151,11 @@ export type FileExtension = (typeof mimes)[MimeType]["extensions"][number];
  *
  * **Example** (Read JSON MIME definition)
  *
- * ```typescript
- * import { mimeTypes } from "@beep/data"
+ * ```ts import.meta.vitest name="Read JSON MIME definition"
+ * import { mimeTypes } from "@beep/data/MimeTypes"
  *
  * const json = mimeTypes["application/json"]
- * // { source: "iana", extensions: ["json", "map"] }
+ * json.extensions.includes("json") // => true
  * ```
  *
  * @category configuration
@@ -232,12 +231,12 @@ function lookupNormalizedExtension(extension: string): false | MimeType {
  *
  * **Example** (Map extensions to MIME types)
  *
- * ```typescript
- * import { getTypes } from "@beep/data"
+ * ```ts import.meta.vitest name="Map extensions to MIME types"
+ * import { getTypes } from "@beep/data/MimeTypes"
  *
  * const types = getTypes()
- * types["json"] // "application/json"
- * types["html"] // "text/html"
+ * types["json"] // => "application/json"
+ * types["html"] // => "text/html"
  * ```
  *
  * @category utilities
@@ -259,12 +258,12 @@ export function getTypes(): Record<FileExtension, MimeType> {
  *
  * **Example** (Map MIME types to extensions)
  *
- * ```typescript
- * import { getExtensions } from "@beep/data"
+ * ```ts import.meta.vitest name="Map MIME types to extensions"
+ * import { getExtensions } from "@beep/data/MimeTypes"
  *
  * const extensions = getExtensions()
- * extensions["application/json"] // ["json", "map"]
- * extensions["text/html"]        // ["html", "htm", "shtml"]
+ * extensions["application/json"].includes("json") // => true
+ * extensions["text/html"].includes("html") // => true
  * ```
  *
  * @category utilities
@@ -286,13 +285,13 @@ export function getExtensions(): Record<MimeType, FileExtension[]> {
  *
  * **Example** (Look up MIME from path)
  *
- * ```typescript
- * import { lookup } from "@beep/data"
+ * ```ts import.meta.vitest name="Look up MIME from path"
+ * import { lookup } from "@beep/data/MimeTypes"
  *
- * lookup("json")            // "application/json"
- * lookup(".html")           // "text/html"
- * lookup("photo.png")       // "image/png"
- * lookup("unknown.zzzzz")   // false
+ * lookup("json") // => "application/json"
+ * lookup(".html") // => "text/html"
+ * lookup("photo.png") // => "image/png"
+ * lookup("unknown.zzzzz") // => false
  * ```
  *
  * @category utilities

--- a/packages/foundation/primitive/data/src/internal/data/mime-types/misc.ts
+++ b/packages/foundation/primitive/data/src/internal/data/mime-types/misc.ts
@@ -16,11 +16,10 @@
  *
  * **Example** (Accessing font/woff2 MIME type)
  *
- * ```typescript
- * import { misc } from "@beep/data/mime-types/misc"
+ * ```ts import.meta.vitest name="Accessing font/woff2 MIME type"
+ * import { misc } from "@beep/data/MimeTypes"
  *
- * misc["font/woff2"]
- * // { source: "iana", extensions: ["woff2"] }
+ * misc["font/woff2"].extensions.includes("woff2") // => true
  * ```
  *
  * @category models

--- a/packages/foundation/primitive/data/src/internal/data/mime-types/text.ts
+++ b/packages/foundation/primitive/data/src/internal/data/mime-types/text.ts
@@ -14,11 +14,10 @@
  *
  * **Example** (Accessing text/html MIME type)
  *
- * ```typescript
- * import { text } from "@beep/data/mime-types/text"
+ * ```ts import.meta.vitest name="Accessing text/html MIME type"
+ * import { text } from "@beep/data/MimeTypes"
  *
- * text["text/html"]
- * // { source: "iana", extensions: ["html", "htm", "shtml"] }
+ * text["text/html"].extensions.includes("html") // => true
  * ```
  *
  * @category models

--- a/packages/foundation/primitive/data/src/internal/data/mime-types/video.ts
+++ b/packages/foundation/primitive/data/src/internal/data/mime-types/video.ts
@@ -14,11 +14,10 @@
  *
  * **Example** (Accessing video/mp4 MIME type)
  *
- * ```typescript
- * import { video } from "@beep/data/mime-types/video"
+ * ```ts import.meta.vitest name="Accessing video/mp4 MIME type"
+ * import { video } from "@beep/data/MimeTypes"
  *
- * video["video/mp4"]
- * // { source: "iana", extensions: ["mp4", "mp4v", "mpg4"] }
+ * video["video/mp4"].extensions.includes("mp4") // => true
  * ```
  *
  * @category models

--- a/packages/foundation/primitive/data/src/internal/index.ts
+++ b/packages/foundation/primitive/data/src/internal/index.ts
@@ -10,7 +10,7 @@
  *
  * **Example** (Importing Calendar month values)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Importing Calendar month values"
  * import { Calendar } from "@beep/data/internal"
  *
  * console.assert(Calendar.MonthNameValues[0] === "january")

--- a/packages/foundation/primitive/types/src/TString.types.ts
+++ b/packages/foundation/primitive/types/src/TString.types.ts
@@ -15,7 +15,7 @@
  *
  * **Example** (Non-empty string type filtering)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Non-empty string type filtering"
  * import type { TString } from "@beep/types"
  *
  * type Hello = TString.NonEmpty<"hello">
@@ -43,7 +43,7 @@ export type NonEmpty<T extends string = string> = T extends "" ? never : T;
  *
  * **Example** (Filtering empty and slash strings)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Filtering empty and slash strings"
  * import type { TString } from "@beep/types"
  *
  * type Segment = TString.NonEmptyTrimmed<"users/42">
@@ -71,7 +71,7 @@ export type NonEmptyTrimmed<T extends string = string> = T extends `/${string}` 
  *
  * **Example** (Splitting string into characters)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Splitting string into characters"
  * import type { TString } from "@beep/types"
  *
  * type ABC = TString.Chars<"abc">
@@ -108,7 +108,7 @@ type IsDotPropertyNameRest<S extends string> = S extends ""
  *
  * **Example** (Validating dot property names)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Validating dot property names"
  * import type { TString } from "@beep/types"
  *
  * type Name = TString.DotPropertyName<"hello4">


### PR DESCRIPTION
## What

Chunk 2 of the doctest marking campaign (after #838's foundation/modeling chunk 1): apply the
`beep docgen doctest mark` codemod to `packages/foundation/capability/**` and
`packages/foundation/primitive/**`, with the four hardened rules from chunk 1's review applied
before publish.

- 529 fences marked across 98 source files (capability 391/81, primitive 138/17).
- 322 console-to-assertion rewrites retained (300 sync, 22 async `.then(console.log)` forms
  rewritten to awaited literal assertions).
- 354 fences restored unmarked: printed values not deterministically assertable.
- 2 runtime reverts: `EffectGraph.ts` ana example (invalid node), `observability/index.ts`
  fire-and-forget runPromise (unhandled Layer error). No `.skip`, no suppressions.
- 42 fences in the four generator-owned `primitive/data/src/generated/*` files left unmarked and
  byte-identical to HEAD (blob hashes proven) — marking them belongs with the `SyncDataToTs`
  renderers, out of scope for this chunk.
- 16 stale example claims corrected (wrong values, missing args, dead import paths in the
  mime-types internals).
- Fence-name audit: 0 backticks, 0 post-strip collisions. Marked-fence safety audit: 0 bare
  console.log, 0 fs/network/env/process patterns.

## Verification

- `bunx vitest run --config vitest.docs.ts`: 309 files, 2,299 doctests green (chunk 1 corpus +
  this chunk).
- ESLint over every changed file: 0 errors, 0 warnings. `docgen:local`: 127/127 tasks green.
- `beep quality test-tsgo`, `fallow audit --check` (`introduced: 0`), jsdoc inventory + ratchet
  (`increased=0`), `changeset-status --since origin/main`: all green.
- Changeset names all 11 touched packages at `patch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790341969&installation_model_id=424656&pr_number=843&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F843&signature=405592fb9b6c5d9cb5a69dec759686843fcb2a143b46f367ca54cca98ed9f04d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->