### PR TITLE
chore(codex): stop pinning approval and sandbox policy in repo config

### DIFF
--- a/.changeset/ai-sync-inherit-permission-policy.md
+++ b/.changeset/ai-sync-inherit-permission-policy.md
@@ -1,0 +1,7 @@
+---
+"@beep/ai-sync": patch
+---
+
+Codex repo safety policy now requires `approval_policy` and `sandbox_mode` to be omitted from
+`.codex/config.toml` so sessions inherit the user's `~/.codex/config.toml`, instead of requiring
+committed `never`/`danger-full-access` pins.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -3,11 +3,8 @@
 # Claude remains the source of truth for the skill bodies in `.claude/skills`.
 # Codex discovers the mirrored repo skill root through `.agents/skills`, which is
 # linked to that Claude tree.
-# Keep repository sessions inside the checkout by default. Network access,
-# writes outside the workspace, and other privileged operations require an
-# explicit approval at the point of use.
-approval_policy = "never"
-sandbox_mode = "danger-full-access"
+# Permission and approval defaults are intentionally inherited from the user's
+# ~/.codex/config.toml; this project does not narrow them.
 
 [features]
   # The ChatGPT app/connectors MCP is useful for ad-hoc GitHub work, but it makes

--- a/packages/tooling/library/ai-sync/src/validation.ts
+++ b/packages/tooling/library/ai-sync/src/validation.ts
@@ -187,7 +187,7 @@ const repoSafetyPolicyError = (relativePath: AiSyncValidatedConfigPath, message:
     cause: O.fromNullishOr(cause),
   });
 
-const codexSettingSafetyFinding = (
+const explicitSettingSafetyFinding = (
   settingName: string,
   expectedValue: string,
   value: string | undefined
@@ -199,6 +199,9 @@ const codexSettingSafetyFinding = (
         O.as(`${settingName} must be "${expectedValue}"`)
       ),
   });
+
+const codexSettingOmittedFinding = (settingName: string, value: O.Option<string>): O.Option<string> =>
+  O.as(value, `${settingName} must be omitted so sessions inherit the user's ~/.codex/config.toml`);
 
 const validateCodexRepoSafetyPolicy = (content: string) =>
   decodeCodexRepoSafetyPolicy(content).pipe(
@@ -215,8 +218,8 @@ const validateCodexRepoSafetyPolicy = (content: string) =>
         O.as("sandbox_workspace_write.writable_roots must be empty or omitted")
       );
       const findings = A.getSomes([
-        codexSettingSafetyFinding("approval_policy", "never", O.getOrUndefined(config.approval_policy)),
-        codexSettingSafetyFinding("sandbox_mode", "danger-full-access", O.getOrUndefined(config.sandbox_mode)),
+        codexSettingOmittedFinding("approval_policy", config.approval_policy),
+        codexSettingOmittedFinding("sandbox_mode", config.sandbox_mode),
         networkAccessFinding,
         writableRootsFinding,
       ]);
@@ -249,7 +252,7 @@ const validateClaudeRepoSafetyPolicy = (content: string) =>
         deniedPermissions,
         (permission) => !isRequiredClaudeRepoDenyPermission(permission)
       );
-      const defaultModeFinding = codexSettingSafetyFinding(
+      const defaultModeFinding = explicitSettingSafetyFinding(
         "permissions.defaultMode",
         "default",
         settings.permissions.pipe(
@@ -394,9 +397,11 @@ export const validateRepoConfig = Effect.fn("AiSync.validateRepoConfig")(functio
  *
  * **Details**
  *
- * Codex must use exactly `on-request` approvals and `workspace-write`
- * sandboxing, disable workspace-write network access, and grant no additional
- * writable roots. Claude must explicitly set `permissions.defaultMode` to
+ * The Codex repo config must omit `approval_policy` and `sandbox_mode`
+ * entirely — permission posture belongs to each user's `~/.codex/config.toml`,
+ * and the repository neither narrows nor widens it. It must also disable
+ * workspace-write network access and grant no additional writable roots.
+ * Claude must explicitly set `permissions.defaultMode` to
  * `default`, and every Bash allow entry must belong to the repository's exact
  * 46-value grant domain. Its deny rules must exactly cover the repository's
  * 19-value destructive-operation domain without out-of-policy additions. Named

--- a/packages/tooling/library/ai-sync/test/ai-sync.test.ts
+++ b/packages/tooling/library/ai-sync/test/ai-sync.test.ts
@@ -313,36 +313,37 @@ layer(NodeServices.layer as Layer.Layer<TUnsafe.Any>)("@beep/ai-sync", (it) => {
           const codexPath = path.join(tmpDir, ".codex/config.toml");
           const claudePath = path.join(tmpDir, ".claude/settings.json");
 
-          yield* writeText(codexPath, 'approval_policy = "never"\nsandbox_mode = "danger-full-access"\n');
+          yield* writeText(codexPath, "");
           assert.strictEqual(
             (yield* validateRepoConfig({ repoRoot: tmpDir, config: ".codex/config.toml" })).schemaId,
             "codex-config"
           );
           yield* validateRepoSafetyPolicy({ repoRoot: tmpDir, config: ".codex/config.toml" });
 
+          yield* writeText(codexPath, 'approval_policy = "never"\nsandbox_mode = "danger-full-access"\n');
+          const pinnedCodex = yield* Effect.flip(
+            validateRepoSafetyPolicy({ repoRoot: tmpDir, config: ".codex/config.toml" })
+          );
+          assert.include(pinnedCodex.message, "approval_policy must be omitted");
+          assert.include(pinnedCodex.message, "sandbox_mode must be omitted");
+
           yield* writeText(codexPath, 'approval_policy = "on-request"\nsandbox_mode = "workspace-write"\n');
-          const unsafeCodex = yield* Effect.flip(
+          const safePinnedCodex = yield* Effect.flip(
             validateRepoSafetyPolicy({ repoRoot: tmpDir, config: ".codex/config.toml" })
           );
-          assert.include(unsafeCodex.message, 'approval_policy must be "never"');
-          assert.include(unsafeCodex.message, 'sandbox_mode must be "danger-full-access"');
+          assert.include(safePinnedCodex.message, "approval_policy must be omitted");
+          assert.include(safePinnedCodex.message, "sandbox_mode must be omitted");
 
-          yield* writeText(codexPath, "");
-          const implicitCodex = yield* Effect.flip(
+          yield* writeText(codexPath, 'sandbox_mode = "workspace-write"\n');
+          const partialPinCodex = yield* Effect.flip(
             validateRepoSafetyPolicy({ repoRoot: tmpDir, config: ".codex/config.toml" })
           );
-          assert.include(implicitCodex.message, 'approval_policy must be explicitly set to "never"');
-          assert.include(implicitCodex.message, 'sandbox_mode must be explicitly set to "danger-full-access"');
-
-          yield* writeText(codexPath, 'approval_policy = "on-failure"\nsandbox_mode = "danger-full-access"\n');
-          const driftedCodexApproval = yield* Effect.flip(
-            validateRepoSafetyPolicy({ repoRoot: tmpDir, config: ".codex/config.toml" })
-          );
-          assert.include(driftedCodexApproval.message, 'approval_policy must be "never"');
+          assert.include(partialPinCodex.message, "sandbox_mode must be omitted");
+          assert.notInclude(partialPinCodex.message, "approval_policy");
 
           yield* writeText(
             codexPath,
-            'approval_policy = "never"\nsandbox_mode = "danger-full-access"\n\n[sandbox_workspace_write]\nnetwork_access = true\nwritable_roots = ["/tmp/outside"]\n'
+            '[sandbox_workspace_write]\nnetwork_access = true\nwritable_roots = ["/tmp/outside"]\n'
           );
           assert.strictEqual(
             (yield* validateRepoConfig({ repoRoot: tmpDir, config: ".codex/config.toml" })).schemaId,
@@ -360,10 +361,7 @@ layer(NodeServices.layer as Layer.Layer<TUnsafe.Any>)("@beep/ai-sync", (it) => {
             "sandbox_workspace_write.writable_roots must be empty or omitted"
           );
 
-          yield* writeText(
-            codexPath,
-            'approval_policy = "never"\nsandbox_mode = "danger-full-access"\n\n[sandbox_workspace_write]\nnetwork_access = false\nwritable_roots = []\n'
-          );
+          yield* writeText(codexPath, "[sandbox_workspace_write]\nnetwork_access = false\nwritable_roots = []\n");
           yield* validateRepoSafetyPolicy({ repoRoot: tmpDir, config: ".codex/config.toml" });
 
           yield* writeText(
@@ -501,7 +499,7 @@ layer(NodeServices.layer as Layer.Layer<TUnsafe.Any>)("@beep/ai-sync", (it) => {
             { discard: true }
           );
 
-          yield* writeText(codexPath, 'approval_policy = "never"\nsandbox_mode = "danger-full-access"\n');
+          yield* writeText(codexPath, "[features]\napps = false\n");
           yield* writeText(
             claudePath,
             yield* encodeJson({
@@ -583,7 +581,7 @@ layer(NodeServices.layer as Layer.Layer<TUnsafe.Any>)("@beep/ai-sync", (it) => {
           const path = yield* Path.Path;
           const codexPath = path.join(tmpDir, ".codex/config.toml");
           const claudePath = path.join(tmpDir, ".claude/settings.json");
-          yield* writeText(codexPath, 'approval_policy = "never"\nsandbox_mode = "danger-full-access"\n');
+          yield* writeText(codexPath, "[features]\napps = false\n");
           yield* writeText(claudePath, yield* encodeJson({ permissions: repoSafeClaudePermissions }));
 
           const readPaths = yield* Ref.make(A.empty<string>());


### PR DESCRIPTION
## What

Removes `approval_policy` and `sandbox_mode` from `.codex/config.toml`. The repo-local
Codex config no longer sets any permission posture; each user's `~/.codex/config.toml`
governs approvals and sandboxing.

## Why

- #688 pinned `on-request` / `workspace-write`. Safe, but it overrode the user's own
  Codex defaults and produced constant approval prompts in every beep-effect session.
- #855 then silently flipped the committed pin to `never` / `danger-full-access` inside
  an unrelated packet-conventions PR - a bad default to advertise in a public repository.
- On 2026-08-28 a Codex desktop session, asked to stop the prompts, swept the working
  copies of all ~34 local checkouts with an uncommitted edit doing exactly what this PR
  does. This PR lands that intent properly, once, through review.

Sessions on this machine keep their yolo behavior via the user-global config; fresh
public clones get stock Codex defaults instead of committed `danger-full-access`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790571539&installation_model_id=424656&pr_number=876&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F876&signature=a5a49ef881d4bfa5d0aafabde10caf95ec7148d98ad104e09d0a75016f6e7b46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->