### PR TITLE
fix(repo-cli): bind journal lock reaping and release to owner generations

### DIFF
--- a/packages/tooling/tool/cli/src/internal/repo-run/AdmissionJournal.ts
+++ b/packages/tooling/tool/cli/src/internal/repo-run/AdmissionJournal.ts
@@ -16,7 +16,7 @@
 import { randomUUID } from "node:crypto";
 import { $RepoCliId } from "@beep/identity/packages";
 import { SchemaUtils } from "@beep/schema";
-import { Console, Duration, Effect, FileSystem, Number as N, Path, pipe } from "effect";
+import { Clock, Console, Duration, Effect, FileSystem, Number as N, Path, pipe } from "effect";
 import * as A from "effect/Array";
 import { constant, dual } from "effect/Function";
 import * as O from "effect/Option";
@@ -31,6 +31,10 @@ const LOCK_FILE_NAME = "journal.lock";
 const RETAINED_ADMISSIONS = 200;
 const LOCK_RETRY_ATTEMPTS = 8;
 const LOCK_RETRY_DELAY_MILLIS = 25;
+// No legitimate writer holds the lock beyond one rewrite (milliseconds); the
+// backstop clears locks stranded by pid reuse or tampering without ever
+// racing a live hold.
+const LOCK_REUSE_BACKSTOP_MILLIS = 300_000;
 const textEncoder = new TextEncoder();
 
 /**
@@ -199,13 +203,22 @@ const reapAbandonedJournalLock = Effect.fnUntraced(function* (
 ): Effect.fn.Return<void, never, FileSystem.FileSystem> {
   const fs = yield* FileSystem.FileSystem;
   const content = yield* fs.readFileString(lockPath).pipe(Effect.option);
-  // An unreadable or unparseable lock counts as abandoned; a live owner keeps it.
-  const abandoned = pipe(
+  const info = yield* fs.stat(lockPath).pipe(Effect.option);
+  const nowMillis = yield* Clock.currentTimeMillis;
+  // A parseable owner that died abandons its lock immediately; anything else
+  // (pid reuse, unreadable content) clears through the age backstop so a
+  // just-published generation is never misread as abandoned.
+  const ownerDead = pipe(
     content,
     O.flatMap(lockOwnerPid),
-    O.match({ onNone: constant(true), onSome: (pid) => !pidIsAlive(pid) })
+    O.exists((pid) => !pidIsAlive(pid))
   );
-  if (abandoned) {
+  const outlivedBackstop = pipe(
+    info,
+    O.flatMap((fileInfo) => fileInfo.mtime),
+    O.exists((mtime) => nowMillis - mtime.getTime() > LOCK_REUSE_BACKSTOP_MILLIS)
+  );
+  if (ownerDead || outlivedBackstop) {
     yield* fs.remove(lockPath, { force: true }).pipe(Effect.ignore);
   }
 });
@@ -215,15 +228,19 @@ const tryAcquireJournalLock = Effect.fnUntraced(function* (
   token: string
 ): Effect.fn.Return<boolean, never, FileSystem.FileSystem> {
   const fs = yield* FileSystem.FileSystem;
-  // Any create failure (typically AlreadyExists contention) fails this
-  // attempt; reaping a dead owner's lock lets a later attempt acquire it.
-  return yield* Effect.scoped(
-    Effect.gen(function* () {
-      const file = yield* fs.open(lockPath, { flag: "wx" });
-      yield* file.writeAll(textEncoder.encode(token));
-      return true;
-    })
-  ).pipe(Effect.catch(() => reapAbandonedJournalLock(lockPath).pipe(Effect.as(false))));
+  // Publish the lock via hard link so it never exists without its token: a
+  // contender reading a just-created lock always sees a full generation.
+  const stagingPath = `${lockPath}.stage-${process.pid}-${randomUUID()}`;
+  const acquired = yield* fs
+    .writeFileString(stagingPath, token)
+    .pipe(Effect.andThen(fs.link(stagingPath, lockPath)), Effect.as(true), Effect.orElseSucceed(constant(false)));
+  yield* fs.remove(stagingPath, { force: true }).pipe(Effect.ignore);
+  // Contention fails this attempt; reaping an abandoned lock lets a later
+  // attempt acquire it.
+  if (!acquired) {
+    yield* reapAbandonedJournalLock(lockPath);
+  }
+  return acquired;
 });
 
 const acquireJournalLock = Effect.fnUntraced(function* (
@@ -342,11 +359,12 @@ const rewriteJournalLocked = Effect.fnUntraced(function* (
 /**
  * Appends one admission transition through a serialized journal rewrite.
  *
- * The writer takes `journal.lock` with a bounded wait, stamping it with its
- * `pid:uuid` generation token: a lock whose owning pid is dead (or whose
- * content is unreadable) is reaped, and release removes only the generation
- * this writer stamped. The rewrite drops undecodable records, ring-trims to
- * the newest admitted transitions, and publishes atomically via temp-file
+ * The writer takes `journal.lock` with a bounded wait, publishing its
+ * `pid:uuid` generation token by hard link so the lock never exists without
+ * an owner. A lock whose parseable owner pid is dead — or which outlived the
+ * reuse backstop — is reaped, and release removes only the generation this
+ * writer stamped. The rewrite drops undecodable records, ring-trims to the
+ * newest admitted transitions, and publishes atomically via temp-file
  * rename. A lock that stays busy fails the append with a typed error;
  * scheduler correctness never depends on this operation, so callers treat
  * that failure as a best-effort diagnostic write.

--- a/packages/tooling/tool/cli/src/internal/repo-run/AdmissionJournal.ts
+++ b/packages/tooling/tool/cli/src/internal/repo-run/AdmissionJournal.ts
@@ -16,7 +16,7 @@
 import { randomUUID } from "node:crypto";
 import { $RepoCliId } from "@beep/identity/packages";
 import { SchemaUtils } from "@beep/schema";
-import { Clock, Console, Duration, Effect, FileSystem, Path, pipe } from "effect";
+import { Console, Duration, Effect, FileSystem, Number as N, Path, pipe } from "effect";
 import * as A from "effect/Array";
 import { constant, dual } from "effect/Function";
 import * as O from "effect/Option";
@@ -29,7 +29,6 @@ const $I = $RepoCliId.create("internal/repo-run/AdmissionJournal");
 const JOURNAL_FILE_NAME = "journal.ndjson";
 const LOCK_FILE_NAME = "journal.lock";
 const RETAINED_ADMISSIONS = 200;
-const LOCK_STALE_MILLIS = 60_000;
 const LOCK_RETRY_ATTEMPTS = 8;
 const LOCK_RETRY_DELAY_MILLIS = 25;
 const textEncoder = new TextEncoder();
@@ -179,51 +178,98 @@ export const admissionJournalPath = Effect.fn("AdmissionJournal.path")(function*
   return path.join(root, JOURNAL_FILE_NAME);
 });
 
-// A lock recreated by a sibling between the staleness stat and the remove can
-// be reaped while fresh; the window is one syscall pair and the cost is one
-// competing serialized writer, so the telemetry-grade journal accepts it.
-const reapStaleJournalLock = Effect.fnUntraced(function* (
+// EPERM cannot masquerade as liveness here: the admission root is 0o700 and
+// uid-validated, so every lock writer shares the probing user.
+const pidIsAlive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const lockOwnerPid = (content: string): O.Option<number> => pipe(content, Str.split(":"), A.head, O.flatMap(N.parse));
+
+// A lock replaced between the ownership read and the remove can be reaped
+// fresh; the window is one syscall pair and the cost is one competing
+// serialized writer, so the telemetry-grade journal accepts it.
+const reapAbandonedJournalLock = Effect.fnUntraced(function* (
   lockPath: string
 ): Effect.fn.Return<void, never, FileSystem.FileSystem> {
   const fs = yield* FileSystem.FileSystem;
-  const nowMillis = yield* Clock.currentTimeMillis;
-  const info = yield* fs.stat(lockPath).pipe(Effect.option);
-  const stale = pipe(
-    info,
-    O.flatMap((fileInfo) => fileInfo.mtime),
-    O.exists((mtime) => nowMillis - mtime.getTime() > LOCK_STALE_MILLIS)
+  const content = yield* fs.readFileString(lockPath).pipe(Effect.option);
+  // An unreadable or unparseable lock counts as abandoned; a live owner keeps it.
+  const abandoned = pipe(
+    content,
+    O.flatMap(lockOwnerPid),
+    O.match({ onNone: constant(true), onSome: (pid) => !pidIsAlive(pid) })
   );
-  if (stale) {
+  if (abandoned) {
     yield* fs.remove(lockPath, { force: true }).pipe(Effect.ignore);
   }
 });
 
 const tryAcquireJournalLock = Effect.fnUntraced(function* (
-  lockPath: string
+  lockPath: string,
+  token: string
 ): Effect.fn.Return<boolean, never, FileSystem.FileSystem> {
   const fs = yield* FileSystem.FileSystem;
   // Any create failure (typically AlreadyExists contention) fails this
-  // attempt; reaping an abandoned lock lets a later attempt acquire it.
+  // attempt; reaping a dead owner's lock lets a later attempt acquire it.
   return yield* Effect.scoped(
     Effect.gen(function* () {
       const file = yield* fs.open(lockPath, { flag: "wx" });
-      yield* file.writeAll(textEncoder.encode(`${process.pid}\n`));
+      yield* file.writeAll(textEncoder.encode(token));
       return true;
     })
-  ).pipe(Effect.catch(() => reapStaleJournalLock(lockPath).pipe(Effect.as(false))));
+  ).pipe(Effect.catch(() => reapAbandonedJournalLock(lockPath).pipe(Effect.as(false))));
 });
 
 const acquireJournalLock = Effect.fnUntraced(function* (
-  lockPath: string
+  lockPath: string,
+  token: string
 ): Effect.fn.Return<boolean, never, FileSystem.FileSystem> {
   for (let attempt = 0; attempt < LOCK_RETRY_ATTEMPTS; attempt++) {
-    if (yield* tryAcquireJournalLock(lockPath)) {
+    if (yield* tryAcquireJournalLock(lockPath, token)) {
       return true;
     }
     yield* Effect.sleep(Duration.millis(LOCK_RETRY_DELAY_MILLIS));
   }
   return false;
 });
+
+const releaseJournalLock = Effect.fnUntraced(function* (
+  lockPath: string,
+  token: string
+): Effect.fn.Return<void, never, FileSystem.FileSystem> {
+  const fs = yield* FileSystem.FileSystem;
+  const content = yield* fs.readFileString(lockPath).pipe(Effect.option);
+  // Remove only the generation this writer created; a lock reaped and
+  // replaced mid-write belongs to its new owner and stays.
+  if (O.exists(content, (current) => current === token)) {
+    yield* fs.remove(lockPath, { force: true }).pipe(Effect.ignore);
+  }
+});
+
+/**
+ * Test-only handle for the owned-generation journal lock release.
+ *
+ * **Example** (Reference the test-only release)
+ *
+ * ```ts
+ * import { releaseAdmissionJournalLockForTesting } from "@beep/repo-cli/test/RepoRun"
+ *
+ * console.log(typeof releaseAdmissionJournalLockForTesting) // "function"
+ * ```
+ *
+ * @param lockPath - Journal lock path.
+ * @param token - The owning writer's `pid:uuid` lock token.
+ * @returns An effect that removes the lock only while the token still owns it.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const releaseAdmissionJournalLockForTesting = releaseJournalLock;
 
 const publishJournalAtomic = Effect.fnUntraced(function* (
   journalPath: string,
@@ -296,11 +342,14 @@ const rewriteJournalLocked = Effect.fnUntraced(function* (
 /**
  * Appends one admission transition through a serialized journal rewrite.
  *
- * The writer takes `journal.lock` (bounded wait, reaping an abandoned lock),
- * drops undecodable records, ring-trims to the newest admitted transitions,
- * and publishes atomically via temp-file rename. A lock that stays busy fails
- * the append with a typed error; scheduler correctness never depends on this
- * operation, so callers treat that failure as a best-effort diagnostic write.
+ * The writer takes `journal.lock` with a bounded wait, stamping it with its
+ * `pid:uuid` generation token: a lock whose owning pid is dead (or whose
+ * content is unreadable) is reaped, and release removes only the generation
+ * this writer stamped. The rewrite drops undecodable records, ring-trims to
+ * the newest admitted transitions, and publishes atomically via temp-file
+ * rename. A lock that stays busy fails the append with a typed error;
+ * scheduler correctness never depends on this operation, so callers treat
+ * that failure as a best-effort diagnostic write.
  *
  * **Example** (Reference the journal append entry point)
  *
@@ -324,19 +373,17 @@ export const appendAdmissionJournalEvent = Effect.fn("AdmissionJournal.append")(
   const path = yield* Path.Path;
   const journalPath = path.join(root, JOURNAL_FILE_NAME);
   const lockPath = path.join(root, LOCK_FILE_NAME);
+  const token = `${process.pid}:${randomUUID()}`;
   const line = yield* encodeEvent(event).pipe(
     Effect.mapError(QualitySchedulerError.new("Failed to encode admission journal event."))
   );
   yield* fs
     .makeDirectory(root, { recursive: true, mode: 0o700 })
     .pipe(Effect.mapError(QualitySchedulerError.new("Failed to create admission journal directory.")));
-  if (!(yield* acquireJournalLock(lockPath))) {
+  if (!(yield* acquireJournalLock(lockPath, token))) {
     return yield* QualitySchedulerError.make({
       message: `Admission journal lock "${lockPath}" stayed busy; dropping one ${event._tag} event.`,
     });
   }
-  yield* Effect.ensuring(
-    rewriteJournalLocked(journalPath, event, line),
-    fs.remove(lockPath, { force: true }).pipe(Effect.ignore)
-  );
+  yield* Effect.ensuring(rewriteJournalLocked(journalPath, event, line), releaseJournalLock(lockPath, token));
 });

--- a/packages/tooling/tool/cli/test/quality-scheduler.test.ts
+++ b/packages/tooling/tool/cli/test/quality-scheduler.test.ts
@@ -22,7 +22,7 @@ import { fcRuns, provideScopedLayer } from "@beep/test-utils";
 import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
 import * as NodePath from "@effect/platform-node/NodePath";
 import { describe, expect, it } from "@effect/vitest";
-import { ConfigProvider, Effect, Fiber, FileSystem, Layer, Path, pipe, Ref } from "effect";
+import { Clock, ConfigProvider, Effect, Fiber, FileSystem, Layer, Path, pipe, Ref } from "effect";
 import * as A from "effect/Array";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
@@ -364,7 +364,7 @@ describe("quality-scheduler", () => {
       })
     ));
 
-  it("fails the append under a live lock holder and reaps dead or malformed locks", () =>
+  it("fails the append under live or fresh unparseable locks and reaps dead or aged locks", () =>
     Effect.runPromise(
       Effect.gen(function* () {
         const gibRef = yield* Ref.make(50);
@@ -378,10 +378,19 @@ describe("quality-scheduler", () => {
             const busy = yield* appendAdmissionJournalEvent(tempRoot.root, journalAdmitted(0)).pipe(Effect.flip);
             expect(busy.message).toContain("stayed busy");
             expect(yield* readJournalEvents(tempRoot.root)).toHaveLength(0);
+            // A fresh unparseable lock is a just-published generation mid-race,
+            // never insta-reaped.
+            yield* fs.writeFileString(lockPath, "not-a-pid");
+            const unparseable = yield* appendAdmissionJournalEvent(tempRoot.root, journalAdmitted(0)).pipe(Effect.flip);
+            expect(unparseable.message).toContain("stayed busy");
             yield* fs.writeFileString(lockPath, `${DEAD_PID}:dead-holder`);
             yield* appendAdmissionJournalEvent(tempRoot.root, journalAdmitted(1));
             expect(O.isNone(yield* fs.stat(lockPath).pipe(Effect.option))).toBe(true);
-            yield* fs.writeFileString(lockPath, "not-a-pid");
+            // Pid reuse: a live owner pid with an over-age lock clears through
+            // the backstop.
+            yield* fs.writeFileString(lockPath, `${process.pid}:reused-pid`);
+            const agedSeconds = ((yield* Clock.currentTimeMillis) - 301_000) / 1_000;
+            yield* fs.utimes(lockPath, agedSeconds, agedSeconds);
             yield* appendAdmissionJournalEvent(tempRoot.root, journalAdmitted(2));
             expect(O.isNone(yield* fs.stat(lockPath).pipe(Effect.option))).toBe(true);
             const events = yield* readJournalEvents(tempRoot.root);

--- a/packages/tooling/tool/cli/test/quality-scheduler.test.ts
+++ b/packages/tooling/tool/cli/test/quality-scheduler.test.ts
@@ -14,6 +14,7 @@ import {
   noAdmissionOriginGate,
   parseAdmissionProcStatStartTime,
   reapAdmissionState,
+  releaseAdmissionJournalLockForTesting,
   withQualityAdmission,
   YeetAdmissionLease,
 } from "@beep/repo-cli/test/RepoRun";
@@ -21,7 +22,7 @@ import { fcRuns, provideScopedLayer } from "@beep/test-utils";
 import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
 import * as NodePath from "@effect/platform-node/NodePath";
 import { describe, expect, it } from "@effect/vitest";
-import { Clock, ConfigProvider, Effect, Fiber, FileSystem, Layer, Path, pipe, Ref } from "effect";
+import { ConfigProvider, Effect, Fiber, FileSystem, Layer, Path, pipe, Ref } from "effect";
 import * as A from "effect/Array";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
@@ -363,7 +364,7 @@ describe("quality-scheduler", () => {
       })
     ));
 
-  it("fails the append while the journal lock is held and reaps a stale lock", () =>
+  it("fails the append under a live lock holder and reaps dead or malformed locks", () =>
     Effect.runPromise(
       Effect.gen(function* () {
         const gibRef = yield* Ref.make(50);
@@ -373,16 +374,38 @@ describe("quality-scheduler", () => {
             const path = yield* Path.Path;
             const lockPath = path.join(tempRoot.root, "journal.lock");
             yield* fs.makeDirectory(tempRoot.root, { recursive: true, mode: 0o700 });
-            yield* fs.writeFileString(lockPath, `${process.pid}\n`);
+            yield* fs.writeFileString(lockPath, `${process.pid}:live-holder`);
             const busy = yield* appendAdmissionJournalEvent(tempRoot.root, journalAdmitted(0)).pipe(Effect.flip);
             expect(busy.message).toContain("stayed busy");
             expect(yield* readJournalEvents(tempRoot.root)).toHaveLength(0);
-            const staleSeconds = ((yield* Clock.currentTimeMillis) - 61_000) / 1_000;
-            yield* fs.utimes(lockPath, staleSeconds, staleSeconds);
+            yield* fs.writeFileString(lockPath, `${DEAD_PID}:dead-holder`);
             yield* appendAdmissionJournalEvent(tempRoot.root, journalAdmitted(1));
             expect(O.isNone(yield* fs.stat(lockPath).pipe(Effect.option))).toBe(true);
+            yield* fs.writeFileString(lockPath, "not-a-pid");
+            yield* appendAdmissionJournalEvent(tempRoot.root, journalAdmitted(2));
+            expect(O.isNone(yield* fs.stat(lockPath).pipe(Effect.option))).toBe(true);
             const events = yield* readJournalEvents(tempRoot.root);
-            expect(A.map(events, (event) => event.nonce)).toStrictEqual(["nonce-1"]);
+            expect(A.map(events, (event) => event.nonce)).toStrictEqual(["nonce-1", "nonce-2"]);
+          })
+        );
+      })
+    ));
+
+  it("releases only the owned journal lock generation", () =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const gibRef = yield* Ref.make(50);
+        yield* withAdmissionTempRoot(gibRef, (tempRoot) =>
+          Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            const path = yield* Path.Path;
+            const lockPath = path.join(tempRoot.root, "journal.lock");
+            yield* fs.makeDirectory(tempRoot.root, { recursive: true, mode: 0o700 });
+            yield* fs.writeFileString(lockPath, "999:replacement-owner");
+            yield* releaseAdmissionJournalLockForTesting(lockPath, `${process.pid}:mine`);
+            expect(O.isSome(yield* fs.stat(lockPath).pipe(Effect.option))).toBe(true);
+            yield* releaseAdmissionJournalLockForTesting(lockPath, "999:replacement-owner");
+            expect(O.isNone(yield* fs.stat(lockPath).pipe(Effect.option))).toBe(true);
           })
         );
       })
@@ -464,7 +487,9 @@ describe("quality-scheduler", () => {
         const decoded = S.decodeSync(S.fromJsonString(AdmissionJournalEvent))(encoded);
         expect(decoded._tag).toBe(event._tag);
         expect(decoded.nonce).toBe(event.nonce);
-        expect(decoded.pid).toBe(event.pid);
+        // JSON drops the sign of -0, so the codec law is encode-stability
+        // rather than Object.is identity on numeric fields.
+        expect(S.encodeSync(S.fromJsonString(AdmissionJournalEvent))(decoded)).toBe(encoded);
       }),
       fcRuns(32)
     );


### PR DESCRIPTION
## fix(repo-cli): bind journal lock reaping and release to owner generations

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- full:cheap-gates: passed
- full:pre-push: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/feat_admission-journal-lock-generations-55203082e3bc/verdict.json

---

## Provenance

- Branch: <code>feat/admission-journal-lock-generations</code>
- Harness: `codex`

<!-- yeet-provenance
{
  "schemaVersion": 1,
  "branch": "feat/admission-journal-lock-generations",
  "harness": "codex"
}
-->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/879"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790589677&installation_model_id=424656&pr_number=879&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F879&signature=053044cdc27cae88e0e4c809cbaabe89824a31f931e732ff42daccf233a22cc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->