### PR TITLE
docs(doctest): mark ui-system examples for the runtime lane

### DIFF
--- a/.changeset/doctest-mark-ui-system.md
+++ b/.changeset/doctest-mark-ui-system.md
@@ -1,0 +1,7 @@
+---
+"@beep/dock": patch
+"@beep/editor": patch
+"@beep/ui": patch
+---
+
+Mark stable UI-system examples for documentation runtime testing.

--- a/packages/foundation/ui-system/dock/src/AnchoredBox.ts
+++ b/packages/foundation/ui-system/dock/src/AnchoredBox.ts
@@ -14,11 +14,11 @@ const $I = $DockId.create("AnchoredBox");
  *
  * **Example** (Make TopLeft coordinates)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make TopLeft coordinates"
  * import { TopLeft } from "@beep/dock"
  *
  * const anchor = TopLeft.make({ left: 24, top: 16 })
- * console.log(anchor._tag) // "TopLeft"
+ * anchor._tag // => "TopLeft"
  * ```
  *
  * @category value-objects
@@ -35,11 +35,11 @@ export class TopLeft extends S.TaggedClass<TopLeft>($I`TopLeft`)(
  *
  * **Example** (Make TopRight coordinates)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make TopRight coordinates"
  * import { TopRight } from "@beep/dock"
  *
  * const anchor = TopRight.make({ right: 24, top: 16 })
- * console.log(anchor.right) // 24
+ * anchor.right // => 24
  * ```
  *
  * @category value-objects
@@ -56,11 +56,11 @@ export class TopRight extends S.TaggedClass<TopRight>($I`TopRight`)(
  *
  * **Example** (Make BottomLeft coordinates)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make BottomLeft coordinates"
  * import { BottomLeft } from "@beep/dock"
  *
  * const anchor = BottomLeft.make({ bottom: 12, left: 20 })
- * console.log(anchor.bottom) // 12
+ * anchor.bottom // => 12
  * ```
  *
  * @category value-objects
@@ -77,11 +77,11 @@ export class BottomLeft extends S.TaggedClass<BottomLeft>($I`BottomLeft`)(
  *
  * **Example** (Make BottomRight coordinates)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make BottomRight coordinates"
  * import { BottomRight } from "@beep/dock"
  *
  * const anchor = BottomRight.make({ bottom: 12, right: 20 })
- * console.log(anchor._tag) // "BottomRight"
+ * anchor._tag // => "BottomRight"
  * ```
  *
  * @category value-objects
@@ -98,11 +98,11 @@ export class BottomRight extends S.TaggedClass<BottomRight>($I`BottomRight`)(
  *
  * **Example** (Make width and height)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make width and height"
  * import { AnchoredSize } from "@beep/dock"
  *
  * const size = AnchoredSize.make({ width: 640, height: 480 })
- * console.log(size.width) // 640
+ * size.width // => 640
  * ```
  *
  * @category value-objects
@@ -118,11 +118,11 @@ export class AnchoredSize extends S.Class<AnchoredSize>($I`AnchoredSize`)(
  *
  * **Example** (Make top-left sized box)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make top-left sized box"
  * import { TopLeftAnchoredBox } from "@beep/dock"
  *
  * const box = TopLeftAnchoredBox.make({ left: 20, top: 12, width: 640, height: 480 })
- * console.log(box._tag) // "TopLeft"
+ * box._tag // => "TopLeft"
  * ```
  *
  * @category value-objects
@@ -142,11 +142,11 @@ export class TopLeftAnchoredBox extends AnchoredSize.extend<TopLeftAnchoredBox>(
  *
  * **Example** (Make top-right sized box)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make top-right sized box"
  * import { TopRightAnchoredBox } from "@beep/dock"
  *
  * const box = TopRightAnchoredBox.make({ right: 20, top: 12, width: 640, height: 480 })
- * console.log(box.right) // 20
+ * box.right // => 20
  * ```
  *
  * @category value-objects
@@ -166,11 +166,11 @@ export class TopRightAnchoredBox extends AnchoredSize.extend<TopRightAnchoredBox
  *
  * **Example** (Make bottom-right sized box)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make bottom-right sized box"
  * import { BottomRightAnchoredBox } from "@beep/dock"
  *
  * const box = BottomRightAnchoredBox.make({ bottom: 12, right: 20, width: 640, height: 480 })
- * console.log(box.bottom) // 12
+ * box.bottom // => 12
  * ```
  *
  * @category value-objects
@@ -190,11 +190,11 @@ export class BottomRightAnchoredBox extends AnchoredSize.extend<BottomRightAncho
  *
  * **Example** (Make bottom-left sized box)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make bottom-left sized box"
  * import { BottomLeftAnchoredBox } from "@beep/dock"
  *
  * const box = BottomLeftAnchoredBox.make({ bottom: 12, left: 20, width: 640, height: 480 })
- * console.log(box.left) // 20
+ * box.left // => 20
  * ```
  *
  * @category value-objects
@@ -214,7 +214,7 @@ export class BottomLeftAnchoredBox extends AnchoredSize.extend<BottomLeftAnchore
  *
  * **Example** (Decode untagged top-left box)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode untagged top-left box"
  * import { AnchoredBox } from "@beep/dock"
  * import * as S from "effect/Schema"
  *
@@ -224,7 +224,7 @@ export class BottomLeftAnchoredBox extends AnchoredSize.extend<BottomLeftAnchore
  *   width: 640,
  *   height: 480
  * })
- * console.log(box._tag) // "TopLeft"
+ * box._tag // => "TopLeft"
  * ```
  *
  * @category value-objects
@@ -244,7 +244,7 @@ export const AnchoredBox = S.Union([
  *
  * **Example** (Type a top-left box)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Type a top-left box"
  * import { AnchoredBox, TopLeftAnchoredBox } from "@beep/dock"
  *
  * const box: AnchoredBox = TopLeftAnchoredBox.make({
@@ -253,7 +253,7 @@ export const AnchoredBox = S.Union([
  *   width: 640,
  *   height: 480
  * })
- * console.log(box._tag) // "TopLeft"
+ * box._tag // => "TopLeft"
  * ```
  *
  * @category value-objects
@@ -265,7 +265,7 @@ export type AnchoredBox = typeof AnchoredBox.Type;
  *
  * **Example** (Declare encoded TopLeft shape)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Declare encoded TopLeft shape"
  * import type { AnchoredBox } from "@beep/dock"
  *
  * const encoded: AnchoredBox.Encoded = {
@@ -275,7 +275,7 @@ export type AnchoredBox = typeof AnchoredBox.Type;
  *   width: 640,
  *   height: 480
  * }
- * console.log(encoded._tag) // "TopLeft"
+ * encoded._tag // => "TopLeft"
  * ```
  *
  * @category value-objects
@@ -287,7 +287,7 @@ export declare namespace AnchoredBox {
    *
    * **Example** (Declare encoded BottomRight shape)
    *
-   * ```ts
+   * ```ts import.meta.vitest name="Declare encoded BottomRight shape"
    * import type { AnchoredBox } from "@beep/dock"
    *
    * const encoded: AnchoredBox.Encoded = {
@@ -297,7 +297,7 @@ export declare namespace AnchoredBox {
    *   width: 640,
    *   height: 480
    * }
-   * console.log(encoded.width) // 640
+   * encoded.width // => 640
    * ```
    *
    * @category value-objects

--- a/packages/foundation/ui-system/dock/src/Dock.ids.ts
+++ b/packages/foundation/ui-system/dock/src/Dock.ids.ts
@@ -16,11 +16,11 @@ const $I = $DockId.create("Dock.ids");
  *
  * **Example** (Make and check PanelId)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make and check PanelId"
  * import { PanelId } from "@beep/dock"
  *
  * const id = PanelId.make("panel-one")
- * console.log(PanelId.is(id)) // true
+ * PanelId.is(id) // => true
  * ```
  *
  * @category identifiers
@@ -41,11 +41,11 @@ export const PanelId = S.NonEmptyString.pipe(
  *
  * **Example** (Typed PanelId assignment)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Typed PanelId assignment"
  * import { PanelId } from "@beep/dock"
  *
  * const id: PanelId = PanelId.make("panel-one")
- * console.log(id) // "panel-one"
+ * id // => "panel-one"
  * ```
  *
  * @category identifiers
@@ -58,11 +58,11 @@ export type PanelId = typeof PanelId.Type;
  *
  * **Example** (Make and check GroupId)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make and check GroupId"
  * import { GroupId } from "@beep/dock"
  *
  * const id = GroupId.make("group-one")
- * console.log(GroupId.is(id)) // true
+ * GroupId.is(id) // => true
  * ```
  *
  * @category identifiers
@@ -83,11 +83,11 @@ export const GroupId = S.NonEmptyString.pipe(
  *
  * **Example** (Typed GroupId assignment)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Typed GroupId assignment"
  * import { GroupId } from "@beep/dock"
  *
  * const id: GroupId = GroupId.make("group-one")
- * console.log(id) // "group-one"
+ * id // => "group-one"
  * ```
  *
  * @category identifiers
@@ -100,11 +100,11 @@ export type GroupId = typeof GroupId.Type;
  *
  * **Example** (Make and check SplitId)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make and check SplitId"
  * import { SplitId } from "@beep/dock"
  *
  * const id = SplitId.make("split-one")
- * console.log(SplitId.is(id)) // true
+ * SplitId.is(id) // => true
  * ```
  *
  * @category identifiers
@@ -125,11 +125,11 @@ export const SplitId = S.NonEmptyString.pipe(
  *
  * **Example** (Typed SplitId assignment)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Typed SplitId assignment"
  * import { SplitId } from "@beep/dock"
  *
  * const id: SplitId = SplitId.make("split-one")
- * console.log(id) // "split-one"
+ * id // => "split-one"
  * ```
  *
  * @category identifiers
@@ -142,11 +142,11 @@ export type SplitId = typeof SplitId.Type;
  *
  * **Example** (Make and check CommandId)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make and check CommandId"
  * import { CommandId } from "@beep/dock"
  *
  * const id = CommandId.make("command-open-one")
- * console.log(CommandId.is(id)) // true
+ * CommandId.is(id) // => true
  * ```
  *
  * @category identifiers
@@ -167,11 +167,11 @@ export const CommandId = S.NonEmptyString.pipe(
  *
  * **Example** (Typed CommandId assignment)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Typed CommandId assignment"
  * import { CommandId } from "@beep/dock"
  *
  * const id: CommandId = CommandId.make("command-open-one")
- * console.log(id) // "command-open-one"
+ * id // => "command-open-one"
  * ```
  *
  * @category identifiers
@@ -184,11 +184,11 @@ export type CommandId = typeof CommandId.Type;
  *
  * **Example** (Make and check RendererKey)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make and check RendererKey"
  * import { RendererKey } from "@beep/dock"
  *
  * const key = RendererKey.make("markdown-preview")
- * console.log(RendererKey.is(key)) // true
+ * RendererKey.is(key) // => true
  * ```
  *
  * @category identifiers
@@ -209,11 +209,11 @@ export const RendererKey = S.NonEmptyString.pipe(
  *
  * **Example** (Typed RendererKey assignment)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Typed RendererKey assignment"
  * import { RendererKey } from "@beep/dock"
  *
  * const key: RendererKey = RendererKey.make("markdown-preview")
- * console.log(key) // "markdown-preview"
+ * key // => "markdown-preview"
  * ```
  *
  * @category identifiers
@@ -226,12 +226,12 @@ export type RendererKey = typeof RendererKey.Type;
  *
  * **Example** (Complement split ratio shares)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Complement split ratio shares"
  * import { SplitRatio } from "@beep/dock"
  *
  * const left = SplitRatio.make(6_000)
  * const right = SplitRatio.complement(left)
- * console.log(right) // 4000
+ * right // => 4000
  * ```
  *
  * @category identifiers
@@ -258,11 +258,11 @@ export const SplitRatio = S.Int.check(
  *
  * **Example** (Typed SplitRatio assignment)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Typed SplitRatio assignment"
  * import { SplitRatio } from "@beep/dock"
  *
  * const ratio: SplitRatio = SplitRatio.make(5_000)
- * console.log(ratio) // 5000
+ * ratio // => 5000
  * ```
  *
  * @category identifiers

--- a/packages/foundation/ui-system/editor/src/artifact-ref-node.tsx
+++ b/packages/foundation/ui-system/editor/src/artifact-ref-node.tsx
@@ -21,7 +21,7 @@ import type { JSX } from "react";
  *
  * **Example** (Satisfy serialized wire shape)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Satisfy serialized wire shape"
  * import type { SerializedArtifactRefNode } from "@beep/editor/artifact-ref-node"
  *
  * const payload = {
@@ -32,7 +32,7 @@ import type { JSX } from "react";
  * } satisfies SerializedArtifactRefNode
  *
  * const artifactId: string = payload.artifactId
- * console.log(artifactId) // "artifact-123"
+ * artifactId // => "artifact-123"
  * ```
  *
  * @category models
@@ -47,11 +47,11 @@ export type SerializedArtifactRefNode = ArtifactRefNodeSchema.Encoded;
  *
  * **Example** (Typed creation input)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Typed creation input"
  * import type { ArtifactRefNodeCreateInput } from "@beep/editor/artifact-ref-node"
  *
  * const input: ArtifactRefNodeCreateInput = { artifactId: "artifact-123", label: "Quarterly report" }
- * console.log(input.artifactId) // "artifact-123"
+ * input.artifactId // => "artifact-123"
  * ```
  *
  * @category models

--- a/packages/foundation/ui-system/editor/src/capability/catalog.ts
+++ b/packages/foundation/ui-system/editor/src/capability/catalog.ts
@@ -77,11 +77,11 @@ const decodeCatalog = S.decodeUnknownResult(CapabilityCatalog);
  *
  * **Example** (Inspect the catalog)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Inspect the catalog"
  * import { editorCapabilityCatalog } from "@beep/editor/capability/catalog"
  * import { Array as A } from "effect"
  *
- * console.log(A.length(editorCapabilityCatalog) > 0) // true
+ * A.length(editorCapabilityCatalog) > 0 // => true
  * ```
  *
  * @category configuration

--- a/packages/foundation/ui-system/editor/src/capability/errors.ts
+++ b/packages/foundation/ui-system/editor/src/capability/errors.ts
@@ -17,14 +17,14 @@ const $I = $EditorId.create("capability/errors");
  *
  * **Example** (Create an unknown capability failure)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Create an unknown capability failure"
  * import { UnknownCapabilityError } from "@beep/editor/capability/errors"
  * import { CapabilityId, ProfileId } from "@beep/editor/capability/schemas"
  *
  * const error = UnknownCapabilityError.make({
  *   profileId: ProfileId.make("editor.test"), capabilityId: CapabilityId.make("node.missing")
  * })
- * console.log(error._tag) // "UnknownCapabilityError"
+ * error._tag // => "UnknownCapabilityError"
  * ```
  *
  * @category errors
@@ -51,7 +51,7 @@ export class UnknownCapabilityError extends S.TaggedError<UnknownCapabilityError
  *
  * **Example** (Create a missing dependency failure)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Create a missing dependency failure"
  * import { MissingDependencyError } from "@beep/editor/capability/errors"
  * import { CapabilityId, ProfileId } from "@beep/editor/capability/schemas"
  *
@@ -59,7 +59,7 @@ export class UnknownCapabilityError extends S.TaggedError<UnknownCapabilityError
  *   profileId: ProfileId.make("editor.test"), capabilityId: CapabilityId.make("authoring.undo"),
  *   dependencyId: CapabilityId.make("extension.history")
  * })
- * console.log(error.dependencyId) // "extension.history"
+ * error.dependencyId // => "extension.history"
  * ```
  *
  * @category errors
@@ -122,7 +122,7 @@ export class DependencyCycleError extends S.TaggedError<DependencyCycleError>($I
  *
  * **Example** (Create a capability conflict failure)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Create a capability conflict failure"
  * import { CapabilityConflictError } from "@beep/editor/capability/errors"
  * import { CapabilityId, ProfileId } from "@beep/editor/capability/schemas"
  *
@@ -130,7 +130,7 @@ export class DependencyCycleError extends S.TaggedError<DependencyCycleError>($I
  *   profileId: ProfileId.make("editor.test"), capabilityId: CapabilityId.make("node.a"),
  *   conflictsWith: CapabilityId.make("node.b")
  * })
- * console.log(error.conflictsWith) // "node.b"
+ * error.conflictsWith // => "node.b"
  * ```
  *
  * @category errors
@@ -158,14 +158,14 @@ export class CapabilityConflictError extends S.TaggedError<CapabilityConflictErr
  *
  * **Example** (Create a development-only failure)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Create a development-only failure"
  * import { DevelopmentOnlyCapabilityError } from "@beep/editor/capability/errors"
  * import { CapabilityId, ProfileId } from "@beep/editor/capability/schemas"
  *
  * const error = DevelopmentOnlyCapabilityError.make({
  *   profileId: ProfileId.make("editor.production"), capabilityId: CapabilityId.make("debug.raw-state")
  * })
- * console.log(error._tag) // "DevelopmentOnlyCapabilityError"
+ * error._tag // => "DevelopmentOnlyCapabilityError"
  * ```
  *
  * @category errors
@@ -194,7 +194,7 @@ export class DevelopmentOnlyCapabilityError extends S.TaggedError<DevelopmentOnl
  *
  * **Example** (Create an incompatible transformer failure)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Create an incompatible transformer failure"
  * import { IncompatibleRegistrationError } from "@beep/editor/capability/errors"
  * import { CapabilityId, ProfileId } from "@beep/editor/capability/schemas"
  *
@@ -202,7 +202,7 @@ export class DevelopmentOnlyCapabilityError extends S.TaggedError<DevelopmentOnl
  *   profileId: ProfileId.make("editor.test"), capabilityId: CapabilityId.make("transformer.heading"),
  *   registration: "HEADING", reason: "transformer requires interchange.markdown"
  * })
- * console.log(error.registration) // "HEADING"
+ * error.registration // => "HEADING"
  * ```
  *
  * @category errors
@@ -233,14 +233,14 @@ export class IncompatibleRegistrationError extends S.TaggedError<IncompatibleReg
  *
  * **Example** (Create an unknown command failure)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Create an unknown command failure"
  * import { UnknownCommandError } from "@beep/editor/capability/errors"
  * import { CommandId, ProfileId } from "@beep/editor/capability/schemas"
  *
  * const error = UnknownCommandError.make({
  *   profileId: ProfileId.make("editor.test"), commandId: CommandId.make("format.missing")
  * })
- * console.log(error.commandId) // "format.missing"
+ * error.commandId // => "format.missing"
  * ```
  *
  * @category errors
@@ -307,7 +307,7 @@ export class KeybindingConflictError extends S.TaggedError<KeybindingConflictErr
  *
  * **Example** (Decode a resolution failure)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode a resolution failure"
  * import { ProfileResolutionError, UnknownCapabilityError } from "@beep/editor/capability/errors"
  * import { CapabilityId, ProfileId } from "@beep/editor/capability/schemas"
  * import * as S from "effect/Schema"
@@ -315,7 +315,7 @@ export class KeybindingConflictError extends S.TaggedError<KeybindingConflictErr
  * const value = UnknownCapabilityError.make({
  *   profileId: ProfileId.make("editor.test"), capabilityId: CapabilityId.make("node.missing")
  * })
- * console.log(S.is(ProfileResolutionError)(value)) // true
+ * S.is(ProfileResolutionError)(value) // => true
  * ```
  *
  * @category errors

--- a/packages/foundation/ui-system/editor/src/capability/profiles.ts
+++ b/packages/foundation/ui-system/editor/src/capability/profiles.ts
@@ -22,10 +22,10 @@ const decodeProfile = S.decodeUnknownResult(EditorProfile);
  *
  * **Example** (Inspect the compatibility profile)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Inspect the compatibility profile"
  * import { compatibilityProfile } from "@beep/editor/capability/profiles"
  *
- * console.log(compatibilityProfile.kind) // "production"
+ * compatibilityProfile.kind // => "production"
  * ```
  *
  * @category configuration

--- a/packages/foundation/ui-system/editor/src/capability/projection.ts
+++ b/packages/foundation/ui-system/editor/src/capability/projection.ts
@@ -21,7 +21,7 @@ const $I = $EditorId.create("capability/projection");
  *
  * **Example** (Create an unbound help row)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Create an unbound help row"
  * import { ShortcutHelpEntry } from "@beep/editor/capability/projection"
  * import { CommandId } from "@beep/editor/capability/schemas"
  * import { Option } from "effect"
@@ -30,7 +30,7 @@ const $I = $EditorId.create("capability/projection");
  *   commandId: CommandId.make("format.bold"), label: "Bold", helpText: "Toggle bold.",
  *   chord: Option.none()
  * })
- * console.log(Option.isNone(entry.chord)) // true
+ * Option.isNone(entry.chord) // => true
  * ```
  *
  * @category projections
@@ -54,7 +54,7 @@ export class ShortcutHelpEntry extends S.Class<ShortcutHelpEntry>($I`ShortcutHel
  *
  * **Example** (Project an empty toolbar)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Project an empty toolbar"
  * import { projectCommands } from "@beep/editor/capability/projection"
  * import { CapabilityRegistrations, ProfileId, ResolvedEditorProfile } from "@beep/editor/capability/schemas"
  *
@@ -63,7 +63,7 @@ export class ShortcutHelpEntry extends S.Class<ShortcutHelpEntry>($I`ShortcutHel
  *   registrations: CapabilityRegistrations.make({ nodes: [], extensions: [], transformers: [] }),
  *   commands: [], guardedChords: []
  * })
- * console.log(projectCommands(resolved, "toolbar")) // []
+ * projectCommands(resolved, "toolbar") // => []
  * ```
  *
  * @category projections
@@ -88,7 +88,7 @@ export const projectCommands: {
  *
  * **Example** (Project empty shortcut help)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Project empty shortcut help"
  * import { projectShortcutHelp } from "@beep/editor/capability/projection"
  * import { CapabilityRegistrations, ProfileId, ResolvedEditorProfile } from "@beep/editor/capability/schemas"
  *
@@ -97,7 +97,7 @@ export const projectCommands: {
  *   registrations: CapabilityRegistrations.make({ nodes: [], extensions: [], transformers: [] }),
  *   commands: [], guardedChords: []
  * })
- * console.log(projectShortcutHelp(resolved, "apple")) // []
+ * projectShortcutHelp(resolved, "apple") // => []
  * ```
  *
  * @category projections
@@ -146,12 +146,12 @@ const formatModifier = (platform: Platform, modifier: Modifier): string =>
  *
  * **Example** (Format an Apple chord)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Format an Apple chord"
  * import { formatChord } from "@beep/editor/capability/projection"
  * import { KeyChord } from "@beep/editor/capability/schemas"
  *
  * const chord = KeyChord.make({ modifiers: ["meta", "shift"], key: "x" })
- * console.log(formatChord("apple", chord)) // "Cmd+Shift+X"
+ * formatChord("apple", chord) // => "Cmd+Shift+X"
  * ```
  *
  * @category formatting
@@ -176,7 +176,7 @@ export const formatChord: {
  *
  * **Example** (Project no slash commands)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Project no slash commands"
  * import { projectSlashItems } from "@beep/editor/capability/projection"
  * import { CapabilityRegistrations, ProfileId, ResolvedEditorProfile } from "@beep/editor/capability/schemas"
  *
@@ -185,7 +185,7 @@ export const formatChord: {
  *   registrations: CapabilityRegistrations.make({ nodes: [], extensions: [], transformers: [] }),
  *   commands: [], guardedChords: []
  * })
- * console.log(projectSlashItems(resolved, () => () => {})) // []
+ * projectSlashItems(resolved, () => () => {}) // => []
  * ```
  *
  * @category projections
@@ -223,12 +223,12 @@ const ariaModifier = Modifier.$match({
  *
  * **Example** (Serialize a chord for assistive technology)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Serialize a chord for assistive technology"
  * import { ariaKeyShortcuts } from "@beep/editor/capability/projection"
  * import { KeyChord } from "@beep/editor/capability/schemas"
  *
  * const chord = KeyChord.make({ modifiers: ["control", "alt"], key: "1" })
- * console.log(ariaKeyShortcuts(chord)) // "Control+Alt+1"
+ * ariaKeyShortcuts(chord) // => "Control+Alt+1"
  * ```
  *
  * @category formatting

--- a/packages/foundation/ui-system/editor/src/capability/resolver.ts
+++ b/packages/foundation/ui-system/editor/src/capability/resolver.ts
@@ -472,7 +472,7 @@ const firstResolutionError = (
  *
  * **Example** (Resolve an empty catalog)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Resolve an empty catalog"
  * import { resolveEditorProfile } from "@beep/editor/capability/resolver"
  * import { EditorProfile, ProfileId } from "@beep/editor/capability/schemas"
  * import { Result } from "effect"
@@ -480,7 +480,7 @@ const firstResolutionError = (
  * const result = resolveEditorProfile([], EditorProfile.make({
  *   id: ProfileId.make("editor.empty"), capabilities: []
  * }))
- * console.log(Result.isSuccess(result)) // true
+ * Result.isSuccess(result) // => true
  * ```
  *
  * @category workflows

--- a/packages/foundation/ui-system/editor/src/capability/runtime.tsx
+++ b/packages/foundation/ui-system/editor/src/capability/runtime.tsx
@@ -76,9 +76,9 @@ import type { CommandId, NodeRegistrationKey, Platform, ResolvedEditorProfile, T
 /** Runtime node constructors keyed by catalog registration name.
  *
  * **Example** (Read the paragraph registration)
- * ```ts
+ * ```ts import.meta.vitest name="Read the paragraph registration"
  * import { nodeRegistrations } from "@beep/editor/capability/runtime"
- * console.log(nodeRegistrations.ParagraphNode.name) // "ParagraphNode"
+ * nodeRegistrations.ParagraphNode.name // => "ParagraphNode"
  * ```
  * @category configuration
  * @since 0.0.0
@@ -104,9 +104,9 @@ export const nodeRegistrations: Record<NodeRegistrationKey, Klass<LexicalNode>> 
 /** Projects node constructors in resolved registration order.
  *
  * **Example** (Project readable nodes)
- * ```ts
+ * ```ts import.meta.vitest name="Project readable nodes"
  * import { resolvedNodes } from "@beep/editor/capability/runtime"
- * console.log(typeof resolvedNodes) // "function"
+ * typeof resolvedNodes // => "function"
  * ```
  * @category combinators
  * @since 0.0.0
@@ -117,9 +117,9 @@ export const resolvedNodes = (resolved: ResolvedEditorProfile): ReadonlyArray<Kl
 /** Markdown transformers keyed by catalog registration name.
  *
  * **Example** (Read heading transformer)
- * ```ts
+ * ```ts import.meta.vitest name="Read heading transformer"
  * import { transformerRegistrations } from "@beep/editor/capability/runtime"
- * console.log(transformerRegistrations.HEADING.type) // "element"
+ * transformerRegistrations.HEADING.type // => "element"
  * ```
  * @category configuration
  * @since 0.0.0
@@ -146,9 +146,9 @@ export const transformerRegistrations: Record<TransformerKey, Transformer> = {
 /** Projects Markdown transformers in resolved registration order.
  *
  * **Example** (Project transformers)
- * ```ts
+ * ```ts import.meta.vitest name="Project transformers"
  * import { resolvedTransformers } from "@beep/editor/capability/runtime"
- * console.log(typeof resolvedTransformers) // "function"
+ * typeof resolvedTransformers // => "function"
  * ```
  * @category combinators
  * @since 0.0.0
@@ -195,9 +195,9 @@ const toggleLink = (editor: LexicalEditor): void => {
 /** Executable Lexical handlers keyed by resolved command id.
  *
  * **Example** (Inspect the bold handler)
- * ```ts
+ * ```ts import.meta.vitest name="Inspect the bold handler"
  * import { commandHandlers } from "@beep/editor/capability/runtime"
- * console.log(typeof commandHandlers["format.bold"]) // "function"
+ * typeof commandHandlers["format.bold"] // => "function"
  * ```
  * @category commands
  * @since 0.0.0
@@ -231,9 +231,9 @@ export const commandHandlers: Readonly<Record<string, (editor: LexicalEditor) =>
 /** Runs a catalog command when a runtime handler exists.
  *
  * **Example** (Reference command runner)
- * ```ts
+ * ```ts import.meta.vitest name="Reference command runner"
  * import { runCommand } from "@beep/editor/capability/runtime"
- * console.log(typeof runCommand) // "function"
+ * typeof runCommand // => "function"
  * ```
  * @category commands
  * @since 0.0.0

--- a/packages/foundation/ui-system/editor/src/capability/schemas.ts
+++ b/packages/foundation/ui-system/editor/src/capability/schemas.ts
@@ -26,10 +26,10 @@ const dottedIdCheck = S.isPattern(dottedIdPattern, {
  *
  * **Example** (Create a capability identifier)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Create a capability identifier"
  * import { CapabilityId } from "@beep/editor/capability/schemas"
  *
- * console.log(CapabilityId.make("format.bold")) // "format.bold"
+ * CapabilityId.make("format.bold") // => "format.bold"
  * ```
  *
  * @category identifiers
@@ -56,10 +56,10 @@ export type CapabilityId = typeof CapabilityId.Type;
  *
  * **Example** (Create a command identifier)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Create a command identifier"
  * import { CommandId } from "@beep/editor/capability/schemas"
  *
- * console.log(CommandId.make("format.bold")) // "format.bold"
+ * CommandId.make("format.bold") // => "format.bold"
  * ```
  *
  * @category identifiers
@@ -86,10 +86,10 @@ export type CommandId = typeof CommandId.Type;
  *
  * **Example** (Create a profile identifier)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Create a profile identifier"
  * import { ProfileId } from "@beep/editor/capability/schemas"
  *
- * console.log(ProfileId.make("editor.reference")) // "editor.reference"
+ * ProfileId.make("editor.reference") // => "editor.reference"
  * ```
  *
  * @category identifiers
@@ -116,10 +116,10 @@ export type ProfileId = typeof ProfileId.Type;
  *
  * **Example** (Check a node category)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check a node category"
  * import { CapabilityCategory } from "@beep/editor/capability/schemas"
  *
- * console.log(CapabilityCategory.is.node("node")) // true
+ * CapabilityCategory.is.node("node") // => true
  * ```
  *
  * @category schemas
@@ -152,10 +152,10 @@ export type CapabilityCategory = typeof CapabilityCategory.Type;
  *
  * **Example** (Check an implementation disposition)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check an implementation disposition"
  * import { CapabilityDisposition } from "@beep/editor/capability/schemas"
  *
- * console.log(CapabilityDisposition.is.implement("implement")) // true
+ * CapabilityDisposition.is.implement("implement") // => true
  * ```
  *
  * @category schemas
@@ -181,10 +181,10 @@ export type CapabilityDisposition = typeof CapabilityDisposition.Type;
  *
  * **Example** (Check lossless compatibility)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check lossless compatibility"
  * import { CanonicalCompatibility } from "@beep/editor/capability/schemas"
  *
- * console.log(CanonicalCompatibility.is.lossless("lossless")) // true
+ * CanonicalCompatibility.is.lossless("lossless") // => true
  * ```
  *
  * @category schemas
@@ -210,10 +210,10 @@ export type CanonicalCompatibility = typeof CanonicalCompatibility.Type;
  *
  * **Example** (Check canonical rendering fallback)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check canonical rendering fallback"
  * import { ReadOnlyFallback } from "@beep/editor/capability/schemas"
  *
- * console.log(ReadOnlyFallback.is["render-canonical"]("render-canonical")) // true
+ * ReadOnlyFallback.is["render-canonical"]("render-canonical") // => true
  * ```
  *
  * @category schemas
@@ -239,10 +239,10 @@ export type ReadOnlyFallback = typeof ReadOnlyFallback.Type;
  *
  * **Example** (Check toolbar activation)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check toolbar activation"
  * import { ActivationSurface } from "@beep/editor/capability/schemas"
  *
- * console.log(ActivationSurface.is.toolbar("toolbar")) // true
+ * ActivationSurface.is.toolbar("toolbar") // => true
  * ```
  *
  * @category schemas
@@ -268,10 +268,10 @@ export type ActivationSurface = typeof ActivationSurface.Type;
  *
  * **Example** (Check Apple platform)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check Apple platform"
  * import { Platform } from "@beep/editor/capability/schemas"
  *
- * console.log(Platform.is.apple("apple")) // true
+ * Platform.is.apple("apple") // => true
  * ```
  *
  * @category schemas
@@ -297,10 +297,10 @@ export type Platform = typeof Platform.Type;
  *
  * **Example** (Inspect modifier order)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Inspect modifier order"
  * import { Modifier } from "@beep/editor/capability/schemas"
  *
- * console.log(Modifier.Options) // ["control", "meta", "alt", "shift"]
+ * Modifier.Options // => ["control", "meta", "alt", "shift"]
  * ```
  *
  * @category schemas
@@ -385,11 +385,11 @@ const sortedModifiers = S.makeFilter<ReadonlyArray<Modifier>>(
  *
  * **Example** (Create a canonical key chord)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Create a canonical key chord"
  * import { KeyChord } from "@beep/editor/capability/schemas"
  *
  * const chord = KeyChord.make({ modifiers: ["control", "shift"], key: "x" })
- * console.log(chord.key) // "x"
+ * chord.key // => "x"
  * ```
  *
  * @category models
@@ -430,13 +430,13 @@ const encodeChord = (chord: KeyChord): string =>
  *
  * **Example** (Decode an authored chord)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode an authored chord"
  * import { KeyChordFromString } from "@beep/editor/capability/schemas"
  * import { Result } from "effect"
  * import * as S from "effect/Schema"
  *
  * const result = S.decodeUnknownResult(KeyChordFromString)("Ctrl+Alt+1")
- * console.log(Result.isSuccess(result)) // true
+ * Result.isSuccess(result) // => true
  * ```
  *
  * @category codecs
@@ -469,14 +469,14 @@ export type KeyChordFromString = typeof KeyChordFromString.Type;
  *
  * **Example** (Create an Apple binding)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Create an Apple binding"
  * import { Keybinding, KeyChord } from "@beep/editor/capability/schemas"
  *
  * const binding = Keybinding.make({
  *   platform: "apple",
  *   chord: KeyChord.make({ modifiers: ["meta"], key: "b" })
  * })
- * console.log(binding.platform) // "apple"
+ * binding.platform // => "apple"
  * ```
  *
  * @category models
@@ -498,10 +498,10 @@ export class Keybinding extends S.Class<Keybinding>($I`Keybinding`)(
  *
  * **Example** (Check paragraph registration)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check paragraph registration"
  * import { NodeRegistrationKey } from "@beep/editor/capability/schemas"
  *
- * console.log(NodeRegistrationKey.is.ParagraphNode("ParagraphNode")) // true
+ * NodeRegistrationKey.is.ParagraphNode("ParagraphNode") // => true
  * ```
  *
  * @category schemas
@@ -543,10 +543,10 @@ export type NodeRegistrationKey = typeof NodeRegistrationKey.Type;
  *
  * **Example** (Check history extension)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check history extension"
  * import { ExtensionKey } from "@beep/editor/capability/schemas"
  *
- * console.log(ExtensionKey.is.HistoryPlugin("HistoryPlugin")) // true
+ * ExtensionKey.is.HistoryPlugin("HistoryPlugin") // => true
  * ```
  *
  * @category schemas
@@ -581,10 +581,10 @@ export type ExtensionKey = typeof ExtensionKey.Type;
  *
  * **Example** (Check heading transformer)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check heading transformer"
  * import { TransformerKey } from "@beep/editor/capability/schemas"
  *
- * console.log(TransformerKey.is.HEADING("HEADING")) // true
+ * TransformerKey.is.HEADING("HEADING") // => true
  * ```
  *
  * @category schemas
@@ -651,11 +651,11 @@ const uniqueCapabilityIds = uniqueValues<CapabilityId>("capability id");
  *
  * **Example** (Create empty registrations)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Create empty registrations"
  * import { CapabilityRegistrations } from "@beep/editor/capability/schemas"
  *
  * const registrations = CapabilityRegistrations.make({ nodes: [], extensions: [], transformers: [] })
- * console.log(registrations.nodes) // []
+ * registrations.nodes // => []
  * ```
  *
  * @category models
@@ -702,14 +702,14 @@ const uniqueBindingPlatforms = S.makeFilter<ReadonlyArray<Keybinding>>(
  *
  * **Example** (Create a toolbar command)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Create a toolbar command"
  * import { CommandDefinition, CommandId } from "@beep/editor/capability/schemas"
  *
  * const command = CommandDefinition.make({
  *   id: CommandId.make("format.bold"), label: "Bold", helpText: "Toggle bold.",
  *   surfaces: ["toolbar"], keybindings: []
  * })
- * console.log(command.label) // "Bold"
+ * command.label // => "Bold"
  * ```
  *
  * @category commands
@@ -738,11 +738,11 @@ export class CommandDefinition extends S.Class<CommandDefinition>($I`CommandDefi
  *
  * **Example** (Create a classification)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Create a classification"
  * import { CapabilityClassification } from "@beep/editor/capability/schemas"
  *
  * const value = CapabilityClassification.make({ category: "authoring", disposition: "implement" })
- * console.log(value.category) // "authoring"
+ * value.category // => "authoring"
  * ```
  *
  * @category models
@@ -764,7 +764,7 @@ export class CapabilityClassification extends S.Class<CapabilityClassification>(
  *
  * **Example** (Create a descriptor)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Create a descriptor"
  * import { CapabilityDescriptor, CapabilityId, CapabilityRegistrations } from "@beep/editor/capability/schemas"
  *
  * const value = CapabilityDescriptor.make({
@@ -775,7 +775,7 @@ export class CapabilityClassification extends S.Class<CapabilityClassification>(
  *   commands: [], readOnlyFallback: "render-canonical", canonicalCompatibility: "lossless",
  *   evidence: "editor-capability-atlas/v1#format.bold"
  * })
- * console.log(value.id) // "format.bold"
+ * value.id // => "format.bold"
  * ```
  *
  * @category models
@@ -914,12 +914,12 @@ const uniqueCatalogRegistrationKeys = S.makeFilter<ReadonlyArray<CapabilityDescr
  *
  * **Example** (Decode an empty catalog)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode an empty catalog"
  * import { CapabilityCatalog } from "@beep/editor/capability/schemas"
  * import { Result } from "effect"
  * import * as S from "effect/Schema"
  *
- * console.log(Result.isSuccess(S.decodeUnknownResult(CapabilityCatalog)([]))) // true
+ * Result.isSuccess(S.decodeUnknownResult(CapabilityCatalog)([])) // => true
  * ```
  *
  * @category schemas
@@ -947,10 +947,10 @@ export type CapabilityCatalog = typeof CapabilityCatalog.Type;
  *
  * **Example** (Check production profile kind)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check production profile kind"
  * import { ProfileKind } from "@beep/editor/capability/schemas"
  *
- * console.log(ProfileKind.is.production("production")) // true
+ * ProfileKind.is.production("production") // => true
  * ```
  *
  * @category schemas
@@ -976,11 +976,11 @@ export type ProfileKind = typeof ProfileKind.Type;
  *
  * **Example** (Unbind a command)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Unbind a command"
  * import { CommandId, KeybindingOverride } from "@beep/editor/capability/schemas"
  *
  * const value = KeybindingOverride.make({ commandId: CommandId.make("format.bold"), keybindings: [] })
- * console.log(value.keybindings) // []
+ * value.keybindings // => []
  * ```
  *
  * @category configuration
@@ -1022,11 +1022,11 @@ const uniqueOverrideCommandIds = S.makeFilter<ReadonlyArray<KeybindingOverride>>
  *
  * **Example** (Create a default production profile)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Create a default production profile"
  * import { EditorProfile, ProfileId } from "@beep/editor/capability/schemas"
  *
  * const profile = EditorProfile.make({ id: ProfileId.make("editor.empty"), capabilities: [] })
- * console.log(profile.kind) // "production"
+ * profile.kind // => "production"
  * ```
  *
  * @category configuration
@@ -1057,10 +1057,10 @@ export class EditorProfile extends S.Class<EditorProfile>($I`EditorProfile`)(
  *
  * **Example** (Check authoring mode)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check authoring mode"
  * import { CapabilityMode } from "@beep/editor/capability/schemas"
  *
- * console.log(CapabilityMode.is.authoring("authoring")) // true
+ * CapabilityMode.is.authoring("authoring") // => true
  * ```
  *
  * @category schemas
@@ -1086,13 +1086,13 @@ export type CapabilityMode = typeof CapabilityMode.Type;
  *
  * **Example** (Create a read-only capability)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Create a read-only capability"
  * import { CapabilityId, ResolvedCapability } from "@beep/editor/capability/schemas"
  *
  * const value = ResolvedCapability.make({
  *   id: CapabilityId.make("node.paragraph"), mode: "read-only", readOnlyFallback: "render-canonical"
  * })
- * console.log(value.mode) // "read-only"
+ * value.mode // => "read-only"
  * ```
  *
  * @category models
@@ -1115,14 +1115,14 @@ export class ResolvedCapability extends S.Class<ResolvedCapability>($I`ResolvedC
  *
  * **Example** (Create a resolved command)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Create a resolved command"
  * import { CapabilityId, CommandId, ResolvedCommand } from "@beep/editor/capability/schemas"
  *
  * const command = ResolvedCommand.make({
  *   id: CommandId.make("format.bold"), capabilityId: CapabilityId.make("format.bold"),
  *   label: "Bold", helpText: "Toggle bold.", surfaces: ["toolbar"], keybindings: []
  * })
- * console.log(command.label) // "Bold"
+ * command.label // => "Bold"
  * ```
  *
  * @category commands
@@ -1148,7 +1148,7 @@ export class ResolvedCommand extends S.Class<ResolvedCommand>($I`ResolvedCommand
  *
  * **Example** (Create an empty resolved profile)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Create an empty resolved profile"
  * import { CapabilityRegistrations, ProfileId, ResolvedEditorProfile } from "@beep/editor/capability/schemas"
  *
  * const value = ResolvedEditorProfile.make({
@@ -1156,7 +1156,7 @@ export class ResolvedCommand extends S.Class<ResolvedCommand>($I`ResolvedCommand
  *   registrations: CapabilityRegistrations.make({ nodes: [], extensions: [], transformers: [] }),
  *   commands: [], guardedChords: []
  * })
- * console.log(value.commands) // []
+ * value.commands // => []
  * ```
  *
  * @category models

--- a/packages/foundation/ui-system/editor/src/chat/atoms.ts
+++ b/packages/foundation/ui-system/editor/src/chat/atoms.ts
@@ -856,10 +856,10 @@ export interface SendHandlerBox {
  *
  * **Example** (Calling unbound sentinel)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Calling unbound sentinel"
  * import { unboundSend } from "@beep/editor/chat/atoms"
  *
- * console.log(unboundSend()) // undefined
+ * unboundSend() // => undefined
  * ```
  *
  * @category constants

--- a/packages/foundation/ui-system/editor/src/chat/attachment-model.ts
+++ b/packages/foundation/ui-system/editor/src/chat/attachment-model.ts
@@ -39,10 +39,10 @@ const decodeMimeType = S.decodeUnknownResult(MimeType);
  *
  * **Example** (Checking PNG MIME eligibility)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Checking PNG MIME eligibility"
  * import { IMAGE_MIME_TYPES } from "@beep/editor/chat/attachment-model"
  *
- * console.log(IMAGE_MIME_TYPES.includes("image/png")) // true
+ * IMAGE_MIME_TYPES.includes("image/png") // => true
  * ```
  *
  * @category configuration
@@ -56,10 +56,10 @@ export const IMAGE_MIME_TYPES = ImageMimeType.pickOptions(["image/png", "image/j
  *
  * **Example** (Validating image MIME type)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Validating image MIME type"
  * import { ImageAttachmentMimeType } from "@beep/editor/chat/attachment-model"
  *
- * console.log(ImageAttachmentMimeType.is("image/png")) // true
+ * ImageAttachmentMimeType.is("image/png") // => true
  * ```
  *
  * @category schemas
@@ -77,11 +77,11 @@ export const ImageAttachmentMimeType = S.Literals(IMAGE_MIME_TYPES).pipe(
  *
  * **Example** (Assigning image MIME type)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Assigning image MIME type"
  * import type { ImageAttachmentMimeType } from "@beep/editor/chat/attachment-model"
  *
  * const mimeType: ImageAttachmentMimeType = "image/png"
- * console.log(mimeType) // "image/png"
+ * mimeType // => "image/png"
  * ```
  *
  * @category models
@@ -94,11 +94,11 @@ export type ImageAttachmentMimeType = typeof ImageAttachmentMimeType.Type;
  *
  * **Example** (Converting default max to MB)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Converting default max to MB"
  * import { DEFAULT_MAX_ATTACHMENT_BYTES } from "@beep/editor/chat/attachment-model"
  *
  * const defaultMegabytes = DEFAULT_MAX_ATTACHMENT_BYTES / 1024 / 1024
- * console.log(defaultMegabytes) // 10
+ * defaultMegabytes // => 10
  * ```
  *
  * @category configuration
@@ -157,7 +157,7 @@ const resolveAttachmentCaptureLimitBytes = (maxBytes: number): number =>
  *
  * **Example** (Creating oversized file rejection)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Creating oversized file rejection"
  * import { AttachmentTooLarge } from "@beep/editor/chat/attachment-model"
  *
  * const rejection = new AttachmentTooLarge({
@@ -166,7 +166,7 @@ const resolveAttachmentCaptureLimitBytes = (maxBytes: number): number =>
  *   maxBytes: 10_485_760,
  * })
  *
- * console.log(rejection._tag) // "AttachmentTooLarge"
+ * rejection._tag // => "AttachmentTooLarge"
  * ```
  *
  * @category errors
@@ -190,7 +190,7 @@ export class AttachmentTooLarge extends S.TaggedError<AttachmentTooLarge>($I`Att
  *
  * **Example** (Creating invalid MIME rejection)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Creating invalid MIME rejection"
  * import { AttachmentInvalidMimeType } from "@beep/editor/chat/attachment-model"
  *
  * const rejection = new AttachmentInvalidMimeType({
@@ -198,7 +198,7 @@ export class AttachmentTooLarge extends S.TaggedError<AttachmentTooLarge>($I`Att
  *   mimeType: "",
  * })
  *
- * console.log(rejection._tag) // "AttachmentInvalidMimeType"
+ * rejection._tag // => "AttachmentInvalidMimeType"
  * ```
  *
  * @category errors
@@ -223,12 +223,12 @@ export class AttachmentInvalidMimeType extends S.TaggedError<AttachmentInvalidMi
  *
  * **Example** (Creating port failure error)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Creating port failure error"
  * import { AttachmentPortFailed } from "@beep/editor/chat/attachment-model"
  *
  * const failure = new AttachmentPortFailed({ message: "Files could not be attached." })
  *
- * console.log(failure._tag) // "AttachmentPortFailed"
+ * failure._tag // => "AttachmentPortFailed"
  * ```
  *
  * @category errors
@@ -255,7 +255,7 @@ export class AttachmentPortFailed extends S.TaggedError<AttachmentPortFailed>($I
  *
  * **Example** (Typing a capture rejection)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Typing a capture rejection"
  * import { AttachmentInvalidMimeType, type AttachmentRejection } from "@beep/editor/chat/attachment-model"
  *
  * const rejection: AttachmentRejection = new AttachmentInvalidMimeType({
@@ -263,7 +263,7 @@ export class AttachmentPortFailed extends S.TaggedError<AttachmentPortFailed>($I
  *   mimeType: "",
  * })
  *
- * console.log(rejection._tag) // "AttachmentInvalidMimeType"
+ * rejection._tag // => "AttachmentInvalidMimeType"
  * ```
  *
  * @category errors
@@ -283,7 +283,7 @@ export const AttachmentRejection = S.Union([AttachmentTooLarge, AttachmentInvali
  *
  * **Example** (Assigning rejection union type)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Assigning rejection union type"
  * import { AttachmentInvalidMimeType, type AttachmentRejection } from "@beep/editor/chat/attachment-model"
  *
  * const rejection: AttachmentRejection = new AttachmentInvalidMimeType({
@@ -291,7 +291,7 @@ export const AttachmentRejection = S.Union([AttachmentTooLarge, AttachmentInvali
  *   mimeType: "",
  * })
  *
- * console.log(rejection._tag) // "AttachmentInvalidMimeType"
+ * rejection._tag // => "AttachmentInvalidMimeType"
  * ```
  *
  * @category errors
@@ -305,13 +305,13 @@ export type AttachmentRejection = typeof AttachmentRejection.Type;
  *
  * **Example** (Typing an attachment failure)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Typing an attachment failure"
  * import { AttachmentPortFailed, type AttachmentFailure } from "@beep/editor/chat/attachment-model"
  *
  * const failure: AttachmentFailure = new AttachmentPortFailed({
  *   message: "Files could not be attached.",
  * })
- * console.log(failure._tag) // "AttachmentPortFailed"
+ * failure._tag // => "AttachmentPortFailed"
  * ```
  *
  * @category errors
@@ -330,13 +330,13 @@ export const AttachmentFailure = S.Union([AttachmentTooLarge, AttachmentInvalidM
  *
  * **Example** (Making attachment failure value)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Making attachment failure value"
  * import { AttachmentPortFailed, type AttachmentFailure } from "@beep/editor/chat/attachment-model"
  *
  * const failure: AttachmentFailure = AttachmentPortFailed.make({
  *   message: "Files could not be attached.",
  * })
- * console.log(failure._tag) // "AttachmentPortFailed"
+ * failure._tag // => "AttachmentPortFailed"
  * ```
  *
  * @category errors

--- a/packages/foundation/ui-system/editor/src/chat/chat-composer.tsx
+++ b/packages/foundation/ui-system/editor/src/chat/chat-composer.tsx
@@ -89,14 +89,14 @@ const PLACEHOLDER_CLASS_NAME =
  *
  * **Example** (Disable attachments in config)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Disable attachments in config"
  * import type { ChatComposerMountConfig } from "@beep/editor/chat/chat-composer"
  *
  * const mountConfig: ChatComposerMountConfig = {
  *   features: { attachments: false },
  *   maxAttachmentBytes: 5_000_000,
  * }
- * console.log(mountConfig.features?.attachments) // false
+ * mountConfig.features?.attachments // => false
  * ```
  *
  * @category configuration
@@ -127,7 +127,7 @@ export interface ChatComposerMountConfig {
  *
  * **Example** (Props with sendOn feature)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Props with sendOn feature"
  * import type { ChatComposerProps } from "@beep/editor/chat/chat-composer"
  *
  * const props: ChatComposerProps = {
@@ -138,7 +138,7 @@ export interface ChatComposerMountConfig {
  * }
  *
  * const sendOn = props.mountConfig?.features?.sendOn
- * console.log(sendOn) // "modifierEnter"
+ * sendOn // => "modifierEnter"
  * ```
  *
  * @category components

--- a/packages/foundation/ui-system/editor/src/chat/config.ts
+++ b/packages/foundation/ui-system/editor/src/chat/config.ts
@@ -33,10 +33,10 @@ const $I = $EditorId.create("chat/config");
  *
  * **Example** (Check enter send mode)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check enter send mode"
  * import { SendOn } from "@beep/editor/chat/config"
  *
- * console.log(SendOn.is.enter("enter")) // true
+ * SendOn.is.enter("enter") // => true
  * ```
  *
  * @category configuration
@@ -53,11 +53,11 @@ export const SendOn = LiteralKit(["enter", "modifierEnter"]).pipe(
  *
  * **Example** (Assign modifierEnter value)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Assign modifierEnter value"
  * import type { SendOn } from "@beep/editor/chat/config"
  *
  * const sendOn: SendOn = "modifierEnter"
- * console.log(sendOn) // "modifierEnter"
+ * sendOn // => "modifierEnter"
  * ```
  *
  * @category models
@@ -73,12 +73,12 @@ export type SendOn = typeof SendOn.Type;
  *
  * **Example** (Partial features with defaults)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Partial features with defaults"
  * import { ComposerFeatures } from "@beep/editor/chat/config"
  *
  * const chat = ComposerFeatures.make({ toolbar: false })
- * console.log(chat.slash) // true
- * console.log(chat.sendOn) // "enter"
+ * chat.slash // => true
+ * chat.sendOn // => "enter"
  * ```
  *
  * @category configuration
@@ -122,7 +122,7 @@ export class ComposerFeatures extends S.Class<ComposerFeatures>($I`ComposerFeatu
  *
  * **Example** (Focus editor effect callback)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Focus editor effect callback"
  * import type { EditorEffect } from "@beep/editor/chat/config"
  *
  * const focusEditor: EditorEffect = (editor) => {
@@ -130,7 +130,7 @@ export class ComposerFeatures extends S.Class<ComposerFeatures>($I`ComposerFeatu
  * }
  *
  * const callbackArity = focusEditor.length
- * console.log(callbackArity) // 1
+ * callbackArity // => 1
  * ```
  *
  * @category models
@@ -154,11 +154,11 @@ const EditorEffectSchema = S.declare<EditorEffect>(isEditorEffect).pipe(
  *
  * **Example** (Make heading slash item)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make heading slash item"
  * import { SlashItem } from "@beep/editor/chat/config"
  *
  * const item = SlashItem.make({ key: "h1", label: "Heading 1", onSelect: () => {} })
- * console.log(item.label) // "Heading 1"
+ * item.label // => "Heading 1"
  * ```
  *
  * @category configuration
@@ -218,7 +218,7 @@ const uniqueSlashItemKeys = S.makeFilter<ReadonlyArray<SlashItem>>(
  *
  * **Example** (Decode slash items array)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode slash items array"
  * import { SlashItem, SlashItems } from "@beep/editor/chat/config"
  * import { Result } from "effect"
  * import * as S from "effect/Schema"
@@ -226,7 +226,7 @@ const uniqueSlashItemKeys = S.makeFilter<ReadonlyArray<SlashItem>>(
  * const items = S.decodeUnknownResult(SlashItems)([
  *   SlashItem.make({ key: "paragraph", label: "Paragraph", onSelect: () => {} }),
  * ])
- * console.log(Result.isSuccess(items)) // true
+ * Result.isSuccess(items) // => true
  * ```
  *
  * @category configuration
@@ -245,11 +245,11 @@ export const SlashItems = S.Array(SlashItem)
  *
  * **Example** (Type empty slash items)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Type empty slash items"
  * import type { SlashItems } from "@beep/editor/chat/config"
  *
  * const items: SlashItems = []
- * console.log(items.length) // 0
+ * items.length // => 0
  * ```
  *
  * @category models
@@ -263,11 +263,11 @@ export type SlashItems = typeof SlashItems.Type;
  *
  * **Example** (Make mention option)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make mention option"
  * import { MentionOption } from "@beep/editor/chat/config"
  *
  * const option = MentionOption.make({ id: "u1", label: "Ada Lovelace" })
- * console.log(option.label) // "Ada Lovelace"
+ * option.label // => "Ada Lovelace"
  * ```
  *
  * @category configuration
@@ -317,13 +317,13 @@ const uniqueMentionOptionIds = S.makeFilter<ReadonlyArray<MentionOption>>(
  *
  * **Example** (Decode mention options array)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode mention options array"
  * import { MentionOptions } from "@beep/editor/chat/config"
  * import { Result } from "effect"
  * import * as S from "effect/Schema"
  *
  * const options = S.decodeUnknownResult(MentionOptions)([{ id: "ada", label: "Ada" }])
- * console.log(Result.isSuccess(options)) // true
+ * Result.isSuccess(options) // => true
  * ```
  *
  * @category configuration
@@ -342,11 +342,11 @@ export const MentionOptions = S.Array(MentionOption)
  *
  * **Example** (Type empty mention options)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Type empty mention options"
  * import type { MentionOptions } from "@beep/editor/chat/config"
  *
  * const options: MentionOptions = []
- * console.log(options.length) // 0
+ * options.length // => 0
  * ```
  *
  * @category models
@@ -361,11 +361,11 @@ export type MentionOptions = typeof MentionOptions.Type;
  *
  * **Example** (Validate mention source function)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Validate mention source function"
  * import { MentionSource } from "@beep/editor/chat/config"
  * import * as S from "effect/Schema"
  *
- * console.log(S.is(MentionSource)((q: string) => [])) // true
+ * S.is(MentionSource)((q: string) => []) // => true
  * ```
  *
  * @category configuration
@@ -381,7 +381,7 @@ const isMentionSource = (u: unknown): u is MentionSource => P.isFunction(u);
  *
  * **Example** (Check source against schema)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check source against schema"
  * import { MentionOption, MentionSource } from "@beep/editor/chat/config"
  * import * as S from "effect/Schema"
  *
@@ -389,7 +389,7 @@ const isMentionSource = (u: unknown): u is MentionSource => P.isFunction(u);
  *   MentionOption.make({ id: query, label: `@${query}` }),
  * ]
  *
- * console.log(S.is(MentionSource)(source)) // true
+ * S.is(MentionSource)(source) // => true
  * ```
  *
  * @category configuration
@@ -427,11 +427,11 @@ export type AttachmentPort = (files: ReadonlyArray<File>) => void | Promise<void
  *
  * **Example** (Define send port callback)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Define send port callback"
  * import type { SendPort } from "@beep/editor/chat/config"
  *
  * const send: SendPort = (state) => state.root.children.length > 0
- * console.log(typeof send) // "function"
+ * typeof send // => "function"
  * ```
  *
  * @category configuration

--- a/packages/foundation/ui-system/editor/src/chat/slash-items.tsx
+++ b/packages/foundation/ui-system/editor/src/chat/slash-items.tsx
@@ -45,10 +45,10 @@ const heading = (editor: LexicalEditor, tag: HeadingTagType): void => setBlock(e
  *
  * **Example** (Log default slash items)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Log default slash items"
  * import { defaultChatSlashItems } from "@beep/editor/chat/slash-items"
  *
- * console.log(defaultChatSlashItems.length > 0) // true
+ * defaultChatSlashItems.length > 0 // => true
  * ```
  *
  * @category configuration

--- a/packages/foundation/ui-system/editor/src/chat/toolbar.tsx
+++ b/packages/foundation/ui-system/editor/src/chat/toolbar.tsx
@@ -63,10 +63,10 @@ const $I = $EditorId.create("chat/toolbar");
  *
  * **Example** (Check code block type)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Check code block type"
  * import { BlockType } from "@beep/editor/chat/toolbar"
  *
- * console.log(BlockType.is.code("code")) // true
+ * BlockType.is.code("code") // => true
  * ```
  *
  * @category schemas
@@ -96,11 +96,11 @@ export const BlockType = LiteralKit([
  *
  * **Example** (Assign selected block type)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Assign selected block type"
  * import type { BlockType } from "@beep/editor/chat/toolbar"
  *
  * const selectedBlock: BlockType = "code"
- * console.log(selectedBlock) // "code"
+ * selectedBlock // => "code"
  * ```
  *
  * @category models

--- a/packages/foundation/ui-system/editor/src/chat/typeahead.tsx
+++ b/packages/foundation/ui-system/editor/src/chat/typeahead.tsx
@@ -220,10 +220,10 @@ const MENU_VIEWPORT_GAP_PX = 4;
  *
  * **Example** (True when caret near bottom)
  *
- * ```ts
+ * ```ts import.meta.vitest name="True when caret near bottom"
  * import { shouldOpenUpward } from "@beep/editor/chat/typeahead"
  *
- * console.log(shouldOpenUpward({ caretTop: 700, caretBottom: 720, viewportHeight: 800 })) // true
+ * shouldOpenUpward({ caretTop: 700, caretBottom: 720, viewportHeight: 800 }) // => true
  * ```
  *
  * @category utilities
@@ -248,7 +248,7 @@ export const shouldOpenUpward = ({
  *
  * **Example** (Clamped position above caret)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Clamped position above caret"
  * import { typeaheadMenuPosition } from "@beep/editor/chat/typeahead"
  *
  * const position = typeaheadMenuPosition({
@@ -256,7 +256,7 @@ export const shouldOpenUpward = ({
  *   viewportHeight: 800,
  *   viewportWidth: 1280
  * })
- * console.log(position.bottom) // 104
+ * position.bottom // => 104
  * ```
  *
  * @category utilities

--- a/packages/foundation/ui-system/editor/src/code-block-node.tsx
+++ b/packages/foundation/ui-system/editor/src/code-block-node.tsx
@@ -41,7 +41,7 @@ const schemaIssueToError = (cause: S.SchemaError | S.SchemaError["issue"]): S.Sc
  *
  * **Example** (Make typescript code payload)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make typescript code payload"
  * import { SerializedCodeBlockNode } from "@beep/editor/code-block-node"
  *
  * const payload = SerializedCodeBlockNode.make({
@@ -51,7 +51,7 @@ const schemaIssueToError = (cause: S.SchemaError | S.SchemaError["issue"]): S.Sc
  *   language: "typescript",
  * })
  *
- * console.log(payload.language) // "typescript"
+ * payload.language // => "typescript"
  * ```
  *
  * @category models

--- a/packages/foundation/ui-system/editor/src/composer.tsx
+++ b/packages/foundation/ui-system/editor/src/composer.tsx
@@ -42,10 +42,10 @@ const resolvedCompatibilityProfile = Result.getOrThrow(
  *
  * **Example** (Import markdown transformers)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Import markdown transformers"
  * import { markdownTransformers } from "@beep/editor/composer"
  *
- * console.log(markdownTransformers.length > 0) // true
+ * markdownTransformers.length > 0 // => true
  * ```
  *
  * @category configuration
@@ -58,11 +58,11 @@ export const markdownTransformers = TRANSFORMERS;
  *
  * **Example** (Type EditorComposer props)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Type EditorComposer props"
  * import type { EditorComposerProps } from "@beep/editor/composer"
  *
  * const props: EditorComposerProps = { placeholder: "Draft response" }
- * console.log(props.placeholder) // "Draft response"
+ * props.placeholder // => "Draft response"
  * ```
  *
  * @category models
@@ -90,7 +90,7 @@ export interface EditorComposerProps {
  *
  * **Example** (Type wire composer props)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Type wire composer props"
  * import type { EditorWireComposerProps } from "@beep/editor/composer"
  *
  * const props: EditorWireComposerProps = {
@@ -104,7 +104,7 @@ export interface EditorComposerProps {
  *     }
  *   },
  * }
- * console.log(typeof props.input) // "object"
+ * typeof props.input // => "object"
  * ```
  *
  * @category models

--- a/packages/foundation/ui-system/editor/src/index.ts
+++ b/packages/foundation/ui-system/editor/src/index.ts
@@ -12,11 +12,11 @@
  *
  * **Example** (Read package version)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Read package version"
  * import { VERSION } from "@beep/editor"
  *
  * const packageVersion: "0.0.0" = VERSION
- * console.log(packageVersion) // "0.0.0"
+ * packageVersion // => "0.0.0"
  * ```
  *
  * @category configuration

--- a/packages/foundation/ui-system/editor/src/mermaid-node.tsx
+++ b/packages/foundation/ui-system/editor/src/mermaid-node.tsx
@@ -41,7 +41,7 @@ const decodeSerializedMermaidNode = (input: unknown) => S.decodeUnknownResult(Se
  *
  * **Example** (Make serialized mermaid payload)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make serialized mermaid payload"
  * import { SerializedMermaidNode } from "@beep/editor/mermaid-node"
  *
  * const payload = SerializedMermaidNode.make({
@@ -50,7 +50,7 @@ const decodeSerializedMermaidNode = (input: unknown) => S.decodeUnknownResult(Se
  *   source: "graph TD\n  A --> B",
  * })
  *
- * console.log(payload.source) // "graph TD\n  A --> B"
+ * payload.source // => "graph TD\n  A --> B"
  * ```
  *
  * @category models

--- a/packages/foundation/ui-system/editor/src/mermaid-view.tsx
+++ b/packages/foundation/ui-system/editor/src/mermaid-view.tsx
@@ -33,11 +33,11 @@ const unsafeDiagramMessage = "Diagram output did not satisfy the desktop safety 
  *
  * **Example** (Make mermaid render error)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Make mermaid render error"
  * import { MermaidRenderError } from "@beep/editor/mermaid-view"
  *
  * const error = MermaidRenderError.make({ message: "Unable to render diagram." })
- * console.log(error._tag) // "MermaidRenderError"
+ * error._tag // => "MermaidRenderError"
  * ```
  *
  * @category errors

--- a/packages/foundation/ui-system/editor/src/nodes.ts
+++ b/packages/foundation/ui-system/editor/src/nodes.ts
@@ -25,10 +25,10 @@ const catalogBaseline = Result.getOrThrow(resolveEditorProfile(editorCapabilityC
  *
  * **Example** (Import and length check)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Import and length check"
  * import { editorNodes } from "@beep/editor/nodes"
  *
- * console.log(editorNodes.length > 0) // true
+ * editorNodes.length > 0 // => true
  * ```
  *
  * @category configuration

--- a/packages/foundation/ui-system/editor/src/runtime.ts
+++ b/packages/foundation/ui-system/editor/src/runtime.ts
@@ -39,7 +39,7 @@ const revalidateSerializedEditorState = (
  *
  * **Example** (Decode valid root state)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Decode valid root state"
  * import { Result } from "effect"
  * import { decodeEditorStateForRuntimeResult } from "@beep/editor/runtime"
  *
@@ -52,7 +52,7 @@ const revalidateSerializedEditorState = (
  *     }]
  *   },
  * })
- * console.log(Result.isSuccess(result)) // true
+ * Result.isSuccess(result) // => true
  * ```
  *
  * @category decoding
@@ -106,11 +106,11 @@ export const decodeEditorStateForRuntime = (input: unknown): Effect.Effect<Seria
  *
  * **Example** (Absent state stays None)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Absent state stays None"
  * import * as O from "effect/Option"
  * import { runtimeInitialStateOption } from "@beep/editor/runtime"
  *
- * console.log(O.isNone(runtimeInitialStateOption(undefined))) // true
+ * O.isNone(runtimeInitialStateOption(undefined)) // => true
  * ```
  *
  * @category decoding

--- a/packages/foundation/ui-system/editor/src/viewer.tsx
+++ b/packages/foundation/ui-system/editor/src/viewer.tsx
@@ -127,14 +127,14 @@ const encodeOnce = (state: SerializedEditorState.Type): { readonly decorated: st
  *
  * **Example** (Build props with className)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Build props with className"
  * import type { EditorViewerProps } from "@beep/editor/viewer"
  *
  * const withProse = (state: EditorViewerProps["state"]): EditorViewerProps => ({
  *   state,
  *   className: "prose",
  * })
- * console.log(typeof withProse) // "function"
+ * typeof withProse // => "function"
  * ```
  *
  * @category models
@@ -152,13 +152,13 @@ export interface EditorViewerProps {
  *
  * **Example** (Minimal result-only props)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Minimal result-only props"
  * import type { EditorCompatibilityViewerProps } from "@beep/editor/viewer"
  *
  * const withoutExtraClasses = (
  *   result: EditorCompatibilityViewerProps["result"]
  * ): EditorCompatibilityViewerProps => ({ result })
- * console.log(typeof withoutExtraClasses) // "function"
+ * typeof withoutExtraClasses // => "function"
  * ```
  *
  * @category models
@@ -176,7 +176,7 @@ export interface EditorCompatibilityViewerProps {
  *
  * **Example** (Props with wire input)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Props with wire input"
  * import type { EditorWireViewerProps } from "@beep/editor/viewer"
  *
  * const props: EditorWireViewerProps = {
@@ -190,7 +190,7 @@ export interface EditorCompatibilityViewerProps {
  *     }
  *   },
  * }
- * console.log(typeof props.input) // "object"
+ * typeof props.input // => "object"
  * ```
  *
  * @category models

--- a/packages/foundation/ui-system/editor/src/youtube-embed.tsx
+++ b/packages/foundation/ui-system/editor/src/youtube-embed.tsx
@@ -177,10 +177,10 @@ export interface YouTubeEmbedProps {
  *
  * **Example** (Sandbox denies top navigation)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Sandbox denies top navigation"
  * import { YOUTUBE_EMBED_SANDBOX } from "@beep/editor/youtube-embed"
  *
- * console.log(YOUTUBE_EMBED_SANDBOX.includes("allow-top-navigation")) // false
+ * YOUTUBE_EMBED_SANDBOX.includes("allow-top-navigation") // => false
  * ```
  *
  * @category configuration

--- a/packages/foundation/ui-system/editor/src/youtube-node.tsx
+++ b/packages/foundation/ui-system/editor/src/youtube-node.tsx
@@ -30,7 +30,7 @@ import type { JSX } from "react";
  *
  * **Example** (Serialized wire payload)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Serialized wire payload"
  * import type { SerializedYouTubeNode } from "@beep/editor/youtube-node"
  *
  * const payload = {
@@ -41,7 +41,7 @@ import type { JSX } from "react";
  * } satisfies SerializedYouTubeNode
  *
  * const videoID: string = payload.videoID
- * console.log(videoID) // "M7lc1UVf-VE"
+ * videoID // => "M7lc1UVf-VE"
  * ```
  *
  * @category models

--- a/packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts
+++ b/packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts
@@ -386,15 +386,15 @@ type SpinParamsValue = {
  *
  * **Example** (Parse editable text into a number)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Parse editable text into a number"
  * import * as O from "effect/Option"
  * import { toNumber } from "@beep/ui/hooks/useNumberInput"
  *
  * const parsed = O.getOrUndefined(toNumber("12.5"))
  * const missing = toNumber("")
  *
- * console.log(parsed) // 12.5
- * console.log(O.isNone(missing)) // true
+ * parsed // => 12.5
+ * O.isNone(missing) // => true
  * ```
  *
  * @category utilities
@@ -414,14 +414,14 @@ export const toNumber: (input: unknown) => O.Option<number> = S.decodeUnknownOpt
  *
  * **Example** (Format a value at fixed precision)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Format a value at fixed precision"
  * import { numberToString } from "@beep/ui/hooks/useNumberInput"
  *
  * const formatted = numberToString(12.345, 2)
  * const empty = numberToString(undefined, 2)
  *
- * console.log(formatted) // "12.35"
- * console.log(empty) // ""
+ * formatted // => "12.35"
+ * empty // => ""
  * ```
  *
  * @category utilities
@@ -453,25 +453,25 @@ export const numberToString: {
  *
  * **Example** (Apply shift and ctrl modifiers)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Apply shift and ctrl modifiers"
  * import { getStepFactor } from "@beep/ui/hooks/useNumberInput"
  *
  * const coarse = getStepFactor({ shiftKey: true }, 2, { precision: 0 })
  * const fine = getStepFactor({ ctrlKey: true }, 2, { precision: 2 })
  *
- * console.log(coarse) // 20
- * console.log(fine) // 0.2
+ * coarse // => 20
+ * fine // => 0.2
  * ```
  *
  * **Example** (Apply the data-last form in a pipe)
  *
- * ```typescript
+ * ```ts import.meta.vitest name="Apply the data-last form in a pipe"
  * import { pipe } from "effect"
  * import { getStepFactor } from "@beep/ui/hooks/useNumberInput"
  *
  * const factor = pipe({ metaKey: true }, getStepFactor(5, { precision: 2 }))
  *
- * console.log(factor) // 0.5
+ * factor // => 0.5
  * ```
  *
  * @category utilities

--- a/packages/foundation/ui-system/ui/src/lib/react-invariant.ts
+++ b/packages/foundation/ui-system/ui/src/lib/react-invariant.ts
@@ -83,11 +83,11 @@ type RequiredReactContext<Value> = Value extends unknown ? Value : never;
  *
  * **Example** (Require context under provider)
  *
- * ```ts
+ * ```ts import.meta.vitest name="Require context under provider"
  * import { requireReactContext } from "@beep/ui/lib/react-invariant"
  *
  * const value = requireReactContext("ok", { message: "missing provider" })
- * console.log(value) // "ok"
+ * value // => "ok"
  * ```
  *
  * @category utilities


### PR DESCRIPTION
## What

Chunk 3 of the doctest marking campaign (after #838 foundation/modeling and #843
capability/primitive): apply the `beep docgen doctest mark` codemod to
`packages/foundation/ui-system/**` with the six hardened rules from chunks 1-2 applied before
publish. This family is React/DOM-heavy, so the retained set is deliberately small and honest.

- 129 fences marked across 29 source files (dock 25, editor 100, ui 5, incl. non-JSX fences in
  tsx hosts); 133 console-to-assertion rewrites retained.
- 363 of 492 pure candidates conservatively restored unmarked: 338 bare-console/no-stable-claim,
  10 DOM/Web API, 5 URL-adjacent, 5 definition-only, 4 Lexical active-editor-context, 1
  environment detection.
- JSX fences excluded by the purity classifier (517 impure candidates never marked).
- Generator surfaces untouched: brand rendered assets and shadcn/registry components proven
  byte-identical to HEAD via `git diff --exit-code`.
- No stale claims found — every retained assertion matched runtime truth on first run.
- Rule audit: 0 backticked names, 0 collisions, 0 bare console.log, 0 DOM/env patterns, 0
  claim-free marked fences.

## Verification

- `bunx vitest run --config vitest.docs.ts`: full corpus 338 files / 2,429 doctests green
  (default-parallel runs flake only on the inherited `Tools/index.ts` cold-start timeout, which
  passes focused and with `--maxWorkers=8`; nothing suppressed).
- ESLint over every changed file: 0 errors, 0 warnings. `docgen:local` green twice.
- `beep quality test-tsgo`, `fallow audit --check` (`introduced: 0`), jsdoc inventory + ratchet
  (`increased=0`), `changeset-status`: all green.
- Changeset: `@beep/dock`, `@beep/editor`, `@beep/ui` at `patch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790348996&installation_model_id=424656&pr_number=844&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F844&signature=c2d54f9bd577cfbe707a211f4bd5fbc5921d0a19a071e8a92ad5fa455395ddc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->