### PR TITLE
chore(cloud): add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,5 @@
+{
+  "name": "beep-effect",
+  "user": "ubuntu",
+  "install": "bash .cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Cloud Agent install: idempotent dependency bootstrap for beep-effect.
+#
+# Runs after the repository is checked out. Safe to run repeatedly and against
+# cached state (an environment build reuses the resulting snapshot). Keep this
+# lean: durable dependency + toolchain preparation only, no dev servers.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+BUN_VERSION="$(tr -d '[:space:]' < .bun-version)"
+export BUN_INSTALL="${HOME}/.bun"
+export PATH="${BUN_INSTALL}/bin:${PATH}"
+
+# 1. Install the pinned Bun toolchain when it is missing or the wrong version.
+if ! command -v bun >/dev/null 2>&1 || [ "$(bun --version 2>/dev/null)" != "${BUN_VERSION}" ]; then
+  curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}"
+fi
+
+# Expose bun to every shell (login, non-login, and the agent) regardless of
+# whether shell profiles are sourced.
+if command -v sudo >/dev/null 2>&1; then
+  sudo ln -sf "${BUN_INSTALL}/bin/bun" /usr/local/bin/bun
+  sudo ln -sf "${BUN_INSTALL}/bin/bunx" /usr/local/bin/bunx
+fi
+
+# 2. Install workspace dependencies.
+#
+# --ignore-scripts skips the repo root lifecycle scripts only. Bun does not run
+# dependency lifecycle scripts without a trustedDependencies allowlist (none is
+# declared here), so nothing dependency-side is lost. The root `postinstall`
+# (`lefthook install` + GHA-runner prep) is intentionally skipped: `lefthook
+# install` fails whenever git core.hooksPath is overridden (as Cursor Cloud
+# does), and neither step is needed to build or run the apps.
+bun install --ignore-scripts
+
+# 3. Apply the Effect tsgo TypeScript patch that the root `prepare` script would
+#    normally run (skipped above alongside the other lifecycle scripts).
+bun run prepare
+
+echo "beep-effect install complete: bun ${BUN_VERSION}, dependencies linked, tsgo patched."

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -25,7 +25,34 @@ if command -v sudo >/dev/null 2>&1; then
   sudo ln -sf "${BUN_INSTALL}/bin/bunx" /usr/local/bin/bunx
 fi
 
-# 2. Install workspace dependencies.
+# 2. Provision the Node.js runtime pinned by .nvmrc (Next.js and portless
+#    require Node 24+). nvm is sourced explicitly because this script runs in a
+#    non-login shell. Guarded so a missing nvm does not abort the install.
+NODE_VERSION="$(tr -d '[:space:]' < .nvmrc 2>/dev/null || echo 24)"
+export NVM_DIR="${NVM_DIR:-${HOME}/.nvm}"
+if [ -s "${NVM_DIR}/nvm.sh" ]; then
+  set +e
+  # shellcheck disable=SC1091
+  . "${NVM_DIR}/nvm.sh"
+  nvm install "${NODE_VERSION}"
+  nvm alias default "${NODE_VERSION}"
+  nvm use "${NODE_VERSION}"
+  set -e
+else
+  echo "WARN: nvm not found at ${NVM_DIR}; skipping Node ${NODE_VERSION} provisioning."
+fi
+
+# 3. Install the portless dev-server proxy globally. Dev servers in this repo
+#    are launched only through portless-wrapped package scripts; it is not a
+#    workspace dependency, so it must be present on PATH.
+if ! command -v portless >/dev/null 2>&1; then
+  bun add -g portless
+fi
+if command -v sudo >/dev/null 2>&1 && [ -x "${BUN_INSTALL}/bin/portless" ]; then
+  sudo ln -sf "${BUN_INSTALL}/bin/portless" /usr/local/bin/portless
+fi
+
+# 4. Install workspace dependencies.
 #
 # --ignore-scripts skips the repo root lifecycle scripts only. Bun does not run
 # dependency lifecycle scripts without a trustedDependencies allowlist (none is
@@ -35,7 +62,7 @@ fi
 # does), and neither step is needed to build or run the apps.
 bun install --ignore-scripts
 
-# 3. Apply the Effect tsgo TypeScript patch that the root `prepare` script would
+# 5. Apply the Effect tsgo TypeScript patch that the root `prepare` script would
 #    normally run (skipped above alongside the other lifecycle scripts).
 bun run prepare
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a Cursor Cloud Agent development environment for `beep-effect`.

- `.cursor/environment.json` — default Ubuntu 24.04 base image, `ubuntu` user, `install` runs the bootstrap script.
- `.cursor/install.sh` — idempotent, non-interactive bootstrap:
  1. Installs the pinned **Bun** toolchain from `.bun-version` (`1.4.0`) if missing, and symlinks `bun`/`bunx` into `/usr/local/bin`.
  2. Provisions **Node 24** (`.nvmrc`) via `nvm`, sets it as the default (Next.js + portless require Node 24+).
  3. Installs **portless** globally (dev servers run only through portless-wrapped package scripts; it is not a workspace dependency).
  4. `bun install --ignore-scripts` to link workspace dependencies.
  5. `bun run prepare` to apply the Effect `tsgo` TypeScript patch.

## Why `--ignore-scripts`

The repo root `postinstall` (`lefthook install` + GHA-runner prep) is not needed to build or run the apps, and `lefthook install` fails whenever git `core.hooksPath` is overridden (as Cursor Cloud does). Bun does not run dependency lifecycle scripts without a `trustedDependencies` allowlist (none is declared), so nothing dependency-side is lost. The one root script that matters for the toolchain — `prepare` (tsgo patch) — is run explicitly.

## Validation

Verified on the VM and re-verified in a **fresh Cloud Agent booted from the tested build**:

| Check | Result |
| --- | --- |
| `bash .cursor/install.sh` | Exits 0; idempotent across repeated runs |
| Clean `bun install` (node_modules removed) | 2484 packages linked, exit 0 |
| Environment build from a clean checkout | SUCCEEDED (Node 24, deps, tsgo patch, exit 0) |
| tsgo type-check (`foundation/primitive/types`) | Passed (exit 0) |
| biome lint (`foundation/primitive/types`) | Passed (11 files) |
| vitest (`foundation/primitive/types`, `foundation/primitive/data`) | 43 tests passed |
| `oip-web` Next.js dev server via portless | `HTTP 200`, homepage renders (hero, Practice Areas, Contact); theme toggle works |
| Fresh Cloud Agent (booted from build) | 5/5 checks pass: bun 1.4.0, portless 0.15.6, Node 24, beep CLI, vitest, tsgo, dev server HTTP 200 |

### End-to-end walkthrough (oip-web dev server)

[oip-web-dev-server-walkthrough.mp4](https://cursor.com/agents/bc-dc644933-40a4-4b30-9a97-570d6c772653/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foip-web-dev-server-walkthrough.mp4)

## Note on Node version display

In Cursor tool/agent shells, `node -v` may report v22 because Cursor's `/exec-daemon` shim precedes `nvm` on `PATH`. Login shells and the actual dev pipeline resolve Node 24 (confirmed by the running Next.js 16 canary dev server). This is a cosmetic PATH-ordering artifact, not an environment defect.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc644933-40a4-4b30-9a97-570d6c772653?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc644933-40a4-4b30-9a97-570d6c772653&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790629210&installation_model_id=424656&pr_number=885&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F885&signature=08d6824a12906282ad871b596e0cf01b484f92d49c8ac6570b6745442d974d54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->