### PR TITLE
fix(repo-cli): isolate Yeet proof locks

### DIFF
--- a/.changeset/yeet-private-proof-locks.md
+++ b/.changeset/yeet-private-proof-locks.md
@@ -1,0 +1,5 @@
+---
+"@beep/repo-cli": patch
+---
+
+Keep Yeet proof locks in a private, owner-validated runtime directory.

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/ArtifactPaths.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/ArtifactPaths.ts
@@ -6,7 +6,7 @@
  */
 
 import { createHash } from "node:crypto";
-import { tmpdir } from "node:os";
+import { hostname, userInfo } from "node:os";
 import { $RepoCliId } from "@beep/identity/packages";
 import { LiteralKit } from "@beep/schema";
 import { Effect, flow, Path, pipe } from "effect";
@@ -14,6 +14,7 @@ import * as A from "effect/Array";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
 import * as Str from "effect/String";
+import { configStringOption } from "../../../internal/cli/EnvConfig.ts";
 import type { RepoRunContext } from "../../../internal/repo-run/index.ts";
 
 const $I = $RepoCliId.create("commands/Yeet/internal/ArtifactPaths");
@@ -130,6 +131,26 @@ export const safeArtifactName: (value: string) => string = flow(
 
 const artifactNameHash = (value: string): string => createHash("sha256").update(value).digest("hex").slice(0, 12);
 
+const effectiveUserId = (): number =>
+  pipe(
+    O.fromUndefinedOr(process.geteuid),
+    O.map((getEffectiveUserId) => getEffectiveUserId()),
+    O.getOrElse(() => userInfo().uid)
+  );
+
+const proofCoordinatorRuntimeRoot = Effect.fn("Yeet.proofCoordinatorRuntimeRoot")(function* () {
+  const path = yield* Path.Path;
+  const configuredRuntimeRoot = yield* configStringOption("XDG_RUNTIME_DIR");
+  return pipe(
+    configuredRuntimeRoot,
+    O.filter(Str.isNonEmpty),
+    O.getOrElse(() => path.join(userInfo().homedir, ".cache"))
+  );
+});
+
+const proofCoordinatorDirectoryName = (): string =>
+  `beep-yeet-proof-locks-${artifactNameHash(hostname())}-uid-${effectiveUserId()}`;
+
 /**
  * Resolve the machine-local coordinator path for one repository identity.
  *
@@ -138,7 +159,9 @@ const artifactNameHash = (value: string): string => createHash("sha256").update(
  * Recognized Git remotes first normalize to a lowercase host plus repository
  * path. Equivalent SCP, SSH, HTTPS, and Git URLs therefore share a lock. The
  * normalized identity is hashed before it reaches the path, so a
- * credential-bearing remote URL never appears in a filename.
+ * credential-bearing remote URL never appears in a filename. Lock files live
+ * under the effective user's XDG runtime directory, with a user-cache fallback,
+ * and the namespace includes opaque machine identity plus the effective UID.
  *
  * **Example** (Share a coordinator across checkouts)
  *
@@ -160,9 +183,10 @@ export const proofCoordinatorLockPath = Effect.fn("Yeet.proofCoordinatorLockPath
   repositoryIdentity: string
 ): Effect.fn.Return<string, never, Path.Path> {
   const path = yield* Path.Path;
+  const runtimeRoot = yield* proofCoordinatorRuntimeRoot();
   return path.join(
-    tmpdir(),
-    "beep-yeet-proof-locks",
+    runtimeRoot,
+    proofCoordinatorDirectoryName(),
     `${artifactNameHash(canonicalRepositoryIdentity(repositoryIdentity))}.lock`
   );
 });

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/ArtifactPaths.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/ArtifactPaths.ts
@@ -6,7 +6,7 @@
  */
 
 import { createHash } from "node:crypto";
-import { hostname, userInfo } from "node:os";
+import { hostname, tmpdir, userInfo } from "node:os";
 import { $RepoCliId } from "@beep/identity/packages";
 import { LiteralKit } from "@beep/schema";
 import { Effect, flow, Path, pipe } from "effect";
@@ -131,21 +131,12 @@ export const safeArtifactName: (value: string) => string = flow(
 
 const artifactNameHash = (value: string): string => createHash("sha256").update(value).digest("hex").slice(0, 12);
 
-const effectiveUserId = (): number =>
-  pipe(
-    O.fromUndefinedOr(process.geteuid),
-    O.map((getEffectiveUserId) => getEffectiveUserId()),
-    O.getOrElse(() => userInfo().uid)
-  );
+const effectiveUserId = (): number => userInfo().uid;
 
 const proofCoordinatorRuntimeRoot = Effect.fn("Yeet.proofCoordinatorRuntimeRoot")(function* () {
   const path = yield* Path.Path;
   const configuredRuntimeRoot = yield* configStringOption("XDG_RUNTIME_DIR");
-  return pipe(
-    configuredRuntimeRoot,
-    O.filter(Str.isNonEmpty),
-    O.getOrElse(() => path.join(userInfo().homedir, ".cache"))
-  );
+  return pipe(configuredRuntimeRoot, O.filter(Str.isNonEmpty), O.filter(path.isAbsolute), O.getOrElse(tmpdir));
 });
 
 const proofCoordinatorDirectoryName = (): string =>
@@ -160,8 +151,9 @@ const proofCoordinatorDirectoryName = (): string =>
  * path. Equivalent SCP, SSH, HTTPS, and Git URLs therefore share a lock. The
  * normalized identity is hashed before it reaches the path, so a
  * credential-bearing remote URL never appears in a filename. Lock files live
- * under the effective user's XDG runtime directory, with a user-cache fallback,
- * and the namespace includes opaque machine identity plus the effective UID.
+ * under an absolute XDG runtime directory, with an ephemeral system-temporary
+ * fallback, and the namespace includes opaque machine identity plus the
+ * effective UID.
  *
  * **Example** (Share a coordinator across checkouts)
  *

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/ProofState.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/ProofState.ts
@@ -347,7 +347,12 @@ const validateProofCoordinatorOwnership = Effect.fn("Yeet.validateProofCoordinat
     O.exists(info.uid, (owner) => owner === effectiveUserId),
     `Yeet proof lock directory ${directory} reported ${reportedOwner}; expected effective uid ${effectiveUserId}. Refusing to use it.`
   );
+});
 
+const validateProofCoordinatorMode = Effect.fn("Yeet.validateProofCoordinatorMode")(function* (
+  directory: string,
+  info: FileSystem.File.Info
+) {
   const mode = info.mode & 0o777;
   yield* requireSafeProofCoordinator(
     mode === 0o700,
@@ -360,22 +365,20 @@ const validateProofCoordinatorDirectory = Effect.fn("Yeet.validateProofCoordinat
   effectiveUserId: O.Option<number>
 ) {
   const fs = yield* FileSystem.FileSystem;
-  const path = yield* Path.Path;
-  const resolvedDirectory = yield* fs
-    .realPath(directory)
-    .pipe(Effect.mapError(YeetCommandError.new(`Failed to resolve Yeet proof lock directory ${directory}.`)));
+  const symbolicLinkTarget = yield* fs.readLink(directory).pipe(Effect.option);
   const info = yield* fs
     .stat(directory)
     .pipe(Effect.mapError(YeetCommandError.new(`Failed to inspect Yeet proof lock directory ${directory}.`)));
 
   yield* requireSafeProofCoordinator(
-    Str.Equivalence(resolvedDirectory, path.resolve(directory)),
+    O.isNone(symbolicLinkTarget),
     `Yeet proof lock directory ${directory} is a symbolic link. Refusing to use it.`
   );
   yield* requireSafeProofCoordinator(
     info.type === "Directory",
     `Yeet proof lock directory ${directory} is not a directory. Refusing to use it.`
   );
+  yield* validateProofCoordinatorMode(directory, info);
 
   yield* O.match(effectiveUserId, {
     onNone: () => Effect.void,
@@ -397,17 +400,17 @@ const validateProofCoordinatorDirectory = Effect.fn("Yeet.validateProofCoordinat
  *
  * @internal
  * @param directory - Existing directory to validate without creating a lock file.
- * @param effectiveUserIdOverride - Optional effective UID used by security-focused tests.
+ * @param effectiveUserIdOverride - Optional effective UID state used by security-focused tests.
  * @returns An Effect that fails when the directory is unsafe for coordination.
  * @category testing
  * @since 0.0.0
  */
 export const validateProofCoordinatorDirectoryForTesting = Effect.fn(
   "Yeet.validateProofCoordinatorDirectoryForTesting"
-)(function* (directory: string, effectiveUserIdOverride?: number) {
+)(function* (directory: string, effectiveUserIdOverride?: O.Option<number>) {
   yield* validateProofCoordinatorDirectory(
     directory,
-    pipe(O.fromUndefinedOr(effectiveUserIdOverride), O.orElse(currentEffectiveUserId))
+    pipe(O.fromUndefinedOr(effectiveUserIdOverride), O.getOrElse(currentEffectiveUserId))
   );
 });
 

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/ProofState.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/ProofState.ts
@@ -325,6 +325,102 @@ const proofCommandForSteps: (steps: ReadonlyArray<RepoPlanStep>) => string = flo
 
 const hashText = (text: string): string => createHash("sha256").update(text).digest("hex");
 
+const requireSafeProofCoordinator = (satisfied: boolean, message: string) =>
+  satisfied ? Effect.void : YeetCommandError.make({ message });
+
+const currentEffectiveUserId = (): O.Option<number> =>
+  pipe(
+    O.fromUndefinedOr(process.geteuid),
+    O.map((getEffectiveUserId) => getEffectiveUserId())
+  );
+
+const validateProofCoordinatorOwnership = Effect.fn("Yeet.validateProofCoordinatorOwnership")(function* (
+  directory: string,
+  info: FileSystem.File.Info,
+  effectiveUserId: number
+) {
+  const reportedOwner = O.match(info.uid, {
+    onNone: () => "no owner",
+    onSome: (owner) => `uid ${owner}`,
+  });
+  yield* requireSafeProofCoordinator(
+    O.exists(info.uid, (owner) => owner === effectiveUserId),
+    `Yeet proof lock directory ${directory} reported ${reportedOwner}; expected effective uid ${effectiveUserId}. Refusing to use it.`
+  );
+
+  const mode = info.mode & 0o777;
+  yield* requireSafeProofCoordinator(
+    mode === 0o700,
+    `Yeet proof lock directory ${directory} has mode ${mode.toString(8)}; expected 0700. Refusing to use it.`
+  );
+});
+
+const validateProofCoordinatorDirectory = Effect.fn("Yeet.validateProofCoordinatorDirectory")(function* (
+  directory: string,
+  effectiveUserId: O.Option<number>
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const resolvedDirectory = yield* fs
+    .realPath(directory)
+    .pipe(Effect.mapError(YeetCommandError.new(`Failed to resolve Yeet proof lock directory ${directory}.`)));
+  const info = yield* fs
+    .stat(directory)
+    .pipe(Effect.mapError(YeetCommandError.new(`Failed to inspect Yeet proof lock directory ${directory}.`)));
+
+  yield* requireSafeProofCoordinator(
+    Str.Equivalence(resolvedDirectory, path.resolve(directory)),
+    `Yeet proof lock directory ${directory} is a symbolic link. Refusing to use it.`
+  );
+  yield* requireSafeProofCoordinator(
+    info.type === "Directory",
+    `Yeet proof lock directory ${directory} is not a directory. Refusing to use it.`
+  );
+
+  yield* O.match(effectiveUserId, {
+    onNone: () => Effect.void,
+    onSome: (userId) => validateProofCoordinatorOwnership(directory, info, userId),
+  });
+});
+
+/**
+ * Validate a proof coordinator directory through the production filesystem boundary.
+ *
+ * **Example** (Build a directory validation Effect)
+ *
+ * ```ts
+ * import { validateProofCoordinatorDirectoryForTesting } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * console.log(Effect.isEffect(validateProofCoordinatorDirectoryForTesting("/tmp/example"))) // true
+ * ```
+ *
+ * @internal
+ * @param directory - Existing directory to validate without creating a lock file.
+ * @param effectiveUserIdOverride - Optional effective UID used by security-focused tests.
+ * @returns An Effect that fails when the directory is unsafe for coordination.
+ * @category testing
+ * @since 0.0.0
+ */
+export const validateProofCoordinatorDirectoryForTesting = Effect.fn(
+  "Yeet.validateProofCoordinatorDirectoryForTesting"
+)(function* (directory: string, effectiveUserIdOverride?: number) {
+  yield* validateProofCoordinatorDirectory(
+    directory,
+    pipe(O.fromUndefinedOr(effectiveUserIdOverride), O.orElse(currentEffectiveUserId))
+  );
+});
+
+const ensureProofCoordinatorDirectory = Effect.fn("Yeet.ensureProofCoordinatorDirectory")(function* (
+  directory: string
+) {
+  const fs = yield* FileSystem.FileSystem;
+  yield* fs
+    .makeDirectory(directory, { recursive: true, mode: 0o700 })
+    .pipe(Effect.mapError(YeetCommandError.new(`Failed to create Yeet proof lock directory ${directory}.`)));
+  yield* validateProofCoordinatorDirectory(directory, currentEffectiveUserId());
+});
+
 const laneProofStateForStep = (step: RepoPlanStep, diffFingerprint: string, verifiedAt: string): YeetLaneProofState => {
   const commandText = commandTextForStep(step);
   return YeetLaneProofState.make({
@@ -803,12 +899,9 @@ export const acquireFullProofLock = Effect.fn("Yeet.acquireFullProofLock")(funct
   YeetCommandError,
   FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
 > {
-  const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const lockPath = yield* proofLockPathForContext(context);
-  yield* fs
-    .makeDirectory(path.dirname(lockPath), { recursive: true })
-    .pipe(Effect.mapError(YeetCommandError.new(`Failed to create Yeet proof lock directory for ${lockPath}.`)));
+  yield* ensureProofCoordinatorDirectory(path.dirname(lockPath));
   const lockState = YeetProofLockState.make({
     schemaVersion: "yeet-proof-lock/v3",
     branch: context.branch,

--- a/packages/tooling/tool/cli/test/yeet-review-fixes.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-review-fixes.test.ts
@@ -1,3 +1,4 @@
+import { tmpdir } from "node:os";
 import {
   emptyTurboPlanSnapshot,
   proofCoordinatorLockPath,
@@ -12,7 +13,7 @@ import { NodeChildProcessSpawner } from "@effect/platform-node";
 import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
 import * as NodePath from "@effect/platform-node/NodePath";
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, FileSystem, Layer, Path, Ref } from "effect";
+import { ConfigProvider, Effect, FileSystem, Layer, Path, Ref } from "effect";
 import * as A from "effect/Array";
 import type { YeetExecutedStep } from "@beep/repo-cli/test/Yeet";
 
@@ -208,6 +209,28 @@ describe("yeet review fixes", () => {
         const repository = yield* proofCoordinatorLockPath("https://github.com/acme/repo.git");
         const other = yield* proofCoordinatorLockPath("https://github.com/acme/other.git");
         expect(repository).not.toBe(other);
+      }).pipe(provideScopedLayer(PlatformLayer))
+    ));
+
+  it("uses only absolute runtime roots and an ephemeral fallback", () =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const repositoryIdentity = "https://github.com/acme/repo.git";
+        const resolveWithEnvironment = (environment: Readonly<Record<string, string>>) =>
+          proofCoordinatorLockPath(repositoryIdentity).pipe(
+            Effect.provideService(ConfigProvider.ConfigProvider, ConfigProvider.fromUnknown(environment))
+          );
+        const fallbackPrefix = path.join(tmpdir(), "beep-yeet-proof-locks-");
+        const configuredRoot = path.join(tmpdir(), "configured-yeet-runtime");
+
+        const missing = yield* resolveWithEnvironment({});
+        const relative = yield* resolveWithEnvironment({ XDG_RUNTIME_DIR: "relative-runtime" });
+        const configured = yield* resolveWithEnvironment({ XDG_RUNTIME_DIR: configuredRoot });
+
+        expect(missing).toContain(fallbackPrefix);
+        expect(relative).toContain(fallbackPrefix);
+        expect(configured).toContain(path.join(configuredRoot, "beep-yeet-proof-locks-"));
       }).pipe(provideScopedLayer(PlatformLayer))
     ));
 

--- a/packages/tooling/tool/cli/test/yeet.test.ts
+++ b/packages/tooling/tool/cli/test/yeet.test.ts
@@ -2618,7 +2618,7 @@ describe("yeet publish scope helpers", () => {
       }).pipe(provideScopedLayer(PlatformLayer))
     ));
 
-  it("rejects symlinked and over-permissive proof coordinator directories", () =>
+  it("accepts symlinked ancestors and rejects unsafe proof coordinator directories", () =>
     Effect.runPromise(
       withTempDirectory((tmpDir) =>
         Effect.gen(function* () {
@@ -2626,6 +2626,7 @@ describe("yeet publish scope helpers", () => {
           const path = yield* Path.Path;
           const target = path.join(tmpDir, "target");
           const symlink = path.join(tmpDir, "symlink");
+          const nestedCoordinator = path.join(symlink, "coordinator");
           const overPermissive = path.join(tmpDir, "over-permissive");
 
           yield* fs.makeDirectory(target, { mode: 0o700 });
@@ -2633,16 +2634,21 @@ describe("yeet publish scope helpers", () => {
           const symlinkRefusal = yield* validateProofCoordinatorDirectoryForTesting(symlink).pipe(Effect.flip);
           expect(symlinkRefusal.message).toContain("is a symbolic link");
 
+          yield* fs.makeDirectory(nestedCoordinator, { mode: 0o700 });
+          yield* validateProofCoordinatorDirectoryForTesting(nestedCoordinator);
+
           const targetInfo = yield* fs.stat(target);
           const ownerRefusal = yield* validateProofCoordinatorDirectoryForTesting(
             target,
-            O.getOrThrow(targetInfo.uid) + 1
+            O.some(O.getOrThrow(targetInfo.uid) + 1)
           ).pipe(Effect.flip);
           expect(ownerRefusal.message).toContain("expected effective uid");
 
           yield* fs.makeDirectory(overPermissive, { mode: 0o700 });
           yield* fs.chmod(overPermissive, 0o755);
-          const modeRefusal = yield* validateProofCoordinatorDirectoryForTesting(overPermissive).pipe(Effect.flip);
+          const modeRefusal = yield* validateProofCoordinatorDirectoryForTesting(overPermissive, O.none()).pipe(
+            Effect.flip
+          );
           expect(modeRefusal.message).toContain("has mode 755; expected 0700");
         })
       )

--- a/packages/tooling/tool/cli/test/yeet.test.ts
+++ b/packages/tooling/tool/cli/test/yeet.test.ts
@@ -76,6 +76,7 @@ import {
   tryReclaimStaleProofLockForTesting,
   tryRecoverObservedProofLockReapClaimForTesting,
   validateMonitorGuards,
+  validateProofCoordinatorDirectoryForTesting,
   validatePublishBranchForTesting,
   validatePublishCommitMessageForTesting,
   YeetAttemptStarted,
@@ -2613,8 +2614,38 @@ describe("yeet publish scope helpers", () => {
         expect(first).toBe(sibling);
         expect(other).not.toBe(first);
         expect(first).not.toContain("github.com");
-        expect(first).toMatch(/beep-yeet-proof-locks\/[a-f0-9]{12}\.lock$/u);
+        expect(first).toMatch(/beep-yeet-proof-locks-[a-f0-9]{12}-uid-[0-9]+\/[a-f0-9]{12}\.lock$/u);
       }).pipe(provideScopedLayer(PlatformLayer))
+    ));
+
+  it("rejects symlinked and over-permissive proof coordinator directories", () =>
+    Effect.runPromise(
+      withTempDirectory((tmpDir) =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const target = path.join(tmpDir, "target");
+          const symlink = path.join(tmpDir, "symlink");
+          const overPermissive = path.join(tmpDir, "over-permissive");
+
+          yield* fs.makeDirectory(target, { mode: 0o700 });
+          yield* fs.symlink(target, symlink);
+          const symlinkRefusal = yield* validateProofCoordinatorDirectoryForTesting(symlink).pipe(Effect.flip);
+          expect(symlinkRefusal.message).toContain("is a symbolic link");
+
+          const targetInfo = yield* fs.stat(target);
+          const ownerRefusal = yield* validateProofCoordinatorDirectoryForTesting(
+            target,
+            O.getOrThrow(targetInfo.uid) + 1
+          ).pipe(Effect.flip);
+          expect(ownerRefusal.message).toContain("expected effective uid");
+
+          yield* fs.makeDirectory(overPermissive, { mode: 0o700 });
+          yield* fs.chmod(overPermissive, 0o755);
+          const modeRefusal = yield* validateProofCoordinatorDirectoryForTesting(overPermissive).pipe(Effect.flip);
+          expect(modeRefusal.message).toContain("has mode 755; expected 0700");
+        })
+      )
     ));
 
   it("acquires an absent proof coordinator and releases present and missing locks", () =>
@@ -2622,12 +2653,14 @@ describe("yeet publish scope helpers", () => {
       withProofCoordinatorRepo(({ lockPath, tempContext }) =>
         Effect.gen(function* () {
           const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
 
           expect(yield* fs.exists(lockPath)).toBe(false);
           const lease = yield* acquireFullProofLock(tempContext, [prePushStep]);
           expect(lease.lockPath).toBe(lockPath);
           expect(yield* fs.exists(lockPath)).toBe(true);
           expect(yield* fs.readFileString(lockPath)).toContain('"schemaVersion":"yeet-proof-lock/v3"');
+          expect((yield* fs.stat(path.dirname(lockPath))).mode & 0o777).toBe(0o700);
 
           yield* releaseProofLock(lease);
           expect(yield* fs.exists(lockPath)).toBe(false);


### PR DESCRIPTION
## fix(repo-cli): isolate Yeet proof locks

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/fix_yeet-private-proof-locks-3d8d23d9881b/verdict.json

---

## Provenance

- Branch: <code>fix/yeet-private-proof-locks</code>
- Harness: `codex`

<!-- yeet-provenance
{
  "schemaVersion": 1,
  "branch": "fix/yeet-private-proof-locks",
  "harness": "codex"
}
-->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/845"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790352953&installation_model_id=424656&pr_number=845&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F845&signature=bd2936981bbc671f135bd65f66be78a3c4d0b4ee652b7293af7eb0df861bdf85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->