### PR TITLE
chore(cloud): install 1Password CLI for secret-backed runs

### DIFF
--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -55,22 +55,46 @@ fi
 # 4. Install the 1Password CLI (op) for secret-backed runs. Secrets are provided
 #    to the VM via the OP_SERVICE_ACCOUNT_TOKEN environment secret; the repo
 #    resolves op:// references in a gitignored .env with `op run --env-file=.env`.
-#    Best-effort and non-fatal: the core toolchain does not depend on it.
+#    The downloaded binary is GPG-verified against 1Password's pinned code-signing
+#    key before it is placed on PATH, so a substituted distribution response fails
+#    closed and never runs with access to OP_SERVICE_ACCOUNT_TOKEN. Best-effort and
+#    non-fatal: the core toolchain does not depend on it.
+#    Pinned 1Password code-signing key (https://downloads.1password.com/linux/keys/1password.asc).
+OP_PINNED_VERSION="2.39.0"
+OP_GPG_FINGERPRINT="3FEF9748469ADBE15DA7CA80AC2D62742012EA22"
+OP_GPG_KEY_URL="https://downloads.1password.com/linux/keys/1password.asc"
 if ! command -v op >/dev/null 2>&1; then
   set +e
-  OP_LATEST="$(curl -fsSL https://app-updates.agilebits.com/check/1/0/CLI2/en/2.0.0/N 2>/dev/null | grep -oE '"version":"[0-9.]+"' | head -1 | grep -oE '[0-9.]+')"
-  OP_VER="v${OP_LATEST:-2.39.0}"
-  if curl -fsSLo /tmp/op.zip "https://cache.agilebits.com/dist/1P/op2/pkg/${OP_VER}/op_linux_amd64_${OP_VER}.zip" \
-    && unzip -o /tmp/op.zip op -d /tmp/opbin >/dev/null; then
-    if command -v sudo >/dev/null 2>&1; then
-      sudo mv /tmp/opbin/op /usr/local/bin/op && sudo chmod +x /usr/local/bin/op
+  op_work="$(mktemp -d)"
+  op_ver="v${OP_PINNED_VERSION}"
+  op_ok=0
+  if curl -fsSLo "${op_work}/op.zip" "https://cache.agilebits.com/dist/1P/op2/pkg/${op_ver}/op_linux_amd64_${op_ver}.zip" \
+    && unzip -oq "${op_work}/op.zip" op op.sig -d "${op_work}" \
+    && [ -f "${op_work}/op" ] && [ -f "${op_work}/op.sig" ]; then
+    # Import the pinned signing key into an ephemeral keyring, assert the imported
+    # fingerprint matches, then require a VALIDSIG from that exact key.
+    export GNUPGHOME="${op_work}/gnupg"
+    mkdir -p "${GNUPGHOME}" && chmod 700 "${GNUPGHOME}"
+    if curl -fsSL "${OP_GPG_KEY_URL}" | gpg --batch --import >/dev/null 2>&1 \
+      && gpg --batch --with-colons --fingerprint 2>/dev/null | grep -q "^fpr:::::::::${OP_GPG_FINGERPRINT}:" \
+      && gpg --batch --status-fd=1 --verify "${op_work}/op.sig" "${op_work}/op" 2>/dev/null \
+        | grep -q "VALIDSIG ${OP_GPG_FINGERPRINT}"; then
+      op_ok=1
     else
-      mv /tmp/opbin/op "${BUN_INSTALL}/bin/op" && chmod +x "${BUN_INSTALL}/bin/op"
+      echo "WARN: 1Password CLI signature verification failed; refusing to install op."
     fi
+    unset GNUPGHOME
   else
     echo "WARN: 1Password CLI download failed; skipping (op-backed secret runs unavailable)."
   fi
-  rm -f /tmp/op.zip
+  if [ "${op_ok}" = "1" ]; then
+    if command -v sudo >/dev/null 2>&1; then
+      sudo install -m 0755 "${op_work}/op" /usr/local/bin/op
+    else
+      install -m 0755 "${op_work}/op" "${BUN_INSTALL}/bin/op"
+    fi
+  fi
+  rm -rf "${op_work}"
   set -e
 fi
 

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -52,7 +52,29 @@ if command -v sudo >/dev/null 2>&1 && [ -x "${BUN_INSTALL}/bin/portless" ]; then
   sudo ln -sf "${BUN_INSTALL}/bin/portless" /usr/local/bin/portless
 fi
 
-# 4. Install workspace dependencies.
+# 4. Install the 1Password CLI (op) for secret-backed runs. Secrets are provided
+#    to the VM via the OP_SERVICE_ACCOUNT_TOKEN environment secret; the repo
+#    resolves op:// references in a gitignored .env with `op run --env-file=.env`.
+#    Best-effort and non-fatal: the core toolchain does not depend on it.
+if ! command -v op >/dev/null 2>&1; then
+  set +e
+  OP_LATEST="$(curl -fsSL https://app-updates.agilebits.com/check/1/0/CLI2/en/2.0.0/N 2>/dev/null | grep -oE '"version":"[0-9.]+"' | head -1 | grep -oE '[0-9.]+')"
+  OP_VER="v${OP_LATEST:-2.39.0}"
+  if curl -fsSLo /tmp/op.zip "https://cache.agilebits.com/dist/1P/op2/pkg/${OP_VER}/op_linux_amd64_${OP_VER}.zip" \
+    && unzip -o /tmp/op.zip op -d /tmp/opbin >/dev/null; then
+    if command -v sudo >/dev/null 2>&1; then
+      sudo mv /tmp/opbin/op /usr/local/bin/op && sudo chmod +x /usr/local/bin/op
+    else
+      mv /tmp/opbin/op "${BUN_INSTALL}/bin/op" && chmod +x "${BUN_INSTALL}/bin/op"
+    fi
+  else
+    echo "WARN: 1Password CLI download failed; skipping (op-backed secret runs unavailable)."
+  fi
+  rm -f /tmp/op.zip
+  set -e
+fi
+
+# 5. Install workspace dependencies.
 #
 # --ignore-scripts skips the repo root lifecycle scripts only. Bun does not run
 # dependency lifecycle scripts without a trustedDependencies allowlist (none is
@@ -62,7 +84,7 @@ fi
 # does), and neither step is needed to build or run the apps.
 bun install --ignore-scripts
 
-# 5. Apply the Effect tsgo TypeScript patch that the root `prepare` script would
+# 6. Apply the Effect tsgo TypeScript patch that the root `prepare` script would
 #    normally run (skipped above alongside the other lifecycle scripts).
 bun run prepare
 

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -63,40 +63,45 @@ fi
 OP_PINNED_VERSION="2.39.0"
 OP_GPG_FINGERPRINT="3FEF9748469ADBE15DA7CA80AC2D62742012EA22"
 OP_GPG_KEY_URL="https://downloads.1password.com/linux/keys/1password.asc"
-if ! command -v op >/dev/null 2>&1; then
-  set +e
-  op_work="$(mktemp -d)"
-  op_ver="v${OP_PINNED_VERSION}"
-  op_ok=0
-  if curl -fsSLo "${op_work}/op.zip" "https://cache.agilebits.com/dist/1P/op2/pkg/${op_ver}/op_linux_amd64_${op_ver}.zip" \
-    && unzip -oq "${op_work}/op.zip" op op.sig -d "${op_work}" \
-    && [ -f "${op_work}/op" ] && [ -f "${op_work}/op.sig" ]; then
-    # Import the pinned signing key into an ephemeral keyring, assert the imported
-    # fingerprint matches, then require a VALIDSIG from that exact key.
-    export GNUPGHOME="${op_work}/gnupg"
-    mkdir -p "${GNUPGHOME}" && chmod 700 "${GNUPGHOME}"
-    if curl -fsSL "${OP_GPG_KEY_URL}" | gpg --batch --import >/dev/null 2>&1 \
-      && gpg --batch --with-colons --fingerprint 2>/dev/null | grep -q "^fpr:::::::::${OP_GPG_FINGERPRINT}:" \
-      && gpg --batch --status-fd=1 --verify "${op_work}/op.sig" "${op_work}/op" 2>/dev/null \
-        | grep -q "VALIDSIG ${OP_GPG_FINGERPRINT}"; then
-      op_ok=1
-    else
-      echo "WARN: 1Password CLI signature verification failed; refusing to install op."
-    fi
-    unset GNUPGHOME
+# Always download, GPG-verify, and install the pinned op — never trust an `op`
+# already on PATH. Presence- or version-based skipping would let a binary
+# retained from an earlier run (or planted on a reused snapshot) handle
+# OP_SERVICE_ACCOUNT_TOKEN without a fresh signature check, and would not pick up
+# a bumped OP_PINNED_VERSION. install runs once per environment build (then the
+# snapshot is reused), so re-verifying every run is cheap and fully fail-closed.
+set +e
+op_work="$(mktemp -d)"
+op_ver="v${OP_PINNED_VERSION}"
+op_ok=0
+if curl -fsSLo "${op_work}/op.zip" "https://cache.agilebits.com/dist/1P/op2/pkg/${op_ver}/op_linux_amd64_${op_ver}.zip" \
+  && unzip -oq "${op_work}/op.zip" op op.sig -d "${op_work}" \
+  && [ -f "${op_work}/op" ] && [ -f "${op_work}/op.sig" ]; then
+  # Import the pinned signing key into an ephemeral keyring, assert the imported
+  # fingerprint matches, then require a VALIDSIG from that exact key.
+  export GNUPGHOME="${op_work}/gnupg"
+  mkdir -p "${GNUPGHOME}" && chmod 700 "${GNUPGHOME}"
+  if curl -fsSL "${OP_GPG_KEY_URL}" | gpg --batch --import >/dev/null 2>&1 \
+    && gpg --batch --with-colons --fingerprint 2>/dev/null | grep -q "^fpr:::::::::${OP_GPG_FINGERPRINT}:" \
+    && gpg --batch --status-fd=1 --verify "${op_work}/op.sig" "${op_work}/op" 2>/dev/null \
+      | grep -q "VALIDSIG ${OP_GPG_FINGERPRINT}"; then
+    op_ok=1
   else
-    echo "WARN: 1Password CLI download failed; skipping (op-backed secret runs unavailable)."
+    echo "WARN: 1Password CLI signature verification failed; refusing to install op."
   fi
-  if [ "${op_ok}" = "1" ]; then
-    if command -v sudo >/dev/null 2>&1; then
-      sudo install -m 0755 "${op_work}/op" /usr/local/bin/op
-    else
-      install -m 0755 "${op_work}/op" "${BUN_INSTALL}/bin/op"
-    fi
-  fi
-  rm -rf "${op_work}"
-  set -e
+  unset GNUPGHOME
+else
+  echo "WARN: 1Password CLI download failed; skipping (op-backed secret runs unavailable)."
 fi
+if [ "${op_ok}" = "1" ]; then
+  # Verified: this pinned binary supersedes any earlier unverified op on PATH.
+  if command -v sudo >/dev/null 2>&1; then
+    sudo install -m 0755 "${op_work}/op" /usr/local/bin/op
+  else
+    install -m 0755 "${op_work}/op" "${BUN_INSTALL}/bin/op"
+  fi
+fi
+rm -rf "${op_work}"
+set -e
 
 # 5. Install workspace dependencies.
 #


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Follow-up to the Cloud Agent environment ([#885](https://github.com/beep-effect/beep-effect/pull/885), merged). Adds the **1Password CLI (`op`)** to the environment install script so credentialed features (e.g. `apps/professional-desktop`) can run end-to-end.

`.cursor/install.sh` now installs `op` (best-effort, non-fatal) alongside Bun, Node 24, and portless.

## Why

`professional-desktop`'s chat sidecar defaults to `CHAT_AGENT=anthropic` and needs `AI_ANTHROPIC_API_KEY`; other drivers (Box, USPTO, …) need their own credentials. Those are provided to the VM via the `OP_SERVICE_ACCOUNT_TOKEN` environment secret (a 1Password service account). With `op` present, a **gitignored** `.env` of `op://` references resolves at runtime:

```bash
op run --env-file=.env -- bun run sidecar
```

No secret values are committed — `.env` stays gitignored; `.env.example` remains the tracked placeholder.

## Validation (professional-desktop, real credentials)

Ran the full app end-to-end on the VM with credentials resolved from 1Password:

| Check | Result |
| --- | --- |
| `op` resolves all `op://` refs (Anthropic, Box CCG quartet, USPTO) | Resolved (values never printed) |
| Sidecar boot (`CHAT_AGENT=anthropic`) | Listening on `:3939`; PGlite migrations applied; **Box CCG auth connected** |
| Frontend via portless | `https://professional-desktop.beep.localhost` HTTP 200; `/rpc` proxy → sidecar 204 |
| **Live chat turn (real Claude)** | Sent a patent-practice question; a coherent four-item answer streamed back with no errors |
| `bash .cursor/install.sh` (with `op` step) | Exits 0; idempotent |

### Walkthrough — professional-desktop live Claude chat (real credentials)
[professional-desktop-live-chat-walkthrough.mp4](https://cursor.com/agents/bc-dc644933-40a4-4b30-9a97-570d6c772653/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fprofessional-desktop-live-chat-walkthrough.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc644933-40a4-4b30-9a97-570d6c772653?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc644933-40a4-4b30-9a97-570d6c772653&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790636363&installation_model_id=424656&pr_number=887&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F887&signature=3bf6b93ee623ba80cf36eaec64f45893b4ba052080fd4138b2fc667004ef5dee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->