### PR TITLE
feat(repo-cli): reap idle tmpfs artifacts and move head-install preflight to disk

### DIFF
--- a/.changeset/tmpfs-lifecycle.md
+++ b/.changeset/tmpfs-lifecycle.md
@@ -1,0 +1,6 @@
+---
+"@beep/repo-cli": patch
+---
+
+Move Yeet clean-HEAD installs onto persistent cache storage and add a dry-run-first tmpfs janitor for idle
+worktrees and tool artifacts. Extend post-merge sweep to reap idle temporary worktrees owned by the current repo.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,9 @@ workflows in skills.
   answer and resolve every one via `bun run beep yeet reply` (drafts in
   `.beep/yeet/reply-drafts.json`); never leave threads standing or ask the
   operator to relay them.
+- Full git checkouts and tool clones never go under `/tmp` (tmpfs is zram-backed
+  memory): agent worktrees belong in the sibling `-worktrees` root, disposable
+  installs under `~/.cache/beep/`. `beep quality tmpfs-reap` is the janitor.
 
 ## Touch → Skill / Command
 

--- a/packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts
@@ -43,6 +43,8 @@ import {
   admissionStatus,
   GITHUB_CHECK_MODE_VALUES,
   reapAdmissionState,
+  runTmpfsReap,
+  TmpfsReapReport,
 } from "../../internal/repo-run/index.ts";
 import { runChangesetGraphCheck } from "./ChangesetGraph.ts";
 import { changesetStatusCommand } from "./ChangesetStatus.ts";
@@ -2749,6 +2751,54 @@ const qualitySchedulerCommand = Command.make("scheduler", {}, () =>
   Command.withSubcommands([schedulerStatusCommand, schedulerReapCommand])
 );
 
+const renderTmpfsCandidateLine = (candidate: TmpfsReapReport["candidates"][number]): string => {
+  const bytes = pipe(
+    O.fromUndefinedOr(candidate.bytes),
+    O.map((value) => ` bytes=${value}`),
+    O.getOrElse(() => "")
+  );
+  const skip = pipe(
+    O.fromUndefinedOr(candidate.skipReason),
+    O.map((reason) => ` reason=${reason}`),
+    O.getOrElse(() => "")
+  );
+  return `- ${candidate.action} class=${candidate.reapClass} age=${candidate.ageHours.toFixed(1)}h refs=${candidate.refCount}${bytes}${skip} ${candidate.path}`;
+};
+
+const tmpfsReapCommand = Command.make(
+  "tmpfs-reap",
+  {
+    apply: Flag.boolean("apply").pipe(
+      Flag.withDefault(false),
+      Flag.withDescription("Apply eligible removals (default: loud dry-run only)")
+    ),
+    json: Flag.boolean("json").pipe(
+      Flag.withDefault(false),
+      Flag.withDescription("Emit the encoded tmpfs-reap/v1 report as JSON")
+    ),
+  },
+  Effect.fn(function* ({ apply, json }) {
+    const report = yield* runTmpfsReap({ apply });
+    if (json) {
+      const encoded = yield* S.encodeUnknownEffect(TmpfsReapReport)(report);
+      yield* printLines([yield* jsonStringifyPretty(encoded)]);
+      return;
+    }
+    yield* printLines([
+      apply
+        ? "TMPFS REAP APPLY — removing only classified, idle artifacts with zero live references"
+        : "TMPFS REAP DRY RUN — nothing will be removed; pass --apply to reap eligible artifacts",
+      ...A.map(report.candidates, renderTmpfsCandidateLine),
+      `totals: candidates=${A.length(report.candidates)} reaped=${report.reapedCount} reclaimed-bytes=${report.reclaimedBytes}`,
+      ...A.map(report.warnings, (warning) => `warning: ${warning}`),
+    ]);
+  })
+).pipe(
+  Command.withDescription(
+    "Dry-run-first janitor for idle tmpfs worktrees and tool artifacts; pass --apply from the janitor timer"
+  )
+);
+
 /**
  * Quality command group for repo operational checks.
  *
@@ -2786,6 +2836,7 @@ export const qualityCommand = Command.make("quality", {}, () =>
     "- bun run beep quality knip --write-baseline",
     "- bun run beep quality turbo-config-proof --base origin/main --head HEAD",
     "- bun run beep quality profile detect",
+    "- bun run beep quality tmpfs-reap [--apply] [--json]",
     "- bun run beep quality package-verify @beep/repo-cli",
     "- bun run beep quality changeset-graph",
     "- bun run beep quality fallow audit --advisory",
@@ -2808,6 +2859,7 @@ export const qualityCommand = Command.make("quality", {}, () =>
     turboConfigProofCommand,
     qualityProfileCommand,
     qualitySchedulerCommand,
+    tmpfsReapCommand,
     packageVerifyCommand,
     changesetGraphCommand,
     changesetStatusCommand,

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/HeadInstallPreflight.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/HeadInstallPreflight.ts
@@ -1,6 +1,11 @@
 /**
  * Clean-HEAD frozen-lockfile install preflight for Yeet publish and verify.
  *
+ * The detached checkout and full install are minted beneath the persistent
+ * cache root, not the tmpfs-backed system temporary directory. A crash can
+ * therefore leak disk rather than zram; `beep quality tmpfs-reap` is the
+ * janitor for abandoned head-install roots.
+ *
  * @packageDocumentation
  * @since 0.0.0
  */
@@ -8,7 +13,12 @@
 import { O } from "@beep/utils";
 import { Console, Effect, FileSystem, Path } from "effect";
 import * as A from "effect/Array";
-import { commandTextForStep, RepoStepRunResult, runRepoCommandCapture } from "../../../internal/repo-run/index.ts";
+import {
+  commandTextForStep,
+  RepoStepRunResult,
+  resolveBeepCacheRoot,
+  runRepoCommandCapture,
+} from "../../../internal/repo-run/index.ts";
 import { YeetCommandError } from "../Yeet.errors.ts";
 import type { ChildProcessSpawner } from "effect/unstable/process";
 import type { RepoPlanStep, RepoRunContext } from "../../../internal/repo-run/index.ts";
@@ -59,8 +69,9 @@ const persistOutput = Effect.fn("Yeet.persistHeadInstallPreflightOutput")(functi
 /**
  * Install the committed repository tree in a detached temporary worktree.
  *
- * The temporary checkout is always removed and pruned, including when the
- * frozen install fails.
+ * The temporary checkout is created on persistent disk and is always removed
+ * and pruned, including when the frozen install fails. If the process crashes,
+ * the tmpfs janitor reaps the abandoned cache root later.
  *
  * @param context - Repository context whose committed HEAD is checked.
  * @param step - Planned preflight lane recorded in run artifacts.
@@ -82,8 +93,15 @@ export const executeHeadInstallPreflight = Effect.fn("Yeet.executeHeadInstallPre
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const commandText = commandTextForStep(step);
+  const cacheRoot = yield* resolveBeepCacheRoot().pipe(
+    Effect.mapError(YeetCommandError.new("Failed to resolve the head-install preflight cache root."))
+  );
+  const headInstallBase = path.join(cacheRoot, "beep", "head-install");
+  yield* fs
+    .makeDirectory(headInstallBase, { recursive: true })
+    .pipe(Effect.mapError(YeetCommandError.new("Failed to create the head-install preflight cache directory.")));
   const tempRoot = yield* fs
-    .makeTempDirectory({ prefix: "beep-yeet-head-install-" })
+    .makeTempDirectory({ directory: headInstallBase, prefix: "beep-yeet-head-install-" })
     .pipe(Effect.mapError(YeetCommandError.new("Failed to create the head-install preflight temp directory.")));
   const worktreePath = path.join(tempRoot, "checkout");
 

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Sweep.schemas.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Sweep.schemas.ts
@@ -55,7 +55,8 @@ const $I = $RepoCliId.create("commands/Yeet/internal/Sweep.schemas");
  * not checked out anywhere); `delete-local-branch` and `delete-remote-branch`
  * retire the merged feature branch; `lockfile-install` runs `bun install` when
  * the `main` update moved `bun.lock`; `end-state` records where the sweep left
- * the clone.
+ * the clone; `tmpfs-worktrees` checks the current repository's temporary
+ * worktrees through the shared tmpfs idleness policy.
  *
  * **Example** (List the sweep step ids)
  *
@@ -75,6 +76,7 @@ export const SweepStepId = LiteralKit([
   "delete-remote-branch",
   "lockfile-install",
   "end-state",
+  "tmpfs-worktrees",
 ]).pipe(
   $I.annoteSchema("SweepStepId", {
     title: "Sweep Step Id",

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Sweep.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Sweep.ts
@@ -1115,50 +1115,73 @@ const runEndStateStep = (
         )
       );
 
-const runTmpfsWorktreesStep = (
-  cwd: string
-): Effect.Effect<
+/**
+ * Reap the current repository's idle tmpfs-resident Git worktrees.
+ *
+ * Lists this checkout's registered worktrees, hands the ones under the
+ * temporary root to the tmpfs janitor's `git-worktree` class, and reports the
+ * outcome in sweep-step shape. The janitor keeps ownership of liveness,
+ * cleanliness, age, and removal semantics.
+ *
+ * **Example** (Build the sweep step effect)
+ *
+ * ```ts
+ * import { runTmpfsWorktreesStep } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * console.log(Effect.isEffect(runTmpfsWorktreesStep("/tmp/example-repo"))) // true
+ * ```
+ *
+ * @param cwd - Repository whose registered worktrees are inspected.
+ * @param tmpRoot - Optional temporary-root override, primarily for fixtures.
+ * @returns The executed/skipped outcome for the sweep report.
+ * @category execution
+ * @since 0.0.0
+ */
+export const runTmpfsWorktreesStep = Effect.fn("Yeet.runTmpfsWorktreesStep")(function* (
+  cwd: string,
+  tmpRoot?: string
+): Effect.fn.Return<
   SweepStepOutcome,
   never,
   FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
-> => {
-  const worktreeList = captureGit(cwd, ["worktree", "list", "--porcelain"]);
-  return worktreeList.pipe(
-    Effect.flatMap((probe) => {
-      if (probeUnreliable(probe)) {
-        return Effect.succeed<SweepStepOutcome>(
-          SweepStepSkipped.make({
-            reason: `${worktreeProbeCommand} failed or was truncated: ${probeFailureText(probe)}`,
-          })
-        );
-      }
-      const worktreePaths = A.map(parseWorktreeList(probe.output), (entry) => entry.path);
-      return runTmpfsReap({ apply: true, classes: ["git-worktree"], gitWorktreePaths: worktreePaths }).pipe(
-        Effect.matchCause({
-          onFailure: (cause): SweepStepOutcome =>
-            SweepStepSkipped.make({ reason: `tmpfs worktree scan failed: ${firstLine(Cause.pretty(cause))}` }),
-          onSuccess: (report): SweepStepOutcome => {
-            if (report.reapedCount > 0) {
-              return SweepStepExecuted.make({
-                detail: O.some(
-                  `reaped ${report.reapedCount} idle tmpfs worktree(s), reclaimed ${report.reclaimedBytes} bytes`
-                ),
-              });
-            }
-            if (!A.isReadonlyArrayEmpty(report.warnings)) {
-              return SweepStepSkipped.make({ reason: A.join(report.warnings, "; ") });
-            }
-            return SweepStepSkipped.make({
-              reason: A.isReadonlyArrayEmpty(report.candidates)
-                ? "no current-repo Git worktrees are under TMPDIR"
-                : "no current-repo TMPDIR worktrees passed the conjunctive idleness test",
-            });
-          },
-        })
-      );
+> {
+  const probe = yield* captureGit(cwd, ["worktree", "list", "--porcelain"]);
+  if (probeUnreliable(probe)) {
+    return SweepStepSkipped.make({
+      reason: `${worktreeProbeCommand} failed or was truncated: ${probeFailureText(probe)}`,
+    });
+  }
+  const worktreePaths = A.map(parseWorktreeList(probe.output), (entry) => entry.path);
+  return yield* runTmpfsReap({
+    apply: true,
+    classes: ["git-worktree"],
+    gitWorktreePaths: worktreePaths,
+    ...(tmpRoot === undefined ? {} : { tmpRoot }),
+  }).pipe(
+    Effect.matchCause({
+      onFailure: (cause): SweepStepOutcome =>
+        SweepStepSkipped.make({ reason: `tmpfs worktree scan failed: ${firstLine(Cause.pretty(cause))}` }),
+      onSuccess: (report): SweepStepOutcome => {
+        if (report.reapedCount > 0) {
+          return SweepStepExecuted.make({
+            detail: O.some(
+              `reaped ${report.reapedCount} idle tmpfs worktree(s), reclaimed ${report.reclaimedBytes} bytes`
+            ),
+          });
+        }
+        if (!A.isReadonlyArrayEmpty(report.warnings)) {
+          return SweepStepSkipped.make({ reason: A.join(report.warnings, "; ") });
+        }
+        return SweepStepSkipped.make({
+          reason: A.isReadonlyArrayEmpty(report.candidates)
+            ? "no current-repo Git worktrees are under TMPDIR"
+            : "no current-repo TMPDIR worktrees passed the conjunctive idleness test",
+        });
+      },
     })
   );
-};
+});
 
 const performSweepStep = (
   context: RepoRunContext,

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Sweep.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Sweep.ts
@@ -68,14 +68,19 @@ import { $RepoCliId } from "@beep/identity/packages";
 import { shellQuote } from "@beep/repo-ai-metrics";
 import { guardLiteralArg } from "@beep/repo-utils";
 import { SchemaUtils } from "@beep/schema";
-import { Clock, DateTime, Effect, flow, Path, pipe } from "effect";
+import { Cause, Clock, DateTime, Effect, flow, Path, pipe } from "effect";
 import * as A from "effect/Array";
 import { dual } from "effect/Function";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
 import * as Str from "effect/String";
 import { GhPrView, ghOutput } from "../../../internal/github/index.ts";
-import { RepoRunContext, runRepoCommandCapture, safeOriginBranchFromBase } from "../../../internal/repo-run/index.ts";
+import {
+  RepoRunContext,
+  runRepoCommandCapture,
+  runTmpfsReap,
+  safeOriginBranchFromBase,
+} from "../../../internal/repo-run/index.ts";
 import { YeetCommandError } from "../Yeet.errors.ts";
 import { artifactDirForContext } from "./ArtifactPaths.ts";
 import { optionFromNonEmpty } from "./GitExec.ts";
@@ -404,6 +409,14 @@ const endStatePlanStep = (state: SweepGitState): SweepPlanStep =>
     requiresOperator: false,
   });
 
+const tmpfsWorktreesPlanStep = (): SweepPlanStep =>
+  SweepPlanStep.make({
+    id: "tmpfs-worktrees",
+    action: "inspect TMPDIR for idle Git worktrees owned by the current repository",
+    preconditions: [],
+    requiresOperator: false,
+  });
+
 /**
  * Turn observed git state into the plan a sweep would execute.
  *
@@ -486,6 +499,7 @@ export const buildSweepPlan: {
         deleteRemoteBranchPlanStep(state),
         lockfileInstallPlanStep(state),
         endStatePlanStep(state),
+        tmpfsWorktreesPlanStep(),
       ],
     })
 );
@@ -1101,11 +1115,60 @@ const runEndStateStep = (
         )
       );
 
+const runTmpfsWorktreesStep = (
+  cwd: string
+): Effect.Effect<
+  SweepStepOutcome,
+  never,
+  FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+> => {
+  const worktreeList = captureGit(cwd, ["worktree", "list", "--porcelain"]);
+  return worktreeList.pipe(
+    Effect.flatMap((probe) => {
+      if (probeUnreliable(probe)) {
+        return Effect.succeed<SweepStepOutcome>(
+          SweepStepSkipped.make({
+            reason: `${worktreeProbeCommand} failed or was truncated: ${probeFailureText(probe)}`,
+          })
+        );
+      }
+      const worktreePaths = A.map(parseWorktreeList(probe.output), (entry) => entry.path);
+      return runTmpfsReap({ apply: true, classes: ["git-worktree"], gitWorktreePaths: worktreePaths }).pipe(
+        Effect.matchCause({
+          onFailure: (cause): SweepStepOutcome =>
+            SweepStepSkipped.make({ reason: `tmpfs worktree scan failed: ${firstLine(Cause.pretty(cause))}` }),
+          onSuccess: (report): SweepStepOutcome => {
+            if (report.reapedCount > 0) {
+              return SweepStepExecuted.make({
+                detail: O.some(
+                  `reaped ${report.reapedCount} idle tmpfs worktree(s), reclaimed ${report.reclaimedBytes} bytes`
+                ),
+              });
+            }
+            if (!A.isReadonlyArrayEmpty(report.warnings)) {
+              return SweepStepSkipped.make({ reason: A.join(report.warnings, "; ") });
+            }
+            return SweepStepSkipped.make({
+              reason: A.isReadonlyArrayEmpty(report.candidates)
+                ? "no current-repo Git worktrees are under TMPDIR"
+                : "no current-repo TMPDIR worktrees passed the conjunctive idleness test",
+            });
+          },
+        })
+      );
+    })
+  );
+};
+
 const performSweepStep = (
   context: RepoRunContext,
   state: SweepGitState,
   planStep: SweepPlanStep
-): Effect.Effect<SweepStepOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+): Effect.Effect<
+  SweepStepOutcome,
+  never,
+  FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+> =>
   SweepStepId.$match(planStep.id, {
     "fetch-prune": () => runCommandStep("git", ["fetch", "--prune", "origin"], context.repoRoot, planStep.action),
     "ff-main": () =>
@@ -1139,13 +1202,18 @@ const performSweepStep = (
       ),
     "lockfile-install": () => runLockfileInstallStep(state, context.repoRoot, planStep.action),
     "end-state": () => runEndStateStep(state, context.repoRoot, planStep.action),
+    "tmpfs-worktrees": () => runTmpfsWorktreesStep(context.repoRoot),
   });
 
 const runSweepStep = Effect.fn("Yeet.runSweepStep")(function* (
   context: RepoRunContext,
   state: SweepGitState,
   planStep: SweepPlanStep
-): Effect.fn.Return<SweepReportStep, never, ChildProcessSpawner.ChildProcessSpawner> {
+): Effect.fn.Return<
+  SweepReportStep,
+  never,
+  FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+> {
   const startedAt = yield* Clock.currentTimeMillis;
   const blocked = sweepStepBlockers(planStep);
   const outcome = A.isReadonlyArrayEmpty(blocked)

--- a/packages/tooling/tool/cli/src/internal/repo-run/TmpfsReap.schemas.ts
+++ b/packages/tooling/tool/cli/src/internal/repo-run/TmpfsReap.schemas.ts
@@ -85,6 +85,7 @@ export const TmpfsReapSkipReason = LiteralKit([
   "live-cwd-ref",
   "live-fd-ref",
   "live-flock",
+  "dirty-worktree",
   "too-young",
   "parent-repo-missing-but-refs",
   "unclassified",

--- a/packages/tooling/tool/cli/src/internal/repo-run/TmpfsReap.schemas.ts
+++ b/packages/tooling/tool/cli/src/internal/repo-run/TmpfsReap.schemas.ts
@@ -1,0 +1,180 @@
+/**
+ * Schema-first report models for the tmpfs artifact janitor.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import { LiteralKit } from "@beep/schema";
+import * as S from "effect/Schema";
+
+const $I = $RepoCliId.create("internal/repo-run/TmpfsReap.schemas");
+
+/**
+ * Artifact families the janitor can classify without inspecting arbitrary paths.
+ *
+ * **Example** (Recognize a worktree class)
+ *
+ * ```ts
+ * import { TmpfsReapClass } from "@beep/repo-cli/test/RepoRun"
+ *
+ * console.log(TmpfsReapClass.is["git-worktree"]("git-worktree")) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const TmpfsReapClass = LiteralKit(["git-worktree", "head-install", "fallow-cache", "scoped-temp"]).pipe(
+  $I.annoteSchema("TmpfsReapClass", {
+    description: "Artifact family recognized by the tmpfs janitor's closed classification policy.",
+  })
+);
+
+/**
+ * Artifact family recognized by the tmpfs janitor.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type TmpfsReapClass = typeof TmpfsReapClass.Type;
+
+/**
+ * Filesystem or Git operation selected for one janitor candidate.
+ *
+ * **Example** (Inspect the removal actions)
+ *
+ * ```ts
+ * import { TmpfsReapAction } from "@beep/repo-cli/test/RepoRun"
+ *
+ * console.log(TmpfsReapAction.Options) // ["worktree-remove", "remove-dir", "skip"]
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const TmpfsReapAction = LiteralKit(["worktree-remove", "remove-dir", "skip"]).pipe(
+  $I.annoteSchema("TmpfsReapAction", {
+    description: "Filesystem or Git operation selected for a classified janitor candidate.",
+  })
+);
+
+/**
+ * Filesystem or Git operation selected for one janitor candidate.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type TmpfsReapAction = typeof TmpfsReapAction.Type;
+
+/**
+ * Conjunctive safety condition that prevented a candidate from being reaped.
+ *
+ * **Example** (Recognize an age refusal)
+ *
+ * ```ts
+ * import { TmpfsReapSkipReason } from "@beep/repo-cli/test/RepoRun"
+ *
+ * console.log(TmpfsReapSkipReason.is["too-young"]("too-young")) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export const TmpfsReapSkipReason = LiteralKit([
+  "live-cwd-ref",
+  "live-fd-ref",
+  "live-flock",
+  "too-young",
+  "parent-repo-missing-but-refs",
+  "unclassified",
+]).pipe(
+  $I.annoteSchema("TmpfsReapSkipReason", {
+    description: "Safety condition that prevented a classified janitor candidate from being reaped.",
+  })
+);
+
+/**
+ * Safety condition that prevented a candidate from being reaped.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type TmpfsReapSkipReason = typeof TmpfsReapSkipReason.Type;
+
+/**
+ * One classified artifact together with its idleness and liveness evidence.
+ *
+ * **Example** (Describe an idle cache)
+ *
+ * ```ts
+ * import { TmpfsReapCandidate } from "@beep/repo-cli/test/RepoRun"
+ *
+ * const candidate = TmpfsReapCandidate.make({
+ *   path: "/tmp/fallow-audit-base-cache-example",
+ *   reapClass: "fallow-cache",
+ *   ageHours: 8,
+ *   refCount: 0,
+ *   action: "remove-dir",
+ *   bytes: 4096,
+ * })
+ * console.log(candidate.action) // "remove-dir"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class TmpfsReapCandidate extends S.Class<TmpfsReapCandidate>($I`TmpfsReapCandidate`)(
+  {
+    path: S.String,
+    reapClass: TmpfsReapClass,
+    ageHours: S.Finite,
+    refCount: S.Int,
+    action: TmpfsReapAction,
+    skipReason: S.optional(TmpfsReapSkipReason),
+    parentRepo: S.optional(S.String),
+    bytes: S.optional(S.Finite),
+  },
+  $I.annote("TmpfsReapCandidate", {
+    description: "One classified temporary artifact with the evidence and action chosen by the janitor.",
+  })
+) {}
+
+/**
+ * Auditable result of one dry-run or applied tmpfs janitor pass.
+ *
+ * **Example** (Construct an empty dry-run report)
+ *
+ * ```ts
+ * import { TmpfsReapReport } from "@beep/repo-cli/test/RepoRun"
+ *
+ * const report = TmpfsReapReport.make({
+ *   scannedAt: "2026-08-29T12:00:00.000Z",
+ *   tmpRoot: "/tmp",
+ *   applied: false,
+ *   candidates: [],
+ *   reapedCount: 0,
+ *   reclaimedBytes: 0,
+ *   warnings: [],
+ * })
+ * console.log(report.schemaVersion) // "tmpfs-reap/v1"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class TmpfsReapReport extends S.Class<TmpfsReapReport>($I`TmpfsReapReport`)(
+  {
+    schemaVersion: S.tag("tmpfs-reap/v1"),
+    scannedAt: S.String,
+    tmpRoot: S.String,
+    applied: S.Boolean,
+    candidates: S.Array(TmpfsReapCandidate),
+    reapedCount: S.Int,
+    reclaimedBytes: S.Finite,
+    warnings: S.Array(S.String),
+  },
+  $I.annote("TmpfsReapReport", {
+    description: "Auditable result of one dry-run or applied tmpfs artifact janitor pass.",
+  })
+) {}

--- a/packages/tooling/tool/cli/src/internal/repo-run/TmpfsReap.ts
+++ b/packages/tooling/tool/cli/src/internal/repo-run/TmpfsReap.ts
@@ -1,0 +1,646 @@
+/**
+ * Conservative janitor for known temporary artifacts on Linux tmpfs roots.
+ *
+ * Discovery is closed over four explicit artifact families. Reaping requires
+ * classification, an old-enough idleness clock, zero live `/proc` cwd or file
+ * descriptor references, and no matching kernel lock. Linked Git worktrees go
+ * through `git worktree remove`; arbitrary directories are never touched.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { $RepoCliId } from "@beep/identity/packages";
+import * as O from "@beep/utils/Option";
+import { Clock, Config, DateTime, Duration, Effect, FileSystem, Number as N, Path, pipe } from "effect";
+import * as A from "effect/Array";
+import * as S from "effect/Schema";
+import * as Str from "effect/String";
+import { runRepoCommandCapture } from "./RepoRun.executor.ts";
+import { TmpfsReapCandidate, TmpfsReapClass, TmpfsReapReport } from "./TmpfsReap.schemas.ts";
+import type { ChildProcessSpawner } from "effect/unstable/process";
+import type { TmpfsReapSkipReason } from "./TmpfsReap.schemas.ts";
+
+const $I = $RepoCliId.create("internal/repo-run/TmpfsReap");
+
+const HEAD_INSTALL_PREFIX = "beep-yeet-head-install-";
+const FALLOW_CACHE_PREFIX = "fallow-audit-base-cache-";
+const SCOPED_TEMP_PREFIXES = [
+  "beep-knowledge-refs-",
+  "beep-research-history-",
+  "beep-fallow-audit-diff-",
+  "beep-docgen-worker-eval-",
+  "agent-effectiveness-schema-first-",
+];
+const GIT_WORKTREE_MARKER = "/.git/worktrees/";
+const PROC_ROOT = "/proc";
+const PROC_LOCKS = "/proc/locks";
+
+const ProcPidName = S.String.pipe(
+  S.check(S.isPattern(/^[0-9]+$/u)),
+  $I.annoteSchema("ProcPidName", {
+    description: "Decimal process directory name under Linux procfs.",
+  })
+);
+const isProcPidName = S.is(ProcPidName);
+
+type DiscoveredCandidate = {
+  readonly path: string;
+  readonly reapClass: TmpfsReapClass;
+  readonly idleSinceMillis: number;
+  readonly classified: boolean;
+  readonly parentRepo: O.Option<string>;
+};
+
+type ProcReferenceSnapshot = {
+  readonly cwdTargets: ReadonlyArray<string>;
+  readonly fdTargets: ReadonlyArray<string>;
+};
+
+type CandidateLiveness = {
+  readonly cwdCount: number;
+  readonly fdCount: number;
+  readonly liveFlock: boolean;
+};
+
+type MeasuredCandidate = {
+  readonly discovered: DiscoveredCandidate;
+  readonly ageHours: number;
+  readonly bytes: O.Option<number>;
+  readonly liveness: CandidateLiveness;
+  readonly skipReason: O.Option<TmpfsReapSkipReason>;
+};
+
+type ApplyOutcome = {
+  readonly reaped: boolean;
+  readonly warnings: ReadonlyArray<string>;
+};
+
+const emptyApplyOutcome = (warning: string): ApplyOutcome => ({ reaped: false, warnings: [warning] });
+
+const sameCandidatePath = (left: DiscoveredCandidate, right: DiscoveredCandidate): boolean => left.path === right.path;
+
+const pathHasPrefix = (target: string, candidate: string, separator: string): boolean =>
+  target === candidate || Str.startsWith(`${candidate}${separator}`)(target);
+
+const pathIsWithin = (pathService: Path.Path, root: string, candidate: string): boolean => {
+  const relative = pathService.relative(root, pathService.resolve(candidate));
+  return (
+    Str.isEmpty(relative) ||
+    (!pathService.isAbsolute(relative) && relative !== ".." && !Str.startsWith(`..${pathService.sep}`)(relative))
+  );
+};
+
+const newestMillis = (values: ReadonlyArray<number>, fallback: number): number =>
+  A.match(values, {
+    onEmpty: () => fallback,
+    onNonEmpty: ([head, ...tail]) => A.reduce(tail, head, N.max),
+  });
+
+const statMtimeMillis = Effect.fnUntraced(function* (
+  filePath: string
+): Effect.fn.Return<O.Option<number>, never, FileSystem.FileSystem> {
+  const fs = yield* FileSystem.FileSystem;
+  const info = yield* fs.stat(filePath).pipe(Effect.option);
+  return pipe(
+    info,
+    O.flatMap((value) => value.mtime),
+    O.map((mtime) => mtime.getTime())
+  );
+});
+
+const readDirectoryOption = Effect.fnUntraced(function* (
+  directory: string
+): Effect.fn.Return<O.Option<ReadonlyArray<string>>, never, FileSystem.FileSystem> {
+  const fs = yield* FileSystem.FileSystem;
+  return yield* fs.readDirectory(directory).pipe(Effect.option);
+});
+
+const directoryNames = Effect.fnUntraced(function* (
+  directory: string
+): Effect.fn.Return<ReadonlyArray<string>, never, FileSystem.FileSystem> {
+  return O.getOrElse(yield* readDirectoryOption(directory), A.empty<string>);
+});
+
+const isDirectory = Effect.fnUntraced(function* (
+  entryPath: string
+): Effect.fn.Return<boolean, never, FileSystem.FileSystem> {
+  const fs = yield* FileSystem.FileSystem;
+  return pipe(
+    yield* fs.stat(entryPath).pipe(Effect.option),
+    O.exists((info) => info.type === "Directory")
+  );
+});
+
+const parentRepoFromGitDir = (pathService: Path.Path, candidatePath: string, gitDir: string): O.Option<string> => {
+  const resolved = pathService.isAbsolute(gitDir)
+    ? pathService.normalize(gitDir)
+    : pathService.resolve(candidatePath, gitDir);
+  return pipe(
+    Str.lastIndexOf(GIT_WORKTREE_MARKER)(resolved),
+    O.map((markerIndex) => Str.slice(0, markerIndex)(resolved)),
+    O.filter(Str.isNonEmpty)
+  );
+};
+
+const discoverGitWorktree = Effect.fnUntraced(function* (
+  candidatePath: string,
+  idleSinceMillis: number
+): Effect.fn.Return<O.Option<DiscoveredCandidate>, never, FileSystem.FileSystem | Path.Path> {
+  const fs = yield* FileSystem.FileSystem;
+  const pathService = yield* Path.Path;
+  const gitFile = pathService.join(candidatePath, ".git");
+  const info = yield* fs.stat(gitFile).pipe(Effect.option);
+  if (!O.exists(info, (value) => value.type === "File")) {
+    return O.none();
+  }
+  const content = yield* fs.readFileString(gitFile).pipe(Effect.option);
+  return pipe(
+    content,
+    O.map(Str.trim),
+    O.filter(Str.startsWith("gitdir:")),
+    O.map((line): DiscoveredCandidate => {
+      const gitDir = Str.trim(Str.slice(Str.length("gitdir:"))(line));
+      const parentRepo = parentRepoFromGitDir(pathService, candidatePath, gitDir);
+      return {
+        path: candidatePath,
+        reapClass: "git-worktree",
+        idleSinceMillis,
+        classified: O.isSome(parentRepo),
+        parentRepo,
+      };
+    })
+  );
+});
+
+const fallowLastUsedPaths = Effect.fnUntraced(function* (
+  candidatePath: string,
+  siblingNames: ReadonlyArray<string>
+): Effect.fn.Return<ReadonlyArray<string>, never, FileSystem.FileSystem | Path.Path> {
+  const pathService = yield* Path.Path;
+  const basename = pathService.basename(candidatePath);
+  const insideNames = yield* directoryNames(candidatePath);
+  const inside = A.map(A.filter(insideNames, Str.endsWith(".last-used")), (name) =>
+    pathService.join(candidatePath, name)
+  );
+  const siblings = A.map(
+    A.filter(siblingNames, (name) => Str.startsWith(basename)(name) && Str.endsWith(".last-used")(name)),
+    (name) => pathService.join(pathService.dirname(candidatePath), name)
+  );
+  return A.dedupe(A.appendAll(inside, siblings));
+});
+
+const fallowIdleSinceMillis = Effect.fnUntraced(function* (
+  candidatePath: string,
+  candidateMtimeMillis: number,
+  siblingNames: ReadonlyArray<string>
+): Effect.fn.Return<number, never, FileSystem.FileSystem | Path.Path> {
+  const lastUsedPaths = yield* fallowLastUsedPaths(candidatePath, siblingNames);
+  const readings = A.getSomes(yield* Effect.forEach(lastUsedPaths, statMtimeMillis, { concurrency: 16 }));
+  return newestMillis(readings, candidateMtimeMillis);
+});
+
+const isScopedTempName = (name: string): boolean =>
+  A.some(SCOPED_TEMP_PREFIXES, (prefix) => Str.startsWith(prefix)(name));
+
+const classifyTopLevelDirectory = Effect.fnUntraced(function* (
+  root: string,
+  name: string,
+  siblingNames: ReadonlyArray<string>
+): Effect.fn.Return<O.Option<DiscoveredCandidate>, never, FileSystem.FileSystem | Path.Path> {
+  const pathService = yield* Path.Path;
+  const candidatePath = pathService.join(root, name);
+  if (!(yield* isDirectory(candidatePath))) {
+    return O.none();
+  }
+  const candidateMtime = O.getOrElse(yield* statMtimeMillis(candidatePath), () => 0);
+  if (Str.startsWith(HEAD_INSTALL_PREFIX)(name)) {
+    return O.some({
+      path: candidatePath,
+      reapClass: "head-install",
+      idleSinceMillis: candidateMtime,
+      classified: true,
+      parentRepo: O.none(),
+    });
+  }
+  if (Str.startsWith(FALLOW_CACHE_PREFIX)(name)) {
+    return O.some({
+      path: candidatePath,
+      reapClass: "fallow-cache",
+      idleSinceMillis: yield* fallowIdleSinceMillis(candidatePath, candidateMtime, siblingNames),
+      classified: true,
+      parentRepo: O.none(),
+    });
+  }
+  if (isScopedTempName(name)) {
+    return O.some({
+      path: candidatePath,
+      reapClass: "scoped-temp",
+      idleSinceMillis: candidateMtime,
+      classified: true,
+      parentRepo: O.none(),
+    });
+  }
+  return yield* discoverGitWorktree(candidatePath, candidateMtime);
+});
+
+const discoverTopLevel = Effect.fnUntraced(function* (
+  root: string
+): Effect.fn.Return<ReadonlyArray<DiscoveredCandidate>, never, FileSystem.FileSystem | Path.Path> {
+  const names = yield* directoryNames(root);
+  return A.getSomes(
+    yield* Effect.forEach(names, (name) => classifyTopLevelDirectory(root, name, names), { concurrency: 16 })
+  );
+});
+
+const discoverCacheHeadInstalls = Effect.fnUntraced(function* (
+  cacheRoot: string
+): Effect.fn.Return<ReadonlyArray<DiscoveredCandidate>, never, FileSystem.FileSystem | Path.Path> {
+  const pathService = yield* Path.Path;
+  const base = pathService.join(cacheRoot, "beep", "head-install");
+  const names = yield* directoryNames(base);
+  const headNames = A.filter(names, Str.startsWith(HEAD_INSTALL_PREFIX));
+  return A.getSomes(
+    yield* Effect.forEach(headNames, (name) => classifyTopLevelDirectory(base, name, names), { concurrency: 16 })
+  );
+});
+
+const discoverExplicitGitWorktrees = Effect.fnUntraced(function* (
+  tmpRoot: string,
+  candidatePaths: ReadonlyArray<string>
+): Effect.fn.Return<ReadonlyArray<DiscoveredCandidate>, never, FileSystem.FileSystem | Path.Path> {
+  const fs = yield* FileSystem.FileSystem;
+  const pathService = yield* Path.Path;
+  const canonicalPaths = A.getSomes(
+    yield* Effect.forEach(A.dedupe(candidatePaths), (candidate) => fs.realPath(candidate).pipe(Effect.option), {
+      concurrency: 16,
+    })
+  );
+  const safePaths = A.filter(canonicalPaths, (candidate) => pathIsWithin(pathService, tmpRoot, candidate));
+  return A.getSomes(
+    yield* Effect.forEach(
+      safePaths,
+      Effect.fnUntraced(function* (candidatePath: string) {
+        if (!(yield* isDirectory(candidatePath))) {
+          return O.none<DiscoveredCandidate>();
+        }
+        const mtime = O.getOrElse(yield* statMtimeMillis(candidatePath), () => 0);
+        return yield* discoverGitWorktree(candidatePath, mtime);
+      }),
+      { concurrency: 16 }
+    )
+  );
+});
+
+const readLinkOption = Effect.fnUntraced(function* (
+  linkPath: string
+): Effect.fn.Return<O.Option<string>, never, FileSystem.FileSystem> {
+  const fs = yield* FileSystem.FileSystem;
+  return yield* fs.readLink(linkPath).pipe(Effect.option);
+});
+
+const processReferences = Effect.fnUntraced(function* (
+  procPath: string
+): Effect.fn.Return<ProcReferenceSnapshot, never, FileSystem.FileSystem | Path.Path> {
+  const pathService = yield* Path.Path;
+  const cwd = yield* readLinkOption(pathService.join(procPath, "cwd"));
+  const fdRoot = pathService.join(procPath, "fd");
+  const fdNames = yield* directoryNames(fdRoot);
+  const fdTargets = A.getSomes(
+    yield* Effect.forEach(fdNames, (name) => readLinkOption(pathService.join(fdRoot, name)), { concurrency: 16 })
+  );
+  return {
+    cwdTargets: O.match(cwd, { onNone: A.empty<string>, onSome: A.of }),
+    fdTargets,
+  };
+});
+
+const scanProcReferences = Effect.fnUntraced(function* (): Effect.fn.Return<
+  ProcReferenceSnapshot,
+  never,
+  FileSystem.FileSystem | Path.Path
+> {
+  const pathService = yield* Path.Path;
+  const pids = A.filter(yield* directoryNames(PROC_ROOT), isProcPidName);
+  const snapshots = yield* Effect.forEach(pids, (pid) => processReferences(pathService.join(PROC_ROOT, pid)), {
+    concurrency: 16,
+  });
+  return {
+    cwdTargets: A.flatten(A.map(snapshots, (snapshot) => snapshot.cwdTargets)),
+    fdTargets: A.flatten(A.map(snapshots, (snapshot) => snapshot.fdTargets)),
+  };
+});
+
+const lockInodes = (locks: string): ReadonlyArray<number> =>
+  A.dedupe(
+    A.getSomes(
+      A.map(Str.split(locks, "\n"), (line) =>
+        pipe(
+          Str.split(Str.trim(line), /\s+/u),
+          A.findFirst((field) => A.length(Str.split(field, ":")) === 3),
+          O.flatMap((deviceAndInode) => A.last(Str.split(deviceAndInode, ":"))),
+          O.flatMap(N.parse)
+        )
+      )
+    )
+  );
+
+const candidateLockInodes = Effect.fnUntraced(function* (
+  candidate: DiscoveredCandidate
+): Effect.fn.Return<ReadonlyArray<number>, never, FileSystem.FileSystem | Path.Path> {
+  if (candidate.reapClass !== "fallow-cache") {
+    return A.empty();
+  }
+  const fs = yield* FileSystem.FileSystem;
+  const pathService = yield* Path.Path;
+  const paths = [`${candidate.path}.lock`, pathService.join(candidate.path, ".lock")];
+  const infos = yield* Effect.forEach(paths, (lockPath) => fs.stat(lockPath).pipe(Effect.option), { concurrency: 2 });
+  return A.getSomes(A.map(A.getSomes(infos), (info) => info.ino));
+});
+
+const candidateLiveness = Effect.fnUntraced(function* (
+  candidate: DiscoveredCandidate,
+  proc: ProcReferenceSnapshot,
+  heldLockInodes: ReadonlyArray<number>,
+  separator: string
+): Effect.fn.Return<CandidateLiveness, never, FileSystem.FileSystem | Path.Path> {
+  const cwdCount = A.length(A.filter(proc.cwdTargets, (target) => pathHasPrefix(target, candidate.path, separator)));
+  const fdCount = A.length(A.filter(proc.fdTargets, (target) => pathHasPrefix(target, candidate.path, separator)));
+  const ownLockInodes = yield* candidateLockInodes(candidate);
+  return {
+    cwdCount,
+    fdCount,
+    liveFlock: A.some(ownLockInodes, (inode) => A.contains(heldLockInodes, inode)),
+  };
+});
+
+const thresholdFor = (reapClass: TmpfsReapClass): Duration.Duration =>
+  TmpfsReapClass.$match(reapClass, {
+    "git-worktree": () => Duration.hours(2),
+    "head-install": () => Duration.hours(1),
+    "fallow-cache": () => Duration.hours(6),
+    "scoped-temp": () => Duration.hours(2),
+  });
+
+const skipReasonFor = (
+  candidate: DiscoveredCandidate,
+  ageHours: number,
+  liveness: CandidateLiveness
+): O.Option<TmpfsReapSkipReason> => {
+  if (!candidate.classified) {
+    return O.some("unclassified");
+  }
+  if (liveness.cwdCount > 0) {
+    return O.some("live-cwd-ref");
+  }
+  if (liveness.fdCount > 0) {
+    return O.some("live-fd-ref");
+  }
+  if (liveness.liveFlock) {
+    return O.some("live-flock");
+  }
+  return ageHours < Duration.toHours(thresholdFor(candidate.reapClass)) ? O.some("too-young") : O.none();
+};
+
+const measureBytes = Effect.fnUntraced(function* (
+  candidatePath: string
+): Effect.fn.Return<O.Option<number>, never, ChildProcessSpawner.ChildProcessSpawner> {
+  const result = yield* runRepoCommandCapture("du", ["-sb", "--", candidatePath], candidatePath).pipe(Effect.option);
+  return pipe(
+    result,
+    O.filter((capture) => capture.exitCode === 0 && !capture.truncated),
+    O.flatMap((capture) => A.head(Str.split(capture.output, /\s+/u))),
+    O.flatMap(N.parse)
+  );
+});
+
+const fallowSiblingArtifacts = Effect.fnUntraced(function* (
+  candidatePath: string
+): Effect.fn.Return<ReadonlyArray<string>, never, FileSystem.FileSystem | Path.Path> {
+  const pathService = yield* Path.Path;
+  const parent = pathService.dirname(candidatePath);
+  const basename = pathService.basename(candidatePath);
+  const names = yield* directoryNames(parent);
+  const lastUsed = A.map(
+    A.filter(names, (name) => Str.startsWith(basename)(name) && Str.endsWith(".last-used")(name)),
+    (name) => pathService.join(parent, name)
+  );
+  return A.appendAll([`${candidatePath}.lock`, `${candidatePath}.sha`], lastUsed);
+});
+
+const removeDirectoryCandidate = Effect.fnUntraced(function* (
+  candidate: DiscoveredCandidate
+): Effect.fn.Return<ApplyOutcome, never, FileSystem.FileSystem | Path.Path> {
+  const fs = yield* FileSystem.FileSystem;
+  const extras = candidate.reapClass === "fallow-cache" ? yield* fallowSiblingArtifacts(candidate.path) : A.empty();
+  const removed = yield* fs.remove(candidate.path, { force: true, recursive: true }).pipe(
+    Effect.as(true),
+    Effect.orElseSucceed(() => false)
+  );
+  if (!removed) {
+    return emptyApplyOutcome(`Failed to remove ${candidate.path}.`);
+  }
+  yield* Effect.forEach(extras, (extra) => fs.remove(extra, { force: true, recursive: true }).pipe(Effect.ignore), {
+    discard: true,
+    concurrency: 4,
+  });
+  return { reaped: true, warnings: [] };
+});
+
+const removeGitWorktreeCandidate = Effect.fnUntraced(function* (
+  candidate: DiscoveredCandidate
+): Effect.fn.Return<ApplyOutcome, never, FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner> {
+  const fs = yield* FileSystem.FileSystem;
+  const pathService = yield* Path.Path;
+  if (O.isNone(candidate.parentRepo)) {
+    return emptyApplyOutcome(`Skipped unclassified Git worktree ${candidate.path}.`);
+  }
+  const parentRepo = candidate.parentRepo.value;
+  const parentPresent = yield* fs.exists(pathService.join(parentRepo, ".git")).pipe(Effect.orElseSucceed(() => false));
+  if (!parentPresent) {
+    return yield* removeDirectoryCandidate(candidate);
+  }
+  const remove = yield* runRepoCommandCapture(
+    "git",
+    ["-C", parentRepo, "worktree", "remove", "--force", candidate.path],
+    parentRepo
+  ).pipe(Effect.option);
+  if (O.isNone(remove) || remove.value.exitCode !== 0) {
+    return emptyApplyOutcome(`Failed to remove Git worktree ${candidate.path} through ${parentRepo}.`);
+  }
+  const prune = yield* runRepoCommandCapture("git", ["-C", parentRepo, "worktree", "prune"], parentRepo).pipe(
+    Effect.option
+  );
+  return {
+    reaped: true,
+    warnings:
+      O.isSome(prune) && prune.value.exitCode === 0
+        ? []
+        : [`Removed ${candidate.path}, but Git worktree prune failed for ${parentRepo}.`],
+  };
+});
+
+const applyCandidate = Effect.fnUntraced(function* (
+  candidate: MeasuredCandidate
+): Effect.fn.Return<ApplyOutcome, never, FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner> {
+  if (O.isSome(candidate.skipReason)) {
+    return { reaped: false, warnings: [] };
+  }
+  return yield* candidate.discovered.reapClass === "git-worktree"
+    ? removeGitWorktreeCandidate(candidate.discovered)
+    : removeDirectoryCandidate(candidate.discovered);
+});
+
+const candidateModel = (candidate: MeasuredCandidate): TmpfsReapCandidate =>
+  TmpfsReapCandidate.make({
+    path: candidate.discovered.path,
+    reapClass: candidate.discovered.reapClass,
+    ageHours: candidate.ageHours,
+    refCount: candidate.liveness.cwdCount + candidate.liveness.fdCount,
+    action: O.isSome(candidate.skipReason)
+      ? "skip"
+      : candidate.discovered.reapClass === "git-worktree"
+        ? "worktree-remove"
+        : "remove-dir",
+    ...O.getSomesStruct({
+      skipReason: candidate.skipReason,
+      parentRepo: candidate.discovered.parentRepo,
+      bytes: candidate.bytes,
+    }),
+  });
+
+/**
+ * Resolve the cache root used for persistent beep temporary installations.
+ *
+ * `XDG_CACHE_HOME` wins when non-empty; otherwise the root is `$HOME/.cache`.
+ * An explicit override bypasses ambient configuration for tests and callers
+ * that already resolved policy.
+ *
+ * **Example** (Build the resolution effect)
+ *
+ * ```ts
+ * import { resolveBeepCacheRoot } from "@beep/repo-cli/test/RepoRun"
+ * import { Effect } from "effect"
+ *
+ * console.log(Effect.isEffect(resolveBeepCacheRoot())) // true
+ * ```
+ *
+ * @param override - Explicit cache root, primarily for fixture isolation.
+ * @returns The absolute cache root.
+ * @category configuration
+ * @since 0.0.0
+ */
+export const resolveBeepCacheRoot = Effect.fn("TmpfsReap.resolveBeepCacheRoot")(function* (override?: string) {
+  const pathService = yield* Path.Path;
+  const explicit = O.fromUndefinedOr(override);
+  if (O.isSome(explicit)) {
+    return pathService.resolve(explicit.value);
+  }
+  const configured = yield* Config.option(Config.string("XDG_CACHE_HOME"));
+  const cacheRoot = O.filter(configured, Str.isNonEmpty);
+  if (O.isSome(cacheRoot)) {
+    return pathService.resolve(cacheRoot.value);
+  }
+  const home = yield* Config.string("HOME");
+  return pathService.join(pathService.resolve(home), ".cache");
+});
+
+/**
+ * Discover known temporary artifacts, prove conjunctive idleness, and optionally reap them.
+ *
+ * Dry-run is the default. Tests may supply isolated `tmpRoot`, `cacheRoot`, and
+ * `nowMillis` values. Sweep may additionally pass the current repository's
+ * porcelain worktree paths and restrict the run to `git-worktree`, while the
+ * same engine retains ownership of liveness, age, and removal semantics.
+ *
+ * **Example** (Build a dry-run janitor effect)
+ *
+ * ```ts
+ * import { runTmpfsReap } from "@beep/repo-cli/test/RepoRun"
+ * import { Effect } from "effect"
+ *
+ * console.log(Effect.isEffect(runTmpfsReap())) // true
+ * ```
+ *
+ * @param options - Optional roots, clock, class filter, and apply flag.
+ * @returns The encoded-report model for the completed scan.
+ * @category workflows
+ * @since 0.0.0
+ */
+export const runTmpfsReap = Effect.fn("TmpfsReap.runTmpfsReap")(function* (
+  options: {
+    readonly apply?: boolean;
+    readonly cacheRoot?: string;
+    readonly classes?: ReadonlyArray<TmpfsReapClass>;
+    readonly gitWorktreePaths?: ReadonlyArray<string>;
+    readonly nowMillis?: number;
+    readonly tmpRoot?: string;
+  } = {}
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const pathService = yield* Path.Path;
+  const requestedTmpRoot = O.fromUndefinedOr(options.tmpRoot);
+  const configuredTmpRoot = O.isSome(requestedTmpRoot)
+    ? requestedTmpRoot.value
+    : yield* Config.string("TMPDIR").pipe(Config.withDefault("/tmp"));
+  const tmpRoot = yield* fs.realPath(configuredTmpRoot);
+  const classes = O.getOrElse(O.fromUndefinedOr(options.classes), () => TmpfsReapClass.Options);
+  const includeClass = (reapClass: TmpfsReapClass): boolean => A.contains(classes, reapClass);
+  const explicitGitWorktreePaths = O.fromUndefinedOr(options.gitWorktreePaths);
+
+  const tmpCandidates = O.isSome(explicitGitWorktreePaths)
+    ? yield* discoverExplicitGitWorktrees(tmpRoot, explicitGitWorktreePaths.value)
+    : yield* discoverTopLevel(tmpRoot);
+  const cacheCandidates = includeClass("head-install")
+    ? yield* discoverCacheHeadInstalls(yield* resolveBeepCacheRoot(options.cacheRoot))
+    : A.empty<DiscoveredCandidate>();
+  const discovered = A.filter(
+    A.dedupeWith(A.appendAll(tmpCandidates, cacheCandidates), sameCandidatePath),
+    (candidate) => includeClass(candidate.reapClass)
+  );
+
+  const proc = yield* scanProcReferences();
+  const heldLockInodes = lockInodes(yield* fs.readFileString(PROC_LOCKS));
+  const nowMillis = yield* Clock.currentTimeMillis;
+  const effectiveNowMillis = O.getOrElse(O.fromUndefinedOr(options.nowMillis), () => nowMillis);
+  const measured = yield* Effect.forEach(
+    discovered,
+    Effect.fnUntraced(function* (candidate: DiscoveredCandidate) {
+      const liveness = yield* candidateLiveness(candidate, proc, heldLockInodes, pathService.sep);
+      const ageHours = Duration.toHours(Duration.millis(N.max(0, effectiveNowMillis - candidate.idleSinceMillis)));
+      const bytes = yield* measureBytes(candidate.path);
+      return {
+        discovered: candidate,
+        ageHours,
+        bytes,
+        liveness,
+        skipReason: skipReasonFor(candidate, ageHours, liveness),
+      } satisfies MeasuredCandidate;
+    }),
+    { concurrency: 8 }
+  );
+
+  const apply = O.getOrElse(O.fromUndefinedOr(options.apply), () => false);
+  const outcomes = apply
+    ? yield* Effect.forEach(measured, applyCandidate)
+    : A.map(measured, (): ApplyOutcome => ({ reaped: false, warnings: [] }));
+  const reapedIndexes = A.map(
+    A.filter(A.zip(measured, outcomes), ([, outcome]) => outcome.reaped),
+    ([candidate]) => candidate
+  );
+  const reclaimedBytes = A.reduce(
+    reapedIndexes,
+    0,
+    (total, candidate) => total + O.getOrElse(candidate.bytes, () => 0)
+  );
+  const scannedAt = yield* DateTime.now.pipe(Effect.map(DateTime.formatIso));
+  return TmpfsReapReport.make({
+    scannedAt,
+    tmpRoot,
+    applied: apply,
+    candidates: A.map(measured, candidateModel),
+    reapedCount: A.length(reapedIndexes),
+    reclaimedBytes,
+    warnings: A.flatten(A.map(outcomes, (outcome) => outcome.warnings)),
+  });
+});

--- a/packages/tooling/tool/cli/src/internal/repo-run/TmpfsReap.ts
+++ b/packages/tooling/tool/cli/src/internal/repo-run/TmpfsReap.ts
@@ -27,6 +27,7 @@ const HEAD_INSTALL_PREFIX = "beep-yeet-head-install-";
 const FALLOW_CACHE_PREFIX = "fallow-audit-base-cache-";
 const SCOPED_TEMP_PREFIXES = [
   "beep-knowledge-refs-",
+  "beep-knowledge-semantic-delta-",
   "beep-research-history-",
   "beep-fallow-audit-diff-",
   "beep-docgen-worker-eval-",
@@ -256,8 +257,10 @@ const discoverTopLevel = Effect.fnUntraced(function* (
 const discoverCacheHeadInstalls = Effect.fnUntraced(function* (
   cacheRoot: string
 ): Effect.fn.Return<ReadonlyArray<DiscoveredCandidate>, never, FileSystem.FileSystem | Path.Path> {
+  const fs = yield* FileSystem.FileSystem;
   const pathService = yield* Path.Path;
-  const base = pathService.join(cacheRoot, "beep", "head-install");
+  const configuredBase = pathService.join(cacheRoot, "beep", "head-install");
+  const base = yield* fs.realPath(configuredBase).pipe(Effect.orElseSucceed(() => configuredBase));
   const names = yield* directoryNames(base);
   const headNames = A.filter(names, Str.startsWith(HEAD_INSTALL_PREFIX));
   return A.getSomes(
@@ -374,6 +377,47 @@ const candidateLiveness = Effect.fnUntraced(function* (
   };
 });
 
+const worktreeIsDirty = Effect.fnUntraced(function* (
+  candidate: DiscoveredCandidate
+): Effect.fn.Return<boolean, never, FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner> {
+  if (candidate.reapClass !== "git-worktree" || O.isNone(candidate.parentRepo)) {
+    return false;
+  }
+  const fs = yield* FileSystem.FileSystem;
+  const pathService = yield* Path.Path;
+  const gitFileContent = yield* fs.readFileString(pathService.join(candidate.path, ".git")).pipe(Effect.option);
+  const gitDir = pipe(
+    gitFileContent,
+    O.map(Str.trim),
+    O.filter(Str.startsWith("gitdir:")),
+    O.map((line) => Str.trim(Str.slice(Str.length("gitdir:"))(line))),
+    O.map((dir) =>
+      pathService.isAbsolute(dir) ? pathService.normalize(dir) : pathService.resolve(candidate.path, dir)
+    )
+  );
+  const locked = yield* pipe(
+    gitDir,
+    O.match({
+      onNone: () => Effect.succeed(false),
+      onSome: (dir) => Effect.map(Effect.option(fs.stat(pathService.join(dir, "locked"))), O.isSome),
+    })
+  );
+  if (locked) {
+    return true;
+  }
+  const status = yield* runRepoCommandCapture(
+    "git",
+    ["-C", candidate.path, "status", "--porcelain", "--no-renames"],
+    candidate.parentRepo.value
+  ).pipe(Effect.option);
+  return O.match(status, {
+    // A worktree whose status cannot be read is treated as dirty: never
+    // force-remove what cannot be proven clean.
+    onNone: () => true,
+    onSome: (capture) => capture.exitCode !== 0 || Str.isNonEmpty(Str.trim(capture.output)),
+  });
+});
+
 const thresholdFor = (reapClass: TmpfsReapClass): Duration.Duration =>
   TmpfsReapClass.$match(reapClass, {
     "git-worktree": () => Duration.hours(2),
@@ -385,7 +429,8 @@ const thresholdFor = (reapClass: TmpfsReapClass): Duration.Duration =>
 const skipReasonFor = (
   candidate: DiscoveredCandidate,
   ageHours: number,
-  liveness: CandidateLiveness
+  liveness: CandidateLiveness,
+  dirtyWorktree: boolean
 ): O.Option<TmpfsReapSkipReason> => {
   if (!candidate.classified) {
     return O.some("unclassified");
@@ -398,6 +443,9 @@ const skipReasonFor = (
   }
   if (liveness.liveFlock) {
     return O.some("live-flock");
+  }
+  if (dirtyWorktree) {
+    return O.some("dirty-worktree");
   }
   return ageHours < Duration.toHours(thresholdFor(candidate.reapClass)) ? O.some("too-young") : O.none();
 };
@@ -428,8 +476,31 @@ const fallowSiblingArtifacts = Effect.fnUntraced(function* (
   return A.appendAll([`${candidatePath}.lock`, `${candidatePath}.sha`], lastUsed);
 });
 
-const removeDirectoryCandidate = Effect.fnUntraced(function* (
+const releaseNestedHeadInstallCheckout = Effect.fnUntraced(function* (
   candidate: DiscoveredCandidate
+): Effect.fn.Return<
+  ReadonlyArray<string>,
+  never,
+  FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+> {
+  if (candidate.reapClass !== "head-install") {
+    return A.empty();
+  }
+  const pathService = yield* Path.Path;
+  const checkout = pathService.join(candidate.path, "checkout");
+  const nested = yield* discoverGitWorktree(checkout, candidate.idleSinceMillis);
+  if (O.isNone(nested) || O.isNone(nested.value.parentRepo)) {
+    return A.empty();
+  }
+  const outcome = yield* removeGitWorktreeCandidate(nested.value);
+  return outcome.reaped
+    ? outcome.warnings
+    : A.append(outcome.warnings, `Nested head-install checkout ${checkout} was not released through Git.`);
+});
+
+const removeDirectoryCandidate = Effect.fnUntraced(function* (
+  candidate: DiscoveredCandidate,
+  nestedWarnings: ReadonlyArray<string> = A.empty()
 ): Effect.fn.Return<ApplyOutcome, never, FileSystem.FileSystem | Path.Path> {
   const fs = yield* FileSystem.FileSystem;
   const extras = candidate.reapClass === "fallow-cache" ? yield* fallowSiblingArtifacts(candidate.path) : A.empty();
@@ -438,13 +509,13 @@ const removeDirectoryCandidate = Effect.fnUntraced(function* (
     Effect.orElseSucceed(() => false)
   );
   if (!removed) {
-    return emptyApplyOutcome(`Failed to remove ${candidate.path}.`);
+    return { reaped: false, warnings: A.append(nestedWarnings, `Failed to remove ${candidate.path}.`) };
   }
   yield* Effect.forEach(extras, (extra) => fs.remove(extra, { force: true, recursive: true }).pipe(Effect.ignore), {
     discard: true,
     concurrency: 4,
   });
-  return { reaped: true, warnings: [] };
+  return { reaped: true, warnings: nestedWarnings };
 });
 
 const removeGitWorktreeCandidate = Effect.fnUntraced(function* (
@@ -486,9 +557,11 @@ const applyCandidate = Effect.fnUntraced(function* (
   if (O.isSome(candidate.skipReason)) {
     return { reaped: false, warnings: [] };
   }
-  return yield* candidate.discovered.reapClass === "git-worktree"
-    ? removeGitWorktreeCandidate(candidate.discovered)
-    : removeDirectoryCandidate(candidate.discovered);
+  if (candidate.discovered.reapClass === "git-worktree") {
+    return yield* removeGitWorktreeCandidate(candidate.discovered);
+  }
+  const nestedWarnings = yield* releaseNestedHeadInstallCheckout(candidate.discovered);
+  return yield* removeDirectoryCandidate(candidate.discovered, nestedWarnings);
 });
 
 const candidateModel = (candidate: MeasuredCandidate): TmpfsReapCandidate =>
@@ -541,8 +614,12 @@ export const resolveBeepCacheRoot = Effect.fn("TmpfsReap.resolveBeepCacheRoot")(
   if (O.isSome(cacheRoot)) {
     return pathService.resolve(cacheRoot.value);
   }
-  const home = yield* Config.string("HOME");
-  return pathService.join(pathService.resolve(home), ".cache");
+  const home = O.filter(yield* Config.option(Config.string("HOME")), Str.isNonEmpty);
+  if (O.isSome(home)) {
+    return pathService.join(pathService.resolve(home.value), ".cache");
+  }
+  const tmpFallback = yield* Config.string("TMPDIR").pipe(Config.withDefault("/tmp"));
+  return pathService.resolve(tmpFallback);
 });
 
 /**
@@ -609,12 +686,13 @@ export const runTmpfsReap = Effect.fn("TmpfsReap.runTmpfsReap")(function* (
       const liveness = yield* candidateLiveness(candidate, proc, heldLockInodes, pathService.sep);
       const ageHours = Duration.toHours(Duration.millis(N.max(0, effectiveNowMillis - candidate.idleSinceMillis)));
       const bytes = yield* measureBytes(candidate.path);
+      const dirtyWorktree = yield* worktreeIsDirty(candidate);
       return {
         discovered: candidate,
         ageHours,
         bytes,
         liveness,
-        skipReason: skipReasonFor(candidate, ageHours, liveness),
+        skipReason: skipReasonFor(candidate, ageHours, liveness, dirtyWorktree),
       } satisfies MeasuredCandidate;
     }),
     { concurrency: 8 }

--- a/packages/tooling/tool/cli/src/internal/repo-run/index.ts
+++ b/packages/tooling/tool/cli/src/internal/repo-run/index.ts
@@ -12,3 +12,5 @@ export * from "./QualityScheduler.ts";
 export * from "./RepoRun.executor.ts";
 export * from "./RepoRun.models.ts";
 export * from "./RepoRun.proofs.ts";
+export * from "./TmpfsReap.schemas.ts";
+export * from "./TmpfsReap.ts";

--- a/packages/tooling/tool/cli/test/tmpfs-reap.test.ts
+++ b/packages/tooling/tool/cli/test/tmpfs-reap.test.ts
@@ -56,29 +56,51 @@ const makeClassificationFixture = Effect.fn("TmpfsReapTest.makeClassificationFix
   const youngScoped = path.join(tmpRoot, "beep-knowledge-refs-young");
   const headInstall = path.join(cacheRoot, "beep", "head-install", "beep-yeet-head-install-old");
 
+  const dirtyWorktree = path.join(tmpRoot, "fixture-worktree-dirty");
+  const oldSemanticDelta = path.join(tmpRoot, "beep-knowledge-semantic-delta-old");
+
   yield* Effect.forEach(
-    [tmpRoot, cacheRoot, fakeParent, fakeWorktree, fallow, youngScoped, headInstall],
+    [tmpRoot, cacheRoot, fakeParent, fallow, youngScoped, oldSemanticDelta, headInstall],
     (directory) => fs.makeDirectory(directory, { recursive: true }),
     { discard: true }
   );
-  yield* fs.writeFileString(
-    path.join(fakeWorktree, ".git"),
-    `gitdir: ${path.join(fakeParent, ".git", "worktrees", "fixture-worktree")}\n`
+  yield* runCommand("git", ["init", "-q"], fakeParent);
+  yield* fs.writeFileString(path.join(fakeParent, "tracked.txt"), "tracked bytes\n");
+  yield* runCommand("git", ["add", "tracked.txt"], fakeParent);
+  yield* runCommand(
+    "git",
+    ["-c", "user.email=fixture@local", "-c", "user.name=fixture", "commit", "-q", "-m", "seed"],
+    fakeParent
   );
-  yield* fs.writeFileString(path.join(fakeWorktree, "payload.txt"), "worktree bytes\n");
+  yield* runCommand("git", ["worktree", "add", "--detach", "-q", fakeWorktree], fakeParent);
+  yield* runCommand("git", ["worktree", "add", "--detach", "-q", dirtyWorktree], fakeParent);
+  yield* fs.writeFileString(path.join(dirtyWorktree, "uncommitted.txt"), "unsaved work\n");
   yield* fs.writeFileString(fallowLastUsed, "used\n");
   yield* fs.writeFileString(fallowSiblingLastUsed, "used\n");
   yield* fs.writeFileString(path.join(fallow, "payload.txt"), "cache bytes\n");
   yield* fs.writeFileString(path.join(youngScoped, "payload.txt"), "young bytes\n");
+  yield* fs.writeFileString(path.join(oldSemanticDelta, "payload.txt"), "delta bytes\n");
   yield* fs.writeFileString(path.join(headInstall, "payload.txt"), "install bytes\n");
 
   yield* runCommand("touch", ["-d", fixtureTimestamp(3), fakeWorktree], root);
+  yield* runCommand("touch", ["-d", fixtureTimestamp(3), dirtyWorktree], root);
   yield* runCommand("touch", ["-d", fixtureTimestamp(8), fallowLastUsed], root);
   yield* runCommand("touch", ["-d", fixtureTimestamp(7), fallowSiblingLastUsed], root);
   yield* runCommand("touch", ["-d", fixtureTimestamp(0), youngScoped], root);
+  yield* runCommand("touch", ["-d", fixtureTimestamp(3), oldSemanticDelta], root);
   yield* runCommand("touch", ["-d", fixtureTimestamp(2), headInstall], root);
 
-  return { cacheRoot, fakeWorktree, fallow, fallowSiblingLastUsed, headInstall, tmpRoot, youngScoped };
+  return {
+    cacheRoot,
+    dirtyWorktree,
+    fakeWorktree,
+    fallow,
+    fallowSiblingLastUsed,
+    headInstall,
+    oldSemanticDelta,
+    tmpRoot,
+    youngScoped,
+  };
 });
 
 describe("tmpfs reap", () => {
@@ -107,6 +129,15 @@ describe("tmpfs reap", () => {
         expect(young.action).toBe("skip");
         expect(young.skipReason).toBe("too-young");
         expect(young.ageHours).toBeLessThan(2);
+
+        const dirty = candidateByPath(report, fixture.dirtyWorktree);
+        expect(dirty.reapClass).toBe("git-worktree");
+        expect(dirty.action).toBe("skip");
+        expect(dirty.skipReason).toBe("dirty-worktree");
+
+        const semanticDelta = candidateByPath(report, fixture.oldSemanticDelta);
+        expect(semanticDelta.reapClass).toBe("scoped-temp");
+        expect(semanticDelta.action).toBe("remove-dir");
       })
     ).pipe(provideScopedLayer(NodeServices.layer))
   );
@@ -145,6 +176,7 @@ describe("tmpfs reap", () => {
     withTempDirectory((root) =>
       Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
         const fixture = yield* makeClassificationFixture(root);
         const report = yield* runTmpfsReap({
           apply: true,
@@ -154,13 +186,16 @@ describe("tmpfs reap", () => {
         });
 
         expect(report.applied).toBe(true);
-        expect(report.reapedCount).toBe(3);
+        expect(report.reapedCount).toBe(4);
         expect(report.reclaimedBytes).toBeGreaterThan(0);
         expect(yield* fs.exists(fixture.fakeWorktree)).toBe(false);
         expect(yield* fs.exists(fixture.fallow)).toBe(false);
         expect(yield* fs.exists(fixture.fallowSiblingLastUsed)).toBe(false);
         expect(yield* fs.exists(fixture.headInstall)).toBe(false);
+        expect(yield* fs.exists(fixture.oldSemanticDelta)).toBe(false);
         expect(yield* fs.exists(fixture.youngScoped)).toBe(true);
+        expect(yield* fs.exists(fixture.dirtyWorktree)).toBe(true);
+        expect(yield* fs.exists(path.join(fixture.dirtyWorktree, "uncommitted.txt"))).toBe(true);
       })
     ).pipe(provideScopedLayer(NodeServices.layer))
   );

--- a/packages/tooling/tool/cli/test/tmpfs-reap.test.ts
+++ b/packages/tooling/tool/cli/test/tmpfs-reap.test.ts
@@ -1,4 +1,5 @@
 import { runRepoCommandCapture, runTmpfsReap } from "@beep/repo-cli/test/RepoRun";
+import { runTmpfsWorktreesStep } from "@beep/repo-cli/test/Yeet";
 import { provideScopedLayer } from "@beep/test-utils";
 import { NodeServices } from "@effect/platform-node";
 import { describe, expect, it } from "@effect/vitest";
@@ -238,6 +239,62 @@ describe("tmpfs reap", () => {
         expect(yield* fs.exists(worktree)).toBe(false);
         const worktreeList = yield* runCommand("git", ["worktree", "list", "--porcelain"], repo);
         expect(Str.includes(worktree)(worktreeList)).toBe(false);
+      })
+    ).pipe(provideScopedLayer(NodeServices.layer))
+  );
+  // it.live: the sweep step consults the real clock, and the fixture ages are wall-clock relative.
+  it.live("sweep step reaps this repo's idle tmpfs worktree and reports the reclaim", () =>
+    withTempDirectory((root) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const tmpRoot = path.join(root, "tmp");
+        const repo = path.join(root, "sweep-repo");
+        const worktree = path.join(tmpRoot, "sweep-worktree");
+        yield* Effect.forEach([tmpRoot, repo], (directory) => fs.makeDirectory(directory, { recursive: true }), {
+          discard: true,
+        });
+        yield* runCommand("git", ["init", "--quiet"], repo);
+        yield* runCommand("git", ["config", "user.email", "tmpfs-reap@example.invalid"], repo);
+        yield* runCommand("git", ["config", "user.name", "Tmpfs Reap Test"], repo);
+        yield* fs.writeFileString(path.join(repo, "README.md"), "fixture\n");
+        yield* runCommand("git", ["add", "README.md"], repo);
+        yield* runCommand("git", ["commit", "--quiet", "-m", "fixture"], repo);
+        yield* runCommand("git", ["worktree", "add", "--quiet", "-b", "sweep-branch", worktree], repo);
+        // The step runs against the real clock, so age the worktree relative to it.
+        yield* runCommand("touch", ["-d", "3 hours ago", worktree], root);
+
+        const outcome = yield* runTmpfsWorktreesStep(repo, tmpRoot);
+        expect(outcome.status === "skipped" ? outcome.reason : "executed").toBe("executed");
+        expect(yield* fs.exists(worktree)).toBe(false);
+        const worktreeList = yield* runCommand("git", ["worktree", "list", "--porcelain"], repo);
+        expect(Str.includes(worktree)(worktreeList)).toBe(false);
+      })
+    ).pipe(provideScopedLayer(NodeServices.layer))
+  );
+
+  it.live("sweep step skips when no repo worktree lives under the temporary root", () =>
+    withTempDirectory((root) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const tmpRoot = path.join(root, "tmp");
+        const repo = path.join(root, "sweep-repo");
+        const diskWorktree = path.join(root, "disk-worktree");
+        yield* Effect.forEach([tmpRoot, repo], (directory) => fs.makeDirectory(directory, { recursive: true }), {
+          discard: true,
+        });
+        yield* runCommand("git", ["init", "--quiet"], repo);
+        yield* runCommand("git", ["config", "user.email", "tmpfs-reap@example.invalid"], repo);
+        yield* runCommand("git", ["config", "user.name", "Tmpfs Reap Test"], repo);
+        yield* fs.writeFileString(path.join(repo, "README.md"), "fixture\n");
+        yield* runCommand("git", ["add", "README.md"], repo);
+        yield* runCommand("git", ["commit", "--quiet", "-m", "fixture"], repo);
+        yield* runCommand("git", ["worktree", "add", "--quiet", "-b", "disk-branch", diskWorktree], repo);
+
+        const outcome = yield* runTmpfsWorktreesStep(repo, tmpRoot);
+        expect(outcome.status).toBe("skipped");
+        expect(yield* fs.exists(diskWorktree)).toBe(true);
       })
     ).pipe(provideScopedLayer(NodeServices.layer))
   );

--- a/packages/tooling/tool/cli/test/tmpfs-reap.test.ts
+++ b/packages/tooling/tool/cli/test/tmpfs-reap.test.ts
@@ -1,0 +1,209 @@
+import { runRepoCommandCapture, runTmpfsReap } from "@beep/repo-cli/test/RepoRun";
+import { provideScopedLayer } from "@beep/test-utils";
+import { NodeServices } from "@effect/platform-node";
+import { describe, expect, it } from "@effect/vitest";
+import { Duration, Effect, FileSystem, Path } from "effect";
+import * as A from "effect/Array";
+import * as O from "effect/Option";
+import * as Str from "effect/String";
+import { ChildProcess } from "effect/unstable/process";
+
+const FIXTURE_NOW_MILLIS = 2_000_000_000_000;
+const fixtureTimestamp = (hoursAgo: number): string =>
+  `@${(FIXTURE_NOW_MILLIS - Duration.toMillis(Duration.hours(hoursAgo))) / 1000}`;
+
+const runCommand = Effect.fn("TmpfsReapTest.runCommand")(function* (
+  command: string,
+  args: ReadonlyArray<string>,
+  cwd: string
+) {
+  const result = yield* runRepoCommandCapture(command, args, cwd);
+  expect(result.exitCode, result.output).toBe(0);
+  return result.output;
+});
+
+const withTempDirectory = <Value, Failure, Requirements>(
+  use: (root: string) => Effect.Effect<Value, Failure, Requirements>
+) =>
+  Effect.acquireUseRelease(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      return yield* fs.makeTempDirectory({ prefix: "tmpfs-reap-test-" });
+    }),
+    use,
+    (root) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        yield* fs.remove(root, { force: true, recursive: true });
+      })
+  );
+
+const candidateByPath = <Candidate extends { readonly path: string }>(
+  report: { readonly candidates: ReadonlyArray<Candidate> },
+  candidatePath: string
+): Candidate => O.getOrThrow(A.findFirst(report.candidates, (candidate) => candidate.path === candidatePath));
+
+const makeClassificationFixture = Effect.fn("TmpfsReapTest.makeClassificationFixture")(function* (root: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const tmpRoot = path.join(root, "tmp");
+  const cacheRoot = path.join(root, "cache");
+  const fakeParent = path.join(root, "fixture-repo");
+  const fakeWorktree = path.join(tmpRoot, "fixture-worktree");
+  const fallow = path.join(tmpRoot, "fallow-audit-base-cache-abc");
+  const fallowLastUsed = path.join(fallow, "worker.last-used");
+  const fallowSiblingLastUsed = `${fallow}.shared.last-used`;
+  const youngScoped = path.join(tmpRoot, "beep-knowledge-refs-young");
+  const headInstall = path.join(cacheRoot, "beep", "head-install", "beep-yeet-head-install-old");
+
+  yield* Effect.forEach(
+    [tmpRoot, cacheRoot, fakeParent, fakeWorktree, fallow, youngScoped, headInstall],
+    (directory) => fs.makeDirectory(directory, { recursive: true }),
+    { discard: true }
+  );
+  yield* fs.writeFileString(
+    path.join(fakeWorktree, ".git"),
+    `gitdir: ${path.join(fakeParent, ".git", "worktrees", "fixture-worktree")}\n`
+  );
+  yield* fs.writeFileString(path.join(fakeWorktree, "payload.txt"), "worktree bytes\n");
+  yield* fs.writeFileString(fallowLastUsed, "used\n");
+  yield* fs.writeFileString(fallowSiblingLastUsed, "used\n");
+  yield* fs.writeFileString(path.join(fallow, "payload.txt"), "cache bytes\n");
+  yield* fs.writeFileString(path.join(youngScoped, "payload.txt"), "young bytes\n");
+  yield* fs.writeFileString(path.join(headInstall, "payload.txt"), "install bytes\n");
+
+  yield* runCommand("touch", ["-d", fixtureTimestamp(3), fakeWorktree], root);
+  yield* runCommand("touch", ["-d", fixtureTimestamp(8), fallowLastUsed], root);
+  yield* runCommand("touch", ["-d", fixtureTimestamp(7), fallowSiblingLastUsed], root);
+  yield* runCommand("touch", ["-d", fixtureTimestamp(0), youngScoped], root);
+  yield* runCommand("touch", ["-d", fixtureTimestamp(2), headInstall], root);
+
+  return { cacheRoot, fakeWorktree, fallow, fallowSiblingLastUsed, headInstall, tmpRoot, youngScoped };
+});
+
+describe("tmpfs reap", () => {
+  it.effect("classifies worktrees, fallow caches, and scoped temporaries with the correct idleness actions", () =>
+    withTempDirectory((root) =>
+      Effect.gen(function* () {
+        const fixture = yield* makeClassificationFixture(root);
+        const report = yield* runTmpfsReap({
+          cacheRoot: fixture.cacheRoot,
+          nowMillis: FIXTURE_NOW_MILLIS,
+          tmpRoot: fixture.tmpRoot,
+        });
+
+        const worktree = candidateByPath(report, fixture.fakeWorktree);
+        expect(worktree.reapClass).toBe("git-worktree");
+        expect(worktree.action).toBe("worktree-remove");
+        expect(worktree.ageHours).toBeGreaterThanOrEqual(2);
+
+        const fallow = candidateByPath(report, fixture.fallow);
+        expect(fallow.reapClass).toBe("fallow-cache");
+        expect(fallow.action).toBe("remove-dir");
+        expect(fallow.ageHours).toBeGreaterThanOrEqual(6);
+
+        const young = candidateByPath(report, fixture.youngScoped);
+        expect(young.reapClass).toBe("scoped-temp");
+        expect(young.action).toBe("skip");
+        expect(young.skipReason).toBe("too-young");
+        expect(young.ageHours).toBeLessThan(2);
+      })
+    ).pipe(provideScopedLayer(NodeServices.layer))
+  );
+
+  it.effect("counts a child process cwd as a live reference and refuses reaping", () =>
+    withTempDirectory((root) =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const tmpRoot = path.join(root, "tmp");
+          const cacheRoot = path.join(root, "cache");
+          const candidatePath = path.join(tmpRoot, "beep-knowledge-refs-live");
+          yield* fs.makeDirectory(candidatePath, { recursive: true });
+          yield* fs.makeDirectory(cacheRoot, { recursive: true });
+          yield* fs.writeFileString(path.join(candidatePath, "payload.txt"), "live\n");
+          yield* runCommand("touch", ["-d", fixtureTimestamp(3), candidatePath], root);
+
+          yield* ChildProcess.make("sh", ["-c", "while :; do sleep 1; done"], {
+            cwd: candidatePath,
+            stdin: "ignore",
+            stderr: "pipe",
+            stdout: "pipe",
+          });
+          const report = yield* runTmpfsReap({ cacheRoot, nowMillis: FIXTURE_NOW_MILLIS, tmpRoot });
+          const candidate = candidateByPath(report, candidatePath);
+          expect(candidate.refCount).toBeGreaterThan(0);
+          expect(candidate.action).toBe("skip");
+          expect(candidate.skipReason).toBe("live-cwd-ref");
+        })
+      )
+    ).pipe(provideScopedLayer(NodeServices.layer))
+  );
+
+  it.effect("applies eligible removals, preserves young artifacts, and reports reclaimed bytes", () =>
+    withTempDirectory((root) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const fixture = yield* makeClassificationFixture(root);
+        const report = yield* runTmpfsReap({
+          apply: true,
+          cacheRoot: fixture.cacheRoot,
+          nowMillis: FIXTURE_NOW_MILLIS,
+          tmpRoot: fixture.tmpRoot,
+        });
+
+        expect(report.applied).toBe(true);
+        expect(report.reapedCount).toBe(3);
+        expect(report.reclaimedBytes).toBeGreaterThan(0);
+        expect(yield* fs.exists(fixture.fakeWorktree)).toBe(false);
+        expect(yield* fs.exists(fixture.fallow)).toBe(false);
+        expect(yield* fs.exists(fixture.fallowSiblingLastUsed)).toBe(false);
+        expect(yield* fs.exists(fixture.headInstall)).toBe(false);
+        expect(yield* fs.exists(fixture.youngScoped)).toBe(true);
+      })
+    ).pipe(provideScopedLayer(NodeServices.layer))
+  );
+
+  it.effect("removes a real linked worktree through git and prunes its registration", () =>
+    withTempDirectory((root) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const tmpRoot = path.join(root, "tmp");
+        const cacheRoot = path.join(root, "cache");
+        const repo = path.join(root, "repo");
+        const worktree = path.join(tmpRoot, "real-worktree");
+        yield* Effect.forEach(
+          [tmpRoot, cacheRoot, repo],
+          (directory) => fs.makeDirectory(directory, { recursive: true }),
+          {
+            discard: true,
+          }
+        );
+        yield* runCommand("git", ["init", "--quiet"], repo);
+        yield* runCommand("git", ["config", "user.email", "tmpfs-reap@example.invalid"], repo);
+        yield* runCommand("git", ["config", "user.name", "Tmpfs Reap Test"], repo);
+        yield* fs.writeFileString(path.join(repo, "README.md"), "fixture\n");
+        yield* runCommand("git", ["add", "README.md"], repo);
+        yield* runCommand("git", ["commit", "--quiet", "-m", "fixture"], repo);
+        yield* runCommand("git", ["worktree", "add", "--quiet", "-b", "fixture-worktree", worktree], repo);
+        yield* runCommand("touch", ["-d", fixtureTimestamp(3), worktree], root);
+
+        const report = yield* runTmpfsReap({
+          apply: true,
+          cacheRoot,
+          nowMillis: FIXTURE_NOW_MILLIS,
+          tmpRoot,
+        });
+        const candidate = candidateByPath(report, worktree);
+        expect(candidate.action).toBe("worktree-remove");
+        expect(candidate.parentRepo).toBe(repo);
+        expect(report.reapedCount).toBe(1);
+        expect(yield* fs.exists(worktree)).toBe(false);
+        const worktreeList = yield* runCommand("git", ["worktree", "list", "--porcelain"], repo);
+        expect(Str.includes(worktree)(worktreeList)).toBe(false);
+      })
+    ).pipe(provideScopedLayer(NodeServices.layer))
+  );
+});

--- a/packages/tooling/tool/cli/test/yeet-sweep-plan.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-sweep-plan.test.ts
@@ -495,7 +495,9 @@ describe("executeSweep", () => {
         const context = sweepContext(root);
         const report = yield* executeSweep(context);
         expect(A.map(report.steps, (step) => step.id)).toEqual([...SweepStepId.Options]);
-        expect(A.map(report.steps, (step) => step.outcome.status)).toEqual(A.map(report.steps, () => "executed"));
+        expect(A.map(report.steps, (step) => step.outcome.status)).toEqual(
+          A.map(report.steps, (step) => (step.id === "tmpfs-worktrees" ? "skipped" : "executed"))
+        );
 
         const fs = yield* FileSystem.FileSystem;
         const written = yield* fs.readFileString(yield* sweepReportPath(context));

--- a/packages/tooling/tool/cli/test/yeet-sweep-schemas.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-sweep-schemas.test.ts
@@ -82,6 +82,7 @@ describe("sweep step ids", () => {
       "delete-remote-branch",
       "lockfile-install",
       "end-state",
+      "tmpfs-worktrees",
     ]);
   });
 });

--- a/packages/tooling/tool/cli/test/yeet.test.ts
+++ b/packages/tooling/tool/cli/test/yeet.test.ts
@@ -2259,7 +2259,12 @@ describe("yeet publish scope helpers", () => {
         const tempContext = RepoRunContext.make({ ...context, cwd: tmpDir, repoRoot: tmpDir });
         const plan = buildYeetRunPlanForTesting({ context: tempContext, message: O.none(), mode: "verify" });
         const step = findStep(plan.steps, "publish:head-install-preflight");
-        const result = yield* executeStepWithArtifacts(tempContext, step);
+        const result = yield* executeStepWithArtifacts(tempContext, step).pipe(
+          Effect.provideService(
+            ConfigProvider.ConfigProvider,
+            ConfigProvider.fromUnknown({ XDG_CACHE_HOME: path.join(tmpDir, "cache") })
+          )
+        );
 
         expect(result.exitCode).not.toBe(0);
         expect(result.output).toContain("Frozen-lockfile clean-HEAD install preflight failed");

--- a/standards/coverage.regression-baseline.jsonc
+++ b/standards/coverage.regression-baseline.jsonc
@@ -20410,15 +20410,15 @@
     },
     "@beep/repo-cli": {
       "path": "packages/tooling/tool/cli",
-      "lines": 75.69,
-      "statements": 75.46,
-      "branches": 62.66,
-      "functions": 69.25,
+      "lines": 76.01,
+      "statements": 75.77,
+      "branches": 63.17,
+      "functions": 69.66,
       "uncovered": {
-        "lines": 8248,
-        "statements": 8690,
-        "branches": 4739,
-        "functions": 3129
+        "lines": 8258,
+        "statements": 8703,
+        "branches": 4732,
+        "functions": 3134
       },
       "files": {
         "packages/tooling/tool/cli/src/bin-main.ts": {
@@ -23470,15 +23470,15 @@
           }
         },
         "packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts": {
-          "lines": 33.16,
-          "statements": 32.85,
-          "branches": 16.66,
-          "functions": 21.38,
+          "lines": 32.64,
+          "statements": 32.33,
+          "branches": 16.29,
+          "functions": 20.55,
           "uncovered": {
-            "lines": 407,
-            "statements": 417,
-            "branches": 145,
-            "functions": 136
+            "lines": 421,
+            "statements": 431,
+            "branches": 149,
+            "functions": 143
           }
         },
         "packages/tooling/tool/cli/src/commands/Quality/Quality.errors.ts": {
@@ -24778,15 +24778,15 @@
           }
         },
         "packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts": {
-          "lines": 92.04,
-          "statements": 83.5,
-          "branches": 0,
-          "functions": 6.25,
+          "lines": 96,
+          "statements": 88.07,
+          "branches": 100,
+          "functions": 43.47,
           "uncovered": {
-            "lines": 7,
-            "statements": 16,
-            "branches": 14,
-            "functions": 15
+            "lines": 4,
+            "statements": 13,
+            "branches": 0,
+            "functions": 13
           }
         },
         "packages/tooling/tool/cli/src/commands/Yeet/Yeet.errors.ts": {
@@ -24946,8 +24946,8 @@
           }
         },
         "packages/tooling/tool/cli/src/commands/Yeet/internal/HeadInstallPreflight.ts": {
-          "lines": 83.72,
-          "statements": 83.72,
+          "lines": 84.78,
+          "statements": 84.78,
           "branches": 61.53,
           "functions": 88.88,
           "uncovered": {
@@ -25066,27 +25066,27 @@
           }
         },
         "packages/tooling/tool/cli/src/commands/Yeet/internal/MonitorComments.ts": {
-          "lines": 95.57,
-          "statements": 95,
-          "branches": 78.94,
-          "functions": 88.88,
+          "lines": 96,
+          "statements": 95.45,
+          "branches": 84.21,
+          "functions": 89.36,
           "uncovered": {
             "lines": 5,
             "statements": 6,
-            "branches": 4,
+            "branches": 3,
             "functions": 5
           }
         },
         "packages/tooling/tool/cli/src/commands/Yeet/internal/MonitorLoop.ts": {
-          "lines": 44.23,
-          "statements": 42.24,
-          "branches": 33.33,
-          "functions": 31.11,
+          "lines": 67.25,
+          "statements": 64.75,
+          "branches": 78.26,
+          "functions": 59.18,
           "uncovered": {
-            "lines": 58,
-            "statements": 67,
-            "branches": 24,
-            "functions": 31
+            "lines": 37,
+            "statements": 43,
+            "branches": 10,
+            "functions": 20
           }
         },
         "packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts": {
@@ -25102,14 +25102,14 @@
           }
         },
         "packages/tooling/tool/cli/src/commands/Yeet/internal/Porcelain.ts": {
-          "lines": 40,
-          "statements": 39.02,
-          "branches": 12.5,
+          "lines": 43.9,
+          "statements": 42.85,
+          "branches": 13.33,
           "functions": 9.09,
           "uncovered": {
-            "lines": 24,
-            "statements": 25,
-            "branches": 14,
+            "lines": 23,
+            "statements": 24,
+            "branches": 13,
             "functions": 10
           }
         },
@@ -25222,15 +25222,15 @@
           }
         },
         "packages/tooling/tool/cli/src/commands/Yeet/internal/Status.ts": {
-          "lines": 52.75,
-          "statements": 52.65,
-          "branches": 47.36,
-          "functions": 40.96,
+          "lines": 54.12,
+          "statements": 53.98,
+          "branches": 50.52,
+          "functions": 42.16,
           "uncovered": {
-            "lines": 103,
-            "statements": 107,
-            "branches": 50,
-            "functions": 49
+            "lines": 100,
+            "statements": 104,
+            "branches": 47,
+            "functions": 48
           }
         },
         "packages/tooling/tool/cli/src/commands/Yeet/internal/Sweep.schemas.ts": {
@@ -25246,15 +25246,15 @@
           }
         },
         "packages/tooling/tool/cli/src/commands/Yeet/internal/Sweep.ts": {
-          "lines": 93.68,
-          "statements": 93.63,
-          "branches": 84.93,
-          "functions": 88.28,
+          "lines": 92.79,
+          "statements": 92.82,
+          "branches": 83.13,
+          "functions": 88.13,
           "uncovered": {
-            "lines": 13,
-            "statements": 14,
-            "branches": 11,
-            "functions": 13
+            "lines": 16,
+            "statements": 17,
+            "branches": 14,
+            "functions": 14
           }
         },
         "packages/tooling/tool/cli/src/commands/Yeet/internal/TurboQuery.ts": {
@@ -25965,6 +25965,18 @@
             "functions": 0
           }
         },
+        "packages/tooling/tool/cli/src/internal/repo-run/AdmissionJournal.ts": {
+          "lines": 100,
+          "statements": 100,
+          "branches": 100,
+          "functions": 100,
+          "uncovered": {
+            "lines": 0,
+            "statements": 0,
+            "branches": 0,
+            "functions": 0
+          }
+        },
         "packages/tooling/tool/cli/src/internal/repo-run/ChangedFiles.ts": {
           "lines": 100,
           "statements": 100,
@@ -26002,10 +26014,10 @@
           }
         },
         "packages/tooling/tool/cli/src/internal/repo-run/QualityScheduler.ts": {
-          "lines": 88.38,
-          "statements": 88.02,
+          "lines": 88.41,
+          "statements": 88.05,
           "branches": 81.13,
-          "functions": 79.66,
+          "functions": 79.31,
           "uncovered": {
             "lines": 41,
             "statements": 43,
@@ -26047,6 +26059,30 @@
             "statements": 1,
             "branches": 0,
             "functions": 1
+          }
+        },
+        "packages/tooling/tool/cli/src/internal/repo-run/TmpfsReap.schemas.ts": {
+          "lines": 100,
+          "statements": 100,
+          "branches": 100,
+          "functions": 100,
+          "uncovered": {
+            "lines": 0,
+            "statements": 0,
+            "branches": 0,
+            "functions": 0
+          }
+        },
+        "packages/tooling/tool/cli/src/internal/repo-run/TmpfsReap.ts": {
+          "lines": 92.52,
+          "statements": 91.02,
+          "branches": 80.61,
+          "functions": 88.65,
+          "uncovered": {
+            "lines": 21,
+            "statements": 27,
+            "branches": 19,
+            "functions": 11
           }
         },
         "packages/tooling/tool/cli/src/internal/repo-run/index.ts": {


### PR DESCRIPTION
## feat(repo-cli): reap idle tmpfs artifacts and move head-install preflight to disk

Move clean-HEAD installs from tmpfs to the persistent beep cache.
Add a dry-run-first janitor and fixture coverage for safe artifact reaping.
Extend Yeet sweep to clean idle current-repo tmpfs worktrees.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

## Local proof

- fallow-advisory-feedback: passed
- publish:head-install-preflight: passed
- full:cheap-gates: passed
- full:pre-push: passed
- publish:git:push: passed

Verdict: .beep/yeet/runs/chore_tmpfs-lifecycle-3960bca76c04/verdict.json

---

## Provenance

- Branch: <code>chore/tmpfs-lifecycle</code>
- Harness: `codex`

<!-- yeet-provenance
{
  "schemaVersion": 1,
  "branch": "chore/tmpfs-lifecycle",
  "harness": "codex"
}
-->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/886"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790630309&installation_model_id=424656&pr_number=886&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F886&signature=c74fe91bca6e7e5aaa67e571606b08a3462dfa77555dbe383a0df246b5366b0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->