### PR TITLE
feat(repo-cli): harden packet-core before close (packet-control-plane-core)

### DIFF
--- a/.changeset/packet-core-rung-4-hardening.md
+++ b/.changeset/packet-core-rung-4-hardening.md
@@ -1,0 +1,13 @@
+---
+"@beep/repo-cli": patch
+---
+
+Harden the packet control-plane core before close: digest verification
+recomputes sha-256 over the raw parsed JSON's canonical encoding so injected
+unknown keys are detectable, `readEventFile` refuses an event whose
+packet/root disagrees with its locator, `explore --check` reports advisory
+`packet-status-drift` against the root-specific manifest status field,
+`set-status` to the current derived status skips instead of appending a
+self-transition, writer requests decode actor and timestamp through the
+event schemas, and fork verdicts sort by a seq-then-digest total order with
+findings keyed by parent digest.

--- a/packages/tooling/tool/cli/src/commands/Explore/Check.ts
+++ b/packages/tooling/tool/cli/src/commands/Explore/Check.ts
@@ -14,9 +14,11 @@
  * @since 0.0.0
  */
 
+import { $RepoCliId } from "@beep/identity/packages";
 import { A, O, pipe, Str } from "@beep/utils";
 import { Console, Effect, FileSystem, Order, Path } from "effect";
-import { constUndefined } from "effect/Function";
+import { constUndefined, dual } from "effect/Function";
+import * as S from "effect/Schema";
 import { GoalDoctorFinding } from "../Goals/Doctor.ts";
 import { parseGoalManifestText, TEMPLATE_SLUG } from "../Goals/Inventory.ts";
 import { decodePacketTraceProjection, isPacketSlug, PacketRoot } from "../Goals/PacketCore/PacketCore.schemas.ts";
@@ -32,9 +34,32 @@ import { PACKET_TRACE_SEGMENTS } from "../Goals/PacketCore/PacketTransitionWrite
 import type { GoalDoctorFindingKind } from "../Goals/Doctor.ts";
 import type {
   PacketDerivedState,
+  PacketForkVerdict,
   PacketTraceProjection,
   StoredPacketEvent,
 } from "../Goals/PacketCore/PacketCore.schemas.ts";
+
+const $I = $RepoCliId.create("commands/Explore/Check");
+
+const GoalPacketManifestStatus = S.Struct({
+  initiative: S.Struct({ status: S.String }),
+}).pipe(
+  $I.annoteSchema("GoalPacketManifestStatus", {
+    description: "Root-specific goal manifest projection used to compare initiative.status with the event fold.",
+  })
+);
+
+const ExplorationPacketManifestStatus = S.Struct({
+  exploration: S.Struct({ status: S.String }),
+}).pipe(
+  $I.annoteSchema("ExplorationPacketManifestStatus", {
+    description:
+      "Root-specific exploration manifest projection used to compare exploration.status with the event fold.",
+  })
+);
+
+const decodeGoalPacketManifestStatus = S.decodeUnknownEffect(GoalPacketManifestStatus);
+const decodeExplorationPacketManifestStatus = S.decodeUnknownEffect(ExplorationPacketManifestStatus);
 
 const finding = (slug: string, kind: GoalDoctorFindingKind, message: string, keySuffix = ""): GoalDoctorFinding =>
   GoalDoctorFinding.make({
@@ -42,6 +67,32 @@ const finding = (slug: string, kind: GoalDoctorFindingKind, message: string, key
     kind,
     severity: "advisory",
     key: keySuffix === "" ? `${slug} ${kind}` : `${slug} ${kind} ${keySuffix}`,
+    message,
+  });
+
+/**
+ * Build the stable finding key for one fork from its parent digest.
+ *
+ * @param slug - Packet slug carrying the fork.
+ * @param fork - Fork verdict whose parent digest identifies the fork.
+ * @returns A goals-doctor finding key that does not collide with another fork at the same sequence.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const packetForkFindingKey: {
+  (slug: string, fork: PacketForkVerdict): string;
+  (fork: PacketForkVerdict): (slug: string) => string;
+} = dual(
+  2,
+  (slug: string, fork: PacketForkVerdict): string => `${slug} packet-stream-fork ${fork.parent ?? "genesis"}`
+);
+
+const forkFinding = (slug: string, fork: PacketForkVerdict, message: string): GoalDoctorFinding =>
+  GoalDoctorFinding.make({
+    slug,
+    kind: "packet-stream-fork",
+    severity: "advisory",
+    key: packetForkFindingKey(slug, fork),
     message,
   });
 
@@ -54,6 +105,42 @@ const derivedSummary = (root: string, slug: string, derived: PacketDerivedState)
   );
   return `- ${root}/${slug}: revision=${derived.revision} tip=${tip} status=${derived.status ?? "—"} furthest=${derived.furthestStage ?? "—"} resume=${derived.resumeStage ?? "—"}`;
 };
+
+const statusDriftFindings = Effect.fn("Explore.statusDriftFindings")(function* (
+  root: PacketRoot,
+  slug: string,
+  packetPath: string,
+  derived: PacketDerivedState
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const manifestPath = path.join(packetPath, "ops", "manifest.json");
+  const text = yield* fs.readFileString(manifestPath).pipe(Effect.map(O.some), Effect.orElseSucceed(O.none<string>));
+  if (O.isNone(text)) {
+    return A.empty<GoalDoctorFinding>();
+  }
+  const parsed = parseGoalManifestText(text.value);
+  if (O.isNone(parsed)) {
+    return A.empty<GoalDoctorFinding>();
+  }
+  const manifestStatus = yield* PacketRoot.$match(root, {
+    goals: () =>
+      decodeGoalPacketManifestStatus(parsed.value).pipe(Effect.map((manifest) => manifest.initiative.status)),
+    explorations: () =>
+      decodeExplorationPacketManifestStatus(parsed.value).pipe(Effect.map((manifest) => manifest.exploration.status)),
+  }).pipe(Effect.map(O.some), Effect.orElseSucceed(O.none<string>));
+  if (O.isNone(manifestStatus) || derived.status === undefined || manifestStatus.value === derived.status) {
+    return A.empty<GoalDoctorFinding>();
+  }
+  return A.of(
+    finding(
+      slug,
+      "packet-status-drift",
+      `${manifestPath} status ${manifestStatus.value} disagrees with stream-derived status ${derived.status}.`,
+      root
+    )
+  );
+});
 
 const traceFindings = Effect.fn("Explore.traceFindings")(function* (
   packetPath: string,
@@ -135,19 +222,19 @@ const streamFindings = Effect.fn("Explore.streamFindings")(function* (
     : undefined;
   for (const fork of derived.forks) {
     const planSummary =
-      repairPlan !== undefined && repairPlan.fork.parent === fork.parent && repairPlan.fork.parentSeq === fork.parentSeq
+      repairPlan !== undefined && repairPlan.fork.parent === fork.parent
         ? ` repair plan (read-only): keep ${pipe(repairPlan.survivor, Str.slice(0, 12))}, rebase ${A.length(repairPlan.rebaseDrafts)} event(s), remove ${A.length(repairPlan.filesToRemove)} file(s).`
         : "";
     findings = A.append(
       findings,
-      finding(
+      forkFinding(
         slug,
-        "packet-stream-fork",
-        `two or more children of one parent at seq ${fork.parentSeq} (${A.length(fork.children)} branches); repair the fork before writing.${planSummary}`,
-        `${fork.parentSeq}`
+        fork,
+        `two or more children of one parent at seq ${fork.parentSeq} (${A.length(fork.children)} branches); repair the fork before writing.${planSummary}`
       )
     );
   }
+  findings = A.appendAll(findings, yield* statusDriftFindings(root, slug, packetPath, derived));
   findings = A.appendAll(findings, yield* traceFindings(packetPath, slug, derived, listing.events));
   return { derived, findings };
 });

--- a/packages/tooling/tool/cli/src/commands/Explore/Check.ts
+++ b/packages/tooling/tool/cli/src/commands/Explore/Check.ts
@@ -73,6 +73,29 @@ const finding = (slug: string, kind: GoalDoctorFindingKind, message: string, key
 /**
  * Build the stable finding key for one fork from its parent digest.
  *
+ * **Example** (Key two forks that share a parent sequence)
+ *
+ * ```ts
+ * import { packetForkFindingKey } from "@beep/repo-cli/commands/Explore/Check"
+ * import { PacketForkVerdict } from "@beep/repo-cli/test/Goals"
+ *
+ * const left = PacketForkVerdict.make({ parent: "a".repeat(64), parentSeq: 2, children: [] })
+ * const right = PacketForkVerdict.make({ parent: "b".repeat(64), parentSeq: 2, children: [] })
+ *
+ * console.log(packetForkFindingKey("demo", left) === packetForkFindingKey("demo", right)) // false
+ * ```
+ *
+ * **Example** (Key a genesis fork that has no parent)
+ *
+ * ```ts
+ * import { packetForkFindingKey } from "@beep/repo-cli/commands/Explore/Check"
+ * import { PacketForkVerdict } from "@beep/repo-cli/test/Goals"
+ *
+ * const genesis = PacketForkVerdict.make({ parentSeq: 0, children: [] })
+ *
+ * console.log(packetForkFindingKey("demo", genesis)) // "demo packet-stream-fork genesis"
+ * ```
+ *
  * @param slug - Packet slug carrying the fork.
  * @param fork - Fork verdict whose parent digest identifies the fork.
  * @returns A goals-doctor finding key that does not collide with another fork at the same sequence.

--- a/packages/tooling/tool/cli/src/commands/Goals/Bootstrap.schemas.ts
+++ b/packages/tooling/tool/cli/src/commands/Goals/Bootstrap.schemas.ts
@@ -750,6 +750,7 @@ const VALIDATION_REQUIREMENTS_BY_FINDING_KIND: Readonly<
   "completion-gate-unsatisfied": [],
   "superseded-without-pointer": [],
   "exploration-backlink-missing": [],
+  "packet-status-drift": [],
   "packet-stream-fork": [],
   "packet-stream-integrity": [],
   "packet-trace-stale": [],

--- a/packages/tooling/tool/cli/src/commands/Goals/Doctor.ts
+++ b/packages/tooling/tool/cli/src/commands/Goals/Doctor.ts
@@ -110,6 +110,7 @@ export const GoalDoctorFindingKind = LiteralKit([
   "exploration-backlink-missing",
   "packet-stream-fork",
   "packet-stream-integrity",
+  "packet-status-drift",
   "packet-trace-stale",
   "packet-trace-missing",
 ]).pipe(

--- a/packages/tooling/tool/cli/src/commands/Goals/PacketCore/PacketCore.schemas.ts
+++ b/packages/tooling/tool/cli/src/commands/Goals/PacketCore/PacketCore.schemas.ts
@@ -774,6 +774,16 @@ export type PacketEventBody = typeof PacketEventBody.Type;
 /**
  * ISO-8601 timestamp recorded on packet events and writer requests.
  *
+ * **Example** (Reject a timestamp that is not ISO-8601)
+ *
+ * ```ts
+ * import { PacketEventTimestamp } from "@beep/repo-cli/test/Goals"
+ * import * as S from "effect/Schema"
+ *
+ * console.log(S.is(PacketEventTimestamp)("2026-08-17T10:00:00.000Z")) // true
+ * console.log(S.is(PacketEventTimestamp)("2026-08-17")) // false
+ * ```
+ *
  * @category models
  * @since 0.0.0
  */
@@ -792,6 +802,16 @@ export const PacketEventTimestamp = S.String.check(
 
 /**
  * Non-empty actor recorded on packet events and writer requests.
+ *
+ * **Example** (Reject an empty actor)
+ *
+ * ```ts
+ * import { PacketEventActor } from "@beep/repo-cli/test/Goals"
+ * import * as S from "effect/Schema"
+ *
+ * console.log(S.is(PacketEventActor)("operator")) // true
+ * console.log(S.is(PacketEventActor)("")) // false
+ * ```
  *
  * @category models
  * @since 0.0.0

--- a/packages/tooling/tool/cli/src/commands/Goals/PacketCore/PacketCore.schemas.ts
+++ b/packages/tooling/tool/cli/src/commands/Goals/PacketCore/PacketCore.schemas.ts
@@ -771,23 +771,59 @@ export const PacketEventBody = S.Union([
  */
 export type PacketEventBody = typeof PacketEventBody.Type;
 
-const PacketEventTimestamp = S.String.check(
+/**
+ * ISO-8601 timestamp recorded on packet events and writer requests.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const PacketEventTimestamp = S.String.check(
   S.isPattern(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/, {
     identifier: $I`PacketEventAtPatternCheck`,
     title: "Packet Event Timestamp Pattern",
     description: "Event timestamps are ISO-8601 date-time strings.",
     message: "Expected an ISO-8601 date-time string",
   })
+).pipe(
+  $I.annoteSchema("PacketEventTimestamp", {
+    description: "ISO-8601 date-time string recorded on packet events and writer requests.",
+  })
 );
 
-const PacketEventActor = S.String.check(
+/**
+ * Non-empty actor recorded on packet events and writer requests.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const PacketEventActor = S.String.check(
   S.isMinLength(1, {
     identifier: $I`PacketEventActorLengthCheck`,
     title: "Packet Event Actor Length",
     description: "The recording actor is a non-empty string.",
     message: "Expected a non-empty actor",
   })
+).pipe(
+  $I.annoteSchema("PacketEventActor", {
+    description: "Non-empty actor recorded on packet events and writer requests.",
+  })
 );
+
+/**
+ * Decoded packet-event timestamp.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type PacketEventTimestamp = typeof PacketEventTimestamp.Type;
+
+/**
+ * Decoded packet-event actor.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type PacketEventActor = typeof PacketEventActor.Type;
 
 const PacketEventGenesisParentCheck = S.makeFilter(
   (event: { readonly seq: number; readonly parent?: PacketEventId }) =>
@@ -1066,6 +1102,7 @@ export const PacketChainIssueKind = LiteralKit([
   "event-invalid",
   "digest-mismatch",
   "file-name-mismatch",
+  "packet-mismatch",
   "missing-parent",
   "parent-seq-mismatch",
 ]).pipe(

--- a/packages/tooling/tool/cli/src/commands/Goals/PacketCore/PacketEventStore.ts
+++ b/packages/tooling/tool/cli/src/commands/Goals/PacketCore/PacketEventStore.ts
@@ -8,9 +8,9 @@
  * Reads are advisory — unreadable, invalid, or tampered files surface as
  * chain issues, never failures — while appends are guarded: a compare-and-set
  * against the folded revision, refused outright on integrity issues or an
- * unresolved fork. Digests are computed over the canonical compact encoding
- * of the event, not the raw file bytes, so reformatting a file does not
- * change its identity while any content edit does.
+ * unresolved fork. Digests are computed over the compact canonical encoding
+ * of the raw parsed JSON, not the raw file bytes. Reformatting a file does not
+ * change its identity, but every content key remains identity-bound.
  *
  * @packageDocumentation
  * @since 0.0.0
@@ -24,13 +24,16 @@ import * as S from "effect/Schema";
 import { PacketCasConflictError, PacketStreamError } from "./PacketCore.errors.ts";
 import { PacketChainIssue, PacketEvent, PacketRoot, PacketSlug, StoredPacketEvent } from "./PacketCore.schemas.ts";
 import {
+  canonicalJsonText,
   packetEventDigest,
   packetEventFileName,
   parsePacketEventFileName,
   renderPacketEventFile,
+  sha256Hex,
 } from "./PacketDigest.ts";
 import { foldPacketEvents, upcastPacketEventJson } from "./PacketFold.ts";
-import type { PacketDerivedState, PacketEventId } from "./PacketCore.schemas.ts";
+import type { PacketDerivedState } from "./PacketCore.schemas.ts";
+import type { PacketEventFileNameParts } from "./PacketDigest.ts";
 
 const $I = $RepoCliId.create("commands/Goals/PacketCore/PacketEventStore");
 
@@ -175,6 +178,31 @@ const readOutcome = (stored: StoredPacketEvent): ReadEventOutcome => ({
 });
 const issueOutcome = (item: PacketChainIssue): ReadEventOutcome => ({ stored: O.none(), issues: A.of(item) });
 
+const storedEventIdentityIssue = (
+  locator: PacketStreamLocator,
+  fileName: string,
+  parts: PacketEventFileNameParts,
+  digest: string,
+  event: PacketEvent
+): O.Option<PacketChainIssue> => {
+  if (digest !== parts.id) {
+    return O.some(issue("digest-mismatch", fileName, `recomputed digest ${digest} disagrees with the file name.`));
+  }
+  if (parts.seq !== event.seq || parts.type !== event.body.type) {
+    return O.some(issue("file-name-mismatch", fileName, "file-name seq/type disagree with the event content."));
+  }
+  if (event.packet !== locator.packet || event.root !== locator.root) {
+    return O.some(
+      issue(
+        "packet-mismatch",
+        fileName,
+        `event identifies ${event.root}/${event.packet}, not locator ${locator.root}/${locator.packet}.`
+      )
+    );
+  }
+  return O.none();
+};
+
 /**
  * Fold a listing and refuse ambiguity: integrity issues or a forked chain.
  *
@@ -237,9 +265,15 @@ const makePacketEventStore = Effect.fn("PacketEventStore.make")(function* () {
 
   const eventsDir = (packetPath: string): string => path.join(packetPath, ...PACKET_EVENTS_SEGMENTS);
 
-  const readEventFile: (directory: string, fileName: string) => Effect.Effect<ReadEventOutcome> = Effect.fn(
-    "PacketEventStore.readEventFile"
-  )(function* (directory: string, fileName: string) {
+  const readEventFile: (
+    locator: PacketStreamLocator,
+    directory: string,
+    fileName: string
+  ) => Effect.Effect<ReadEventOutcome> = Effect.fn("PacketEventStore.readEventFile")(function* (
+    locator: PacketStreamLocator,
+    directory: string,
+    fileName: string
+  ) {
     const parts = parsePacketEventFileName(fileName);
     if (O.isNone(parts)) {
       return issueOutcome(
@@ -252,36 +286,23 @@ const makePacketEventStore = Effect.fn("PacketEventStore.make")(function* () {
     if (O.isNone(text)) {
       return issueOutcome(issue("event-unreadable", fileName, "event file could not be read."));
     }
-    const decoded = yield* decodeJsonUnknown(text.value).pipe(
-      Effect.map((raw) => O.some(upcastPacketEventJson(raw))),
-      Effect.orElseSucceed(O.none<unknown>)
-    );
-    if (O.isNone(decoded)) {
+    const raw = yield* decodeJsonUnknown(text.value).pipe(Effect.map(O.some), Effect.orElseSucceed(O.none<unknown>));
+    if (O.isNone(raw)) {
       return issueOutcome(issue("event-invalid", fileName, "event file is not valid JSON."));
     }
-    const event = yield* decodePacketEventEffect(decoded.value).pipe(
+    const event = yield* decodePacketEventEffect(upcastPacketEventJson(raw.value)).pipe(
       Effect.map(O.some),
       Effect.orElseSucceed(O.none<PacketEvent>)
     );
     if (O.isNone(event)) {
       return issueOutcome(issue("event-invalid", fileName, "event file does not decode as PacketEvent."));
     }
-    const digest = yield* packetEventDigest(event.value).pipe(
-      Effect.map(O.some),
-      Effect.orElseSucceed(O.none<PacketEventId>)
-    );
-    if (O.isNone(digest)) {
-      return issueOutcome(issue("event-invalid", fileName, "event could not be re-encoded for digest verification."));
+    const digest = sha256Hex(canonicalJsonText(raw.value));
+    const identity = storedEventIdentityIssue(locator, fileName, parts.value, digest, event.value);
+    if (O.isSome(identity)) {
+      return issueOutcome(identity.value);
     }
-    if (digest.value !== parts.value.id) {
-      return issueOutcome(
-        issue("digest-mismatch", fileName, `recomputed digest ${digest.value} disagrees with the file name.`)
-      );
-    }
-    if (parts.value.seq !== event.value.seq || parts.value.type !== event.value.body.type) {
-      return issueOutcome(issue("file-name-mismatch", fileName, "file-name seq/type disagree with the event content."));
-    }
-    return readOutcome(StoredPacketEvent.make({ id: digest.value, fileName, event: event.value }));
+    return readOutcome(StoredPacketEvent.make({ id: digest, fileName, event: event.value }));
   });
 
   const hasStream = Effect.fn("PacketEventStore.hasStream")(function* (packetPath: string) {
@@ -295,7 +316,7 @@ const makePacketEventStore = Effect.fn("PacketEventStore.make")(function* () {
     let events = A.empty<StoredPacketEvent>();
     let issues = A.empty<PacketChainIssue>();
     for (const fileName of fileNames) {
-      const outcome = yield* readEventFile(directory, fileName);
+      const outcome = yield* readEventFile(locator, directory, fileName);
       events = pipe(outcome.stored, O.match({ onNone: () => events, onSome: (stored) => A.append(events, stored) }));
       issues = A.appendAll(issues, outcome.issues);
     }

--- a/packages/tooling/tool/cli/src/commands/Goals/PacketCore/PacketFold.ts
+++ b/packages/tooling/tool/cli/src/commands/Goals/PacketCore/PacketFold.ts
@@ -120,6 +120,11 @@ const storedBySeqThenId = Order.combine(
   Order.mapInput(Order.String, (stored: StoredPacketEvent) => stored.id)
 );
 
+const forkBySeqThenDigest = Order.combine(
+  Order.mapInput(Order.Number, (verdict: PacketForkVerdict) => verdict.parentSeq),
+  Order.mapInput(Order.String, (verdict: PacketForkVerdict) => verdict.parent ?? GENESIS_PARENT_KEY)
+);
+
 const parentKey = (stored: StoredPacketEvent): string => stored.event.parent ?? GENESIS_PARENT_KEY;
 
 const buildChildIndex = (
@@ -158,10 +163,7 @@ const collectForkVerdicts = (
       })
     );
   }
-  return A.sort(
-    verdicts,
-    Order.mapInput(Order.Number, (verdict: PacketForkVerdict) => verdict.parentSeq)
-  );
+  return A.sort(verdicts, forkBySeqThenDigest);
 };
 
 const missingParentIssues = (events: ReadonlyArray<StoredPacketEvent>): ReadonlyArray<PacketChainIssue> => {

--- a/packages/tooling/tool/cli/src/commands/Goals/PacketCore/PacketFold.ts
+++ b/packages/tooling/tool/cli/src/commands/Goals/PacketCore/PacketFold.ts
@@ -120,9 +120,19 @@ const storedBySeqThenId = Order.combine(
   Order.mapInput(Order.String, (stored: StoredPacketEvent) => stored.id)
 );
 
+/**
+ * Fork verdicts carry their parent key alongside the verdict so the total order can
+ * sort on the key the child index was built from. The genesis group's key is the
+ * sentinel rather than an absent digest, so ordering never has to reconstruct it.
+ */
+type ForkEntry = {
+  readonly key: string;
+  readonly verdict: PacketForkVerdict;
+};
+
 const forkBySeqThenDigest = Order.combine(
-  Order.mapInput(Order.Number, (verdict: PacketForkVerdict) => verdict.parentSeq),
-  Order.mapInput(Order.String, (verdict: PacketForkVerdict) => verdict.parent ?? GENESIS_PARENT_KEY)
+  Order.mapInput(Order.Number, (entry: ForkEntry) => entry.verdict.parentSeq),
+  Order.mapInput(Order.String, (entry: ForkEntry) => entry.key)
 );
 
 const parentKey = (stored: StoredPacketEvent): string => stored.event.parent ?? GENESIS_PARENT_KEY;
@@ -142,7 +152,7 @@ const buildChildIndex = (
 const collectForkVerdicts = (
   index: MutableHashMap.MutableHashMap<string, ReadonlyArray<StoredPacketEvent>>
 ): ReadonlyArray<PacketForkVerdict> => {
-  let verdicts = A.empty<PacketForkVerdict>();
+  let entries = A.empty<ForkEntry>();
   for (const key of MutableHashMap.keys(index)) {
     const children = pipe(MutableHashMap.get(index, key), O.getOrElse(A.empty<StoredPacketEvent>));
     if (A.length(children) < 2) {
@@ -154,16 +164,16 @@ const collectForkVerdicts = (
       O.map((stored) => stored.event.seq),
       O.getOrElse(() => 1)
     );
-    verdicts = A.append(
-      verdicts,
-      PacketForkVerdict.make({
+    entries = A.append(entries, {
+      key,
+      verdict: PacketForkVerdict.make({
         ...(key === GENESIS_PARENT_KEY ? {} : { parent: key }),
         parentSeq: childSeq - 1,
         children: A.map(sorted, (stored) => stored.id),
-      })
-    );
+      }),
+    });
   }
-  return A.sort(verdicts, forkBySeqThenDigest);
+  return A.map(A.sort(entries, forkBySeqThenDigest), (entry) => entry.verdict);
 };
 
 const missingParentIssues = (events: ReadonlyArray<StoredPacketEvent>): ReadonlyArray<PacketChainIssue> => {

--- a/packages/tooling/tool/cli/src/commands/Goals/PacketCore/PacketTransitionWriter.ts
+++ b/packages/tooling/tool/cli/src/commands/Goals/PacketCore/PacketTransitionWriter.ts
@@ -22,6 +22,7 @@
  */
 
 import { $RepoCliId } from "@beep/identity/packages";
+import { LiteralKit } from "@beep/schema";
 import { A, O, pipe } from "@beep/utils";
 import { Context, Effect, FileSystem, Layer, Path } from "effect";
 import * as S from "effect/Schema";
@@ -30,6 +31,8 @@ import { PacketStreamError } from "./PacketCore.errors.ts";
 import {
   PacketDerivedState,
   PacketEvent,
+  PacketEventActor,
+  PacketEventTimestamp,
   PacketRevision,
   PacketRiskTier,
   PacketStage,
@@ -68,6 +71,12 @@ const $I = $RepoCliId.create("commands/Goals/PacketCore/PacketTransitionWriter")
  * @since 0.0.0
  */
 export const PACKET_TRACE_SEGMENTS = ["ops", "trace.json"] as const;
+
+const PacketTransitionDisposition = LiteralKit(["append", "skipped", "streamless"]).pipe(
+  $I.annoteSchema("PacketTransitionDisposition", {
+    description: "Guarded transition disposition: append events, skip an idempotent transition, or no stream.",
+  })
+);
 
 const PacketTransitionGenesisPairCheck = S.makeFilter(
   (request: { readonly genesisStage?: PacketStage; readonly genesisOrdinal?: PacketStageOrdinal }) =>
@@ -116,8 +125,8 @@ export class PacketTransitionRequest extends S.Class<PacketTransitionRequest>($I
     previousStatus: PacketStatusToken,
     genesisStage: S.optionalKey(PacketStage),
     genesisOrdinal: S.optionalKey(PacketStageOrdinal),
-    actor: S.String,
-    at: S.String,
+    actor: PacketEventActor,
+    at: PacketEventTimestamp,
   }).check(PacketTransitionGenesisPairCheck),
   $I.annote("PacketTransitionRequest", {
     description: "One requested status transition with caller-validated vocabulary and genesis stage info.",
@@ -166,8 +175,8 @@ export class PacketRiskTierOverrideRequest extends S.Class<PacketRiskTierOverrid
     genesisStatus: PacketStatusToken,
     genesisStage: S.optionalKey(PacketStage),
     genesisOrdinal: S.optionalKey(PacketStageOrdinal),
-    actor: S.String,
-    at: S.String,
+    actor: PacketEventActor,
+    at: PacketEventTimestamp,
   }).check(PacketTransitionGenesisPairCheck),
   $I.annote("PacketRiskTierOverrideRequest", {
     description: "One requested operator risk-tier override with its recorded reason and genesis fallback.",
@@ -242,6 +251,7 @@ export type PacketPlanRequest = typeof PacketPlanRequest.Type;
  *     actor: "operator",
  *     at: "2026-08-17T00:00:00.000Z",
  *   }),
+ *   disposition: "streamless",
  *   streamPresent: false,
  *   currentRevision: 0,
  *   events: [],
@@ -256,6 +266,7 @@ export type PacketPlanRequest = typeof PacketPlanRequest.Type;
 export class PacketTransitionPlan extends S.Class<PacketTransitionPlan>($I`PacketTransitionPlan`)(
   {
     request: PacketPlanRequest,
+    disposition: PacketTransitionDisposition,
     streamPresent: S.Boolean,
     currentRevision: PacketRevision,
     currentTip: S.optionalKey(PacketTip),
@@ -277,6 +288,7 @@ export class PacketTransitionPlan extends S.Class<PacketTransitionPlan>($I`Packe
  * import { PacketTransitionOutcome } from "@beep/repo-cli/test/Goals"
  *
  * const outcome = PacketTransitionOutcome.make({
+ *   disposition: "streamless",
  *   appended: 0,
  *   tracePath: "goals/demo/ops/trace.json",
  *   traceWritten: false,
@@ -289,13 +301,14 @@ export class PacketTransitionPlan extends S.Class<PacketTransitionPlan>($I`Packe
  */
 export class PacketTransitionOutcome extends S.Class<PacketTransitionOutcome>($I`PacketTransitionOutcome`)(
   {
+    disposition: PacketTransitionDisposition,
     appended: PacketRevision,
     tip: S.optionalKey(PacketTip),
     tracePath: S.String,
     traceWritten: S.Boolean,
   },
   $I.annote("PacketTransitionOutcome", {
-    description: "Committed-transition result: appended event count, new tip, trace projection path.",
+    description: "Committed-transition result with an explicit append, skipped, or streamless disposition.",
   })
 ) {}
 
@@ -501,12 +514,14 @@ const makePacketTransitionWriter = Effect.fn("PacketTransitionWriter.make")(func
     request: PacketPlanRequest,
     stream: GuardedStream,
     events: ReadonlyArray<PacketEvent>,
-    tracePath: string
+    tracePath: string,
+    disposition: typeof PacketTransitionDisposition.Type
   ) => Effect.Effect<PacketTransitionPlan, PacketStreamError> = Effect.fnUntraced(function* (
     request: PacketPlanRequest,
     stream: GuardedStream,
     events: ReadonlyArray<PacketEvent>,
-    tracePath: string
+    tracePath: string,
+    disposition: typeof PacketTransitionDisposition.Type
   ) {
     const drafts = yield* storedDrafts(request.locator.packet, events);
     const derivedAfter = foldPacketEvents({
@@ -516,6 +531,7 @@ const makePacketTransitionWriter = Effect.fn("PacketTransitionWriter.make")(func
     });
     return PacketTransitionPlan.make({
       request,
+      disposition,
       streamPresent: true,
       currentRevision: stream.derived.revision,
       ...optionalProp("currentTip", O.fromUndefinedOr(stream.derived.tip)),
@@ -531,6 +547,7 @@ const makePacketTransitionWriter = Effect.fn("PacketTransitionWriter.make")(func
     if (!streamPresent) {
       return PacketTransitionPlan.make({
         request,
+        disposition: "streamless",
         streamPresent: false,
         currentRevision: 0,
         events: A.empty<PacketEvent>(),
@@ -538,8 +555,11 @@ const makePacketTransitionWriter = Effect.fn("PacketTransitionWriter.make")(func
       });
     }
     const stream = yield* foldGuardedStream(request.locator);
+    if (stream.derived.status === request.status) {
+      return yield* sealedPlan(request, stream, A.empty<PacketEvent>(), tracePath, "skipped");
+    }
     const events = yield* draftEvents(request, stream.derived);
-    return yield* sealedPlan(request, stream, events, tracePath);
+    return yield* sealedPlan(request, stream, events, tracePath, "append");
   });
 
   const planRiskTierOverride = Effect.fn("PacketTransitionWriter.planRiskTierOverride")(function* (
@@ -555,14 +575,16 @@ const makePacketTransitionWriter = Effect.fn("PacketTransitionWriter.make")(func
     }
     const stream = yield* foldGuardedStream(request.locator);
     const events = yield* draftOverrideEvents(request, stream.derived);
-    return yield* sealedPlan(request, stream, events, tracePath);
+    return yield* sealedPlan(request, stream, events, tracePath, "append");
   });
 
   const commit = Effect.fn("PacketTransitionWriter.commit")(function* (transitionPlan: PacketTransitionPlan) {
     const locator = transitionPlan.request.locator;
-    if (!transitionPlan.streamPresent) {
+    if (transitionPlan.disposition !== "append") {
       return PacketTransitionOutcome.make({
+        disposition: transitionPlan.disposition,
         appended: 0,
+        ...optionalProp("tip", O.fromUndefinedOr(transitionPlan.currentTip)),
         tracePath: transitionPlan.tracePath,
         traceWritten: false,
       });
@@ -583,6 +605,7 @@ const makePacketTransitionWriter = Effect.fn("PacketTransitionWriter.make")(func
         )
       );
     return PacketTransitionOutcome.make({
+      disposition: "append",
       appended: A.length(transitionPlan.events),
       ...optionalProp("tip", O.fromUndefinedOr(derived.tip)),
       tracePath: transitionPlan.tracePath,

--- a/packages/tooling/tool/cli/src/commands/Goals/PacketCore/PacketTransitionWriter.ts
+++ b/packages/tooling/tool/cli/src/commands/Goals/PacketCore/PacketTransitionWriter.ts
@@ -24,7 +24,7 @@
 import { $RepoCliId } from "@beep/identity/packages";
 import { LiteralKit } from "@beep/schema";
 import { A, O, pipe } from "@beep/utils";
-import { Context, Effect, FileSystem, Layer, Path } from "effect";
+import { Context, Effect, Equal, FileSystem, Layer, Path } from "effect";
 import * as S from "effect/Schema";
 import { optionalProp } from "../../../internal/cli/OptionRecord.ts";
 import { PacketStreamError } from "./PacketCore.errors.ts";
@@ -394,6 +394,16 @@ const draftAppendedEvent = (request: PacketPlanRequest, base: DraftBase, body: P
     body,
   });
 
+const tipDigest = (tip: PacketTip | undefined): O.Option<string> =>
+  pipe(
+    O.fromUndefinedOr(tip),
+    O.map((value) => value.id)
+  );
+
+const packetStreamMoved = (transitionPlan: PacketTransitionPlan, derived: PacketDerivedState): boolean =>
+  derived.revision !== transitionPlan.currentRevision ||
+  !Equal.equals(tipDigest(derived.tip), tipDigest(transitionPlan.currentTip));
+
 const makePacketTransitionWriter = Effect.fn("PacketTransitionWriter.make")(function* () {
   const store = yield* PacketEventStore;
   const fs = yield* FileSystem.FileSystem;
@@ -578,32 +588,93 @@ const makePacketTransitionWriter = Effect.fn("PacketTransitionWriter.make")(func
     return yield* sealedPlan(request, stream, events, tracePath, "append");
   });
 
+  const traceTextFor: (
+    packet: string,
+    derived: PacketDerivedState,
+    events: ReadonlyArray<StoredPacketEvent>
+  ) => Effect.Effect<string, PacketStreamError> = Effect.fnUntraced(function* (
+    packet: string,
+    derived: PacketDerivedState,
+    events: ReadonlyArray<StoredPacketEvent>
+  ) {
+    return yield* renderPacketTraceFile(projectPacketTrace(derived, events)).pipe(
+      Effect.mapError(streamErrorFromSchema(packet, "trace projection could not be rendered"))
+    );
+  });
+
+  const writeTraceFile: (packet: string, tracePath: string, text: string) => Effect.Effect<void, PacketStreamError> =
+    Effect.fnUntraced(function* (packet: string, tracePath: string, text: string) {
+      yield* fs
+        .writeFileString(tracePath, text)
+        .pipe(
+          Effect.mapError((error) => PacketStreamError.new(packet, `trace projection write failed: ${String(error)}`))
+        );
+    });
+
+  const writeTraceWhenStale: (
+    packet: string,
+    tracePath: string,
+    text: string
+  ) => Effect.Effect<boolean, PacketStreamError> = Effect.fnUntraced(function* (
+    packet: string,
+    tracePath: string,
+    text: string
+  ) {
+    const committed = yield* fs
+      .readFileString(tracePath)
+      .pipe(Effect.map(O.some), Effect.orElseSucceed(O.none<string>));
+    if (Equal.equals(committed, O.some(text))) {
+      return false;
+    }
+    yield* writeTraceFile(packet, tracePath, text);
+    return true;
+  });
+
+  const commitSkipped: (
+    transitionPlan: PacketTransitionPlan
+  ) => Effect.Effect<PacketTransitionOutcome, PacketStreamError> = Effect.fnUntraced(function* (
+    transitionPlan: PacketTransitionPlan
+  ) {
+    const locator = transitionPlan.request.locator;
+    const stream = yield* foldGuardedStream(locator);
+    if (packetStreamMoved(transitionPlan, stream.derived)) {
+      return yield* PacketStreamError.new(
+        locator.packet,
+        `stream moved between plan and commit (planned revision ${transitionPlan.currentRevision}, found ${stream.derived.revision}); re-plan the transition.`
+      );
+    }
+    const traceText = yield* traceTextFor(locator.packet, stream.derived, stream.listing.events);
+    const traceWritten = yield* writeTraceWhenStale(locator.packet, transitionPlan.tracePath, traceText);
+    return PacketTransitionOutcome.make({
+      disposition: "skipped",
+      appended: 0,
+      ...optionalProp("tip", O.fromUndefinedOr(stream.derived.tip)),
+      tracePath: transitionPlan.tracePath,
+      traceWritten,
+    });
+  });
+
   const commit = Effect.fn("PacketTransitionWriter.commit")(function* (transitionPlan: PacketTransitionPlan) {
     const locator = transitionPlan.request.locator;
-    if (transitionPlan.disposition !== "append") {
+    if (transitionPlan.disposition === "streamless") {
       return PacketTransitionOutcome.make({
-        disposition: transitionPlan.disposition,
+        disposition: "streamless",
         appended: 0,
         ...optionalProp("tip", O.fromUndefinedOr(transitionPlan.currentTip)),
         tracePath: transitionPlan.tracePath,
         traceWritten: false,
       });
     }
+    if (transitionPlan.disposition === "skipped") {
+      return yield* commitSkipped(transitionPlan);
+    }
     for (const event of transitionPlan.events) {
       yield* store.append(locator, event);
     }
     const listing = yield* store.list(locator);
     const derived = foldPacketEvents({ packet: locator.packet, root: locator.root, events: listing.events });
-    const traceText = yield* renderPacketTraceFile(projectPacketTrace(derived, listing.events)).pipe(
-      Effect.mapError(streamErrorFromSchema(locator.packet, "trace projection could not be rendered"))
-    );
-    yield* fs
-      .writeFileString(transitionPlan.tracePath, traceText)
-      .pipe(
-        Effect.mapError((error) =>
-          PacketStreamError.new(locator.packet, `trace projection write failed: ${String(error)}`)
-        )
-      );
+    const traceText = yield* traceTextFor(locator.packet, derived, listing.events);
+    yield* writeTraceFile(locator.packet, transitionPlan.tracePath, traceText);
     return PacketTransitionOutcome.make({
       disposition: "append",
       appended: A.length(transitionPlan.events),

--- a/packages/tooling/tool/cli/src/commands/Goals/SetStatus.ts
+++ b/packages/tooling/tool/cli/src/commands/Goals/SetStatus.ts
@@ -249,6 +249,13 @@ const printTransitionPreview = Effect.fn("Goals.printTransitionPreview")(functio
     O.match({ onNone: () => "empty", onSome: (tip) => `${tip.seq}@${shortTip(tip.id)}` })
   );
   yield* Console.log(`[goals:set-status] stream: revision ${transition.currentRevision}, tip ${tipText}`);
+  if (transition.disposition === "skipped") {
+    yield* Console.log(
+      `[goals:set-status] outcome: skipped; stream already derives status ${status}, so no event or trace write is planned.`
+    );
+    yield* Console.log("[goals:set-status] preview only — nothing written.");
+    return;
+  }
   for (const event of transition.events) {
     yield* Console.log(`[goals:set-status] ${previewEventLine(event)}`);
   }
@@ -394,9 +401,13 @@ const setStatusForSlug = Effect.fn("Goals.setStatusForSlug")(function* (
 
   if (O.isSome(plan)) {
     const outcome = yield* writer.commit(plan.value);
-    yield* Console.log(
-      `[goals:set-status] ${slug}: appended ${outcome.appended} event(s); regenerated ${outcome.tracePath}.`
-    );
+    if (outcome.disposition === "skipped") {
+      yield* Console.log(`[goals:set-status] ${slug}: skipped; stream already derives status ${status}.`);
+    } else {
+      yield* Console.log(
+        `[goals:set-status] ${slug}: appended ${outcome.appended} event(s); regenerated ${outcome.tracePath}.`
+      );
+    }
   }
 
   let nextManifest = applyJsoncModification({ content: manifestText, path: ["initiative", "status"], value: status });

--- a/packages/tooling/tool/cli/test/explore-check.test.ts
+++ b/packages/tooling/tool/cli/test/explore-check.test.ts
@@ -186,6 +186,47 @@ describe("explore --check", () => {
             const forkB = PacketForkVerdict.make({ parent: parentB, parentSeq: 1, children: [] });
             expect(packetForkFindingKey("twinned", forkA)).toBe(`twinned packet-stream-fork ${parentA}`);
             expect(packetForkFindingKey("twinned", forkB)).toBe(`twinned packet-stream-fork ${parentB}`);
+            // A parentless genesis fork keys off the sentinel instead of an absent digest.
+            const genesisFork = PacketForkVerdict.make({ parentSeq: 0, children: [] });
+            expect(packetForkFindingKey("twinned", genesisFork)).toBe("twinned packet-stream-fork genesis");
+          })
+        ).pipe(provideScopedLayer(testLayer))
+      ),
+    30_000
+  );
+
+  it(
+    "stays silent on an unparseable manifest and skips non-packet directory entries",
+    () =>
+      Effect.runPromise(
+        withTempWorkingDirectory(
+          Effect.gen(function* () {
+            const genesis = PacketEvent.make({
+              schemaVersion: "packet-event/v1",
+              packet: "unparseable",
+              root: "goals",
+              seq: 1,
+              expectedRevision: 0,
+              at: "2026-08-17T00:00:00.000Z",
+              actor: "test",
+              body: { type: "packet-created", status: "active" },
+            });
+            yield* writeEvent("goals/unparseable", genesis);
+            // Present but not JSON: the drift check has nothing to compare against and must not guess.
+            yield* writeProjectFile("goals/unparseable/ops/manifest.json", "{ not json\n");
+            // Valid JSON that is not a trace projection: reported as stale, distinct from
+            // the not-JSON-at-all case, and never decoded on a guess.
+            yield* writeProjectFile("goals/unparseable/ops/trace.json", '{"not":"a trace"}\n');
+            // The template, dot-directories, and non-slug entries are skipped by the scan filter.
+            yield* writeProjectFile("goals/_template/README.md", "# template\n");
+            yield* writeProjectFile("goals/.hidden/README.md", "# hidden\n");
+            yield* writeProjectFile("goals/Not A Slug/README.md", "# not a slug\n");
+
+            const exit = yield* Effect.exit(runExploreCommand(["--check"]));
+            expect(Exit.isSuccess(exit)).toBe(true);
+            const output = yield* consoleText();
+            expect(output).toContain("does not decode as PacketTraceProjection");
+            expect(output).not.toContain("packet-status-drift");
           })
         ).pipe(provideScopedLayer(testLayer))
       ),

--- a/packages/tooling/tool/cli/test/explore-check.test.ts
+++ b/packages/tooling/tool/cli/test/explore-check.test.ts
@@ -1,7 +1,8 @@
-import { exploreCommand } from "@beep/repo-cli/test/Explore";
+import { exploreCommand, packetForkFindingKey } from "@beep/repo-cli/test/Explore";
 import {
   foldPacketEvents,
   PacketEvent,
+  PacketForkVerdict,
   packetEventDigest,
   packetEventFileName,
   projectPacketTrace,
@@ -179,6 +180,65 @@ describe("explore --check", () => {
             const summaryCount = A.length(Str.split(output, "repair plan (read-only)")) - 1;
             expect(forkCount).toBe(2);
             expect(summaryCount).toBe(1);
+            const parentA = "a".repeat(64);
+            const parentB = "b".repeat(64);
+            const forkA = PacketForkVerdict.make({ parent: parentA, parentSeq: 1, children: [] });
+            const forkB = PacketForkVerdict.make({ parent: parentB, parentSeq: 1, children: [] });
+            expect(packetForkFindingKey("twinned", forkA)).toBe(`twinned packet-stream-fork ${parentA}`);
+            expect(packetForkFindingKey("twinned", forkB)).toBe(`twinned packet-stream-fork ${parentB}`);
+          })
+        ).pipe(provideScopedLayer(testLayer))
+      ),
+    30_000
+  );
+
+  it(
+    "reports root-specific manifest status drift for goals and explorations without blocking",
+    () =>
+      Effect.runPromise(
+        withTempWorkingDirectory(
+          Effect.gen(function* () {
+            const goalEvent = PacketEvent.make({
+              schemaVersion: "packet-event/v1",
+              packet: "goal-drift",
+              root: "goals",
+              seq: 1,
+              expectedRevision: 0,
+              at: "2026-08-17T00:00:00.000Z",
+              actor: "test",
+              body: { type: "packet-created", status: "paused" },
+            });
+            yield* writeEvent("goals/goal-drift", goalEvent);
+            yield* writeProjectFile(
+              "goals/goal-drift/ops/manifest.json",
+              '{"initiative":{"status":"active"},"exploration":{"status":"paused"}}\n'
+            );
+
+            const explorationEvent = PacketEvent.make({
+              ...goalEvent,
+              packet: "exploration-drift",
+              root: "explorations",
+            });
+            yield* writeEvent("explorations/exploration-drift", explorationEvent);
+            yield* writeProjectFile(
+              "explorations/exploration-drift/ops/manifest.json",
+              '{"initiative":{"status":"paused"},"exploration":{"status":"graduated"}}\n'
+            );
+
+            const alignedEvent = PacketEvent.make({ ...goalEvent, packet: "aligned" });
+            yield* writeEvent("goals/aligned", alignedEvent);
+            yield* writeProjectFile(
+              "goals/aligned/ops/manifest.json",
+              '{"initiative":{"status":"paused"},"exploration":{"status":"active"}}\n'
+            );
+
+            const exit = yield* Effect.exit(runExploreCommand(["--check"]));
+            expect(Exit.isSuccess(exit)).toBe(true);
+            const output = yield* consoleText();
+            expect(A.length(Str.split(output, "[packet-status-drift]")) - 1).toBe(2);
+            expect(output).toContain("goals/goal-drift/ops/manifest.json status active");
+            expect(output).toContain("explorations/exploration-drift/ops/manifest.json status graduated");
+            expect(output).not.toContain("- aligned [packet-status-drift]");
           })
         ).pipe(provideScopedLayer(testLayer))
       ),

--- a/packages/tooling/tool/cli/test/fixtures/packet-core/packet-mismatch/ops/events/00001-packet-created-38d88c5951f93fb4b2eb4434cc1e4d8efafb73e45a85d1dd2a94d157be1017a2.json
+++ b/packages/tooling/tool/cli/test/fixtures/packet-core/packet-mismatch/ops/events/00001-packet-created-38d88c5951f93fb4b2eb4434cc1e4d8efafb73e45a85d1dd2a94d157be1017a2.json
@@ -1,0 +1,15 @@
+{
+  "actor": "fixture",
+  "at": "2026-08-17T00:00:00.000Z",
+  "body": {
+    "ordinal": 0,
+    "stage": "capture",
+    "status": "active",
+    "type": "packet-created"
+  },
+  "expectedRevision": 0,
+  "packet": "golden-linear",
+  "root": "goals",
+  "schemaVersion": "packet-event/v1",
+  "seq": 1
+}

--- a/packages/tooling/tool/cli/test/fixtures/packet-core/raw-unknown-key/ops/events/00001-packet-created-38d88c5951f93fb4b2eb4434cc1e4d8efafb73e45a85d1dd2a94d157be1017a2.json
+++ b/packages/tooling/tool/cli/test/fixtures/packet-core/raw-unknown-key/ops/events/00001-packet-created-38d88c5951f93fb4b2eb4434cc1e4d8efafb73e45a85d1dd2a94d157be1017a2.json
@@ -1,0 +1,16 @@
+{
+  "actor": "fixture",
+  "at": "2026-08-17T00:00:00.000Z",
+  "body": {
+    "ordinal": 0,
+    "stage": "capture",
+    "status": "active",
+    "type": "packet-created"
+  },
+  "expectedRevision": 0,
+  "injected": "unknown-key-must-affect-identity",
+  "packet": "golden-linear",
+  "root": "goals",
+  "schemaVersion": "packet-event/v1",
+  "seq": 1
+}

--- a/packages/tooling/tool/cli/test/goals-packet-core.test.ts
+++ b/packages/tooling/tool/cli/test/goals-packet-core.test.ts
@@ -36,6 +36,8 @@ const FIXTURES_ROOT = new URL("./fixtures/packet-core", import.meta.url).pathnam
 const GOLDEN_PATH = `${FIXTURES_ROOT}/golden-linear`;
 const FORKED_PATH = `${FIXTURES_ROOT}/forked`;
 const RISK_OVERRIDE_PATH = `${FIXTURES_ROOT}/risk-override`;
+const RAW_UNKNOWN_KEY_PATH = `${FIXTURES_ROOT}/raw-unknown-key`;
+const PACKET_MISMATCH_PATH = `${FIXTURES_ROOT}/packet-mismatch`;
 
 type EventBody = PacketEvent["body"];
 
@@ -330,6 +332,39 @@ describe("foldPacketEvents", () => {
           expect(A.length(derived.issues)).toBe(1);
           expect(derived.issues[0]?.kind).toBe("missing-parent");
           expect(derived.revision).toBe(0);
+        })
+      ),
+    20_000
+  );
+
+  it(
+    "orders same-sequence fork verdicts by parent digest",
+    () =>
+      Effect.runPromise(
+        Effect.gen(function* () {
+          let events = A.empty<StoredPacketEvent>();
+          for (const parentByte of ["b", "a"]) {
+            for (const at of ["2026-08-17T00:00:00.000Z", "2026-08-17T00:00:01.000Z"]) {
+              const event = PacketEvent.make({
+                schemaVersion: "packet-event/v1",
+                packet: "demo",
+                root: "goals",
+                seq: 2,
+                parent: parentByte.repeat(64),
+                expectedRevision: 1,
+                at,
+                actor: "test",
+                body: { type: "status-set", status: "paused", previous: "active" },
+              });
+              const id = yield* packetEventDigest(event);
+              events = A.append(
+                events,
+                StoredPacketEvent.make({ id, fileName: packetEventFileName(event, id), event })
+              );
+            }
+          }
+          const derived = foldPacketEvents({ packet: "demo", root: "goals", events });
+          expect(A.map(derived.forks, (fork) => fork.parent)).toStrictEqual(["a".repeat(64), "b".repeat(64)]);
         })
       ),
     20_000
@@ -695,6 +730,44 @@ describe("store read robustness", () => {
       actor: "test",
       body: { type: "packet-created", status: "active" },
     });
+
+  it(
+    "rejects an otherwise decodable event whose raw JSON carries an unknown key",
+    () =>
+      Effect.runPromise(
+        Effect.gen(function* () {
+          const store = yield* PacketEventStore;
+          const listing = yield* store.list(
+            PacketStreamLocator.make({ packet: "golden-linear", root: "goals", packetPath: RAW_UNKNOWN_KEY_PATH })
+          );
+          expect(listing.events).toStrictEqual([]);
+          expect(A.map(listing.issues, (item) => item.kind)).toStrictEqual(["digest-mismatch"]);
+        }).pipe(provideScopedLayer(testLayer))
+      ),
+    20_000
+  );
+
+  it(
+    "rejects copied history whose packet and root disagree with the locator",
+    () =>
+      Effect.runPromise(
+        Effect.gen(function* () {
+          const store = yield* PacketEventStore;
+          const listing = yield* store.list(
+            PacketStreamLocator.make({
+              packet: "copied-history",
+              root: "explorations",
+              packetPath: PACKET_MISMATCH_PATH,
+            })
+          );
+          expect(listing.events).toStrictEqual([]);
+          expect(A.map(listing.issues, (item) => item.kind)).toStrictEqual(["packet-mismatch"]);
+          expect(listing.issues[0]?.detail).toContain("goals/golden-linear");
+          expect(listing.issues[0]?.detail).toContain("explorations/copied-history");
+        }).pipe(provideScopedLayer(testLayer))
+      ),
+    20_000
+  );
 
   it(
     "reports unreadable names, invalid JSON, undecodable events, and digest or name mismatches as issues",

--- a/packages/tooling/tool/cli/test/goals-packet-core.test.ts
+++ b/packages/tooling/tool/cli/test/goals-packet-core.test.ts
@@ -306,6 +306,62 @@ describe("foldPacketEvents", () => {
   );
 
   it(
+    "orders a genesis fork by digest when two roots claim sequence one",
+    () =>
+      Effect.runPromise(
+        Effect.gen(function* () {
+          const events = yield* chainEvents("demo", [
+            { body: { type: "packet-created", status: "active" }, at: "2026-08-17T00:00:00.000Z" },
+          ]);
+          // A second parentless root: the fork's parent key falls back to the genesis sentinel.
+          const rival = PacketEvent.make({
+            schemaVersion: "packet-event/v1",
+            packet: "demo",
+            root: "goals",
+            seq: 1,
+            expectedRevision: 0,
+            at: "2026-08-17T00:00:30.000Z",
+            actor: "test",
+            body: { type: "packet-created", status: "paused" },
+          });
+          const rivalId = yield* packetEventDigest(rival);
+          // A second, parented fork one level down, so the verdict sort has to order a
+          // parentless verdict against a parented one.
+          const parentId = storedIdAt(events, 0);
+          const childA = PacketEvent.make({
+            schemaVersion: "packet-event/v1",
+            packet: "demo",
+            root: "goals",
+            seq: 2,
+            ...(parentId === undefined ? {} : { parent: parentId }),
+            expectedRevision: 1,
+            at: "2026-08-17T00:01:00.000Z",
+            actor: "test",
+            body: { type: "stage-entered", stage: "align", ordinal: 2 },
+          });
+          const childB = PacketEvent.make({ ...childA, at: "2026-08-17T00:01:30.000Z" });
+          const childAId = yield* packetEventDigest(childA);
+          const childBId = yield* packetEventDigest(childB);
+          const forked = A.appendAll(events, [
+            StoredPacketEvent.make({ id: rivalId, fileName: packetEventFileName(rival, rivalId), event: rival }),
+            StoredPacketEvent.make({ id: childAId, fileName: packetEventFileName(childA, childAId), event: childA }),
+            StoredPacketEvent.make({ id: childBId, fileName: packetEventFileName(childB, childBId), event: childB }),
+          ]);
+          const derived = foldPacketEvents({ packet: "demo", root: "goals", events: forked });
+          expect(A.length(derived.forks)).toBe(2);
+          // The genesis fork sorts ahead of the parented one, and its parent stays absent.
+          const genesisFork = derived.forks[0];
+          expect(genesisFork?.parent).toBeUndefined();
+          expect(genesisFork?.children.length).toBe(2);
+          expect(derived.forks[1]?.parent).toBe(parentId);
+          // Nothing derives past an unresolved genesis fork.
+          expect(derived.revision).toBe(0);
+        })
+      ),
+    20_000
+  );
+
+  it(
     "reports a missing parent digest as a chain issue",
     () =>
       Effect.runPromise(

--- a/packages/tooling/tool/cli/test/goals-set-status-stream.test.ts
+++ b/packages/tooling/tool/cli/test/goals-set-status-stream.test.ts
@@ -256,6 +256,152 @@ describe("set-status guarded stream writer", () => {
   );
 
   it(
+    "regenerates a stale trace while skipping the redundant status event",
+    () =>
+      Effect.runPromise(
+        withTempWorkingDirectory(
+          Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            yield* writeStreamPacket("skip-stale-trace-demo");
+            const seeded = yield* Effect.exit(runGoalsCommand(["set-status", "skip-stale-trace-demo", "paused"]));
+            expect(Exit.isSuccess(seeded)).toBe(true);
+
+            const tracePath = "goals/skip-stale-trace-demo/ops/trace.json";
+            const freshTrace = yield* fs.readFileString(tracePath);
+            const beforeFiles = yield* listEventFiles("skip-stale-trace-demo");
+            // Model the interrupted writer: the event landed, the projection never did.
+            yield* fs.remove(tracePath);
+
+            const writer = yield* PacketTransitionWriter;
+            const plan = yield* writer.plan(
+              PacketTransitionRequest.make({
+                locator: PacketStreamLocator.make({
+                  packet: "skip-stale-trace-demo",
+                  root: "goals",
+                  packetPath: "goals/skip-stale-trace-demo",
+                }),
+                status: "paused",
+                previousStatus: "active",
+                actor: "test",
+                at: "2026-08-17T10:00:00.000Z",
+              })
+            );
+            expect(plan.disposition).toBe("skipped");
+
+            const outcome = yield* writer.commit(plan);
+            expect(outcome.disposition).toBe("skipped");
+            expect(outcome.appended).toBe(0);
+            expect(outcome.traceWritten).toBe(true);
+            expect(yield* fs.readFileString(tracePath)).toBe(freshTrace);
+            expect(yield* listEventFiles("skip-stale-trace-demo")).toStrictEqual(beforeFiles);
+          })
+        ).pipe(provideScopedLayer(testLayer))
+      ),
+    30_000
+  );
+
+  it(
+    "refuses a skipped plan whose stream moved between plan and commit",
+    () =>
+      Effect.runPromise(
+        withTempWorkingDirectory(
+          Effect.gen(function* () {
+            yield* writeStreamPacket("skip-cas-demo");
+            const seeded = yield* Effect.exit(runGoalsCommand(["set-status", "skip-cas-demo", "paused"]));
+            expect(Exit.isSuccess(seeded)).toBe(true);
+
+            const locator = PacketStreamLocator.make({
+              packet: "skip-cas-demo",
+              root: "goals",
+              packetPath: "goals/skip-cas-demo",
+            });
+            const writer = yield* PacketTransitionWriter;
+            const stalePlan = yield* writer.plan(
+              PacketTransitionRequest.make({
+                locator,
+                status: "paused",
+                previousStatus: "active",
+                actor: "test",
+                at: "2026-08-17T10:00:00.000Z",
+              })
+            );
+            expect(stalePlan.disposition).toBe("skipped");
+
+            // A concurrent writer advances the stream after the skipped plan was sealed.
+            const concurrent = yield* writer.plan(
+              PacketTransitionRequest.make({
+                locator,
+                status: "active",
+                previousStatus: "paused",
+                actor: "other",
+                at: "2026-08-17T11:00:00.000Z",
+              })
+            );
+            expect(concurrent.disposition).toBe("append");
+            expect((yield* writer.commit(concurrent)).appended).toBe(1);
+
+            const refused = yield* Effect.exit(writer.commit(stalePlan));
+            expect(Exit.isFailure(refused)).toBe(true);
+            if (Exit.isFailure(refused)) {
+              expect(String(Cause.squash(refused.cause))).toContain("stream moved between plan and commit");
+            }
+          })
+        ).pipe(provideScopedLayer(testLayer))
+      ),
+    30_000
+  );
+
+  it(
+    "previews a skipped transition without planning an event or a trace write",
+    () =>
+      Effect.runPromise(
+        withTempWorkingDirectory(
+          Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            yield* writeStreamPacket("skip-preview-demo");
+            const seeded = yield* Effect.exit(runGoalsCommand(["set-status", "skip-preview-demo", "paused"]));
+            expect(Exit.isSuccess(seeded)).toBe(true);
+
+            const beforeFiles = yield* listEventFiles("skip-preview-demo");
+            const beforeTrace = yield* fs.readFileString("goals/skip-preview-demo/ops/trace.json");
+
+            const previewed = yield* Effect.exit(
+              runGoalsCommand(["set-status", "skip-preview-demo", "paused", "--preview"])
+            );
+            expect(Exit.isSuccess(previewed)).toBe(true);
+            expect(yield* listEventFiles("skip-preview-demo")).toStrictEqual(beforeFiles);
+            expect(yield* fs.readFileString("goals/skip-preview-demo/ops/trace.json")).toBe(beforeTrace);
+          })
+        ).pipe(provideScopedLayer(testLayer))
+      ),
+    30_000
+  );
+
+  it(
+    "reports a skipped write through the set-status command surface",
+    () =>
+      Effect.runPromise(
+        withTempWorkingDirectory(
+          Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            yield* writeStreamPacket("skip-write-demo");
+            const seeded = yield* Effect.exit(runGoalsCommand(["set-status", "skip-write-demo", "paused"]));
+            expect(Exit.isSuccess(seeded)).toBe(true);
+
+            const beforeFiles = yield* listEventFiles("skip-write-demo");
+            const repeated = yield* Effect.exit(runGoalsCommand(["set-status", "skip-write-demo", "paused"]));
+            expect(Exit.isSuccess(repeated)).toBe(true);
+
+            expect(yield* listEventFiles("skip-write-demo")).toStrictEqual(beforeFiles);
+            const manifest = yield* fs.readFileString("goals/skip-write-demo/ops/manifest.json");
+            expect(manifest).toContain("paused");
+          })
+        ).pipe(provideScopedLayer(testLayer))
+      ),
+    30_000
+  );
+
+  it(
     "fails invalid writer actors during request decode",
     () =>
       Effect.runPromise(

--- a/packages/tooling/tool/cli/test/goals-set-status-stream.test.ts
+++ b/packages/tooling/tool/cli/test/goals-set-status-stream.test.ts
@@ -201,11 +201,79 @@ describe("set-status guarded stream writer", () => {
               })
             );
             expect(plan.streamPresent).toBe(false);
+            expect(plan.disposition).toBe("streamless");
             const outcome = yield* writer.commit(plan);
+            expect(outcome.disposition).toBe("streamless");
             expect(outcome.appended).toBe(0);
             expect(outcome.traceWritten).toBe(false);
           })
         ).pipe(provideScopedLayer(testLayer))
+      ),
+    30_000
+  );
+
+  it(
+    "returns an explicit skipped plan and outcome for the current derived status",
+    () =>
+      Effect.runPromise(
+        withTempWorkingDirectory(
+          Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            yield* writeStreamPacket("idempotent-demo");
+            const seeded = yield* Effect.exit(runGoalsCommand(["set-status", "idempotent-demo", "paused"]));
+            expect(Exit.isSuccess(seeded)).toBe(true);
+
+            const beforeFiles = yield* listEventFiles("idempotent-demo");
+            const beforeTrace = yield* fs.readFileString("goals/idempotent-demo/ops/trace.json");
+            const writer = yield* PacketTransitionWriter;
+            const plan = yield* writer.plan(
+              PacketTransitionRequest.make({
+                locator: PacketStreamLocator.make({
+                  packet: "idempotent-demo",
+                  root: "goals",
+                  packetPath: "goals/idempotent-demo",
+                }),
+                status: "paused",
+                previousStatus: "active",
+                actor: "test",
+                at: "2026-08-17T10:00:00.000Z",
+              })
+            );
+            expect(plan.disposition).toBe("skipped");
+            expect(plan.events).toStrictEqual([]);
+            expect(plan.derivedAfter?.status).toBe("paused");
+
+            const outcome = yield* writer.commit(plan);
+            expect(outcome.disposition).toBe("skipped");
+            expect(outcome.appended).toBe(0);
+            expect(outcome.traceWritten).toBe(false);
+            expect(yield* listEventFiles("idempotent-demo")).toStrictEqual(beforeFiles);
+            expect(yield* fs.readFileString("goals/idempotent-demo/ops/trace.json")).toBe(beforeTrace);
+          })
+        ).pipe(provideScopedLayer(testLayer))
+      ),
+    30_000
+  );
+
+  it(
+    "fails invalid writer actors during request decode",
+    () =>
+      Effect.runPromise(
+        Effect.gen(function* () {
+          const decoded = yield* Effect.exit(
+            S.decodeEffect(PacketTransitionRequest)({
+              locator: { packet: "decode-demo", root: "goals", packetPath: "goals/decode-demo" },
+              status: "paused",
+              previousStatus: "active",
+              actor: "",
+              at: "2026-08-17T10:00:00.000Z",
+            })
+          );
+          expect(Exit.isFailure(decoded)).toBe(true);
+          if (Exit.isFailure(decoded)) {
+            expect(String(Cause.squash(decoded.cause))).toContain("Expected a non-empty actor");
+          }
+        })
       ),
     30_000
   );


### PR DESCRIPTION
## feat(repo-cli): harden packet-core before close (packet-control-plane-core)

## Local proof

- fallow-advisory-feedback: passed
- publish:head-install-preflight: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/feat_packet-core-rung-4-ec5306880515/verdict.json

---

## Provenance

- Branch: <code>feat/packet-core-rung-4</code>
- Harness: `codex`

<!-- yeet-provenance
{
  "schemaVersion": 1,
  "branch": "feat/packet-core-rung-4",
  "harness": "codex"
}
-->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790363159&installation_model_id=424656&pr_number=848&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F848&signature=e28446b8fa30574a9f57afb9ecf75b8dbd2997d10eb94ce49de7fd041f03c71f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->