### PR TITLE
feat(repo-cli): retain admission linkage and journal admission transitions

### DIFF
--- a/.changeset/admission-transition-journal.md
+++ b/.changeset/admission-transition-journal.md
@@ -1,0 +1,12 @@
+---
+{}
+---
+
+No release: retain admission linkage across the ticket→lease handoff and journal
+admission transitions.
+
+Leases now carry the ticket `nonce` and enqueue instant (legacy lease files decode
+with `""`/`0` sentinels), and a ring-buffered best-effort NDJSON journal at
+`$XDG_RUNTIME_DIR/beep/admit/journal.ndjson` records admitted/released events keyed
+by ticket nonce and pid, so granted queue-wait (admittedAt − enqueuedAt) survives
+lease release instead of erasing with the ticket and lease files.

--- a/.claude/skills/yeet/SKILL.md
+++ b/.claude/skills/yeet/SKILL.md
@@ -486,7 +486,10 @@ turbo work, so they are cheap to run mid-loop.
   dead or pid-reused state is reaped automatically, and malformed state is
   quarantined visibly. Inspect with `bun run beep quality scheduler status`
   and repair with `bun run beep quality scheduler reap [--apply]` (dry-run by
-  default). `Ctrl-C` while queued removes the ticket.
+  default). `Ctrl-C` while queued removes the ticket. Admission transitions
+  are journaled best-effort to `$XDG_RUNTIME_DIR/beep/admit/journal.ndjson`
+  (ring-buffered NDJSON; admitted and released events keyed by ticket nonce
+  and pid), so granted queue-wait survives lease release.
   `verify --tier review-fix` remains the cheaper loop lane while a full proof
   is active (one token, never the origin lock); `--tier cheap-gates` takes
   neither admission nor the lock.

--- a/packages/tooling/tool/cli/src/internal/repo-run/AdmissionJournal.ts
+++ b/packages/tooling/tool/cli/src/internal/repo-run/AdmissionJournal.ts
@@ -2,17 +2,21 @@
  * Machine-wide best-effort admission-transition journal at
  * `<admission root>/journal.ndjson`.
  *
- * The journal is ring-buffered for diagnostics. Scheduler correctness lives
- * exclusively in ticket and lease files; `bypassAdmission` on sub-envelope
- * machines mints neither file and journals no transition.
+ * Every write serializes under `<admission root>/journal.lock`: the writer
+ * reads the journal, drops undecodable records, appends its event, ring-trims
+ * to the newest admitted transitions, and publishes the result with an atomic
+ * temp-file rename. Scheduler correctness lives exclusively in ticket and
+ * lease files; `bypassAdmission` on sub-envelope machines mints neither file
+ * and journals no transition.
  *
  * @packageDocumentation
  * @since 0.0.0
  */
 
+import { randomUUID } from "node:crypto";
 import { $RepoCliId } from "@beep/identity/packages";
 import { SchemaUtils } from "@beep/schema";
-import { Clock, Console, Effect, FileSystem, Path, pipe } from "effect";
+import { Clock, Console, Duration, Effect, FileSystem, Path, pipe } from "effect";
 import * as A from "effect/Array";
 import { constant, dual } from "effect/Function";
 import * as O from "effect/Option";
@@ -26,6 +30,8 @@ const JOURNAL_FILE_NAME = "journal.ndjson";
 const LOCK_FILE_NAME = "journal.lock";
 const RETAINED_ADMISSIONS = 200;
 const LOCK_STALE_MILLIS = 60_000;
+const LOCK_RETRY_ATTEMPTS = 8;
+const LOCK_RETRY_DELAY_MILLIS = 25;
 const textEncoder = new TextEncoder();
 
 /**
@@ -173,9 +179,12 @@ export const admissionJournalPath = Effect.fn("AdmissionJournal.path")(function*
   return path.join(root, JOURNAL_FILE_NAME);
 });
 
-const inspectStaleCompactionLock = Effect.fnUntraced(function* (
+// A lock recreated by a sibling between the staleness stat and the remove can
+// be reaped while fresh; the window is one syscall pair and the cost is one
+// competing serialized writer, so the telemetry-grade journal accepts it.
+const reapStaleJournalLock = Effect.fnUntraced(function* (
   lockPath: string
-): Effect.fn.Return<boolean, never, FileSystem.FileSystem> {
+): Effect.fn.Return<void, never, FileSystem.FileSystem> {
   const fs = yield* FileSystem.FileSystem;
   const nowMillis = yield* Clock.currentTimeMillis;
   const info = yield* fs.stat(lockPath).pipe(Effect.option);
@@ -187,84 +196,111 @@ const inspectStaleCompactionLock = Effect.fnUntraced(function* (
   if (stale) {
     yield* fs.remove(lockPath, { force: true }).pipe(Effect.ignore);
   }
-  return false;
 });
 
-const tryAcquireCompactionLock = Effect.fnUntraced(function* (
+const tryAcquireJournalLock = Effect.fnUntraced(function* (
   lockPath: string
 ): Effect.fn.Return<boolean, never, FileSystem.FileSystem> {
   const fs = yield* FileSystem.FileSystem;
-  // Any create failure (typically AlreadyExists contention) skips this round;
-  // the stale inspection reaps an abandoned lock so the next append compacts.
+  // Any create failure (typically AlreadyExists contention) fails this
+  // attempt; reaping an abandoned lock lets a later attempt acquire it.
   return yield* Effect.scoped(
     Effect.gen(function* () {
       const file = yield* fs.open(lockPath, { flag: "wx" });
       yield* file.writeAll(textEncoder.encode(`${process.pid}\n`));
       return true;
     })
-  ).pipe(Effect.catch(() => inspectStaleCompactionLock(lockPath)));
+  ).pipe(Effect.catch(() => reapStaleJournalLock(lockPath).pipe(Effect.as(false))));
 });
 
-const compactLocked = Effect.fnUntraced(function* (
-  journalPath: string
+const acquireJournalLock = Effect.fnUntraced(function* (
+  lockPath: string
+): Effect.fn.Return<boolean, never, FileSystem.FileSystem> {
+  for (let attempt = 0; attempt < LOCK_RETRY_ATTEMPTS; attempt++) {
+    if (yield* tryAcquireJournalLock(lockPath)) {
+      return true;
+    }
+    yield* Effect.sleep(Duration.millis(LOCK_RETRY_DELAY_MILLIS));
+  }
+  return false;
+});
+
+const publishJournalAtomic = Effect.fnUntraced(function* (
+  journalPath: string,
+  content: string
+): Effect.fn.Return<void, QualitySchedulerError, FileSystem.FileSystem> {
+  const fs = yield* FileSystem.FileSystem;
+  const stagingPath = `${journalPath}.tmp-${process.pid}-${randomUUID()}`;
+  yield* Effect.scoped(
+    Effect.gen(function* () {
+      const file = yield* fs.open(stagingPath, { flag: "w" });
+      yield* file.writeAll(textEncoder.encode(content));
+      yield* file.sync;
+    })
+  ).pipe(Effect.mapError(QualitySchedulerError.new(`Failed to stage admission journal "${journalPath}".`)));
+  yield* fs
+    .rename(stagingPath, journalPath)
+    .pipe(Effect.mapError(QualitySchedulerError.new(`Failed to publish admission journal "${journalPath}".`)));
+});
+
+const rewriteJournalLocked = Effect.fnUntraced(function* (
+  journalPath: string,
+  event: AdmissionJournalEvent,
+  line: string
 ): Effect.fn.Return<void, QualitySchedulerError, FileSystem.FileSystem> {
   const fs = yield* FileSystem.FileSystem;
   const text = yield* fs
     .readFileString(journalPath)
-    .pipe(Effect.mapError(QualitySchedulerError.new(`Failed to read admission journal "${journalPath}".`)));
+    .pipe(
+      Effect.catchTag("PlatformError", (error) =>
+        error.reason._tag === "NotFound"
+          ? Effect.succeed(Str.empty)
+          : Effect.fail(QualitySchedulerError.new(`Failed to read admission journal "${journalPath}".`)(error))
+      )
+    );
   const rawLines = pipe(Str.split("\n")(text), A.filter(Str.isNonEmpty));
-  const probed = yield* Effect.forEach(rawLines, (line) =>
-    decodeAdmissionJournalEvent(line).pipe(Effect.option, Effect.map(O.map((event) => ({ event, line }))))
+  const probed = yield* Effect.forEach(rawLines, (raw) =>
+    decodeAdmissionJournalEvent(raw).pipe(
+      Effect.option,
+      Effect.map(O.map((decoded) => ({ event: decoded, line: raw })))
+    )
   );
-  const records = A.getSomes(probed);
-  const droppedCount = A.length(rawLines) - A.length(records);
+  const retained = A.getSomes(probed);
+  const droppedCount = A.length(rawLines) - A.length(retained);
   if (droppedCount > 0) {
     yield* Console.warn(`dropped ${droppedCount} undecodable admission journal record(s) from "${journalPath}"`);
   }
+  const records = A.append(retained, { event, line });
   const admittedIndexes = pipe(
     A.zip(
-      A.map(records, ({ event }) => event),
+      A.map(records, (record) => record.event),
       A.range(0, A.length(records) - 1)
     ),
-    A.map(([event, index]) => (event._tag === "admission-admitted" ? O.some(index) : O.none())),
+    A.map(([recorded, index]) => (recorded._tag === "admission-admitted" ? O.some(index) : O.none())),
     A.getSomes
   );
   const firstRetainedIndex =
     A.length(admittedIndexes) <= RETAINED_ADMISSIONS
       ? 0
       : pipe(admittedIndexes, A.takeRight(RETAINED_ADMISSIONS), A.head, O.getOrElse(constant(0)));
-  if (droppedCount === 0 && firstRetainedIndex === 0) {
-    return;
-  }
-  yield* fs
-    .writeFileString(
-      journalPath,
-      pipe(
-        A.drop(records, firstRetainedIndex),
-        A.map(({ line }) => `${line}\n`),
-        A.join(Str.empty)
-      )
+  yield* publishJournalAtomic(
+    journalPath,
+    pipe(
+      A.drop(records, firstRetainedIndex),
+      A.map((record) => `${record.line}\n`),
+      A.join(Str.empty)
     )
-    .pipe(Effect.mapError(QualitySchedulerError.new(`Failed to compact admission journal "${journalPath}".`)));
-});
-
-const compactAdmissionJournal = Effect.fnUntraced(function* (
-  journalPath: string,
-  lockPath: string
-): Effect.fn.Return<void, QualitySchedulerError, FileSystem.FileSystem> {
-  const acquired = yield* tryAcquireCompactionLock(lockPath);
-  if (!acquired) {
-    return;
-  }
-  const fs = yield* FileSystem.FileSystem;
-  yield* Effect.ensuring(compactLocked(journalPath), fs.remove(lockPath, { force: true }).pipe(Effect.ignore));
+  );
 });
 
 /**
- * Appends, syncs, self-heals, and bounds the machine-wide admission journal.
+ * Appends one admission transition through a serialized journal rewrite.
  *
- * Scheduler correctness does not depend on this operation; callers may handle
- * its typed failure as a best-effort diagnostic write.
+ * The writer takes `journal.lock` (bounded wait, reaping an abandoned lock),
+ * drops undecodable records, ring-trims to the newest admitted transitions,
+ * and publishes atomically via temp-file rename. A lock that stays busy fails
+ * the append with a typed error; scheduler correctness never depends on this
+ * operation, so callers treat that failure as a best-effort diagnostic write.
  *
  * **Example** (Reference the journal append entry point)
  *
@@ -276,7 +312,7 @@ const compactAdmissionJournal = Effect.fnUntraced(function* (
  *
  * @param root - Machine-wide admission root directory.
  * @param event - Admission transition to append.
- * @returns An effect that appends and compacts the admission journal.
+ * @returns An effect that appends to the serialized admission journal.
  * @category utilities
  * @since 0.0.0
  */
@@ -286,7 +322,7 @@ export const appendAdmissionJournalEvent = Effect.fn("AdmissionJournal.append")(
 ): Effect.fn.Return<void, QualitySchedulerError, FileSystem.FileSystem | Path.Path> {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
-  const journalPath = yield* admissionJournalPath(root);
+  const journalPath = path.join(root, JOURNAL_FILE_NAME);
   const lockPath = path.join(root, LOCK_FILE_NAME);
   const line = yield* encodeEvent(event).pipe(
     Effect.mapError(QualitySchedulerError.new("Failed to encode admission journal event."))
@@ -294,18 +330,13 @@ export const appendAdmissionJournalEvent = Effect.fn("AdmissionJournal.append")(
   yield* fs
     .makeDirectory(root, { recursive: true, mode: 0o700 })
     .pipe(Effect.mapError(QualitySchedulerError.new("Failed to create admission journal directory.")));
-  yield* Effect.scoped(
-    Effect.gen(function* () {
-      const file = yield* fs
-        .open(journalPath, { flag: "a" })
-        .pipe(Effect.mapError(QualitySchedulerError.new(`Failed to open admission journal "${journalPath}".`)));
-      yield* file
-        .writeAll(textEncoder.encode(`${line}\n`))
-        .pipe(Effect.mapError(QualitySchedulerError.new(`Failed to append admission journal "${journalPath}".`)));
-      yield* file.sync.pipe(
-        Effect.mapError(QualitySchedulerError.new(`Failed to sync admission journal "${journalPath}".`))
-      );
-    })
+  if (!(yield* acquireJournalLock(lockPath))) {
+    return yield* QualitySchedulerError.make({
+      message: `Admission journal lock "${lockPath}" stayed busy; dropping one ${event._tag} event.`,
+    });
+  }
+  yield* Effect.ensuring(
+    rewriteJournalLocked(journalPath, event, line),
+    fs.remove(lockPath, { force: true }).pipe(Effect.ignore)
   );
-  yield* compactAdmissionJournal(journalPath, lockPath);
 });

--- a/packages/tooling/tool/cli/src/internal/repo-run/AdmissionJournal.ts
+++ b/packages/tooling/tool/cli/src/internal/repo-run/AdmissionJournal.ts
@@ -1,0 +1,324 @@
+/**
+ * Machine-wide best-effort admission-transition journal at
+ * `<admission root>/journal.ndjson`.
+ *
+ * The journal is ring-buffered for diagnostics. Scheduler correctness lives
+ * exclusively in ticket and lease files; `bypassAdmission` on sub-envelope
+ * machines mints neither file and journals no transition.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { SchemaUtils } from "@beep/schema";
+import { Clock, Console, Effect, FileSystem, Path, pipe } from "effect";
+import * as A from "effect/Array";
+import { dual } from "effect/Function";
+import * as O from "effect/Option";
+import * as S from "effect/Schema";
+import * as Str from "effect/String";
+import { AdmissionPriority, AdmissionWorkKind, QualitySchedulerError } from "./QualityScheduler.schemas.ts";
+import type * as SchemaAST from "effect/SchemaAST";
+
+const $I = $RepoCliId.create("internal/repo-run/AdmissionJournal");
+const JOURNAL_FILE_NAME = "journal.ndjson";
+const LOCK_FILE_NAME = "journal.lock";
+const RETAINED_ADMISSIONS = 200;
+const LOCK_STALE_MILLIS = 60_000;
+const textEncoder = new TextEncoder();
+
+/**
+ * Durable transition recorded when a queued ticket becomes an active lease.
+ *
+ * **Example** (Reference an admitted transition)
+ *
+ * ```ts
+ * import { AdmissionJournalAdmitted } from "@beep/repo-cli/test/RepoRun"
+ *
+ * console.log(typeof AdmissionJournalAdmitted) // "function"
+ * ```
+ *
+ * @category domain-events
+ * @since 0.0.0
+ */
+export class AdmissionJournalAdmitted extends S.Class<AdmissionJournalAdmitted>($I`AdmissionJournalAdmitted`)(
+  {
+    schemaVersion: S.Literal("yeet-admission-journal/v1"),
+    _tag: S.Literal("admission-admitted"),
+    nonce: S.String,
+    pid: S.Finite,
+    procStart: S.String,
+    kind: AdmissionWorkKind,
+    weightTokens: S.Finite,
+    priority: AdmissionPriority,
+    originKey: S.String,
+    enqueuedAtMillis: S.Finite,
+    admittedAtMillis: S.Finite,
+  },
+  $I.annote("AdmissionJournalAdmitted", {
+    description: "Durable transition recorded when a queued ticket becomes an active admission lease.",
+  })
+) {}
+
+/**
+ * Durable transition recorded when an active admission lease is released.
+ *
+ * **Example** (Reference a released transition)
+ *
+ * ```ts
+ * import { AdmissionJournalReleased } from "@beep/repo-cli/test/RepoRun"
+ *
+ * console.log(typeof AdmissionJournalReleased) // "function"
+ * ```
+ *
+ * @category domain-events
+ * @since 0.0.0
+ */
+export class AdmissionJournalReleased extends S.Class<AdmissionJournalReleased>($I`AdmissionJournalReleased`)(
+  {
+    schemaVersion: S.Literal("yeet-admission-journal/v1"),
+    _tag: S.Literal("admission-released"),
+    nonce: S.String,
+    pid: S.Finite,
+    releasedAtMillis: S.Finite,
+  },
+  $I.annote("AdmissionJournalReleased", {
+    description: "Durable transition recorded when an active admission lease is released.",
+  })
+) {}
+
+/**
+ * Schema-decoded transition stored in the machine-wide admission journal.
+ *
+ * **Example** (Reference the admission event schema)
+ *
+ * ```ts
+ * import { AdmissionJournalEvent } from "@beep/repo-cli/test/RepoRun"
+ *
+ * console.log(typeof AdmissionJournalEvent) // "object"
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const AdmissionJournalEvent = S.Union([AdmissionJournalAdmitted, AdmissionJournalReleased]).pipe(
+  S.toTaggedUnion("_tag"),
+  $I.annoteSchema("AdmissionJournalEvent", {
+    description: "Schema-decoded transition stored in the machine-wide admission journal.",
+  })
+);
+
+/**
+ * Decoded admission-transition event retained by {@link AdmissionJournalEvent}.
+ *
+ * **Example** (Read an admission event tag)
+ *
+ * ```ts
+ * import type { AdmissionJournalEvent } from "@beep/repo-cli/test/RepoRun"
+ *
+ * const tagOf = (event: AdmissionJournalEvent) => event._tag
+ * console.log(typeof tagOf) // "function"
+ * ```
+ *
+ * @see {@link AdmissionJournalEvent} for the runtime schema and decoding behavior.
+ * @category models
+ * @since 0.0.0
+ */
+export type AdmissionJournalEvent = typeof AdmissionJournalEvent.Type;
+
+const encodeEvent = S.encodeUnknownEffect(S.fromJsonString(AdmissionJournalEvent));
+
+/**
+ * Decodes one NDJSON record into an admission-transition event.
+ *
+ * **Example** (Reference the journal decoder)
+ *
+ * ```ts
+ * import { decodeAdmissionJournalEvent } from "@beep/repo-cli/test/RepoRun"
+ *
+ * console.log(typeof decodeAdmissionJournalEvent) // "function"
+ * ```
+ *
+ * @param input - One raw admission-journal line.
+ * @returns The decoded admission-transition event effect.
+ * @category decoding
+ * @since 0.0.0
+ */
+export const decodeAdmissionJournalEvent: {
+  (options?: SchemaAST.ParseOptions): (input: unknown) => Effect.Effect<AdmissionJournalEvent, S.SchemaError>;
+  (input: unknown, options?: SchemaAST.ParseOptions): Effect.Effect<AdmissionJournalEvent, S.SchemaError>;
+} = dual(SchemaUtils.isCodecDataFirst, S.decodeUnknownEffect(S.fromJsonString(AdmissionJournalEvent)));
+
+/**
+ * Resolves the machine-wide admission journal path beneath a scheduler root.
+ *
+ * **Example** (Reference the path resolver)
+ *
+ * ```ts
+ * import { admissionJournalPath } from "@beep/repo-cli/test/RepoRun"
+ *
+ * console.log(typeof admissionJournalPath) // "function"
+ * ```
+ *
+ * @param root - Machine-wide admission root directory.
+ * @returns The admission journal path effect.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const admissionJournalPath = Effect.fn("AdmissionJournal.path")(function* (
+  root: string
+): Effect.fn.Return<string, never, Path.Path> {
+  const path = yield* Path.Path;
+  return path.join(root, JOURNAL_FILE_NAME);
+});
+
+const inspectStaleCompactionLock = Effect.fnUntraced(function* (
+  lockPath: string
+): Effect.fn.Return<boolean, never, FileSystem.FileSystem> {
+  const fs = yield* FileSystem.FileSystem;
+  const nowMillis = yield* Clock.currentTimeMillis;
+  const info = yield* fs.stat(lockPath).pipe(Effect.option);
+  const stale = pipe(
+    info,
+    O.flatMap((fileInfo) => fileInfo.mtime),
+    O.exists((mtime) => nowMillis - mtime.getTime() > LOCK_STALE_MILLIS)
+  );
+  if (stale) {
+    yield* fs.remove(lockPath, { force: true }).pipe(Effect.ignore);
+  }
+  return false;
+});
+
+const tryAcquireCompactionLock = Effect.fnUntraced(function* (
+  lockPath: string
+): Effect.fn.Return<boolean, never, FileSystem.FileSystem> {
+  const fs = yield* FileSystem.FileSystem;
+  return yield* Effect.scoped(
+    Effect.gen(function* () {
+      const file = yield* fs.open(lockPath, { flag: "wx" });
+      yield* file.writeAll(textEncoder.encode(`${process.pid}\n`));
+      return true;
+    })
+  ).pipe(
+    Effect.catchTag("PlatformError", (error) =>
+      error.reason._tag === "AlreadyExists" ? inspectStaleCompactionLock(lockPath) : Effect.succeed(false)
+    )
+  );
+});
+
+const compactLocked = Effect.fnUntraced(function* (
+  journalPath: string
+): Effect.fn.Return<void, QualitySchedulerError, FileSystem.FileSystem> {
+  const fs = yield* FileSystem.FileSystem;
+  const text = yield* fs
+    .readFileString(journalPath)
+    .pipe(
+      Effect.catchTag("PlatformError", (error) =>
+        error.reason._tag === "NotFound"
+          ? Effect.succeed(Str.empty)
+          : Effect.fail(QualitySchedulerError.new(`Failed to read admission journal "${journalPath}".`)(error))
+      )
+    );
+  const rawLines = pipe(Str.split("\n")(text), A.filter(Str.isNonEmpty));
+  const probed = yield* Effect.forEach(rawLines, (line) =>
+    decodeAdmissionJournalEvent(line).pipe(Effect.option, Effect.map(O.map((event) => ({ event, line }))))
+  );
+  const records = A.getSomes(probed);
+  const droppedCount = A.length(rawLines) - A.length(records);
+  if (droppedCount > 0) {
+    yield* Console.warn(`dropped ${droppedCount} undecodable admission journal record(s) from "${journalPath}"`);
+  }
+  const admittedIndexes = pipe(
+    A.zip(
+      A.map(records, ({ event }) => event),
+      A.range(0, A.length(records) - 1)
+    ),
+    A.map(([event, index]) => (event._tag === "admission-admitted" ? O.some(index) : O.none())),
+    A.getSomes
+  );
+  const firstRetainedIndex =
+    A.length(admittedIndexes) <= RETAINED_ADMISSIONS
+      ? 0
+      : pipe(
+          admittedIndexes,
+          A.takeRight(RETAINED_ADMISSIONS),
+          A.head,
+          O.getOrElse(() => 0)
+        );
+  if (droppedCount === 0 && firstRetainedIndex === 0) {
+    return;
+  }
+  yield* fs
+    .writeFileString(
+      journalPath,
+      pipe(
+        A.drop(records, firstRetainedIndex),
+        A.map(({ line }) => `${line}\n`),
+        A.join(Str.empty)
+      )
+    )
+    .pipe(Effect.mapError(QualitySchedulerError.new(`Failed to compact admission journal "${journalPath}".`)));
+});
+
+const compactAdmissionJournal = Effect.fnUntraced(function* (
+  journalPath: string,
+  lockPath: string
+): Effect.fn.Return<void, QualitySchedulerError, FileSystem.FileSystem> {
+  const acquired = yield* tryAcquireCompactionLock(lockPath);
+  if (!acquired) {
+    return;
+  }
+  const fs = yield* FileSystem.FileSystem;
+  yield* Effect.ensuring(compactLocked(journalPath), fs.remove(lockPath, { force: true }).pipe(Effect.ignore));
+});
+
+/**
+ * Appends, syncs, self-heals, and bounds the machine-wide admission journal.
+ *
+ * Scheduler correctness does not depend on this operation; callers may handle
+ * its typed failure as a best-effort diagnostic write.
+ *
+ * **Example** (Reference the journal append entry point)
+ *
+ * ```ts
+ * import { appendAdmissionJournalEvent } from "@beep/repo-cli/test/RepoRun"
+ *
+ * console.log(typeof appendAdmissionJournalEvent) // "function"
+ * ```
+ *
+ * @param root - Machine-wide admission root directory.
+ * @param event - Admission transition to append.
+ * @returns An effect that appends and compacts the admission journal.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const appendAdmissionJournalEvent = Effect.fn("AdmissionJournal.append")(function* (
+  root: string,
+  event: AdmissionJournalEvent
+): Effect.fn.Return<void, QualitySchedulerError, FileSystem.FileSystem | Path.Path> {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const journalPath = yield* admissionJournalPath(root);
+  const lockPath = path.join(root, LOCK_FILE_NAME);
+  const line = yield* encodeEvent(event).pipe(
+    Effect.mapError(QualitySchedulerError.new("Failed to encode admission journal event."))
+  );
+  yield* fs
+    .makeDirectory(root, { recursive: true, mode: 0o700 })
+    .pipe(Effect.mapError(QualitySchedulerError.new("Failed to create admission journal directory.")));
+  yield* Effect.scoped(
+    Effect.gen(function* () {
+      const file = yield* fs
+        .open(journalPath, { flag: "a" })
+        .pipe(Effect.mapError(QualitySchedulerError.new(`Failed to open admission journal "${journalPath}".`)));
+      yield* file
+        .writeAll(textEncoder.encode(`${line}\n`))
+        .pipe(Effect.mapError(QualitySchedulerError.new(`Failed to append admission journal "${journalPath}".`)));
+      yield* file.sync.pipe(
+        Effect.mapError(QualitySchedulerError.new(`Failed to sync admission journal "${journalPath}".`))
+      );
+    })
+  );
+  yield* compactAdmissionJournal(journalPath, lockPath);
+});

--- a/packages/tooling/tool/cli/src/internal/repo-run/AdmissionJournal.ts
+++ b/packages/tooling/tool/cli/src/internal/repo-run/AdmissionJournal.ts
@@ -14,7 +14,7 @@ import { $RepoCliId } from "@beep/identity/packages";
 import { SchemaUtils } from "@beep/schema";
 import { Clock, Console, Effect, FileSystem, Path, pipe } from "effect";
 import * as A from "effect/Array";
-import { dual } from "effect/Function";
+import { constant, dual } from "effect/Function";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
 import * as Str from "effect/String";
@@ -194,17 +194,15 @@ const tryAcquireCompactionLock = Effect.fnUntraced(function* (
   lockPath: string
 ): Effect.fn.Return<boolean, never, FileSystem.FileSystem> {
   const fs = yield* FileSystem.FileSystem;
+  // Any create failure (typically AlreadyExists contention) skips this round;
+  // the stale inspection reaps an abandoned lock so the next append compacts.
   return yield* Effect.scoped(
     Effect.gen(function* () {
       const file = yield* fs.open(lockPath, { flag: "wx" });
       yield* file.writeAll(textEncoder.encode(`${process.pid}\n`));
       return true;
     })
-  ).pipe(
-    Effect.catchTag("PlatformError", (error) =>
-      error.reason._tag === "AlreadyExists" ? inspectStaleCompactionLock(lockPath) : Effect.succeed(false)
-    )
-  );
+  ).pipe(Effect.catch(() => inspectStaleCompactionLock(lockPath)));
 });
 
 const compactLocked = Effect.fnUntraced(function* (
@@ -213,13 +211,7 @@ const compactLocked = Effect.fnUntraced(function* (
   const fs = yield* FileSystem.FileSystem;
   const text = yield* fs
     .readFileString(journalPath)
-    .pipe(
-      Effect.catchTag("PlatformError", (error) =>
-        error.reason._tag === "NotFound"
-          ? Effect.succeed(Str.empty)
-          : Effect.fail(QualitySchedulerError.new(`Failed to read admission journal "${journalPath}".`)(error))
-      )
-    );
+    .pipe(Effect.mapError(QualitySchedulerError.new(`Failed to read admission journal "${journalPath}".`)));
   const rawLines = pipe(Str.split("\n")(text), A.filter(Str.isNonEmpty));
   const probed = yield* Effect.forEach(rawLines, (line) =>
     decodeAdmissionJournalEvent(line).pipe(Effect.option, Effect.map(O.map((event) => ({ event, line }))))
@@ -240,12 +232,7 @@ const compactLocked = Effect.fnUntraced(function* (
   const firstRetainedIndex =
     A.length(admittedIndexes) <= RETAINED_ADMISSIONS
       ? 0
-      : pipe(
-          admittedIndexes,
-          A.takeRight(RETAINED_ADMISSIONS),
-          A.head,
-          O.getOrElse(() => 0)
-        );
+      : pipe(admittedIndexes, A.takeRight(RETAINED_ADMISSIONS), A.head, O.getOrElse(constant(0)));
   if (droppedCount === 0 && firstRetainedIndex === 0) {
     return;
   }

--- a/packages/tooling/tool/cli/src/internal/repo-run/QualityScheduler.schemas.ts
+++ b/packages/tooling/tool/cli/src/internal/repo-run/QualityScheduler.schemas.ts
@@ -124,7 +124,9 @@ const admissionOwnerFields = {
  *
  * `pid` plus `procStart` (the `/proc/<pid>/stat` start time) identify the
  * owner across pid reuse; leases are reaped only when the pid is dead or the
- * recorded start time no longer matches.
+ * recorded start time no longer matches. The lease retains the originating
+ * ticket identity (`nonce`) and queue instant (`enqueuedAtMillis`); legacy
+ * lease files decode those fields with `""` and `0` sentinels.
  *
  * **Example** (Construct a lease value)
  *
@@ -144,7 +146,9 @@ const admissionOwnerFields = {
  *   command: "bun run beep yeet verify",
  *   startedAt: "2026-08-27T14:00:00Z",
  *   admittedAtMillis: 0,
- *   heartbeatAtMillis: 0
+ *   heartbeatAtMillis: 0,
+ *   enqueuedAtMillis: 0,
+ *   nonce: "d0a7b0dc"
  * })
  * console.log(lease.weightTokens) // 3
  * ```
@@ -160,6 +164,11 @@ export class YeetAdmissionLease extends S.Class<YeetAdmissionLease>($I`YeetAdmis
     startedAt: S.String,
     admittedAtMillis: S.Finite,
     heartbeatAtMillis: S.Finite,
+    enqueuedAtMillis: S.Finite.pipe(
+      S.withConstructorDefault(Effect.succeed(0)),
+      S.withDecodingDefault(Effect.succeed(0))
+    ),
+    nonce: S.String.pipe(S.withConstructorDefault(Effect.succeed("")), S.withDecodingDefault(Effect.succeed(""))),
     hotPaths: S.Array(S.String).pipe(
       S.withConstructorDefault(Effect.succeed(A.empty<string>())),
       S.withDecodingDefault(Effect.succeed(A.empty<string>()))

--- a/packages/tooling/tool/cli/src/internal/repo-run/QualityScheduler.ts
+++ b/packages/tooling/tool/cli/src/internal/repo-run/QualityScheduler.ts
@@ -39,6 +39,7 @@ import * as P from "effect/Predicate";
 import * as S from "effect/Schema";
 import * as Str from "effect/String";
 import { configStringOption } from "../cli/EnvConfig.ts";
+import { AdmissionJournalAdmitted, AdmissionJournalReleased, appendAdmissionJournalEvent } from "./AdmissionJournal.ts";
 import {
   AdmissionConfig,
   AdmissionRequest,
@@ -889,6 +890,8 @@ const stageSelfLease = Effect.fnUntraced(function* (
     startedAt: yield* DateTime.now.pipe(Effect.map(DateTime.formatIso)),
     admittedAtMillis: nowMillis,
     heartbeatAtMillis: nowMillis,
+    enqueuedAtMillis: ticket.enqueuedAtMillis,
+    nonce: ticket.nonce,
   });
   const leasePath = path.join(directories.leases, `${ticket.nonce}-${ticket.pid}.lease.json`);
   const created = yield* tryCreateExclusive(leasePath, `${yield* encodeLeaseText(lease)}\n`);
@@ -962,6 +965,22 @@ const tryPromoteTicket = Effect.fnUntraced(function* <OriginLease, GateError, Ga
   if (O.isNone(attempt.admitted)) {
     return { admitted: O.none(), info, originBusy: attempt.originBusy };
   }
+  yield* appendAdmissionJournalEvent(
+    directories.root,
+    AdmissionJournalAdmitted.make({
+      schemaVersion: "yeet-admission-journal/v1",
+      _tag: "admission-admitted",
+      nonce: ticket.nonce,
+      pid: ticket.pid,
+      procStart: ticket.procStart,
+      kind: ticket.kind,
+      weightTokens: ticket.weightTokens,
+      priority: ticket.priority,
+      originKey: ticket.originKey,
+      enqueuedAtMillis: ticket.enqueuedAtMillis,
+      admittedAtMillis: attempt.admitted.value.lease.admittedAtMillis,
+    })
+  ).pipe(Effect.catch((error) => Console.warn(`[yeet] admission journal append failed: ${error.message}`)));
   const fs = yield* FileSystem.FileSystem;
   yield* fs.remove(ticketPath, { force: true }).pipe(Effect.ignore);
   return { admitted: attempt.admitted, info, originBusy: false };
@@ -1056,6 +1075,7 @@ const waitForAdmission = Effect.fnUntraced(function* <OriginLease, GateError, Ga
 });
 
 const runAdmitted = Effect.fnUntraced(function* <Success, UseError, UseRequirements, OriginLease, GateRequirements>(
+  directories: AdmissionDirectories,
   admitted: AdmittedState<OriginLease>,
   releaseOrigin: (lease: OriginLease) => Effect.Effect<void, never, GateRequirements>,
   use: Effect.Effect<Success, UseError, UseRequirements>,
@@ -1066,13 +1086,24 @@ const runAdmitted = Effect.fnUntraced(function* <Success, UseError, UseRequireme
 ): Effect.fn.Return<
   Success,
   UseError | QualitySchedulerError,
-  UseRequirements | FileSystem.FileSystem | GateRequirements
+  UseRequirements | FileSystem.FileSystem | Path.Path | GateRequirements
 > {
   return yield* Effect.acquireUseRelease(
     Effect.forkChild(heartbeatLoop(admitted.leasePath, admitted.lease, config)),
     () => restore(use),
     Effect.fnUntraced(function* (heartbeat) {
       yield* Fiber.interrupt(heartbeat);
+      const releasedAtMillis = yield* Clock.currentTimeMillis;
+      yield* appendAdmissionJournalEvent(
+        directories.root,
+        AdmissionJournalReleased.make({
+          schemaVersion: "yeet-admission-journal/v1",
+          _tag: "admission-released",
+          nonce: admitted.lease.nonce,
+          pid: admitted.lease.pid,
+          releasedAtMillis,
+        })
+      ).pipe(Effect.catch((error) => Console.warn(`[yeet] admission journal append failed: ${error.message}`)));
       const fs = yield* FileSystem.FileSystem;
       yield* fs.remove(admitted.leasePath, { force: true }).pipe(Effect.ignore);
       yield* releaseOrigin(admitted.originLease);
@@ -1187,7 +1218,7 @@ export const withQualityAdmission = Effect.fn("QualityScheduler.withQualityAdmis
           resolved,
           restore
         );
-        return yield* runAdmitted(admitted, gate.release, use, resolved, restore);
+        return yield* runAdmitted(directories, admitted, gate.release, use, resolved, restore);
       }),
       Effect.fnUntraced(function* () {
         const fs = yield* FileSystem.FileSystem;

--- a/packages/tooling/tool/cli/src/internal/repo-run/index.ts
+++ b/packages/tooling/tool/cli/src/internal/repo-run/index.ts
@@ -5,6 +5,7 @@
  * @since 0.0.0
  */
 
+export * from "./AdmissionJournal.ts";
 export * from "./GitExec.ts";
 export * from "./QualityScheduler.schemas.ts";
 export * from "./QualityScheduler.ts";

--- a/packages/tooling/tool/cli/test/quality-scheduler.test.ts
+++ b/packages/tooling/tool/cli/test/quality-scheduler.test.ts
@@ -1,9 +1,14 @@
 import {
   AdmissionConfig,
+  AdmissionJournalAdmitted,
+  AdmissionJournalEvent,
   AdmissionRequest,
   admissionCapacityTokensFor,
+  admissionJournalPath,
   admissionStatus,
   admissionTokenWeight,
+  appendAdmissionJournalEvent,
+  decodeAdmissionJournalEvent,
   isOvershootLoserForTesting,
   MemoryStats,
   noAdmissionOriginGate,
@@ -16,11 +21,12 @@ import { fcRuns, provideScopedLayer } from "@beep/test-utils";
 import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
 import * as NodePath from "@effect/platform-node/NodePath";
 import { describe, expect, it } from "@effect/vitest";
-import { ConfigProvider, Effect, Fiber, FileSystem, Layer, Path, Ref } from "effect";
+import { Clock, ConfigProvider, Effect, Fiber, FileSystem, Layer, Path, pipe, Ref } from "effect";
 import * as A from "effect/Array";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
 import * as Str from "effect/String";
+import * as Struct from "effect/Struct";
 import { FastCheck as fc } from "effect/testing";
 
 const PlatformLayer = Layer.mergeAll(NodeFileSystem.layer, NodePath.layer);
@@ -36,6 +42,32 @@ const fastConfig = AdmissionConfig.make({
 });
 
 const encodeLease = S.encodeUnknownEffect(S.fromJsonString(YeetAdmissionLease));
+const decodeLease = S.decodeUnknownEffect(S.fromJsonString(YeetAdmissionLease));
+const decodeJsonObject = S.decodeUnknownEffect(S.fromJsonString(S.JsonObject));
+const encodeJsonObject = S.encodeUnknownEffect(S.fromJsonString(S.JsonObject));
+
+const readJournalEvents = Effect.fnUntraced(function* (root: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const journalPath = yield* admissionJournalPath(root);
+  const text = yield* fs.readFileString(journalPath).pipe(Effect.orElseSucceed(() => Str.empty));
+  const lines = pipe(text, Str.split("\n"), A.filter(Str.isNonEmpty));
+  return yield* Effect.forEach(lines, (line) => decodeAdmissionJournalEvent(line));
+});
+
+const journalAdmitted = (index: number) =>
+  AdmissionJournalAdmitted.make({
+    schemaVersion: "yeet-admission-journal/v1",
+    _tag: "admission-admitted",
+    nonce: `nonce-${index}`,
+    pid: index,
+    procStart: `${index}`,
+    kind: "full-proof",
+    weightTokens: 3,
+    priority: "verify",
+    originKey: `origin-${index}`,
+    enqueuedAtMillis: index,
+    admittedAtMillis: index,
+  });
 
 const request = (overrides: Partial<Parameters<typeof AdmissionRequest.make>[0]> = {}) =>
   AdmissionRequest.make({
@@ -193,6 +225,227 @@ describe("quality-scheduler", () => {
         );
       })
     ));
+
+  it("copies ticket nonce and enqueuedAtMillis onto the published lease", () =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const gibRef = yield* Ref.make(50);
+        yield* withAdmissionTempRoot(gibRef, (tempRoot) =>
+          withQualityAdmission(
+            request(),
+            noAdmissionOriginGate,
+            Effect.gen(function* () {
+              const fs = yield* FileSystem.FileSystem;
+              const path = yield* Path.Path;
+              const leases = yield* listDirectory(tempRoot.leases);
+              expect(leases).toHaveLength(1);
+              const leaseName = pipe(
+                A.head(leases),
+                O.getOrElse(() => Str.empty)
+              );
+              const lease = yield* fs
+                .readFileString(path.join(tempRoot.leases, leaseName))
+                .pipe(Effect.flatMap(decodeLease));
+              expect(lease.nonce).toHaveLength(8);
+              expect(leaseName).toBe(`${lease.nonce}-${lease.pid}.lease.json`);
+              expect(lease.enqueuedAtMillis).toBeGreaterThan(0);
+              expect(lease.enqueuedAtMillis).toBeLessThanOrEqual(lease.admittedAtMillis);
+            }),
+            fastConfig
+          )
+        );
+      })
+    ));
+
+  it("journals admitted and released events that outlive every ticket and lease file", () =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const gibRef = yield* Ref.make(50);
+        yield* withAdmissionTempRoot(gibRef, (tempRoot) =>
+          Effect.gen(function* () {
+            const admissionRequest = request();
+            yield* withQualityAdmission(admissionRequest, noAdmissionOriginGate, Effect.void, fastConfig);
+            expect(yield* listDirectory(tempRoot.leases)).toHaveLength(0);
+            expect(yield* listDirectory(tempRoot.queue)).toHaveLength(0);
+            const events = yield* readJournalEvents(tempRoot.root);
+            expect(A.map(events, (event) => event._tag)).toStrictEqual(["admission-admitted", "admission-released"]);
+            const admitted = pipe(
+              events,
+              A.findFirst(AdmissionJournalEvent.guards["admission-admitted"]),
+              O.getOrThrow
+            );
+            const released = pipe(
+              events,
+              A.findFirst(AdmissionJournalEvent.guards["admission-released"]),
+              O.getOrThrow
+            );
+            expect(admitted.kind).toBe(admissionRequest.kind);
+            expect(admitted.weightTokens).toBe(admissionRequest.weightTokens);
+            expect(admitted.priority).toBe(admissionRequest.priority);
+            expect(admitted.originKey).toBe(admissionRequest.originKey);
+            expect(admitted.pid).toBe(process.pid);
+            expect(released.nonce).toBe(admitted.nonce);
+            expect(released.pid).toBe(admitted.pid);
+            expect(admitted.enqueuedAtMillis).toBeLessThanOrEqual(admitted.admittedAtMillis);
+            expect(admitted.admittedAtMillis).toBeLessThanOrEqual(released.releasedAtMillis);
+          })
+        );
+      })
+    ));
+
+  it("journals a released event when the admitted work fails", () =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const gibRef = yield* Ref.make(50);
+        yield* withAdmissionTempRoot(gibRef, (tempRoot) =>
+          Effect.gen(function* () {
+            const failed = yield* withQualityAdmission(
+              request(),
+              noAdmissionOriginGate,
+              Effect.fail("boom" as const),
+              fastConfig
+            ).pipe(Effect.flip);
+            expect(failed).toBe("boom");
+            const events = yield* readJournalEvents(tempRoot.root);
+            expect(A.map(events, (event) => event._tag)).toStrictEqual(["admission-admitted", "admission-released"]);
+            const admitted = pipe(
+              events,
+              A.findFirst(AdmissionJournalEvent.guards["admission-admitted"]),
+              O.getOrThrow
+            );
+            const released = pipe(
+              events,
+              A.findFirst(AdmissionJournalEvent.guards["admission-released"]),
+              O.getOrThrow
+            );
+            expect(released.nonce).toBe(admitted.nonce);
+          })
+        );
+      })
+    ));
+
+  it("retains the newest bounded set of admitted transitions", () =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const gibRef = yield* Ref.make(50);
+        yield* withAdmissionTempRoot(gibRef, (tempRoot) =>
+          Effect.gen(function* () {
+            yield* Effect.forEach(
+              A.makeBy(201, (index) => index),
+              (index) => appendAdmissionJournalEvent(tempRoot.root, journalAdmitted(index)),
+              { discard: true, concurrency: 1 }
+            );
+            const events = yield* readJournalEvents(tempRoot.root);
+            expect(events).toHaveLength(200);
+            expect(events[0]?.nonce).toBe("nonce-1");
+            expect(events[199]?.nonce).toBe("nonce-200");
+          })
+        );
+      })
+    ));
+
+  it("recovers from a torn trailing journal record", () =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const gibRef = yield* Ref.make(50);
+        yield* withAdmissionTempRoot(gibRef, (tempRoot) =>
+          Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            const journalPath = yield* admissionJournalPath(tempRoot.root);
+            yield* appendAdmissionJournalEvent(tempRoot.root, journalAdmitted(1));
+            const intact = yield* fs.readFileString(journalPath);
+            yield* fs.writeFileString(journalPath, `${intact}{"schemaVersion":"yeet-admission-jour`);
+            yield* appendAdmissionJournalEvent(tempRoot.root, journalAdmitted(2));
+            const events = yield* readJournalEvents(tempRoot.root);
+            expect(events).toHaveLength(1);
+            expect(events[0]?.nonce).toBe("nonce-1");
+          })
+        );
+      })
+    ));
+
+  it("skips compaction while the journal lock is held and reaps a stale lock", () =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const gibRef = yield* Ref.make(50);
+        yield* withAdmissionTempRoot(gibRef, (tempRoot) =>
+          Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            const path = yield* Path.Path;
+            const lockPath = path.join(tempRoot.root, "journal.lock");
+            yield* fs.makeDirectory(tempRoot.root, { recursive: true, mode: 0o700 });
+            yield* fs.writeFileString(lockPath, `${process.pid}\n`);
+            yield* Effect.forEach(
+              A.makeBy(201, (index) => index),
+              (index) => appendAdmissionJournalEvent(tempRoot.root, journalAdmitted(index)),
+              { discard: true, concurrency: 1 }
+            );
+            const journalPath = yield* admissionJournalPath(tempRoot.root);
+            const lines = pipe(yield* fs.readFileString(journalPath), Str.split("\n"), A.filter(Str.isNonEmpty));
+            expect(lines).toHaveLength(201);
+            const staleSeconds = ((yield* Clock.currentTimeMillis) - 61_000) / 1_000;
+            yield* fs.utimes(lockPath, staleSeconds, staleSeconds);
+            yield* appendAdmissionJournalEvent(tempRoot.root, journalAdmitted(201));
+            expect(O.isNone(yield* fs.stat(lockPath).pipe(Effect.option))).toBe(true);
+          })
+        );
+      })
+    ));
+
+  it("decodes legacy lease files without nonce or enqueuedAtMillis", () =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const gibRef = yield* Ref.make(50);
+        yield* withAdmissionTempRoot(gibRef, (tempRoot) =>
+          Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            const path = yield* Path.Path;
+            const procStart = yield* ownProcStart();
+            const encoded = yield* encodeLease(
+              YeetAdmissionLease.make({
+                schemaVersion: "yeet-admission-lease/v1",
+                pid: process.pid,
+                procStart,
+                kind: "full-proof",
+                weightTokens: 3,
+                priority: "verify",
+                originKey: "origin-legacy",
+                checkoutRoot: "/repo/legacy",
+                branch: "feat/legacy",
+                command: "bun run beep yeet verify",
+                startedAt: "2026-08-27T00:00:00Z",
+                admittedAtMillis: 100,
+                heartbeatAtMillis: 100,
+              })
+            );
+            const legacy = pipe(yield* decodeJsonObject(encoded), Struct.omit(["nonce", "enqueuedAtMillis"]));
+            yield* fs.makeDirectory(tempRoot.leases, { recursive: true, mode: 0o700 });
+            const leasePath = path.join(tempRoot.leases, `legacy-${process.pid}.lease.json`);
+            yield* fs.writeFileString(leasePath, yield* encodeJsonObject(legacy));
+            const raw = yield* fs.readFileString(leasePath);
+            const decoded = yield* decodeLease(raw);
+            expect(decoded.nonce).toBe("");
+            expect(decoded.enqueuedAtMillis).toBe(0);
+            const snapshot = yield* admissionStatus(fastConfig);
+            expect(snapshot.leases).toHaveLength(1);
+          })
+        );
+      })
+    ));
+
+  it("property: admission journal events round-trip through the NDJSON codec", () => {
+    const EventArbitrary = S.toArbitrary(AdmissionJournalEvent)(fc);
+    fc.assert(
+      fc.property(EventArbitrary, (event) => {
+        const encoded = S.encodeSync(S.fromJsonString(AdmissionJournalEvent))(event);
+        const decoded = S.decodeSync(S.fromJsonString(AdmissionJournalEvent))(encoded);
+        expect(decoded._tag).toBe(event._tag);
+        expect(decoded.nonce).toBe(event.nonce);
+        expect(decoded.pid).toBe(event.pid);
+      }),
+      fcRuns(32)
+    );
+  });
 
   it("queues while tokens are held and admits when the holder releases", () =>
     Effect.runPromise(

--- a/packages/tooling/tool/cli/test/quality-scheduler.test.ts
+++ b/packages/tooling/tool/cli/test/quality-scheduler.test.ts
@@ -357,14 +357,13 @@ describe("quality-scheduler", () => {
             yield* fs.writeFileString(journalPath, `${intact}{"schemaVersion":"yeet-admission-jour`);
             yield* appendAdmissionJournalEvent(tempRoot.root, journalAdmitted(2));
             const events = yield* readJournalEvents(tempRoot.root);
-            expect(events).toHaveLength(1);
-            expect(events[0]?.nonce).toBe("nonce-1");
+            expect(A.map(events, (event) => event.nonce)).toStrictEqual(["nonce-1", "nonce-2"]);
           })
         );
       })
     ));
 
-  it("skips compaction while the journal lock is held and reaps a stale lock", () =>
+  it("fails the append while the journal lock is held and reaps a stale lock", () =>
     Effect.runPromise(
       Effect.gen(function* () {
         const gibRef = yield* Ref.make(50);
@@ -375,18 +374,15 @@ describe("quality-scheduler", () => {
             const lockPath = path.join(tempRoot.root, "journal.lock");
             yield* fs.makeDirectory(tempRoot.root, { recursive: true, mode: 0o700 });
             yield* fs.writeFileString(lockPath, `${process.pid}\n`);
-            yield* Effect.forEach(
-              A.makeBy(201, (index) => index),
-              (index) => appendAdmissionJournalEvent(tempRoot.root, journalAdmitted(index)),
-              { discard: true, concurrency: 1 }
-            );
-            const journalPath = yield* admissionJournalPath(tempRoot.root);
-            const lines = pipe(yield* fs.readFileString(journalPath), Str.split("\n"), A.filter(Str.isNonEmpty));
-            expect(lines).toHaveLength(201);
+            const busy = yield* appendAdmissionJournalEvent(tempRoot.root, journalAdmitted(0)).pipe(Effect.flip);
+            expect(busy.message).toContain("stayed busy");
+            expect(yield* readJournalEvents(tempRoot.root)).toHaveLength(0);
             const staleSeconds = ((yield* Clock.currentTimeMillis) - 61_000) / 1_000;
             yield* fs.utimes(lockPath, staleSeconds, staleSeconds);
-            yield* appendAdmissionJournalEvent(tempRoot.root, journalAdmitted(201));
+            yield* appendAdmissionJournalEvent(tempRoot.root, journalAdmitted(1));
             expect(O.isNone(yield* fs.stat(lockPath).pipe(Effect.option))).toBe(true);
+            const events = yield* readJournalEvents(tempRoot.root);
+            expect(A.map(events, (event) => event.nonce)).toStrictEqual(["nonce-1"]);
           })
         );
       })

--- a/packages/tooling/tool/cli/test/quality-scheduler.test.ts
+++ b/packages/tooling/tool/cli/test/quality-scheduler.test.ts
@@ -433,6 +433,33 @@ describe("quality-scheduler", () => {
       })
     ));
 
+  it("keeps admission green when the journal cannot be written", () =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const gibRef = yield* Ref.make(50);
+        yield* withAdmissionTempRoot(gibRef, (tempRoot) =>
+          Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            const journalPath = yield* admissionJournalPath(tempRoot.root);
+            // A directory squatting on the journal path fails every append;
+            // admission and release must still complete and clean up.
+            yield* fs.makeDirectory(tempRoot.root, { recursive: true, mode: 0o700 });
+            yield* fs.makeDirectory(journalPath, { mode: 0o700 });
+            const during = yield* withQualityAdmission(
+              request(),
+              noAdmissionOriginGate,
+              admissionStatus(fastConfig),
+              fastConfig
+            );
+            expect(during.leases).toHaveLength(1);
+            expect(yield* listDirectory(tempRoot.leases)).toHaveLength(0);
+            expect(yield* listDirectory(tempRoot.queue)).toHaveLength(0);
+            expect(yield* readJournalEvents(tempRoot.root)).toHaveLength(0);
+          })
+        );
+      })
+    ));
+
   it("property: admission journal events round-trip through the NDJSON codec", () => {
     const EventArbitrary = S.toArbitrary(AdmissionJournalEvent)(fc);
     fc.assert(


### PR DESCRIPTION
## feat(repo-cli): retain admission linkage and journal admission transitions

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/feat_admission-transition-journal-43562456f570/verdict.json

---

## Provenance

- Branch: <code>feat/admission-transition-journal</code>
- Harness: `codex`

<!-- yeet-provenance
{
  "schemaVersion": 1,
  "branch": "feat/admission-transition-journal",
  "harness": "codex"
}
-->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790583561&installation_model_id=424656&pr_number=878&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F878&signature=ad6aff6834213e327c12a1ccbe5eff719459d46cfe554c56e12a7ad69719fd1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->