### PR TITLE
chore(agents): pin next-devtools MCP and align project MCP defaults

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -77,7 +77,7 @@
     "phoenix-docs",
     "phoenix"
   ],
-  "disabledMcpjsonServers": ["serena", "sourcegraph", "webstorm"],
+  "disabledMcpjsonServers": ["chrome-devtools", "serena", "webstorm"],
   "hooks": {
     "PreToolUse": [
       {

--- a/.mcp.json
+++ b/.mcp.json
@@ -8,7 +8,7 @@
     "next-devtools": {
       "type": "stdio",
       "command": "bunx",
-      "args": ["next-devtools-mcp@latest"]
+      "args": ["next-devtools-mcp@0.4.0"]
     },
     "serena": {
       "type": "stdio",


### PR DESCRIPTION
## Summary

Project-scoped MCP config hygiene for the `main` checkout, judged against the repo's own
doctrine (MCP config is operator-level; repo config must not ship unpinned or silently
auto-enabled tooling — see `goals/codex-security-findings-2026-07-14/findings/CSF-002.md`,
and `AGENTS.md` → Tool Routing).

- `.mcp.json`: pin `next-devtools-mcp@latest` → `next-devtools-mcp@0.4.0` (current npm
  latest). It was the only unpinned package in the file; every other stdio server is pinned.
- `.claude/settings.json` → `disabledMcpjsonServers`:
  - add `chrome-devtools` — `AGENTS.md` states it is "slim and default-disabled, for
    perf-trace/computed-style introspection during QA sessions", but the tracked settings did
    not disable it, so every fresh checkout was prompted for it.
  - drop `sourcegraph` — no such server exists in `.mcp.json` (stale entry).

Deliberately unchanged (called out so reviewers can disagree):

- `shadcn`, `next-devtools`, `nlp`, `fallow` stay opt-in (neither enabled nor disabled);
  operators decide per checkout via `settings.local.json`.
- `.codex/config.toml` carries only the HTTP servers; `basic-memory`/`codegraph` for Codex are
  user-level per `standards/memory-architecture/07-shared-memory-adoption.md`.
- `phoenix` (tailnet URL) stays enabled as landed in #863; `webstorm` stays disabled.
- Existing pins (`shadcn@4.11.0`, `chrome-devtools-mcp@1.6.0`, `basic-memory@0.22.1`) are not
  bumped — this PR is hygiene, not upgrades.

Note for reviewers: `.claude/settings.json` is covered by the repo's `Edit(**/.claude/settings.json)`
deny rule for in-repo agent sessions; this change was made from an operator-directed session and
is intentionally limited to the two `disabledMcpjsonServers` entries above.

Verification: `bun run --cwd packages/tooling/library/ai-sync check` (validates
`.codex/config.toml` + `.claude/settings.json` against schema + repo safety policy) and
`bun run beep yeet repair` (cheap-gates tier) are green; the full Yeet proof runs with publish.

## chore(agents): pin next-devtools MCP and align project MCP defaults

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/chore_mcp-config-hygiene-838a497effcb/verdict.json

---

## Provenance

- Branch: <code>chore/mcp-config-hygiene</code>
- Harness: `codex`

<!-- yeet-provenance
{
  "schemaVersion": 1,
  "branch": "chore/mcp-config-hygiene",
  "harness": "codex"
}
-->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/877"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790580190&installation_model_id=424656&pr_number=877&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F877&signature=0dc25d381b16b91a3e40fdcbabae1648cd84bcd9c958553ffa6b3e5525c60700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
