### PR TITLE
feat(repo-cli): walk every scratch root and classify vitest and worktree-stub leaks

### DIFF
--- a/packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts
@@ -2805,7 +2805,12 @@ const renderTmpfsCandidateLine = (candidate: TmpfsReapReport["candidates"][numbe
     O.map((reason) => ` reason=${reason}`),
     O.getOrElse(() => "")
   );
-  return `- ${candidate.action} class=${candidate.reapClass} age=${candidate.ageHours.toFixed(1)}h refs=${candidate.refCount}${bytes}${skip} ${candidate.path}`;
+  const root = pipe(
+    O.fromUndefinedOr(candidate.root),
+    O.map((value) => ` root=${value}`),
+    O.getOrElse(() => "")
+  );
+  return `- ${candidate.action} class=${candidate.reapClass}${root} age=${candidate.ageHours.toFixed(1)}h refs=${candidate.refCount}${bytes}${skip} ${candidate.path}`;
 };
 
 const tmpfsReapCommand = Command.make(
@@ -2831,6 +2836,10 @@ const tmpfsReapCommand = Command.make(
       apply
         ? "TMPFS REAP APPLY — removing only classified, idle artifacts with zero live references"
         : "TMPFS REAP DRY RUN — nothing will be removed; pass --apply to reap eligible artifacts",
+      `scratch roots: ${A.join(
+        O.getOrElse(O.fromUndefinedOr(report.tmpRoots), () => [report.tmpRoot]),
+        ", "
+      )}`,
       ...A.map(report.candidates, renderTmpfsCandidateLine),
       `totals: candidates=${A.length(report.candidates)} reaped=${report.reapedCount} reclaimed-bytes=${report.reclaimedBytes}`,
       ...A.map(report.warnings, (warning) => `warning: ${warning}`),
@@ -2838,7 +2847,7 @@ const tmpfsReapCommand = Command.make(
   })
 ).pipe(
   Command.withDescription(
-    "Dry-run-first janitor for idle tmpfs worktrees and tool artifacts; pass --apply from the janitor timer"
+    "Dry-run-first janitor for idle artifacts under /tmp and a distinct absolute TMPDIR; includes Vitest forks scratch and dangling worktree stubs"
   )
 );
 

--- a/packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts
@@ -2813,6 +2813,46 @@ const renderTmpfsCandidateLine = (candidate: TmpfsReapReport["candidates"][numbe
   return `- ${candidate.action} class=${candidate.reapClass}${root} age=${candidate.ageHours.toFixed(1)}h refs=${candidate.refCount}${bytes}${skip} ${candidate.path}`;
 };
 
+const renderTmpfsReportLines = (report: TmpfsReapReport, apply: boolean): ReadonlyArray<string> => [
+  apply
+    ? "TMPFS REAP APPLY — removing only classified, idle artifacts with zero live references"
+    : "TMPFS REAP DRY RUN — nothing will be removed; pass --apply to reap eligible artifacts",
+  `scratch roots: ${A.join(
+    O.getOrElse(O.fromUndefinedOr(report.tmpRoots), () => [report.tmpRoot]),
+    ", "
+  )}`,
+  ...A.map(report.candidates, renderTmpfsCandidateLine),
+  `totals: candidates=${A.length(report.candidates)} reaped=${report.reapedCount} reclaimed-bytes=${report.reclaimedBytes}`,
+  ...A.map(report.warnings, (warning) => `warning: ${warning}`),
+];
+
+/**
+ * Render the operator-facing tmpfs janitor report without running the command.
+ *
+ * **Example** (Render a dry-run report)
+ *
+ * ```ts
+ * import { TmpfsReapReport } from "@beep/repo-cli/test/RepoRun"
+ * import { renderTmpfsReportLinesForTesting } from "@beep/repo-cli/test/Quality"
+ *
+ * const report = TmpfsReapReport.make({
+ *   scannedAt: "2026-08-30T12:00:00.000Z", tmpRoot: "/tmp", applied: false,
+ *   candidates: [], reapedCount: 0, reclaimedBytes: 0, warnings: [],
+ * })
+ * console.log(renderTmpfsReportLinesForTesting(report, false)[1]) // "scratch roots: /tmp"
+ * ```
+ *
+ * @param report - Completed janitor report to render.
+ * @param apply - Whether the command was invoked in apply mode.
+ * @returns Operator-facing summary, candidate, total, and warning lines.
+ * @category testing
+ * @since 0.0.0
+ */
+export const renderTmpfsReportLinesForTesting: {
+  (report: TmpfsReapReport, apply: boolean): ReadonlyArray<string>;
+  (apply: boolean): (report: TmpfsReapReport) => ReadonlyArray<string>;
+} = dual(2, renderTmpfsReportLines);
+
 const tmpfsReapCommand = Command.make(
   "tmpfs-reap",
   {
@@ -2832,18 +2872,7 @@ const tmpfsReapCommand = Command.make(
       yield* printLines([yield* jsonStringifyPretty(encoded)]);
       return;
     }
-    yield* printLines([
-      apply
-        ? "TMPFS REAP APPLY — removing only classified, idle artifacts with zero live references"
-        : "TMPFS REAP DRY RUN — nothing will be removed; pass --apply to reap eligible artifacts",
-      `scratch roots: ${A.join(
-        O.getOrElse(O.fromUndefinedOr(report.tmpRoots), () => [report.tmpRoot]),
-        ", "
-      )}`,
-      ...A.map(report.candidates, renderTmpfsCandidateLine),
-      `totals: candidates=${A.length(report.candidates)} reaped=${report.reapedCount} reclaimed-bytes=${report.reclaimedBytes}`,
-      ...A.map(report.warnings, (warning) => `warning: ${warning}`),
-    ]);
+    yield* printLines(renderTmpfsReportLines(report, apply));
   })
 ).pipe(
   Command.withDescription(

--- a/packages/tooling/tool/cli/src/commands/Worktree/Worktree.command.ts
+++ b/packages/tooling/tool/cli/src/commands/Worktree/Worktree.command.ts
@@ -20,14 +20,13 @@ import { Argument, Command, Flag } from "effect/unstable/cli";
 import { failWithReportedExit } from "../../internal/cli/ExitCodeError.ts";
 import { runGitOutput, runRepoCommandStreamingCapture } from "../../internal/repo-run/index.ts";
 import { worktreeFleetCommand } from "./Fleet.command.ts";
+import { WORKTREES_ROOT_SUFFIX } from "./Worktree.constants.ts";
 import { WorktreeCommandError, WorktreeDirtyError, WorktreeExistsError } from "./Worktree.errors.ts";
 import { parseWorktreePorcelain, WorktreeListEntry } from "./Worktree.schemas.ts";
 import type { ChildProcessSpawner } from "effect/unstable/process";
 import type { GitCommandErrorAdapter } from "../../internal/repo-run/index.ts";
 
 const $I = $RepoCliId.create("commands/Worktree/Worktree.command");
-
-const WORKTREES_ROOT_SUFFIX = "-worktrees";
 
 /**
  * Local-only files copied from the main checkout into a fresh worktree.

--- a/packages/tooling/tool/cli/src/commands/Worktree/Worktree.constants.ts
+++ b/packages/tooling/tool/cli/src/commands/Worktree/Worktree.constants.ts
@@ -1,0 +1,15 @@
+/**
+ * Suffix appended to a main checkout path for its sibling worktree container.
+ *
+ * **Example** (Build a sibling worktree root name)
+ *
+ * ```ts
+ * import { WORKTREES_ROOT_SUFFIX } from "@beep/repo-cli/commands/Worktree"
+ *
+ * console.log(`beep-effect${WORKTREES_ROOT_SUFFIX}`) // "beep-effect-worktrees"
+ * ```
+ *
+ * @category constants
+ * @since 0.0.0
+ */
+export const WORKTREES_ROOT_SUFFIX = "-worktrees";

--- a/packages/tooling/tool/cli/src/commands/Worktree/index.ts
+++ b/packages/tooling/tool/cli/src/commands/Worktree/index.ts
@@ -26,6 +26,13 @@ export * from "./Fleet.service.ts";
  */
 export * from "./Worktree.command.ts";
 /**
+ * Public worktree constants export.
+ *
+ * @category cli-commands
+ * @since 0.0.0
+ */
+export * from "./Worktree.constants.ts";
+/**
  * Public worktree command error exports.
  *
  * @category cli-commands

--- a/packages/tooling/tool/cli/src/internal/repo-run/TmpfsReap.schemas.ts
+++ b/packages/tooling/tool/cli/src/internal/repo-run/TmpfsReap.schemas.ts
@@ -11,6 +11,12 @@ import * as S from "effect/Schema";
 
 const $I = $RepoCliId.create("internal/repo-run/TmpfsReap.schemas");
 
+const TmpfsSystemRoot = S.String.pipe(
+  $I.annoteSchema("TmpfsSystemRoot", {
+    description: "Canonical system temporary root and first entry in tmpRoots.",
+  })
+);
+
 /**
  * Artifact families the janitor can classify without inspecting arbitrary paths.
  *
@@ -25,7 +31,14 @@ const $I = $RepoCliId.create("internal/repo-run/TmpfsReap.schemas");
  * @category models
  * @since 0.0.0
  */
-export const TmpfsReapClass = LiteralKit(["git-worktree", "head-install", "fallow-cache", "scoped-temp"]).pipe(
+export const TmpfsReapClass = LiteralKit([
+  "git-worktree",
+  "head-install",
+  "fallow-cache",
+  "scoped-temp",
+  "vitest-forks-tmp",
+  "dangling-worktree-stub",
+]).pipe(
   $I.annoteSchema("TmpfsReapClass", {
     description: "Artifact family recognized by the tmpfs janitor's closed classification policy.",
   })
@@ -88,6 +101,10 @@ export const TmpfsReapSkipReason = LiteralKit([
   "dirty-worktree",
   "too-young",
   "parent-repo-missing-but-refs",
+  "wrong-shape",
+  "gitdir-target-exists",
+  "parent-repo-present",
+  "live-runner",
   "unclassified",
 ]).pipe(
   $I.annoteSchema("TmpfsReapSkipReason", {
@@ -112,6 +129,7 @@ export type TmpfsReapSkipReason = typeof TmpfsReapSkipReason.Type;
  * import { TmpfsReapCandidate } from "@beep/repo-cli/test/RepoRun"
  *
  * const candidate = TmpfsReapCandidate.make({
+ *   root: "/tmp",
  *   path: "/tmp/fallow-audit-base-cache-example",
  *   reapClass: "fallow-cache",
  *   ageHours: 8,
@@ -127,6 +145,7 @@ export type TmpfsReapSkipReason = typeof TmpfsReapSkipReason.Type;
  */
 export class TmpfsReapCandidate extends S.Class<TmpfsReapCandidate>($I`TmpfsReapCandidate`)(
   {
+    root: S.optional(S.String),
     path: S.String,
     reapClass: TmpfsReapClass,
     ageHours: S.Finite,
@@ -152,6 +171,7 @@ export class TmpfsReapCandidate extends S.Class<TmpfsReapCandidate>($I`TmpfsReap
  * const report = TmpfsReapReport.make({
  *   scannedAt: "2026-08-29T12:00:00.000Z",
  *   tmpRoot: "/tmp",
+ *   tmpRoots: ["/tmp"],
  *   applied: false,
  *   candidates: [],
  *   reapedCount: 0,
@@ -168,7 +188,8 @@ export class TmpfsReapReport extends S.Class<TmpfsReapReport>($I`TmpfsReapReport
   {
     schemaVersion: S.tag("tmpfs-reap/v1"),
     scannedAt: S.String,
-    tmpRoot: S.String,
+    tmpRoot: TmpfsSystemRoot,
+    tmpRoots: S.String.pipe(S.Array, S.optional),
     applied: S.Boolean,
     candidates: S.Array(TmpfsReapCandidate),
     reapedCount: S.Int,

--- a/packages/tooling/tool/cli/src/internal/repo-run/TmpfsReap.schemas.ts
+++ b/packages/tooling/tool/cli/src/internal/repo-run/TmpfsReap.schemas.ts
@@ -104,6 +104,7 @@ export const TmpfsReapSkipReason = LiteralKit([
   "wrong-shape",
   "gitdir-target-exists",
   "parent-repo-present",
+  "contents-present",
   "live-runner",
   "unclassified",
 ]).pipe(

--- a/packages/tooling/tool/cli/src/internal/repo-run/TmpfsReap.ts
+++ b/packages/tooling/tool/cli/src/internal/repo-run/TmpfsReap.ts
@@ -1,7 +1,8 @@
 /**
  * Conservative janitor for known temporary artifacts on Linux tmpfs roots.
  *
- * Discovery is closed over four explicit artifact families. Reaping requires
+ * Discovery is closed over six explicit artifact families across `/tmp` and
+ * a distinct absolute `TMPDIR`. Reaping requires
  * classification, an old-enough idleness clock, zero live `/proc` cwd or file
  * descriptor references, and no matching kernel lock. Linked Git worktrees go
  * through `git worktree remove`; arbitrary directories are never touched.
@@ -11,11 +12,13 @@
  */
 
 import { $RepoCliId } from "@beep/identity/packages";
+import { LiteralKit } from "@beep/schema";
 import * as O from "@beep/utils/Option";
 import { Clock, Config, DateTime, Duration, Effect, FileSystem, Number as N, Path, pipe } from "effect";
 import * as A from "effect/Array";
 import * as S from "effect/Schema";
 import * as Str from "effect/String";
+import { WORKTREES_ROOT_SUFFIX } from "../../commands/Worktree/Worktree.constants.ts";
 import { runRepoCommandCapture } from "./RepoRun.executor.ts";
 import { TmpfsReapCandidate, TmpfsReapClass, TmpfsReapReport } from "./TmpfsReap.schemas.ts";
 import type { ChildProcessSpawner } from "effect/unstable/process";
@@ -34,6 +37,7 @@ const SCOPED_TEMP_PREFIXES = [
   "agent-effectiveness-schema-first-",
 ];
 const GIT_WORKTREE_MARKER = "/.git/worktrees/";
+const VitestForksChild = LiteralKit(["ssr", "client"]);
 const PROC_ROOT = "/proc";
 const PROC_LOCKS = "/proc/locks";
 
@@ -45,17 +49,38 @@ const ProcPidName = S.String.pipe(
 );
 const isProcPidName = S.is(ProcPidName);
 
+const VitestForksTmpName = S.String.pipe(
+  S.check(S.isPattern(/^[A-Za-z0-9_-]{21}$/u)),
+  $I.annoteSchema("VitestForksTmpName", {
+    description: "A 21-character name from Nano ID's URL-safe default alphabet.",
+  })
+);
+const isVitestForksTmpName = S.is(VitestForksTmpName);
+
 type DiscoveredCandidate = {
+  readonly root: string;
   readonly path: string;
   readonly reapClass: TmpfsReapClass;
   readonly idleSinceMillis: number;
   readonly classified: boolean;
+  readonly shapeSkipReason: O.Option<TmpfsReapSkipReason>;
   readonly parentRepo: O.Option<string>;
 };
 
-type ProcReferenceSnapshot = {
+type ProcessReferences = {
   readonly cwdTargets: ReadonlyArray<string>;
   readonly fdTargets: ReadonlyArray<string>;
+};
+
+type ProcReferenceSnapshot = ProcessReferences & {
+  readonly vitestRunning: boolean;
+};
+
+type ProcessCommandLineListing = () => Effect.Effect<ReadonlyArray<string>, never, FileSystem.FileSystem | Path.Path>;
+
+type TmpfsRootsResolution = {
+  readonly roots: ReadonlyArray<string>;
+  readonly warnings: ReadonlyArray<string>;
 };
 
 type CandidateLiveness = {
@@ -79,16 +104,19 @@ type ApplyOutcome = {
 
 const emptyApplyOutcome = (warning: string): ApplyOutcome => ({ reaped: false, warnings: [warning] });
 
-const sameCandidatePath = (left: DiscoveredCandidate, right: DiscoveredCandidate): boolean => left.path === right.path;
+const sameCandidatePath = (left: DiscoveredCandidate, right: DiscoveredCandidate): boolean =>
+  Str.Equivalence(left.path, right.path);
 
 const pathHasPrefix = (target: string, candidate: string, separator: string): boolean =>
-  target === candidate || Str.startsWith(`${candidate}${separator}`)(target);
+  Str.Equivalence(target, candidate) || Str.startsWith(`${candidate}${separator}`)(target);
 
 const pathIsWithin = (pathService: Path.Path, root: string, candidate: string): boolean => {
   const relative = pathService.relative(root, pathService.resolve(candidate));
   return (
     Str.isEmpty(relative) ||
-    (!pathService.isAbsolute(relative) && relative !== ".." && !Str.startsWith(`..${pathService.sep}`)(relative))
+    (!pathService.isAbsolute(relative) &&
+      !Str.Equivalence(relative, "..") &&
+      !Str.startsWith(`..${pathService.sep}`)(relative))
   );
 };
 
@@ -129,7 +157,19 @@ const isDirectory = Effect.fnUntraced(function* (
   const fs = yield* FileSystem.FileSystem;
   return pipe(
     yield* fs.stat(entryPath).pipe(Effect.option),
-    O.exists((info) => info.type === "Directory")
+    O.exists((info) => Str.Equivalence(info.type, "Directory"))
+  );
+});
+
+const statIsMissing = Effect.fnUntraced(function* (
+  entryPath: string
+): Effect.fn.Return<O.Option<boolean>, never, FileSystem.FileSystem> {
+  const fs = yield* FileSystem.FileSystem;
+  return yield* fs.stat(entryPath).pipe(
+    Effect.as(O.some(false)),
+    Effect.catch((error) =>
+      Str.Equivalence(error.reason._tag, "NotFound") ? Effect.succeed(O.some(true)) : Effect.succeed(O.none<boolean>())
+    )
   );
 });
 
@@ -144,7 +184,19 @@ const parentRepoFromGitDir = (pathService: Path.Path, candidatePath: string, git
   );
 };
 
+const gitDirFromGitFile = (pathService: Path.Path, candidatePath: string, content: string): O.Option<string> =>
+  pipe(
+    Str.trim(content),
+    O.liftPredicate(Str.startsWith("gitdir:")),
+    O.map((line) => Str.trim(Str.slice(Str.length("gitdir:"))(line))),
+    O.filter(Str.isNonEmpty),
+    O.map((target) =>
+      pathService.isAbsolute(target) ? pathService.normalize(target) : pathService.resolve(candidatePath, target)
+    )
+  );
+
 const discoverGitWorktree = Effect.fnUntraced(function* (
+  root: string,
   candidatePath: string,
   idleSinceMillis: number
 ): Effect.fn.Return<O.Option<DiscoveredCandidate>, never, FileSystem.FileSystem | Path.Path> {
@@ -152,22 +204,22 @@ const discoverGitWorktree = Effect.fnUntraced(function* (
   const pathService = yield* Path.Path;
   const gitFile = pathService.join(candidatePath, ".git");
   const info = yield* fs.stat(gitFile).pipe(Effect.option);
-  if (!O.exists(info, (value) => value.type === "File")) {
+  if (!O.exists(info, (value) => Str.Equivalence(value.type, "File"))) {
     return O.none();
   }
   const content = yield* fs.readFileString(gitFile).pipe(Effect.option);
   return pipe(
     content,
-    O.map(Str.trim),
-    O.filter(Str.startsWith("gitdir:")),
-    O.map((line): DiscoveredCandidate => {
-      const gitDir = Str.trim(Str.slice(Str.length("gitdir:"))(line));
+    O.flatMap((value) => gitDirFromGitFile(pathService, candidatePath, value)),
+    O.map((gitDir): DiscoveredCandidate => {
       const parentRepo = parentRepoFromGitDir(pathService, candidatePath, gitDir);
       return {
+        root,
         path: candidatePath,
         reapClass: "git-worktree",
         idleSinceMillis,
         classified: O.isSome(parentRepo),
+        shapeSkipReason: O.none(),
         parentRepo,
       };
     })
@@ -204,6 +256,163 @@ const fallowIdleSinceMillis = Effect.fnUntraced(function* (
 const isScopedTempName = (name: string): boolean =>
   A.some(SCOPED_TEMP_PREFIXES, (prefix) => Str.startsWith(prefix)(name));
 
+const discoverVitestForksTmp = Effect.fnUntraced(function* (
+  root: string,
+  candidatePath: string,
+  name: string,
+  idleSinceMillis: number
+): Effect.fn.Return<O.Option<DiscoveredCandidate>, never, FileSystem.FileSystem | Path.Path> {
+  if (!isVitestForksTmpName(name)) {
+    return O.none();
+  }
+  const pathService = yield* Path.Path;
+  const children = yield* directoryNames(candidatePath);
+  const childDirectories = yield* Effect.forEach(
+    children,
+    (child) => isDirectory(pathService.join(candidatePath, child)),
+    { concurrency: 2 }
+  );
+  const hasVitestShape =
+    !A.isReadonlyArrayEmpty(children) &&
+    A.every(children, (child) => VitestForksChild.is.ssr(child) || VitestForksChild.is.client(child)) &&
+    A.every(childDirectories, (isChildDirectory) => isChildDirectory);
+  if (!hasVitestShape) {
+    return O.none();
+  }
+  const childMtimes = yield* Effect.forEach(
+    children,
+    (child) => statMtimeMillis(pathService.join(candidatePath, child)),
+    { concurrency: 2 }
+  );
+  if (A.length(A.getSomes(childMtimes)) !== A.length(children)) {
+    return O.none();
+  }
+  return O.some({
+    root,
+    path: candidatePath,
+    reapClass: "vitest-forks-tmp",
+    idleSinceMillis: newestMillis(A.getSomes(childMtimes), idleSinceMillis),
+    classified: true,
+    shapeSkipReason: O.none(),
+    parentRepo: O.none(),
+  });
+});
+
+const discoverDanglingWorktreeStub = Effect.fnUntraced(function* (
+  root: string,
+  candidatePath: string,
+  idleSinceMillis: number
+): Effect.fn.Return<DiscoveredCandidate, never, FileSystem.FileSystem | Path.Path> {
+  const fs = yield* FileSystem.FileSystem;
+  const pathService = yield* Path.Path;
+  const gitFile = pathService.join(candidatePath, ".git");
+  const gitFileInfo = yield* fs.stat(gitFile).pipe(Effect.option);
+  const gitFileContent = O.exists(gitFileInfo, (info) => Str.Equivalence(info.type, "File"))
+    ? yield* fs.readFileString(gitFile).pipe(Effect.option)
+    : O.none<string>();
+  const gitDir = pipe(
+    gitFileContent,
+    O.flatMap((content) => gitDirFromGitFile(pathService, candidatePath, content))
+  );
+  const parentRepo = pipe(
+    gitDir,
+    O.flatMap((target) => parentRepoFromGitDir(pathService, candidatePath, target))
+  );
+  const gitDirMissing = O.isSome(gitDir) ? yield* statIsMissing(gitDir.value) : O.none<boolean>();
+  const parentRepoMissing = O.isSome(parentRepo) ? yield* statIsMissing(parentRepo.value) : O.none<boolean>();
+  const classified = O.contains(gitDirMissing, true) && O.contains(parentRepoMissing, true);
+  const shapeSkipReason = classified
+    ? O.none<TmpfsReapSkipReason>()
+    : O.contains(gitDirMissing, false)
+      ? O.some<TmpfsReapSkipReason>("gitdir-target-exists")
+      : O.contains(gitDirMissing, true) && O.contains(parentRepoMissing, false)
+        ? O.some<TmpfsReapSkipReason>("parent-repo-present")
+        : O.some<TmpfsReapSkipReason>("wrong-shape");
+  return {
+    root,
+    path: candidatePath,
+    reapClass: "dangling-worktree-stub",
+    idleSinceMillis,
+    classified,
+    shapeSkipReason,
+    parentRepo,
+  };
+});
+
+const discoverWorktreeStubs = Effect.fnUntraced(function* (
+  root: string,
+  topLevelNames: ReadonlyArray<string>
+): Effect.fn.Return<ReadonlyArray<DiscoveredCandidate>, never, FileSystem.FileSystem | Path.Path> {
+  const pathService = yield* Path.Path;
+  const fs = yield* FileSystem.FileSystem;
+  const worktreesRoots = A.filter(topLevelNames, Str.endsWith(WORKTREES_ROOT_SUFFIX));
+  return A.flatten(
+    yield* Effect.forEach(
+      worktreesRoots,
+      Effect.fnUntraced(function* (worktreesRootName: string) {
+        const configuredWorktreesRoot = pathService.join(root, worktreesRootName);
+        if (!(yield* isDirectory(configuredWorktreesRoot))) {
+          return A.empty<DiscoveredCandidate>();
+        }
+        const canonicalWorktreesRoot = yield* fs.realPath(configuredWorktreesRoot).pipe(Effect.option);
+        if (O.isNone(canonicalWorktreesRoot)) {
+          return A.empty<DiscoveredCandidate>();
+        }
+        if (!pathIsWithin(pathService, root, canonicalWorktreesRoot.value)) {
+          return A.of<DiscoveredCandidate>({
+            root,
+            path: canonicalWorktreesRoot.value,
+            reapClass: "dangling-worktree-stub",
+            idleSinceMillis: O.getOrElse(yield* statMtimeMillis(canonicalWorktreesRoot.value), () => 0),
+            classified: false,
+            shapeSkipReason: O.some("wrong-shape"),
+            parentRepo: O.none(),
+          });
+        }
+        const worktreesRoot = canonicalWorktreesRoot.value;
+        const names = yield* directoryNames(worktreesRoot);
+        const directoryEntries = A.filter(
+          yield* Effect.forEach(
+            names,
+            Effect.fnUntraced(function* (name: string) {
+              const entryPath = pathService.join(worktreesRoot, name);
+              return (yield* isDirectory(entryPath)) ? O.some(entryPath) : O.none<string>();
+            }),
+            { concurrency: 16 }
+          ),
+          O.isSome
+        );
+        const candidates = yield* Effect.forEach(
+          A.map(directoryEntries, (entry) => entry.value),
+          Effect.fnUntraced(function* (name: string) {
+            const canonicalCandidate = yield* fs.realPath(name).pipe(Effect.option);
+            if (O.isNone(canonicalCandidate)) {
+              return O.none<DiscoveredCandidate>();
+            }
+            const candidatePath = canonicalCandidate.value;
+            const idleSinceMillis = O.getOrElse(yield* statMtimeMillis(candidatePath), () => 0);
+            if (!pathIsWithin(pathService, worktreesRoot, candidatePath)) {
+              return O.some<DiscoveredCandidate>({
+                root,
+                path: candidatePath,
+                reapClass: "dangling-worktree-stub",
+                idleSinceMillis,
+                classified: false,
+                shapeSkipReason: O.some("wrong-shape"),
+                parentRepo: O.none(),
+              });
+            }
+            return O.some(yield* discoverDanglingWorktreeStub(root, candidatePath, idleSinceMillis));
+          }),
+          { concurrency: 16 }
+        );
+        return A.getSomes(candidates);
+      }),
+      { concurrency: 8 }
+    )
+  );
+});
+
 const classifyTopLevelDirectory = Effect.fnUntraced(function* (
   root: string,
   name: string,
@@ -217,41 +426,49 @@ const classifyTopLevelDirectory = Effect.fnUntraced(function* (
   const candidateMtime = O.getOrElse(yield* statMtimeMillis(candidatePath), () => 0);
   if (Str.startsWith(HEAD_INSTALL_PREFIX)(name)) {
     return O.some({
+      root,
       path: candidatePath,
       reapClass: "head-install",
       idleSinceMillis: candidateMtime,
       classified: true,
+      shapeSkipReason: O.none(),
       parentRepo: O.none(),
     });
   }
   if (Str.startsWith(FALLOW_CACHE_PREFIX)(name)) {
     return O.some({
+      root,
       path: candidatePath,
       reapClass: "fallow-cache",
       idleSinceMillis: yield* fallowIdleSinceMillis(candidatePath, candidateMtime, siblingNames),
       classified: true,
+      shapeSkipReason: O.none(),
       parentRepo: O.none(),
     });
   }
   if (isScopedTempName(name)) {
     return O.some({
+      root,
       path: candidatePath,
       reapClass: "scoped-temp",
       idleSinceMillis: candidateMtime,
       classified: true,
+      shapeSkipReason: O.none(),
       parentRepo: O.none(),
     });
   }
-  return yield* discoverGitWorktree(candidatePath, candidateMtime);
+  const vitest = yield* discoverVitestForksTmp(root, candidatePath, name, candidateMtime);
+  return O.isSome(vitest) ? vitest : yield* discoverGitWorktree(root, candidatePath, candidateMtime);
 });
 
 const discoverTopLevel = Effect.fnUntraced(function* (
   root: string
 ): Effect.fn.Return<ReadonlyArray<DiscoveredCandidate>, never, FileSystem.FileSystem | Path.Path> {
   const names = yield* directoryNames(root);
-  return A.getSomes(
+  const topLevel = A.getSomes(
     yield* Effect.forEach(names, (name) => classifyTopLevelDirectory(root, name, names), { concurrency: 16 })
   );
+  return A.appendAll(topLevel, yield* discoverWorktreeStubs(root, names));
 });
 
 const discoverCacheHeadInstalls = Effect.fnUntraced(function* (
@@ -288,7 +505,7 @@ const discoverExplicitGitWorktrees = Effect.fnUntraced(function* (
           return O.none<DiscoveredCandidate>();
         }
         const mtime = O.getOrElse(yield* statMtimeMillis(candidatePath), () => 0);
-        return yield* discoverGitWorktree(candidatePath, mtime);
+        return yield* discoverGitWorktree(tmpRoot, candidatePath, mtime);
       }),
       { concurrency: 16 }
     )
@@ -304,7 +521,7 @@ const readLinkOption = Effect.fnUntraced(function* (
 
 const processReferences = Effect.fnUntraced(function* (
   procPath: string
-): Effect.fn.Return<ProcReferenceSnapshot, never, FileSystem.FileSystem | Path.Path> {
+): Effect.fn.Return<ProcessReferences, never, FileSystem.FileSystem | Path.Path> {
   const pathService = yield* Path.Path;
   const cwd = yield* readLinkOption(pathService.join(procPath, "cwd"));
   const fdRoot = pathService.join(procPath, "fd");
@@ -318,19 +535,36 @@ const processReferences = Effect.fnUntraced(function* (
   };
 });
 
-const scanProcReferences = Effect.fnUntraced(function* (): Effect.fn.Return<
-  ProcReferenceSnapshot,
+const listHostProcessCommandLines = Effect.fnUntraced(function* (): Effect.fn.Return<
+  ReadonlyArray<string>,
   never,
   FileSystem.FileSystem | Path.Path
 > {
+  const fs = yield* FileSystem.FileSystem;
+  const pathService = yield* Path.Path;
+  const pids = A.filter(yield* directoryNames(PROC_ROOT), isProcPidName);
+  return A.getSomes(
+    yield* Effect.forEach(
+      pids,
+      (pid) => fs.readFileString(pathService.join(PROC_ROOT, pid, "cmdline")).pipe(Effect.option),
+      { concurrency: 16 }
+    )
+  );
+});
+
+const scanProcReferences = Effect.fnUntraced(function* (
+  processListing: ProcessCommandLineListing
+): Effect.fn.Return<ProcReferenceSnapshot, never, FileSystem.FileSystem | Path.Path> {
   const pathService = yield* Path.Path;
   const pids = A.filter(yield* directoryNames(PROC_ROOT), isProcPidName);
   const snapshots = yield* Effect.forEach(pids, (pid) => processReferences(pathService.join(PROC_ROOT, pid)), {
     concurrency: 16,
   });
+  const commandLines = yield* processListing();
   return {
     cwdTargets: A.flatten(A.map(snapshots, (snapshot) => snapshot.cwdTargets)),
     fdTargets: A.flatten(A.map(snapshots, (snapshot) => snapshot.fdTargets)),
+    vitestRunning: A.some(commandLines, Str.includes("vitest")),
   };
 });
 
@@ -351,7 +585,7 @@ const lockInodes = (locks: string): ReadonlyArray<number> =>
 const candidateLockInodes = Effect.fnUntraced(function* (
   candidate: DiscoveredCandidate
 ): Effect.fn.Return<ReadonlyArray<number>, never, FileSystem.FileSystem | Path.Path> {
-  if (candidate.reapClass !== "fallow-cache") {
+  if (!Str.Equivalence(candidate.reapClass, "fallow-cache")) {
     return A.empty();
   }
   const fs = yield* FileSystem.FileSystem;
@@ -380,7 +614,7 @@ const candidateLiveness = Effect.fnUntraced(function* (
 const worktreeIsDirty = Effect.fnUntraced(function* (
   candidate: DiscoveredCandidate
 ): Effect.fn.Return<boolean, never, FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner> {
-  if (candidate.reapClass !== "git-worktree" || O.isNone(candidate.parentRepo)) {
+  if (!Str.Equivalence(candidate.reapClass, "git-worktree") || O.isNone(candidate.parentRepo)) {
     return false;
   }
   const fs = yield* FileSystem.FileSystem;
@@ -388,12 +622,7 @@ const worktreeIsDirty = Effect.fnUntraced(function* (
   const gitFileContent = yield* fs.readFileString(pathService.join(candidate.path, ".git")).pipe(Effect.option);
   const gitDir = pipe(
     gitFileContent,
-    O.map(Str.trim),
-    O.filter(Str.startsWith("gitdir:")),
-    O.map((line) => Str.trim(Str.slice(Str.length("gitdir:"))(line))),
-    O.map((dir) =>
-      pathService.isAbsolute(dir) ? pathService.normalize(dir) : pathService.resolve(candidate.path, dir)
-    )
+    O.flatMap((content) => gitDirFromGitFile(pathService, candidate.path, content))
   );
   const locked = yield* pipe(
     gitDir,
@@ -424,16 +653,25 @@ const thresholdFor = (reapClass: TmpfsReapClass): Duration.Duration =>
     "head-install": () => Duration.hours(1),
     "fallow-cache": () => Duration.hours(6),
     "scoped-temp": () => Duration.hours(2),
+    "vitest-forks-tmp": () => Duration.hours(24),
+    "dangling-worktree-stub": () => Duration.hours(2),
   });
 
 const skipReasonFor = (
   candidate: DiscoveredCandidate,
   ageHours: number,
   liveness: CandidateLiveness,
-  dirtyWorktree: boolean
+  dirtyWorktree: boolean,
+  vitestRunning: boolean
 ): O.Option<TmpfsReapSkipReason> => {
+  if (O.isSome(candidate.shapeSkipReason)) {
+    return candidate.shapeSkipReason;
+  }
   if (!candidate.classified) {
     return O.some("unclassified");
+  }
+  if (Str.Equivalence(candidate.reapClass, "vitest-forks-tmp") && vitestRunning) {
+    return O.some("live-runner");
   }
   if (liveness.cwdCount > 0) {
     return O.some("live-cwd-ref");
@@ -483,12 +721,12 @@ const releaseNestedHeadInstallCheckout = Effect.fnUntraced(function* (
   never,
   FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
 > {
-  if (candidate.reapClass !== "head-install") {
+  if (!Str.Equivalence(candidate.reapClass, "head-install")) {
     return A.empty();
   }
   const pathService = yield* Path.Path;
   const checkout = pathService.join(candidate.path, "checkout");
-  const nested = yield* discoverGitWorktree(checkout, candidate.idleSinceMillis);
+  const nested = yield* discoverGitWorktree(candidate.root, checkout, candidate.idleSinceMillis);
   if (O.isNone(nested) || O.isNone(nested.value.parentRepo)) {
     return A.empty();
   }
@@ -503,7 +741,10 @@ const removeDirectoryCandidate = Effect.fnUntraced(function* (
   nestedWarnings: ReadonlyArray<string> = A.empty()
 ): Effect.fn.Return<ApplyOutcome, never, FileSystem.FileSystem | Path.Path> {
   const fs = yield* FileSystem.FileSystem;
-  const extras = candidate.reapClass === "fallow-cache" ? yield* fallowSiblingArtifacts(candidate.path) : A.empty();
+  const pathService = yield* Path.Path;
+  const extras = Str.Equivalence(candidate.reapClass, "fallow-cache")
+    ? yield* fallowSiblingArtifacts(candidate.path)
+    : A.empty();
   const removed = yield* fs.remove(candidate.path, { force: true, recursive: true }).pipe(
     Effect.as(true),
     Effect.orElseSucceed(() => false)
@@ -515,7 +756,33 @@ const removeDirectoryCandidate = Effect.fnUntraced(function* (
     discard: true,
     concurrency: 4,
   });
-  return { reaped: true, warnings: nestedWarnings };
+  if (!Str.Equivalence(candidate.reapClass, "dangling-worktree-stub")) {
+    return { reaped: true, warnings: nestedWarnings };
+  }
+  const parent = pathService.dirname(candidate.path);
+  const parentEntries = yield* readDirectoryOption(parent);
+  if (O.isNone(parentEntries)) {
+    return {
+      reaped: true,
+      warnings: A.append(nestedWarnings, `Could not verify whether dangling-stub container ${parent} is empty.`),
+    };
+  }
+  if (!A.isReadonlyArrayEmpty(parentEntries.value) || !pathIsWithin(pathService, candidate.root, parent)) {
+    return { reaped: true, warnings: nestedWarnings };
+  }
+  const removedParent = yield* fs.remove(parent, { force: true, recursive: true }).pipe(
+    Effect.as(true),
+    Effect.orElseSucceed(() => false)
+  );
+  return removedParent
+    ? { reaped: true, warnings: nestedWarnings }
+    : {
+        reaped: true,
+        warnings: A.append(
+          nestedWarnings,
+          `Removed ${candidate.path}, but failed to remove empty container ${parent}.`
+        ),
+      };
 });
 
 const removeGitWorktreeCandidate = Effect.fnUntraced(function* (
@@ -557,7 +824,7 @@ const applyCandidate = Effect.fnUntraced(function* (
   if (O.isSome(candidate.skipReason)) {
     return { reaped: false, warnings: [] };
   }
-  if (candidate.discovered.reapClass === "git-worktree") {
+  if (Str.Equivalence(candidate.discovered.reapClass, "git-worktree")) {
     return yield* removeGitWorktreeCandidate(candidate.discovered);
   }
   const nestedWarnings = yield* releaseNestedHeadInstallCheckout(candidate.discovered);
@@ -566,13 +833,14 @@ const applyCandidate = Effect.fnUntraced(function* (
 
 const candidateModel = (candidate: MeasuredCandidate): TmpfsReapCandidate =>
   TmpfsReapCandidate.make({
+    root: candidate.discovered.root,
     path: candidate.discovered.path,
     reapClass: candidate.discovered.reapClass,
     ageHours: candidate.ageHours,
     refCount: candidate.liveness.cwdCount + candidate.liveness.fdCount,
     action: O.isSome(candidate.skipReason)
       ? "skip"
-      : candidate.discovered.reapClass === "git-worktree"
+      : Str.Equivalence(candidate.discovered.reapClass, "git-worktree")
         ? "worktree-remove"
         : "remove-dir",
     ...O.getSomesStruct({
@@ -622,11 +890,70 @@ export const resolveBeepCacheRoot = Effect.fn("TmpfsReap.resolveBeepCacheRoot")(
   return pathService.resolve(tmpFallback);
 });
 
+const resolveTmpfsRoots = Effect.fnUntraced(function* (
+  explicitTmpRoot: O.Option<string>,
+  systemTmpRootOverride: O.Option<string>
+): Effect.fn.Return<TmpfsRootsResolution, never, FileSystem.FileSystem | Path.Path> {
+  const fs = yield* FileSystem.FileSystem;
+  const pathService = yield* Path.Path;
+  const canonicalize = (root: string) => fs.realPath(root).pipe(Effect.option);
+  if (O.isSome(explicitTmpRoot)) {
+    const explicit = yield* canonicalize(explicitTmpRoot.value);
+    return {
+      roots: [O.getOrElse(explicit, () => pathService.resolve(explicitTmpRoot.value))],
+      warnings: A.empty(),
+    };
+  }
+  const configuredSystemRoot = O.getOrElse(systemTmpRootOverride, () => "/tmp");
+  const canonicalSystemRoot = yield* canonicalize(configuredSystemRoot);
+  const systemTmpRoot = O.getOrElse(canonicalSystemRoot, () => pathService.resolve(configuredSystemRoot));
+  const configuredTmpRoot = O.filter(
+    yield* Config.option(Config.string("TMPDIR")).pipe(Effect.orElseSucceed(() => O.none())),
+    Str.isNonEmpty
+  );
+  if (O.isNone(configuredTmpRoot)) {
+    return { roots: [systemTmpRoot], warnings: A.empty() };
+  }
+  if (!pathService.isAbsolute(configuredTmpRoot.value)) {
+    return { roots: [systemTmpRoot], warnings: ["Dropped TMPDIR because it is not an absolute path."] };
+  }
+  const canonicalConfiguredRoot = yield* canonicalize(configuredTmpRoot.value);
+  if (O.isNone(canonicalConfiguredRoot)) {
+    return { roots: [systemTmpRoot], warnings: ["Dropped TMPDIR because its canonical path is unreadable."] };
+  }
+  const configuredRoot = canonicalConfiguredRoot.value;
+  if (Str.Equivalence(configuredRoot, systemTmpRoot)) {
+    return { roots: [systemTmpRoot], warnings: A.empty() };
+  }
+  const configuredHome = O.filter(
+    yield* Config.option(Config.string("HOME")).pipe(Effect.orElseSucceed(() => O.none())),
+    Str.isNonEmpty
+  );
+  const canonicalHome = O.isSome(configuredHome) ? yield* canonicalize(configuredHome.value) : O.none<string>();
+  const canonicalCheckout = yield* canonicalize(process.cwd());
+  if (Str.Equivalence(configuredRoot, pathService.parse(configuredRoot).root)) {
+    return { roots: [systemTmpRoot], warnings: ["Dropped TMPDIR because it resolves to the filesystem root."] };
+  }
+  if (O.exists(canonicalHome, (home) => Str.Equivalence(configuredRoot, home))) {
+    return { roots: [systemTmpRoot], warnings: ["Dropped TMPDIR because it resolves to HOME."] };
+  }
+  if (O.exists(canonicalHome, (home) => pathIsWithin(pathService, configuredRoot, home))) {
+    return { roots: [systemTmpRoot], warnings: ["Dropped TMPDIR because it is an ancestor of HOME."] };
+  }
+  if (O.exists(canonicalCheckout, (checkout) => pathIsWithin(pathService, configuredRoot, checkout))) {
+    return { roots: [systemTmpRoot], warnings: ["Dropped TMPDIR because it contains the invoking checkout."] };
+  }
+  return { roots: A.dedupe([systemTmpRoot, configuredRoot]), warnings: A.empty() };
+});
+
 /**
  * Discover known temporary artifacts, prove conjunctive idleness, and optionally reap them.
  *
- * Dry-run is the default. Tests may supply isolated `tmpRoot`, `cacheRoot`, and
- * `nowMillis` values. Sweep may additionally pass the current repository's
+ * Dry-run is the default. Production scans `/tmp` and a distinct absolute
+ * `TMPDIR`. Tests may supply an isolated `tmpRoot`, which deliberately disables
+ * ambient multi-root discovery, plus `cacheRoot`, `nowMillis`, and the
+ * `systemTmpRoot` seam values. Sweep
+ * may additionally pass the current repository's
  * porcelain worktree paths and restrict the run to `git-worktree`, while the
  * same engine retains ownership of liveness, age, and removal semantics.
  *
@@ -650,24 +977,32 @@ export const runTmpfsReap = Effect.fn("TmpfsReap.runTmpfsReap")(function* (
     readonly cacheRoot?: string;
     readonly classes?: ReadonlyArray<TmpfsReapClass>;
     readonly gitWorktreePaths?: ReadonlyArray<string>;
+    readonly listProcessCommandLines?: ProcessCommandLineListing;
     readonly nowMillis?: number;
+    readonly systemTmpRoot?: string;
     readonly tmpRoot?: string;
   } = {}
 ) {
   const fs = yield* FileSystem.FileSystem;
   const pathService = yield* Path.Path;
   const requestedTmpRoot = O.fromUndefinedOr(options.tmpRoot);
-  const configuredTmpRoot = O.isSome(requestedTmpRoot)
-    ? requestedTmpRoot.value
-    : yield* Config.string("TMPDIR").pipe(Config.withDefault("/tmp"));
-  const tmpRoot = yield* fs.realPath(configuredTmpRoot);
+  const rootResolution = yield* resolveTmpfsRoots(requestedTmpRoot, O.fromUndefinedOr(options.systemTmpRoot));
+  const tmpRoots = rootResolution.roots;
+  const tmpRoot = O.getOrThrow(A.head(tmpRoots));
   const classes = O.getOrElse(O.fromUndefinedOr(options.classes), () => TmpfsReapClass.Options);
   const includeClass = (reapClass: TmpfsReapClass): boolean => A.contains(classes, reapClass);
   const explicitGitWorktreePaths = O.fromUndefinedOr(options.gitWorktreePaths);
 
-  const tmpCandidates = O.isSome(explicitGitWorktreePaths)
-    ? yield* discoverExplicitGitWorktrees(tmpRoot, explicitGitWorktreePaths.value)
-    : yield* discoverTopLevel(tmpRoot);
+  const tmpCandidates = A.flatten(
+    yield* Effect.forEach(
+      tmpRoots,
+      (root) =>
+        O.isSome(explicitGitWorktreePaths)
+          ? discoverExplicitGitWorktrees(root, explicitGitWorktreePaths.value)
+          : discoverTopLevel(root),
+      { concurrency: 2 }
+    )
+  );
   const cacheCandidates = includeClass("head-install")
     ? yield* discoverCacheHeadInstalls(yield* resolveBeepCacheRoot(options.cacheRoot))
     : A.empty<DiscoveredCandidate>();
@@ -676,7 +1011,11 @@ export const runTmpfsReap = Effect.fn("TmpfsReap.runTmpfsReap")(function* (
     (candidate) => includeClass(candidate.reapClass)
   );
 
-  const proc = yield* scanProcReferences();
+  const processListing: ProcessCommandLineListing = O.getOrElse(
+    O.fromUndefinedOr(options.listProcessCommandLines),
+    () => listHostProcessCommandLines
+  );
+  const proc = yield* scanProcReferences(processListing);
   const heldLockInodes = lockInodes(yield* fs.readFileString(PROC_LOCKS));
   const nowMillis = yield* Clock.currentTimeMillis;
   const effectiveNowMillis = O.getOrElse(O.fromUndefinedOr(options.nowMillis), () => nowMillis);
@@ -692,7 +1031,7 @@ export const runTmpfsReap = Effect.fn("TmpfsReap.runTmpfsReap")(function* (
         ageHours,
         bytes,
         liveness,
-        skipReason: skipReasonFor(candidate, ageHours, liveness, dirtyWorktree),
+        skipReason: skipReasonFor(candidate, ageHours, liveness, dirtyWorktree, proc.vitestRunning),
       } satisfies MeasuredCandidate;
     }),
     { concurrency: 8 }
@@ -715,10 +1054,11 @@ export const runTmpfsReap = Effect.fn("TmpfsReap.runTmpfsReap")(function* (
   return TmpfsReapReport.make({
     scannedAt,
     tmpRoot,
+    tmpRoots,
     applied: apply,
     candidates: A.map(measured, candidateModel),
     reapedCount: A.length(reapedIndexes),
     reclaimedBytes,
-    warnings: A.flatten(A.map(outcomes, (outcome) => outcome.warnings)),
+    warnings: A.appendAll(rootResolution.warnings, A.flatten(A.map(outcomes, (outcome) => outcome.warnings))),
   });
 });

--- a/packages/tooling/tool/cli/src/internal/repo-run/TmpfsReap.ts
+++ b/packages/tooling/tool/cli/src/internal/repo-run/TmpfsReap.ts
@@ -195,6 +195,49 @@ const gitDirFromGitFile = (pathService: Path.Path, candidatePath: string, conten
     )
   );
 
+const gitDirForCandidate = Effect.fnUntraced(function* (
+  candidatePath: string
+): Effect.fn.Return<O.Option<string>, never, FileSystem.FileSystem | Path.Path> {
+  const fs = yield* FileSystem.FileSystem;
+  const pathService = yield* Path.Path;
+  const gitFile = pathService.join(candidatePath, ".git");
+  const gitFileInfo = yield* fs.stat(gitFile).pipe(Effect.option);
+  const gitFileContent = yield* pipe(
+    gitFileInfo,
+    O.filter((info) => Str.Equivalence(info.type, "File")),
+    O.match({
+      onNone: () => Effect.succeed(O.none<string>()),
+      onSome: () => fs.readFileString(gitFile).pipe(Effect.option),
+    })
+  );
+  return pipe(
+    gitFileContent,
+    O.flatMap((content) => gitDirFromGitFile(pathService, candidatePath, content))
+  );
+});
+
+const optionalStatIsMissing = (entryPath: O.Option<string>) =>
+  O.match(entryPath, {
+    onNone: () => Effect.succeed(O.none<boolean>()),
+    onSome: statIsMissing,
+  });
+
+const skipReasonWhen = (condition: boolean, reason: TmpfsReapSkipReason): O.Option<TmpfsReapSkipReason> =>
+  condition ? O.some(reason) : O.none();
+
+const danglingStubShape = (
+  gitDirMissing: O.Option<boolean>,
+  parentRepoMissing: O.Option<boolean>
+): Pick<DiscoveredCandidate, "classified" | "shapeSkipReason"> => {
+  const classified = O.contains(gitDirMissing, true) && O.contains(parentRepoMissing, true);
+  const shapeSkipReason = O.firstSomeOf([
+    skipReasonWhen(O.contains(gitDirMissing, false), "gitdir-target-exists"),
+    skipReasonWhen(O.contains(gitDirMissing, true) && O.contains(parentRepoMissing, false), "parent-repo-present"),
+    O.some<TmpfsReapSkipReason>("wrong-shape"),
+  ]);
+  return { classified, shapeSkipReason: classified ? O.none() : shapeSkipReason };
+};
+
 const discoverGitWorktree = Effect.fnUntraced(function* (
   root: string,
   candidatePath: string,
@@ -303,38 +346,20 @@ const discoverDanglingWorktreeStub = Effect.fnUntraced(function* (
   candidatePath: string,
   idleSinceMillis: number
 ): Effect.fn.Return<DiscoveredCandidate, never, FileSystem.FileSystem | Path.Path> {
-  const fs = yield* FileSystem.FileSystem;
   const pathService = yield* Path.Path;
-  const gitFile = pathService.join(candidatePath, ".git");
-  const gitFileInfo = yield* fs.stat(gitFile).pipe(Effect.option);
-  const gitFileContent = O.exists(gitFileInfo, (info) => Str.Equivalence(info.type, "File"))
-    ? yield* fs.readFileString(gitFile).pipe(Effect.option)
-    : O.none<string>();
-  const gitDir = pipe(
-    gitFileContent,
-    O.flatMap((content) => gitDirFromGitFile(pathService, candidatePath, content))
-  );
+  const gitDir = yield* gitDirForCandidate(candidatePath);
   const parentRepo = pipe(
     gitDir,
     O.flatMap((target) => parentRepoFromGitDir(pathService, candidatePath, target))
   );
-  const gitDirMissing = O.isSome(gitDir) ? yield* statIsMissing(gitDir.value) : O.none<boolean>();
-  const parentRepoMissing = O.isSome(parentRepo) ? yield* statIsMissing(parentRepo.value) : O.none<boolean>();
-  const classified = O.contains(gitDirMissing, true) && O.contains(parentRepoMissing, true);
-  const shapeSkipReason = classified
-    ? O.none<TmpfsReapSkipReason>()
-    : O.contains(gitDirMissing, false)
-      ? O.some<TmpfsReapSkipReason>("gitdir-target-exists")
-      : O.contains(gitDirMissing, true) && O.contains(parentRepoMissing, false)
-        ? O.some<TmpfsReapSkipReason>("parent-repo-present")
-        : O.some<TmpfsReapSkipReason>("wrong-shape");
+  const gitDirMissing = yield* optionalStatIsMissing(gitDir);
+  const parentRepoMissing = yield* optionalStatIsMissing(parentRepo);
   return {
     root,
     path: candidatePath,
     reapClass: "dangling-worktree-stub",
     idleSinceMillis,
-    classified,
-    shapeSkipReason,
+    ...danglingStubShape(gitDirMissing, parentRepoMissing),
     parentRepo,
   };
 });
@@ -657,36 +682,56 @@ const thresholdFor = (reapClass: TmpfsReapClass): Duration.Duration =>
     "dangling-worktree-stub": () => Duration.hours(2),
   });
 
-const skipReasonFor = (
+const classificationSkipReason = (
   candidate: DiscoveredCandidate,
-  ageHours: number,
-  liveness: CandidateLiveness,
-  dirtyWorktree: boolean,
   vitestRunning: boolean
-): O.Option<TmpfsReapSkipReason> => {
-  if (O.isSome(candidate.shapeSkipReason)) {
-    return candidate.shapeSkipReason;
-  }
-  if (!candidate.classified) {
-    return O.some("unclassified");
-  }
-  if (Str.Equivalence(candidate.reapClass, "vitest-forks-tmp") && vitestRunning) {
-    return O.some("live-runner");
-  }
+): O.Option<TmpfsReapSkipReason> =>
+  O.firstSomeOf([
+    candidate.shapeSkipReason,
+    candidate.classified ? O.none<TmpfsReapSkipReason>() : O.some<TmpfsReapSkipReason>("unclassified"),
+    TmpfsReapClass.$match(candidate.reapClass, {
+      "git-worktree": O.none<TmpfsReapSkipReason>,
+      "head-install": O.none<TmpfsReapSkipReason>,
+      "fallow-cache": O.none<TmpfsReapSkipReason>,
+      "scoped-temp": O.none<TmpfsReapSkipReason>,
+      "vitest-forks-tmp": () => skipReasonWhen(vitestRunning, "live-runner"),
+      "dangling-worktree-stub": O.none<TmpfsReapSkipReason>,
+    }),
+  ]);
+
+const livenessSkipReason = (liveness: CandidateLiveness): O.Option<TmpfsReapSkipReason> => {
   if (liveness.cwdCount > 0) {
     return O.some("live-cwd-ref");
   }
   if (liveness.fdCount > 0) {
     return O.some("live-fd-ref");
   }
-  if (liveness.liveFlock) {
-    return O.some("live-flock");
-  }
+  return liveness.liveFlock ? O.some("live-flock") : O.none();
+};
+
+const stateSkipReason = (
+  candidate: DiscoveredCandidate,
+  ageHours: number,
+  dirtyWorktree: boolean
+): O.Option<TmpfsReapSkipReason> => {
   if (dirtyWorktree) {
     return O.some("dirty-worktree");
   }
   return ageHours < Duration.toHours(thresholdFor(candidate.reapClass)) ? O.some("too-young") : O.none();
 };
+
+const skipReasonFor = (
+  candidate: DiscoveredCandidate,
+  ageHours: number,
+  liveness: CandidateLiveness,
+  dirtyWorktree: boolean,
+  vitestRunning: boolean
+): O.Option<TmpfsReapSkipReason> =>
+  O.firstSomeOf([
+    classificationSkipReason(candidate, vitestRunning),
+    livenessSkipReason(liveness),
+    stateSkipReason(candidate, ageHours, dirtyWorktree),
+  ]);
 
 const measureBytes = Effect.fnUntraced(function* (
   candidatePath: string
@@ -890,34 +935,53 @@ export const resolveBeepCacheRoot = Effect.fn("TmpfsReap.resolveBeepCacheRoot")(
   return pathService.resolve(tmpFallback);
 });
 
-const resolveTmpfsRoots = Effect.fnUntraced(function* (
-  explicitTmpRoot: O.Option<string>,
-  systemTmpRootOverride: O.Option<string>
+const configuredPath = (name: string) =>
+  Config.option(Config.string(name)).pipe(
+    Effect.orElseSucceed(() => O.none()),
+    Effect.map(O.filter(Str.isNonEmpty))
+  );
+
+const canonicalRoot = Effect.fnUntraced(function* (
+  root: string
+): Effect.fn.Return<string, never, FileSystem.FileSystem | Path.Path> {
+  const fs = yield* FileSystem.FileSystem;
+  const pathService = yield* Path.Path;
+  return O.getOrElse(yield* fs.realPath(root).pipe(Effect.option), () => pathService.resolve(root));
+});
+
+const unsafeTmpRootWarning = (
+  pathService: Path.Path,
+  configuredRoot: string,
+  canonicalHome: O.Option<string>,
+  canonicalCheckout: O.Option<string>
+): O.Option<string> => {
+  if (Str.Equivalence(configuredRoot, pathService.parse(configuredRoot).root)) {
+    return O.some("Dropped TMPDIR because it resolves to the filesystem root.");
+  }
+  if (O.exists(canonicalHome, (home) => Str.Equivalence(configuredRoot, home))) {
+    return O.some("Dropped TMPDIR because it resolves to HOME.");
+  }
+  if (O.exists(canonicalHome, (home) => pathIsWithin(pathService, configuredRoot, home))) {
+    return O.some("Dropped TMPDIR because it is an ancestor of HOME.");
+  }
+  return O.exists(canonicalCheckout, (checkout) => pathIsWithin(pathService, configuredRoot, checkout))
+    ? O.some("Dropped TMPDIR because it contains the invoking checkout.")
+    : O.none();
+};
+
+const resolveAmbientTmpfsRoots = Effect.fnUntraced(function* (
+  systemTmpRoot: string
 ): Effect.fn.Return<TmpfsRootsResolution, never, FileSystem.FileSystem | Path.Path> {
   const fs = yield* FileSystem.FileSystem;
   const pathService = yield* Path.Path;
-  const canonicalize = (root: string) => fs.realPath(root).pipe(Effect.option);
-  if (O.isSome(explicitTmpRoot)) {
-    const explicit = yield* canonicalize(explicitTmpRoot.value);
-    return {
-      roots: [O.getOrElse(explicit, () => pathService.resolve(explicitTmpRoot.value))],
-      warnings: A.empty(),
-    };
-  }
-  const configuredSystemRoot = O.getOrElse(systemTmpRootOverride, () => "/tmp");
-  const canonicalSystemRoot = yield* canonicalize(configuredSystemRoot);
-  const systemTmpRoot = O.getOrElse(canonicalSystemRoot, () => pathService.resolve(configuredSystemRoot));
-  const configuredTmpRoot = O.filter(
-    yield* Config.option(Config.string("TMPDIR")).pipe(Effect.orElseSucceed(() => O.none())),
-    Str.isNonEmpty
-  );
+  const configuredTmpRoot = yield* configuredPath("TMPDIR");
   if (O.isNone(configuredTmpRoot)) {
     return { roots: [systemTmpRoot], warnings: A.empty() };
   }
   if (!pathService.isAbsolute(configuredTmpRoot.value)) {
     return { roots: [systemTmpRoot], warnings: ["Dropped TMPDIR because it is not an absolute path."] };
   }
-  const canonicalConfiguredRoot = yield* canonicalize(configuredTmpRoot.value);
+  const canonicalConfiguredRoot = yield* fs.realPath(configuredTmpRoot.value).pipe(Effect.option);
   if (O.isNone(canonicalConfiguredRoot)) {
     return { roots: [systemTmpRoot], warnings: ["Dropped TMPDIR because its canonical path is unreadable."] };
   }
@@ -925,25 +989,34 @@ const resolveTmpfsRoots = Effect.fnUntraced(function* (
   if (Str.Equivalence(configuredRoot, systemTmpRoot)) {
     return { roots: [systemTmpRoot], warnings: A.empty() };
   }
-  const configuredHome = O.filter(
-    yield* Config.option(Config.string("HOME")).pipe(Effect.orElseSucceed(() => O.none())),
-    Str.isNonEmpty
+  const configuredHome = yield* configuredPath("HOME");
+  const canonicalHome = yield* pipe(
+    configuredHome,
+    O.match({
+      onNone: () => Effect.succeed(O.none<string>()),
+      onSome: (home) => fs.realPath(home).pipe(Effect.option),
+    })
   );
-  const canonicalHome = O.isSome(configuredHome) ? yield* canonicalize(configuredHome.value) : O.none<string>();
-  const canonicalCheckout = yield* canonicalize(process.cwd());
-  if (Str.Equivalence(configuredRoot, pathService.parse(configuredRoot).root)) {
-    return { roots: [systemTmpRoot], warnings: ["Dropped TMPDIR because it resolves to the filesystem root."] };
+  const canonicalCheckout = yield* fs.realPath(process.cwd()).pipe(Effect.option);
+  const warning = unsafeTmpRootWarning(pathService, configuredRoot, canonicalHome, canonicalCheckout);
+  return O.match(warning, {
+    onNone: () => ({ roots: A.dedupe([systemTmpRoot, configuredRoot]), warnings: A.empty() }),
+    onSome: (message) => ({ roots: [systemTmpRoot], warnings: [message] }),
+  });
+});
+
+const resolveTmpfsRoots = Effect.fnUntraced(function* (
+  explicitTmpRoot: O.Option<string>,
+  systemTmpRootOverride: O.Option<string>
+): Effect.fn.Return<TmpfsRootsResolution, never, FileSystem.FileSystem | Path.Path> {
+  if (O.isSome(explicitTmpRoot)) {
+    return {
+      roots: [yield* canonicalRoot(explicitTmpRoot.value)],
+      warnings: A.empty(),
+    };
   }
-  if (O.exists(canonicalHome, (home) => Str.Equivalence(configuredRoot, home))) {
-    return { roots: [systemTmpRoot], warnings: ["Dropped TMPDIR because it resolves to HOME."] };
-  }
-  if (O.exists(canonicalHome, (home) => pathIsWithin(pathService, configuredRoot, home))) {
-    return { roots: [systemTmpRoot], warnings: ["Dropped TMPDIR because it is an ancestor of HOME."] };
-  }
-  if (O.exists(canonicalCheckout, (checkout) => pathIsWithin(pathService, configuredRoot, checkout))) {
-    return { roots: [systemTmpRoot], warnings: ["Dropped TMPDIR because it contains the invoking checkout."] };
-  }
-  return { roots: A.dedupe([systemTmpRoot, configuredRoot]), warnings: A.empty() };
+  const configuredSystemRoot = O.getOrElse(systemTmpRootOverride, () => "/tmp");
+  return yield* resolveAmbientTmpfsRoots(yield* canonicalRoot(configuredSystemRoot));
 });
 
 /**

--- a/packages/tooling/tool/cli/src/internal/repo-run/TmpfsReap.ts
+++ b/packages/tooling/tool/cli/src/internal/repo-run/TmpfsReap.ts
@@ -14,7 +14,7 @@
 import { $RepoCliId } from "@beep/identity/packages";
 import { LiteralKit } from "@beep/schema";
 import * as O from "@beep/utils/Option";
-import { Clock, Config, DateTime, Duration, Effect, FileSystem, Number as N, Path, pipe } from "effect";
+import { BigInt, Clock, Config, DateTime, Duration, Effect, FileSystem, Number as N, Path, pipe } from "effect";
 import * as A from "effect/Array";
 import * as S from "effect/Schema";
 import * as Str from "effect/String";
@@ -40,6 +40,8 @@ const GIT_WORKTREE_MARKER = "/.git/worktrees/";
 const VitestForksChild = LiteralKit(["ssr", "client"]);
 const PROC_ROOT = "/proc";
 const PROC_LOCKS = "/proc/locks";
+const DANGLING_STUB_ENTRY_LIMIT = 16;
+const DANGLING_STUB_BYTE_LIMIT = FileSystem.Size(1024 * 1024);
 
 const ProcPidName = S.String.pipe(
   S.check(S.isPattern(/^[0-9]+$/u)),
@@ -95,6 +97,12 @@ type MeasuredCandidate = {
   readonly bytes: O.Option<number>;
   readonly liveness: CandidateLiveness;
   readonly skipReason: O.Option<TmpfsReapSkipReason>;
+};
+
+type DanglingStubCensus = {
+  readonly bytes: bigint;
+  readonly complete: boolean;
+  readonly entries: number;
 };
 
 type ApplyOutcome = {
@@ -238,6 +246,76 @@ const danglingStubShape = (
   return { classified, shapeSkipReason: classified ? O.none() : shapeSkipReason };
 };
 
+const censusWithinLimits = (census: DanglingStubCensus): boolean =>
+  census.complete &&
+  census.entries <= DANGLING_STUB_ENTRY_LIMIT &&
+  BigInt.isLessThanOrEqualTo(census.bytes, DANGLING_STUB_BYTE_LIMIT);
+
+const censusDirectory = (
+  candidateRoot: string,
+  directory: string,
+  initial: DanglingStubCensus
+): Effect.Effect<DanglingStubCensus, never, FileSystem.FileSystem | Path.Path> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const pathService = yield* Path.Path;
+    const names = yield* readDirectoryOption(directory);
+    if (O.isNone(names)) {
+      return { ...initial, complete: false };
+    }
+    return yield* Effect.reduce(
+      names.value,
+      () => initial,
+      (census, name) => {
+        if (!censusWithinLimits(census)) {
+          return Effect.succeed(census);
+        }
+        const entryPath = pathService.join(directory, name);
+        if (Str.Equivalence(directory, candidateRoot) && Str.Equivalence(name, ".git")) {
+          return fs.stat(entryPath).pipe(
+            Effect.option,
+            Effect.map(
+              O.match({
+                onNone: () => ({ ...census, complete: false }),
+                onSome: (info) => ({ ...census, bytes: BigInt.sum(census.bytes, info.size) }),
+              })
+            )
+          );
+        }
+        return Effect.gen(function* () {
+          if (O.isSome(yield* fs.readLink(entryPath).pipe(Effect.option))) {
+            return { ...census, complete: false };
+          }
+          const info = yield* fs.stat(entryPath).pipe(Effect.option);
+          if (O.isNone(info)) {
+            return { ...census, complete: false };
+          }
+          const next = {
+            bytes: Str.Equivalence(info.value.type, "Directory")
+              ? census.bytes
+              : BigInt.sum(census.bytes, info.value.size),
+            complete: true,
+            entries: N.increment(census.entries),
+          } satisfies DanglingStubCensus;
+          return Str.Equivalence(info.value.type, "Directory") && censusWithinLimits(next)
+            ? yield* censusDirectory(candidateRoot, entryPath, next)
+            : next;
+        });
+      }
+    );
+  });
+
+const danglingStubContentsWithinLimits = Effect.fnUntraced(function* (
+  candidatePath: string
+): Effect.fn.Return<boolean, never, FileSystem.FileSystem | Path.Path> {
+  const census = yield* censusDirectory(candidatePath, candidatePath, {
+    bytes: BigInt.BigInt(0),
+    complete: true,
+    entries: 0,
+  });
+  return censusWithinLimits(census);
+});
+
 const discoverGitWorktree = Effect.fnUntraced(function* (
   root: string,
   candidatePath: string,
@@ -354,12 +432,15 @@ const discoverDanglingWorktreeStub = Effect.fnUntraced(function* (
   );
   const gitDirMissing = yield* optionalStatIsMissing(gitDir);
   const parentRepoMissing = yield* optionalStatIsMissing(parentRepo);
+  const shape = danglingStubShape(gitDirMissing, parentRepoMissing);
+  const contentsWithinLimits = shape.classified ? yield* danglingStubContentsWithinLimits(candidatePath) : false;
   return {
     root,
     path: candidatePath,
     reapClass: "dangling-worktree-stub",
     idleSinceMillis,
-    ...danglingStubShape(gitDirMissing, parentRepoMissing),
+    classified: shape.classified && contentsWithinLimits,
+    shapeSkipReason: shape.classified && !contentsWithinLimits ? O.some("contents-present") : shape.shapeSkipReason,
     parentRepo,
   };
 });
@@ -815,19 +896,8 @@ const removeDirectoryCandidate = Effect.fnUntraced(function* (
   if (!A.isReadonlyArrayEmpty(parentEntries.value) || !pathIsWithin(pathService, candidate.root, parent)) {
     return { reaped: true, warnings: nestedWarnings };
   }
-  const removedParent = yield* fs.remove(parent, { force: true, recursive: true }).pipe(
-    Effect.as(true),
-    Effect.orElseSucceed(() => false)
-  );
-  return removedParent
-    ? { reaped: true, warnings: nestedWarnings }
-    : {
-        reaped: true,
-        warnings: A.append(
-          nestedWarnings,
-          `Removed ${candidate.path}, but failed to remove empty container ${parent}.`
-        ),
-      };
+  yield* fs.remove(parent).pipe(Effect.ignore);
+  return { reaped: true, warnings: nestedWarnings };
 });
 
 const removeGitWorktreeCandidate = Effect.fnUntraced(function* (
@@ -1097,14 +1167,18 @@ export const runTmpfsReap = Effect.fn("TmpfsReap.runTmpfsReap")(function* (
     Effect.fnUntraced(function* (candidate: DiscoveredCandidate) {
       const liveness = yield* candidateLiveness(candidate, proc, heldLockInodes, pathService.sep);
       const ageHours = Duration.toHours(Duration.millis(N.max(0, effectiveNowMillis - candidate.idleSinceMillis)));
-      const bytes = yield* measureBytes(candidate.path);
       const dirtyWorktree = yield* worktreeIsDirty(candidate);
+      const skipReason = skipReasonFor(candidate, ageHours, liveness, dirtyWorktree, proc.vitestRunning);
+      const bytes =
+        O.isNone(skipReason) && !Str.Equivalence(candidate.reapClass, "git-worktree")
+          ? yield* measureBytes(candidate.path)
+          : O.none<number>();
       return {
         discovered: candidate,
         ageHours,
         bytes,
         liveness,
-        skipReason: skipReasonFor(candidate, ageHours, liveness, dirtyWorktree, proc.vitestRunning),
+        skipReason,
       } satisfies MeasuredCandidate;
     }),
     { concurrency: 8 }

--- a/packages/tooling/tool/cli/src/internal/repo-run/TmpfsReap.ts
+++ b/packages/tooling/tool/cli/src/internal/repo-run/TmpfsReap.ts
@@ -251,28 +251,50 @@ const censusWithinLimits = (census: DanglingStubCensus): boolean =>
   census.entries <= DANGLING_STUB_ENTRY_LIMIT &&
   BigInt.isLessThanOrEqualTo(census.bytes, DANGLING_STUB_BYTE_LIMIT);
 
-const censusDirectory = (
+const censusEntry = Effect.fnUntraced(function* (
+  candidateRoot: string,
+  entryPath: string,
+  census: DanglingStubCensus
+): Effect.fn.Return<DanglingStubCensus, never, FileSystem.FileSystem | Path.Path> {
+  const fs = yield* FileSystem.FileSystem;
+  if (O.isSome(yield* fs.readLink(entryPath).pipe(Effect.option))) {
+    return { ...census, complete: false };
+  }
+  const info = yield* fs.stat(entryPath).pipe(Effect.option);
+  if (O.isNone(info)) {
+    return { ...census, complete: false };
+  }
+  const next = {
+    bytes: Str.Equivalence(info.value.type, "Directory") ? census.bytes : BigInt.sum(census.bytes, info.value.size),
+    complete: true,
+    entries: N.increment(census.entries),
+  } satisfies DanglingStubCensus;
+  return Str.Equivalence(info.value.type, "Directory") && censusWithinLimits(next)
+    ? yield* censusDirectory(candidateRoot, entryPath, next)
+    : next;
+});
+
+const censusDirectory = Effect.fnUntraced(function* (
   candidateRoot: string,
   directory: string,
   initial: DanglingStubCensus
-): Effect.Effect<DanglingStubCensus, never, FileSystem.FileSystem | Path.Path> =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const pathService = yield* Path.Path;
-    const names = yield* readDirectoryOption(directory);
-    if (O.isNone(names)) {
-      return { ...initial, complete: false };
-    }
-    return yield* Effect.reduce(
-      names.value,
-      () => initial,
-      (census, name) => {
-        if (!censusWithinLimits(census)) {
-          return Effect.succeed(census);
-        }
-        const entryPath = pathService.join(directory, name);
-        if (Str.Equivalence(directory, candidateRoot) && Str.Equivalence(name, ".git")) {
-          return fs.stat(entryPath).pipe(
+): Effect.fn.Return<DanglingStubCensus, never, FileSystem.FileSystem | Path.Path> {
+  const fs = yield* FileSystem.FileSystem;
+  const pathService = yield* Path.Path;
+  const names = yield* readDirectoryOption(directory);
+  if (O.isNone(names)) {
+    return { ...initial, complete: false };
+  }
+  return yield* Effect.reduce(
+    names.value,
+    () => initial,
+    (census, name) => {
+      if (!censusWithinLimits(census)) {
+        return Effect.succeed(census);
+      }
+      const entryPath = pathService.join(directory, name);
+      return Str.Equivalence(directory, candidateRoot) && Str.Equivalence(name, ".git")
+        ? fs.stat(entryPath).pipe(
             Effect.option,
             Effect.map(
               O.match({
@@ -280,30 +302,11 @@ const censusDirectory = (
                 onSome: (info) => ({ ...census, bytes: BigInt.sum(census.bytes, info.size) }),
               })
             )
-          );
-        }
-        return Effect.gen(function* () {
-          if (O.isSome(yield* fs.readLink(entryPath).pipe(Effect.option))) {
-            return { ...census, complete: false };
-          }
-          const info = yield* fs.stat(entryPath).pipe(Effect.option);
-          if (O.isNone(info)) {
-            return { ...census, complete: false };
-          }
-          const next = {
-            bytes: Str.Equivalence(info.value.type, "Directory")
-              ? census.bytes
-              : BigInt.sum(census.bytes, info.value.size),
-            complete: true,
-            entries: N.increment(census.entries),
-          } satisfies DanglingStubCensus;
-          return Str.Equivalence(info.value.type, "Directory") && censusWithinLimits(next)
-            ? yield* censusDirectory(candidateRoot, entryPath, next)
-            : next;
-        });
-      }
-    );
-  });
+          )
+        : censusEntry(candidateRoot, entryPath, census);
+    }
+  );
+});
 
 const danglingStubContentsWithinLimits = Effect.fnUntraced(function* (
   candidatePath: string

--- a/packages/tooling/tool/cli/src/test/Quality.test-kit.ts
+++ b/packages/tooling/tool/cli/src/test/Quality.test-kit.ts
@@ -71,5 +71,8 @@ export {
   tagsFromComment,
 } from "../commands/Quality/internal/QualityArtifactSupport.ts";
 export * from "../commands/Quality/internal/TurboConfigProof.ts";
-export { renderAdmissionSnapshotLinesForTesting } from "../commands/Quality/Quality.command.ts";
+export {
+  renderAdmissionSnapshotLinesForTesting,
+  renderTmpfsReportLinesForTesting,
+} from "../commands/Quality/Quality.command.ts";
 export * from "../internal/process/index.ts";

--- a/packages/tooling/tool/cli/test/quality-tmpfs-render.test.ts
+++ b/packages/tooling/tool/cli/test/quality-tmpfs-render.test.ts
@@ -1,0 +1,48 @@
+import { renderTmpfsReportLinesForTesting } from "@beep/repo-cli/test/Quality";
+import { TmpfsReapCandidate, TmpfsReapReport } from "@beep/repo-cli/test/RepoRun";
+import { describe, expect, it } from "@effect/vitest";
+import { pipe } from "effect";
+
+const report = TmpfsReapReport.make({
+  scannedAt: "2026-08-30T12:00:00.000Z",
+  tmpRoot: "/tmp",
+  tmpRoots: ["/tmp", "/scratch"],
+  applied: false,
+  candidates: [
+    TmpfsReapCandidate.make({
+      root: "/scratch",
+      path: "/scratch/beep-knowledge-refs-old",
+      reapClass: "scoped-temp",
+      ageHours: 3.25,
+      refCount: 2,
+      action: "skip",
+      skipReason: "live-fd-ref",
+      bytes: 4096,
+    }),
+  ],
+  reapedCount: 0,
+  reclaimedBytes: 0,
+  warnings: ["fixture warning"],
+});
+
+describe("tmpfs reap quality rendering", () => {
+  it("renders scratch roots and complete candidate evidence", () => {
+    const lines = renderTmpfsReportLinesForTesting(report, false);
+
+    expect(lines).toEqual([
+      "TMPFS REAP DRY RUN — nothing will be removed; pass --apply to reap eligible artifacts",
+      "scratch roots: /tmp, /scratch",
+      "- skip class=scoped-temp root=/scratch age=3.3h refs=2 bytes=4096 reason=live-fd-ref /scratch/beep-knowledge-refs-old",
+      "totals: candidates=1 reaped=0 reclaimed-bytes=0",
+      "warning: fixture warning",
+    ]);
+  });
+
+  it("falls back to the legacy root and supports the pipeable apply form", () => {
+    const legacy = TmpfsReapReport.make({ ...report, tmpRoots: undefined, candidates: [], warnings: [] });
+    const lines = pipe(legacy, renderTmpfsReportLinesForTesting(true));
+
+    expect(lines[0]).toBe("TMPFS REAP APPLY — removing only classified, idle artifacts with zero live references");
+    expect(lines[1]).toBe("scratch roots: /tmp");
+  });
+});

--- a/packages/tooling/tool/cli/test/tmpfs-reap.test.ts
+++ b/packages/tooling/tool/cli/test/tmpfs-reap.test.ts
@@ -1,6 +1,6 @@
 import { runRepoCommandCapture, runTmpfsReap, TmpfsReapReport } from "@beep/repo-cli/test/RepoRun";
 import { runTmpfsWorktreesStep } from "@beep/repo-cli/test/Yeet";
-import { provideScopedLayer } from "@beep/test-utils";
+import { fcRuns, provideScopedLayer } from "@beep/test-utils";
 import { NodeServices } from "@effect/platform-node";
 import { describe, expect, it } from "@effect/vitest";
 import { ConfigProvider, Duration, Effect, FileSystem, Path } from "effect";
@@ -8,6 +8,7 @@ import * as A from "effect/Array";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
 import * as Str from "effect/String";
+import { FastCheck as fc } from "effect/testing";
 import { ChildProcess } from "effect/unstable/process";
 
 const FIXTURE_NOW_MILLIS = 2_000_000_000_000;
@@ -120,6 +121,8 @@ const makeNewClassFixtures = Effect.fn("TmpfsReapTest.makeNewClassFixtures")(fun
   const stubYoung = path.join(worktreesRoot, "young");
   const stubLive = path.join(worktreesRoot, "live");
   const stubWrongShape = path.join(worktreesRoot, "wrong-shape");
+  const stubMalformedGitFile = path.join(worktreesRoot, "malformed-git-file");
+  const stubRelativeGitDir = path.join(worktreesRoot, "relative-gitdir");
   const stubExistingTarget = path.join(worktreesRoot, "target-exists");
   const stubParentPresent = path.join(worktreesRoot, "parent-present");
   const soleWorktreesRoot = path.join(tmpRoot, "sole-worktrees");
@@ -128,6 +131,7 @@ const makeNewClassFixtures = Effect.fn("TmpfsReapTest.makeNewClassFixtures")(fun
   const existingRepo = path.join(root, "existing-repo");
   const existingGitDir = path.join(existingRepo, ".git", "worktrees", "target-exists");
   const parentPresentRepo = path.join(root, "parent-present-repo");
+  const unclassifiedWorktree = path.join(tmpRoot, "unclassified-worktree");
 
   yield* Effect.forEach(
     [
@@ -141,11 +145,14 @@ const makeNewClassFixtures = Effect.fn("TmpfsReapTest.makeNewClassFixtures")(fun
       stubYoung,
       stubLive,
       stubWrongShape,
+      stubMalformedGitFile,
+      stubRelativeGitDir,
       stubExistingTarget,
       stubParentPresent,
       stubSoleEligible,
       existingGitDir,
       parentPresentRepo,
+      unclassifiedWorktree,
     ],
     (directory) => fs.makeDirectory(directory, { recursive: true }),
     { discard: true }
@@ -154,6 +161,8 @@ const makeNewClassFixtures = Effect.fn("TmpfsReapTest.makeNewClassFixtures")(fun
   yield* fs.writeFileString(path.join(stubYoung, ".git"), `gitdir: ${missingRepo}/.git/worktrees/young\n`);
   yield* fs.writeFileString(path.join(stubLive, ".git"), `gitdir: ${missingRepo}/.git/worktrees/live\n`);
   yield* fs.writeFileString(path.join(stubSoleEligible, ".git"), `gitdir: ${missingRepo}/.git/worktrees/sole\n`);
+  yield* fs.writeFileString(path.join(stubMalformedGitFile, ".git"), "gitdir: \n");
+  yield* fs.writeFileString(path.join(stubRelativeGitDir, ".git"), "gitdir: ../../missing/.git/worktrees/relative\n");
   yield* fs.writeFileString(path.join(stubExistingTarget, ".git"), `gitdir: ${existingGitDir}\n`);
   yield* fs.writeFileString(
     path.join(stubParentPresent, ".git"),
@@ -163,8 +172,20 @@ const makeNewClassFixtures = Effect.fn("TmpfsReapTest.makeNewClassFixtures")(fun
     path.join(vitestWrongShape, ".git"),
     `gitdir: ${missingRepo}/.git/worktrees/nanoid-git-worktree\n`
   );
+  yield* fs.writeFileString(path.join(unclassifiedWorktree, ".git"), `gitdir: ${missingRepo}/not-a-worktree\n`);
   yield* Effect.forEach(
-    [stubEligible, stubLive, stubWrongShape, stubExistingTarget, stubParentPresent, stubSoleEligible, vitestWrongShape],
+    [
+      stubEligible,
+      stubLive,
+      stubWrongShape,
+      stubMalformedGitFile,
+      stubRelativeGitDir,
+      stubExistingTarget,
+      stubParentPresent,
+      stubSoleEligible,
+      unclassifiedWorktree,
+      vitestWrongShape,
+    ],
     (candidate) => runCommand("touch", ["-d", fixtureTimestamp(3), candidate], root),
     { discard: true }
   );
@@ -189,12 +210,15 @@ const makeNewClassFixtures = Effect.fn("TmpfsReapTest.makeNewClassFixtures")(fun
     stubEligible,
     stubExistingTarget,
     stubLive,
+    stubMalformedGitFile,
     stubParentPresent,
+    stubRelativeGitDir,
     stubSoleEligible,
     stubWrongShape,
     stubYoung,
     soleWorktreesRoot,
     tmpRoot,
+    unclassifiedWorktree,
     vitestEligible,
     vitestLive,
     vitestWrongShape,
@@ -340,6 +364,12 @@ describe("tmpfs reap", () => {
           expect(stubWrongShape.skipReason).toBe("wrong-shape");
           expect(yield* fs.exists(fixture.stubWrongShape)).toBe(true);
 
+          expect(candidateByPath(report, fixture.stubMalformedGitFile).skipReason).toBe("wrong-shape");
+
+          const stubRelativeGitDir = candidateByPath(report, fixture.stubRelativeGitDir);
+          expect(stubRelativeGitDir.action).toBe("remove-dir");
+          expect(yield* fs.exists(fixture.stubRelativeGitDir)).toBe(false);
+
           const stubExistingTarget = candidateByPath(report, fixture.stubExistingTarget);
           expect(stubExistingTarget.skipReason).toBe("gitdir-target-exists");
           expect(yield* fs.exists(fixture.stubExistingTarget)).toBe(true);
@@ -348,10 +378,12 @@ describe("tmpfs reap", () => {
           expect(stubParentPresent.skipReason).toBe("parent-repo-present");
           expect(yield* fs.exists(fixture.stubParentPresent)).toBe(true);
 
+          expect(candidateByPath(report, fixture.unclassifiedWorktree).skipReason).toBe("unclassified");
+
           expect(candidateByPath(report, fixture.stubSoleEligible).action).toBe("remove-dir");
           expect(yield* fs.exists(fixture.stubSoleEligible)).toBe(false);
           expect(yield* fs.exists(fixture.soleWorktreesRoot), A.join(report.warnings, "\n")).toBe(false);
-          expect(report.reapedCount).toBe(3);
+          expect(report.reapedCount).toBe(4);
         })
       )
     ).pipe(provideScopedLayer(NodeServices.layer))
@@ -388,6 +420,77 @@ describe("tmpfs reap", () => {
         expect(candidate.action).toBe("skip");
         expect(yield* fs.exists(candidatePath)).toBe(true);
       })
+    ).pipe(provideScopedLayer(NodeServices.layer))
+  );
+
+  it.effect("distinguishes a live file descriptor from a live working-directory reference", () =>
+    withTempDirectory((root) =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const tmpRoot = path.join(root, "tmp");
+          const cacheRoot = path.join(root, "cache");
+          const candidatePath = path.join(tmpRoot, "beep-knowledge-refs-live-fd");
+          const payloadPath = path.join(candidatePath, "payload.txt");
+          yield* Effect.forEach(
+            [candidatePath, cacheRoot],
+            (directory) => fs.makeDirectory(directory, { recursive: true }),
+            {
+              discard: true,
+            }
+          );
+          yield* fs.writeFileString(payloadPath, "held open\n");
+          yield* runCommand("touch", ["-d", fixtureTimestamp(3), candidatePath], root);
+
+          yield* ChildProcess.make(
+            "sh",
+            ["-c", 'exec 3< "$1"; while :; do sleep 1; done', "tmpfs-reap-fd", payloadPath],
+            { cwd: root, stdin: "ignore", stderr: "pipe", stdout: "pipe" }
+          );
+
+          const report = yield* runTmpfsReap({ cacheRoot, nowMillis: FIXTURE_NOW_MILLIS, tmpRoot });
+          const candidate = candidateByPath(report, candidatePath);
+          expect(candidate.refCount).toBeGreaterThan(0);
+          expect(candidate.skipReason).toBe("live-fd-ref");
+        })
+      )
+    ).pipe(provideScopedLayer(NodeServices.layer))
+  );
+
+  it.effect("recognizes a held fallow-cache flock independently of path references", () =>
+    withTempDirectory((root) =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const tmpRoot = path.join(root, "tmp");
+          const cacheRoot = path.join(root, "cache");
+          const candidatePath = path.join(tmpRoot, "fallow-audit-base-cache-locked");
+          const lockPath = `${candidatePath}.lock`;
+          yield* Effect.forEach(
+            [candidatePath, cacheRoot],
+            (directory) => fs.makeDirectory(directory, { recursive: true }),
+            {
+              discard: true,
+            }
+          );
+          yield* fs.writeFileString(path.join(candidatePath, "payload.txt"), "cached\n");
+          yield* runCommand("touch", ["-d", fixtureTimestamp(8), candidatePath], root);
+
+          yield* ChildProcess.make("flock", ["-x", lockPath, "sh", "-c", "while :; do sleep 1; done"], {
+            cwd: root,
+            stdin: "ignore",
+            stderr: "pipe",
+            stdout: "pipe",
+          });
+
+          const report = yield* runTmpfsReap({ cacheRoot, nowMillis: FIXTURE_NOW_MILLIS, tmpRoot });
+          const candidate = candidateByPath(report, candidatePath);
+          expect(candidate.refCount).toBe(0);
+          expect(candidate.skipReason).toBe("live-flock");
+        })
+      )
     ).pipe(provideScopedLayer(NodeServices.layer))
   );
 
@@ -500,6 +603,43 @@ describe("tmpfs reap", () => {
           systemTmpRoot,
         }).pipe(provideScopedLayer(ConfigProvider.layer(ConfigProvider.fromUnknown({ TMPDIR: "relative-tmp" }))));
         expect(relativeReport.tmpRoots).toEqual([systemTmpRoot]);
+
+        const missingTmpRoot = path.join(root, "missing-tmpdir");
+        const unreadableReport = yield* runTmpfsReap({
+          cacheRoot,
+          classes: ["scoped-temp"],
+          nowMillis: FIXTURE_NOW_MILLIS,
+          systemTmpRoot,
+        }).pipe(provideScopedLayer(ConfigProvider.layer(ConfigProvider.fromUnknown({ TMPDIR: missingTmpRoot }))));
+        expect(unreadableReport.warnings).toContain("Dropped TMPDIR because its canonical path is unreadable.");
+
+        const rootReport = yield* runTmpfsReap({
+          cacheRoot,
+          classes: ["scoped-temp"],
+          nowMillis: FIXTURE_NOW_MILLIS,
+          systemTmpRoot,
+        }).pipe(provideScopedLayer(ConfigProvider.layer(ConfigProvider.fromUnknown({ TMPDIR: "/" }))));
+        expect(rootReport.warnings).toContain("Dropped TMPDIR because it resolves to the filesystem root.");
+
+        const ancestorReport = yield* runTmpfsReap({
+          cacheRoot,
+          classes: ["scoped-temp"],
+          nowMillis: FIXTURE_NOW_MILLIS,
+          systemTmpRoot,
+        }).pipe(provideScopedLayer(ConfigProvider.layer(ConfigProvider.fromUnknown({ HOME: homeRoot, TMPDIR: root }))));
+        expect(ancestorReport.warnings).toContain("Dropped TMPDIR because it is an ancestor of HOME.");
+
+        const checkoutReport = yield* runTmpfsReap({
+          cacheRoot,
+          classes: ["scoped-temp"],
+          nowMillis: FIXTURE_NOW_MILLIS,
+          systemTmpRoot,
+        }).pipe(provideScopedLayer(ConfigProvider.layer(ConfigProvider.fromUnknown({ TMPDIR: process.cwd() }))));
+        expect(checkoutReport.warnings).toContain("Dropped TMPDIR because it contains the invoking checkout.");
+
+        const explicitMissingRoot = path.join(root, "missing-explicit-root");
+        const explicitReport = yield* runTmpfsReap({ cacheRoot, tmpRoot: explicitMissingRoot });
+        expect(explicitReport.tmpRoots).toEqual([explicitMissingRoot]);
       })
     ).pipe(provideScopedLayer(NodeServices.layer))
   );
@@ -576,6 +716,54 @@ describe("tmpfs reap", () => {
         expect(yield* fs.exists(fixture.youngScoped)).toBe(true);
         expect(yield* fs.exists(fixture.dirtyWorktree)).toBe(true);
         expect(yield* fs.exists(path.join(fixture.dirtyWorktree, "uncommitted.txt"))).toBe(true);
+      })
+    ).pipe(provideScopedLayer(NodeServices.layer))
+  );
+
+  it.effect("releases nested head-install worktrees and reports a locked release failure", () =>
+    withTempDirectory((root) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const tmpRoot = path.join(root, "tmp");
+        const cacheRoot = path.join(root, "cache");
+        const repo = path.join(root, "repo");
+        const headInstallRoot = path.join(cacheRoot, "beep", "head-install");
+        const releasedInstall = path.join(headInstallRoot, "beep-yeet-head-install-released");
+        const lockedInstall = path.join(headInstallRoot, "beep-yeet-head-install-locked");
+        const releasedCheckout = path.join(releasedInstall, "checkout");
+        const lockedCheckout = path.join(lockedInstall, "checkout");
+        yield* Effect.forEach([tmpRoot, repo], (directory) => fs.makeDirectory(directory, { recursive: true }), {
+          discard: true,
+        });
+        yield* runCommand("git", ["init", "--quiet"], repo);
+        yield* runCommand("git", ["config", "user.email", "tmpfs-reap@example.invalid"], repo);
+        yield* runCommand("git", ["config", "user.name", "Tmpfs Reap Test"], repo);
+        yield* fs.writeFileString(path.join(repo, "README.md"), "fixture\n");
+        yield* runCommand("git", ["add", "README.md"], repo);
+        yield* runCommand("git", ["commit", "--quiet", "-m", "fixture"], repo);
+        yield* runCommand("git", ["worktree", "add", "--quiet", "-b", "released-install", releasedCheckout], repo);
+        yield* runCommand("git", ["worktree", "add", "--quiet", "-b", "locked-install", lockedCheckout], repo);
+        yield* runCommand("git", ["worktree", "lock", lockedCheckout], repo);
+        yield* Effect.forEach(
+          [releasedInstall, lockedInstall],
+          (candidate) => runCommand("touch", ["-d", fixtureTimestamp(2), candidate], root),
+          { discard: true }
+        );
+
+        const report = yield* runTmpfsReap({
+          apply: true,
+          cacheRoot,
+          classes: ["head-install"],
+          listProcessCommandLines: noProcessCommandLines,
+          nowMillis: FIXTURE_NOW_MILLIS,
+          tmpRoot,
+        });
+
+        expect(report.reapedCount).toBe(2);
+        expect(yield* fs.exists(releasedInstall)).toBe(false);
+        expect(yield* fs.exists(lockedInstall)).toBe(false);
+        expect(A.some(report.warnings, Str.includes(`Nested head-install checkout ${lockedCheckout}`))).toBe(true);
       })
     ).pipe(provideScopedLayer(NodeServices.layer))
   );
@@ -677,4 +865,21 @@ describe("tmpfs reap", () => {
       })
     ).pipe(provideScopedLayer(NodeServices.layer))
   );
+
+  it("property: tmpfs-reap reports round-trip through the JSON codec", () => {
+    const ReportArbitrary = S.toArbitrary(TmpfsReapReport)(fc);
+    fc.assert(
+      fc.property(ReportArbitrary, (report) => {
+        const encoded = S.encodeSync(S.fromJsonString(TmpfsReapReport))(report);
+        const decoded = S.decodeSync(S.fromJsonString(TmpfsReapReport))(encoded);
+        expect(decoded.schemaVersion).toBe(report.schemaVersion);
+        expect(decoded.tmpRoot).toBe(report.tmpRoot);
+        expect(A.length(decoded.candidates)).toBe(A.length(report.candidates));
+        // JSON drops the sign of -0, so the codec law is encode-stability
+        // rather than Object.is identity on numeric fields.
+        expect(S.encodeSync(S.fromJsonString(TmpfsReapReport))(decoded)).toBe(encoded);
+      }),
+      fcRuns(32)
+    );
+  });
 });

--- a/packages/tooling/tool/cli/test/tmpfs-reap.test.ts
+++ b/packages/tooling/tool/cli/test/tmpfs-reap.test.ts
@@ -125,6 +125,7 @@ const makeNewClassFixtures = Effect.fn("TmpfsReapTest.makeNewClassFixtures")(fun
   const stubRelativeGitDir = path.join(worktreesRoot, "relative-gitdir");
   const stubExistingTarget = path.join(worktreesRoot, "target-exists");
   const stubParentPresent = path.join(worktreesRoot, "parent-present");
+  const stubContentsPresent = path.join(worktreesRoot, "contents-present");
   const soleWorktreesRoot = path.join(tmpRoot, "sole-worktrees");
   const stubSoleEligible = path.join(soleWorktreesRoot, "eligible");
   const missingRepo = path.join(root, "missing-repo");
@@ -149,6 +150,7 @@ const makeNewClassFixtures = Effect.fn("TmpfsReapTest.makeNewClassFixtures")(fun
       stubRelativeGitDir,
       stubExistingTarget,
       stubParentPresent,
+      stubContentsPresent,
       stubSoleEligible,
       existingGitDir,
       parentPresentRepo,
@@ -169,6 +171,11 @@ const makeNewClassFixtures = Effect.fn("TmpfsReapTest.makeNewClassFixtures")(fun
     `gitdir: ${parentPresentRepo}/.git/worktrees/missing\n`
   );
   yield* fs.writeFileString(
+    path.join(stubContentsPresent, ".git"),
+    `gitdir: ${missingRepo}/.git/worktrees/contents-present\n`
+  );
+  yield* fs.writeFileString(path.join(stubContentsPresent, "unsaved.bin"), Str.repeat(1024 * 1024 + 1)("x"));
+  yield* fs.writeFileString(
     path.join(vitestWrongShape, ".git"),
     `gitdir: ${missingRepo}/.git/worktrees/nanoid-git-worktree\n`
   );
@@ -182,6 +189,7 @@ const makeNewClassFixtures = Effect.fn("TmpfsReapTest.makeNewClassFixtures")(fun
       stubRelativeGitDir,
       stubExistingTarget,
       stubParentPresent,
+      stubContentsPresent,
       stubSoleEligible,
       unclassifiedWorktree,
       vitestWrongShape,
@@ -212,6 +220,7 @@ const makeNewClassFixtures = Effect.fn("TmpfsReapTest.makeNewClassFixtures")(fun
     stubLive,
     stubMalformedGitFile,
     stubParentPresent,
+    stubContentsPresent,
     stubRelativeGitDir,
     stubSoleEligible,
     stubWrongShape,
@@ -372,20 +381,57 @@ describe("tmpfs reap", () => {
 
           const stubExistingTarget = candidateByPath(report, fixture.stubExistingTarget);
           expect(stubExistingTarget.skipReason).toBe("gitdir-target-exists");
+          expect(stubExistingTarget.bytes).toBeUndefined();
           expect(yield* fs.exists(fixture.stubExistingTarget)).toBe(true);
 
           const stubParentPresent = candidateByPath(report, fixture.stubParentPresent);
           expect(stubParentPresent.skipReason).toBe("parent-repo-present");
+          expect(stubParentPresent.bytes).toBeUndefined();
           expect(yield* fs.exists(fixture.stubParentPresent)).toBe(true);
+
+          const stubContentsPresent = candidateByPath(report, fixture.stubContentsPresent);
+          expect(stubContentsPresent.skipReason).toBe("contents-present");
+          expect(stubContentsPresent.bytes).toBeUndefined();
+          expect(yield* fs.exists(fixture.stubContentsPresent)).toBe(true);
 
           expect(candidateByPath(report, fixture.unclassifiedWorktree).skipReason).toBe("unclassified");
 
           expect(candidateByPath(report, fixture.stubSoleEligible).action).toBe("remove-dir");
           expect(yield* fs.exists(fixture.stubSoleEligible)).toBe(false);
-          expect(yield* fs.exists(fixture.soleWorktreesRoot), A.join(report.warnings, "\n")).toBe(false);
           expect(report.reapedCount).toBe(4);
         })
       )
+    ).pipe(provideScopedLayer(NodeServices.layer))
+  );
+
+  it.effect("preserves a container child created when non-recursive cleanup begins", () =>
+    withTempDirectory((root) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const fixture = yield* makeNewClassFixtures(root);
+        const racedChild = path.join(fixture.soleWorktreesRoot, "concurrent-worktree");
+        const racingFileSystem = FileSystem.makeNoop({
+          ...fs,
+          remove: (target, options) =>
+            Str.Equivalence(target, fixture.soleWorktreesRoot)
+              ? fs.makeDirectory(racedChild).pipe(Effect.andThen(fs.remove(target, options)))
+              : fs.remove(target, options),
+        });
+        const report = yield* runTmpfsReap({
+          apply: true,
+          cacheRoot: fixture.cacheRoot,
+          classes: ["dangling-worktree-stub"],
+          listProcessCommandLines: noProcessCommandLines,
+          nowMillis: FIXTURE_NOW_MILLIS,
+          tmpRoot: fixture.tmpRoot,
+        }).pipe(Effect.provideService(FileSystem.FileSystem, racingFileSystem));
+
+        expect(candidateByPath(report, fixture.stubSoleEligible).action).toBe("remove-dir");
+        expect(yield* fs.exists(fixture.stubSoleEligible)).toBe(false);
+        expect(yield* fs.exists(racedChild)).toBe(true);
+        expect(A.some(report.warnings, Str.includes(fixture.soleWorktreesRoot))).toBe(false);
+      })
     ).pipe(provideScopedLayer(NodeServices.layer))
   );
 

--- a/packages/tooling/tool/cli/test/tmpfs-reap.test.ts
+++ b/packages/tooling/tool/cli/test/tmpfs-reap.test.ts
@@ -1,15 +1,17 @@
-import { runRepoCommandCapture, runTmpfsReap } from "@beep/repo-cli/test/RepoRun";
+import { runRepoCommandCapture, runTmpfsReap, TmpfsReapReport } from "@beep/repo-cli/test/RepoRun";
 import { runTmpfsWorktreesStep } from "@beep/repo-cli/test/Yeet";
 import { provideScopedLayer } from "@beep/test-utils";
 import { NodeServices } from "@effect/platform-node";
 import { describe, expect, it } from "@effect/vitest";
-import { Duration, Effect, FileSystem, Path } from "effect";
+import { ConfigProvider, Duration, Effect, FileSystem, Path } from "effect";
 import * as A from "effect/Array";
 import * as O from "effect/Option";
+import * as S from "effect/Schema";
 import * as Str from "effect/String";
 import { ChildProcess } from "effect/unstable/process";
 
 const FIXTURE_NOW_MILLIS = 2_000_000_000_000;
+const noProcessCommandLines = () => Effect.succeed(A.empty<string>());
 const fixtureTimestamp = (hoursAgo: number): string =>
   `@${(FIXTURE_NOW_MILLIS - Duration.toMillis(Duration.hours(hoursAgo))) / 1000}`;
 
@@ -104,6 +106,102 @@ const makeClassificationFixture = Effect.fn("TmpfsReapTest.makeClassificationFix
   };
 });
 
+const makeNewClassFixtures = Effect.fn("TmpfsReapTest.makeNewClassFixtures")(function* (root: string) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const tmpRoot = path.join(root, "tmp");
+  const cacheRoot = path.join(root, "cache");
+  const vitestEligible = path.join(tmpRoot, "0123456789abcdefghijk");
+  const vitestYoung = path.join(tmpRoot, "1234567890abcdefghijk");
+  const vitestLive = path.join(tmpRoot, "2345678901abcdefghijk");
+  const vitestWrongShape = path.join(tmpRoot, "3456789012abcdefghijk");
+  const worktreesRoot = path.join(tmpRoot, "fixture-worktrees");
+  const stubEligible = path.join(worktreesRoot, "eligible");
+  const stubYoung = path.join(worktreesRoot, "young");
+  const stubLive = path.join(worktreesRoot, "live");
+  const stubWrongShape = path.join(worktreesRoot, "wrong-shape");
+  const stubExistingTarget = path.join(worktreesRoot, "target-exists");
+  const stubParentPresent = path.join(worktreesRoot, "parent-present");
+  const soleWorktreesRoot = path.join(tmpRoot, "sole-worktrees");
+  const stubSoleEligible = path.join(soleWorktreesRoot, "eligible");
+  const missingRepo = path.join(root, "missing-repo");
+  const existingRepo = path.join(root, "existing-repo");
+  const existingGitDir = path.join(existingRepo, ".git", "worktrees", "target-exists");
+  const parentPresentRepo = path.join(root, "parent-present-repo");
+
+  yield* Effect.forEach(
+    [
+      cacheRoot,
+      path.join(vitestEligible, "ssr"),
+      path.join(vitestEligible, "client"),
+      path.join(vitestYoung, "client"),
+      path.join(vitestLive, "ssr"),
+      path.join(vitestWrongShape, "coverage"),
+      stubEligible,
+      stubYoung,
+      stubLive,
+      stubWrongShape,
+      stubExistingTarget,
+      stubParentPresent,
+      stubSoleEligible,
+      existingGitDir,
+      parentPresentRepo,
+    ],
+    (directory) => fs.makeDirectory(directory, { recursive: true }),
+    { discard: true }
+  );
+  yield* fs.writeFileString(path.join(stubEligible, ".git"), `gitdir: ${missingRepo}/.git/worktrees/eligible\n`);
+  yield* fs.writeFileString(path.join(stubYoung, ".git"), `gitdir: ${missingRepo}/.git/worktrees/young\n`);
+  yield* fs.writeFileString(path.join(stubLive, ".git"), `gitdir: ${missingRepo}/.git/worktrees/live\n`);
+  yield* fs.writeFileString(path.join(stubSoleEligible, ".git"), `gitdir: ${missingRepo}/.git/worktrees/sole\n`);
+  yield* fs.writeFileString(path.join(stubExistingTarget, ".git"), `gitdir: ${existingGitDir}\n`);
+  yield* fs.writeFileString(
+    path.join(stubParentPresent, ".git"),
+    `gitdir: ${parentPresentRepo}/.git/worktrees/missing\n`
+  );
+  yield* fs.writeFileString(
+    path.join(vitestWrongShape, ".git"),
+    `gitdir: ${missingRepo}/.git/worktrees/nanoid-git-worktree\n`
+  );
+  yield* Effect.forEach(
+    [stubEligible, stubLive, stubWrongShape, stubExistingTarget, stubParentPresent, stubSoleEligible, vitestWrongShape],
+    (candidate) => runCommand("touch", ["-d", fixtureTimestamp(3), candidate], root),
+    { discard: true }
+  );
+  yield* Effect.forEach(
+    [vitestEligible, path.join(vitestEligible, "ssr"), path.join(vitestEligible, "client")],
+    (candidate) => runCommand("touch", ["-d", fixtureTimestamp(30), candidate], root),
+    { discard: true }
+  );
+  yield* Effect.forEach(
+    [vitestYoung, vitestLive, path.join(vitestLive, "ssr")],
+    (candidate) => runCommand("touch", ["-d", fixtureTimestamp(30), candidate], root),
+    { discard: true }
+  );
+  yield* Effect.forEach(
+    [path.join(vitestYoung, "client"), stubYoung],
+    (candidate) => runCommand("touch", ["-d", fixtureTimestamp(1), candidate], root),
+    { discard: true }
+  );
+
+  return {
+    cacheRoot,
+    stubEligible,
+    stubExistingTarget,
+    stubLive,
+    stubParentPresent,
+    stubSoleEligible,
+    stubWrongShape,
+    stubYoung,
+    soleWorktreesRoot,
+    tmpRoot,
+    vitestEligible,
+    vitestLive,
+    vitestWrongShape,
+    vitestYoung,
+  };
+});
+
 describe("tmpfs reap", () => {
   it.effect("classifies worktrees, fallow caches, and scoped temporaries with the correct idleness actions", () =>
     withTempDirectory((root) =>
@@ -170,6 +268,287 @@ describe("tmpfs reap", () => {
           expect(candidate.skipReason).toBe("live-cwd-ref");
         })
       )
+    ).pipe(provideScopedLayer(NodeServices.layer))
+  );
+
+  it.effect("classifies and applies Vitest forks scratch and dangling worktree stubs conservatively", () =>
+    withTempDirectory((root) =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const fixture = yield* makeNewClassFixtures(root);
+          yield* ChildProcess.make("sh", ["-c", "while :; do sleep 1; done"], {
+            cwd: fixture.vitestLive,
+            stdin: "ignore",
+            stderr: "pipe",
+            stdout: "pipe",
+          });
+          yield* ChildProcess.make("sh", ["-c", "while :; do sleep 1; done"], {
+            cwd: fixture.stubLive,
+            stdin: "ignore",
+            stderr: "pipe",
+            stdout: "pipe",
+          });
+
+          const report = yield* runTmpfsReap({
+            apply: true,
+            cacheRoot: fixture.cacheRoot,
+            classes: ["vitest-forks-tmp", "dangling-worktree-stub", "git-worktree"],
+            listProcessCommandLines: noProcessCommandLines,
+            nowMillis: FIXTURE_NOW_MILLIS,
+            tmpRoot: fixture.tmpRoot,
+          });
+
+          const vitestEligible = candidateByPath(report, fixture.vitestEligible);
+          expect(vitestEligible.root).toBe(fixture.tmpRoot);
+          expect(vitestEligible.reapClass).toBe("vitest-forks-tmp");
+          expect(vitestEligible.action).toBe("remove-dir");
+          expect(yield* fs.exists(fixture.vitestEligible)).toBe(false);
+
+          const vitestYoung = candidateByPath(report, fixture.vitestYoung);
+          expect(vitestYoung.action).toBe("skip");
+          expect(vitestYoung.skipReason).toBe("too-young");
+          expect(yield* fs.exists(fixture.vitestYoung)).toBe(true);
+
+          const vitestLive = candidateByPath(report, fixture.vitestLive);
+          expect(vitestLive.refCount).toBeGreaterThan(0);
+          expect(vitestLive.skipReason).toBe("live-cwd-ref");
+          expect(yield* fs.exists(fixture.vitestLive)).toBe(true);
+
+          const vitestWrongShape = candidateByPath(report, fixture.vitestWrongShape);
+          expect(vitestWrongShape.action).toBe("skip");
+          expect(vitestWrongShape.reapClass).toBe("git-worktree");
+          expect(vitestWrongShape.skipReason).toBe("dirty-worktree");
+          expect(yield* fs.exists(fixture.vitestWrongShape)).toBe(true);
+
+          const stubEligible = candidateByPath(report, fixture.stubEligible);
+          expect(stubEligible.root).toBe(fixture.tmpRoot);
+          expect(stubEligible.reapClass).toBe("dangling-worktree-stub");
+          expect(stubEligible.action).toBe("remove-dir");
+          expect(yield* fs.exists(fixture.stubEligible)).toBe(false);
+
+          const stubYoung = candidateByPath(report, fixture.stubYoung);
+          expect(stubYoung.skipReason).toBe("too-young");
+          expect(yield* fs.exists(fixture.stubYoung)).toBe(true);
+
+          const stubLive = candidateByPath(report, fixture.stubLive);
+          expect(stubLive.refCount).toBeGreaterThan(0);
+          expect(stubLive.skipReason).toBe("live-cwd-ref");
+          expect(yield* fs.exists(fixture.stubLive)).toBe(true);
+
+          const stubWrongShape = candidateByPath(report, fixture.stubWrongShape);
+          expect(stubWrongShape.skipReason).toBe("wrong-shape");
+          expect(yield* fs.exists(fixture.stubWrongShape)).toBe(true);
+
+          const stubExistingTarget = candidateByPath(report, fixture.stubExistingTarget);
+          expect(stubExistingTarget.skipReason).toBe("gitdir-target-exists");
+          expect(yield* fs.exists(fixture.stubExistingTarget)).toBe(true);
+
+          const stubParentPresent = candidateByPath(report, fixture.stubParentPresent);
+          expect(stubParentPresent.skipReason).toBe("parent-repo-present");
+          expect(yield* fs.exists(fixture.stubParentPresent)).toBe(true);
+
+          expect(candidateByPath(report, fixture.stubSoleEligible).action).toBe("remove-dir");
+          expect(yield* fs.exists(fixture.stubSoleEligible)).toBe(false);
+          expect(yield* fs.exists(fixture.soleWorktreesRoot), A.join(report.warnings, "\n")).toBe(false);
+          expect(report.reapedCount).toBe(3);
+        })
+      )
+    ).pipe(provideScopedLayer(NodeServices.layer))
+  );
+
+  it.effect("skips every Vitest forks candidate when the injected process listing sees a live runner", () =>
+    withTempDirectory((root) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const tmpRoot = path.join(root, "tmp");
+        const cacheRoot = path.join(root, "cache");
+        const candidatePath = path.join(tmpRoot, "4567890123abcdefghijk");
+        const ssr = path.join(candidatePath, "ssr");
+        yield* Effect.forEach([ssr, cacheRoot], (directory) => fs.makeDirectory(directory, { recursive: true }), {
+          discard: true,
+        });
+        yield* Effect.forEach(
+          [candidatePath, ssr],
+          (candidate) => runCommand("touch", ["-d", fixtureTimestamp(30), candidate], root),
+          { discard: true }
+        );
+
+        const report = yield* runTmpfsReap({
+          apply: true,
+          cacheRoot,
+          classes: ["vitest-forks-tmp"],
+          listProcessCommandLines: () => Effect.succeed(["bun\u0000vitest\u0000run"]),
+          nowMillis: FIXTURE_NOW_MILLIS,
+          tmpRoot,
+        });
+        const candidate = candidateByPath(report, candidatePath);
+        expect(candidate.skipReason).toBe("live-runner");
+        expect(candidate.action).toBe("skip");
+        expect(yield* fs.exists(candidatePath)).toBe(true);
+      })
+    ).pipe(provideScopedLayer(NodeServices.layer))
+  );
+
+  it.effect("rejects symlink escapes and ignores non-directory worktree-container entries", () =>
+    withTempDirectory((root) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const tmpRoot = path.join(root, "tmp");
+        const cacheRoot = path.join(root, "cache");
+        const safeWorktreesRoot = path.join(tmpRoot, "safe-worktrees");
+        const escapedRootTarget = path.join(root, "escaped-root-target");
+        const escapedChildTarget = path.join(root, "escaped-child-target");
+        const missingRepo = path.join(root, "missing-repo");
+        yield* Effect.forEach(
+          [safeWorktreesRoot, escapedRootTarget, escapedChildTarget, cacheRoot],
+          (directory) => fs.makeDirectory(directory, { recursive: true }),
+          { discard: true }
+        );
+        yield* fs.writeFileString(
+          path.join(escapedChildTarget, ".git"),
+          `gitdir: ${missingRepo}/.git/worktrees/escaped\n`
+        );
+        yield* fs.writeFileString(path.join(safeWorktreesRoot, "not-a-directory"), "fixture\n");
+        yield* fs.symlink(escapedChildTarget, path.join(safeWorktreesRoot, "escaped-child"));
+        yield* fs.symlink(escapedRootTarget, path.join(tmpRoot, "escaped-worktrees"));
+
+        const report = yield* runTmpfsReap({
+          apply: true,
+          cacheRoot,
+          classes: ["dangling-worktree-stub"],
+          listProcessCommandLines: noProcessCommandLines,
+          nowMillis: FIXTURE_NOW_MILLIS,
+          tmpRoot,
+        });
+        const escapedChild = candidateByPath(report, escapedChildTarget);
+        expect(escapedChild.skipReason).toBe("wrong-shape");
+        expect(candidateByPath(report, escapedRootTarget).skipReason).toBe("wrong-shape");
+        expect(yield* fs.exists(escapedChildTarget)).toBe(true);
+        expect(yield* fs.exists(escapedRootTarget)).toBe(true);
+        expect(report.candidates).toHaveLength(2);
+      })
+    ).pipe(provideScopedLayer(NodeServices.layer))
+  );
+
+  it.effect("walks the mandatory scratch root plus a distinct absolute TMPDIR and de-duplicates them", () =>
+    withTempDirectory((root) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const systemTmpRoot = path.join(root, "system-tmp");
+        const configuredTmpRoot = path.join(root, "configured-tmp");
+        const homeRoot = path.join(root, "home");
+        const cacheRoot = path.join(root, "cache");
+        const systemCandidate = path.join(systemTmpRoot, "beep-knowledge-refs-system");
+        const configuredCandidate = path.join(configuredTmpRoot, "beep-knowledge-refs-configured");
+        yield* Effect.forEach(
+          [systemCandidate, configuredCandidate, cacheRoot, homeRoot],
+          (directory) => fs.makeDirectory(directory, { recursive: true }),
+          { discard: true }
+        );
+        yield* Effect.forEach(
+          [systemCandidate, configuredCandidate],
+          (candidate) => runCommand("touch", ["-d", fixtureTimestamp(3), candidate], root),
+          { discard: true }
+        );
+
+        const configuredReport = yield* runTmpfsReap({
+          cacheRoot,
+          classes: ["scoped-temp"],
+          nowMillis: FIXTURE_NOW_MILLIS,
+          systemTmpRoot,
+        }).pipe(provideScopedLayer(ConfigProvider.layer(ConfigProvider.fromUnknown({ TMPDIR: configuredTmpRoot }))));
+        expect(configuredReport.tmpRoots).toEqual([systemTmpRoot, configuredTmpRoot]);
+        expect(candidateByPath(configuredReport, systemCandidate).root).toBe(systemTmpRoot);
+        expect(candidateByPath(configuredReport, configuredCandidate).root).toBe(configuredTmpRoot);
+
+        const unsetReport = yield* runTmpfsReap({
+          cacheRoot,
+          classes: ["scoped-temp"],
+          nowMillis: FIXTURE_NOW_MILLIS,
+          systemTmpRoot,
+        }).pipe(provideScopedLayer(ConfigProvider.layer(ConfigProvider.fromUnknown({}))));
+        expect(unsetReport.tmpRoots).toEqual([systemTmpRoot]);
+        expect(unsetReport.candidates).toHaveLength(1);
+
+        const duplicateReport = yield* runTmpfsReap({
+          cacheRoot,
+          classes: ["scoped-temp"],
+          nowMillis: FIXTURE_NOW_MILLIS,
+          systemTmpRoot,
+        }).pipe(provideScopedLayer(ConfigProvider.layer(ConfigProvider.fromUnknown({ TMPDIR: `${systemTmpRoot}/` }))));
+        expect(duplicateReport.tmpRoots).toEqual([systemTmpRoot]);
+
+        const homeReport = yield* runTmpfsReap({
+          cacheRoot,
+          classes: ["scoped-temp"],
+          nowMillis: FIXTURE_NOW_MILLIS,
+          systemTmpRoot,
+        }).pipe(
+          provideScopedLayer(ConfigProvider.layer(ConfigProvider.fromUnknown({ HOME: homeRoot, TMPDIR: homeRoot })))
+        );
+        expect(homeReport.tmpRoots).toEqual([systemTmpRoot]);
+        expect(A.some(homeReport.warnings, Str.includes("HOME"))).toBe(true);
+
+        const relativeReport = yield* runTmpfsReap({
+          cacheRoot,
+          classes: ["scoped-temp"],
+          nowMillis: FIXTURE_NOW_MILLIS,
+          systemTmpRoot,
+        }).pipe(provideScopedLayer(ConfigProvider.layer(ConfigProvider.fromUnknown({ TMPDIR: "relative-tmp" }))));
+        expect(relativeReport.tmpRoots).toEqual([systemTmpRoot]);
+      })
+    ).pipe(provideScopedLayer(NodeServices.layer))
+  );
+
+  it.effect("round-trips the additive tmpfs-reap/v1 root fields through the report schema", () =>
+    withTempDirectory((root) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const tmpRoot = path.join(root, "tmp");
+        const cacheRoot = path.join(root, "cache");
+        const candidatePath = path.join(tmpRoot, "beep-knowledge-refs-round-trip");
+        yield* Effect.forEach(
+          [candidatePath, cacheRoot],
+          (directory) => fs.makeDirectory(directory, { recursive: true }),
+          {
+            discard: true,
+          }
+        );
+        yield* runCommand("touch", ["-d", fixtureTimestamp(3), candidatePath], root);
+        const report = yield* runTmpfsReap({ cacheRoot, nowMillis: FIXTURE_NOW_MILLIS, tmpRoot });
+        const encoded = yield* S.encodeEffect(S.fromJsonString(TmpfsReapReport))(report);
+        const decoded = yield* S.decodeEffect(S.fromJsonString(TmpfsReapReport))(encoded);
+        expect(decoded).toEqual(report);
+        expect(decoded.schemaVersion).toBe("tmpfs-reap/v1");
+        expect(candidateByPath(decoded, candidatePath).root).toBe(tmpRoot);
+
+        const legacy = yield* S.decodeEffect(TmpfsReapReport)({
+          schemaVersion: "tmpfs-reap/v1",
+          scannedAt: "2026-08-29T12:00:00.000Z",
+          tmpRoot: "/tmp",
+          applied: false,
+          candidates: [
+            {
+              path: "/tmp/beep-knowledge-refs-legacy",
+              reapClass: "scoped-temp",
+              ageHours: 3,
+              refCount: 0,
+              action: "remove-dir",
+              bytes: 1,
+            },
+          ],
+          reapedCount: 0,
+          reclaimedBytes: 0,
+          warnings: [],
+        });
+        expect(legacy.tmpRoots).toBeUndefined();
+        expect(legacy.candidates[0]?.root).toBeUndefined();
+      })
     ).pipe(provideScopedLayer(NodeServices.layer))
   );
 

--- a/packages/tooling/tool/cli/test/worktree-command.test.ts
+++ b/packages/tooling/tool/cli/test/worktree-command.test.ts
@@ -52,11 +52,14 @@ const withScratchRepo = <A, E, R>(use: (repoRoot: string) => Effect.Effect<A, E,
     Effect.acquireUseRelease(
       Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
-        const tmpDir = yield* fs.makeTempDirectory();
-        yield* initScratchRepo(tmpDir);
-        return { fs, tmpDir } as const;
+        const path = yield* Path.Path;
+        const tmpDir = yield* fs.makeTempDirectory({ prefix: "worktree-command-test-" });
+        const repoRoot = path.join(tmpDir, "main");
+        yield* fs.makeDirectory(repoRoot);
+        yield* initScratchRepo(repoRoot);
+        return { fs, repoRoot, tmpDir } as const;
       }),
-      ({ tmpDir }) => use(tmpDir),
+      ({ repoRoot }) => use(repoRoot),
       ({ fs, tmpDir }) => fs.remove(tmpDir, { recursive: true, force: true }).pipe(Effect.ignore)
     ).pipe(provideScopedLayer(testLayer))
   );

--- a/standards/jsdoc-documentation.inventory.jsonc
+++ b/standards/jsdoc-documentation.inventory.jsonc
@@ -1,7 +1,7 @@
 {
   "standard": "jsdoc-documentation",
   "version": 1,
-  "generatedAt": "2026-08-30T00:14:38.060Z",
+  "generatedAt": "2026-08-30T11:19:29.667Z",
   "source": {
     "packageUniverseCommand": "bun run topo-sort",
     "generator": "bun run beep quality jsdoc-inventory",
@@ -65,16 +65,16 @@
     "cleanPackages": 73,
     "packagesWithoutPublicSrcSurface": 3,
     "packagesNeedingRemediation": 58,
-    "publicModules": 2935,
-    "publicExports": 20407,
+    "publicModules": 2950,
+    "publicExports": 20563,
     "openModules": 347,
-    "openExports": 98,
+    "openExports": 99,
     "missingExportExamples": 4,
     "missingExportCategories": 0,
     "missingExportSince": 0,
     "forbiddenTagFindings": 0,
     "malformedConditionalTagFindings": 0,
-    "exampleImportFindings": 0,
+    "exampleImportFindings": 1,
     "unsafeExampleFindings": 0,
     "schemaAnnotationFindings": 0,
     "undescribed-see": 12,
@@ -11561,7 +11561,7 @@
         "srcDir": "src",
         "sourceFileCount": 22,
         "publicModuleCount": 22,
-        "publicExportCount": 80
+        "publicExportCount": 81
       },
       "docgenCoverage": {
         "hasDocgenConfig": true,
@@ -11850,7 +11850,7 @@
           "schemaAnnotationGaps": [],
           "categoryViolations": [],
           "documentationShapeViolations": [],
-          "exportCount": 4,
+          "exportCount": 5,
           "remediationStatus": "resolved"
         },
         {
@@ -12584,12 +12584,34 @@
           "remediationStatus": "resolved"
         },
         {
+          "symbolName": "PracticeKgPatentDocumentInput",
+          "exportKind": "class",
+          "filePath": "src/PracticeKg.claims.ts",
+          "repoPath": "packages/law-practice/server/src/PracticeKg.claims.ts",
+          "line": 69,
+          "anchor": "packages-law-practice-server-src-practicekg-claims-ts-69-practicekgpatentdocumentinput",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
           "symbolName": "PracticeKgClaimsOptions",
           "exportKind": "class",
           "filePath": "src/PracticeKg.claims.ts",
           "repoPath": "packages/law-practice/server/src/PracticeKg.claims.ts",
-          "line": 120,
-          "anchor": "packages-law-practice-server-src-practicekg-claims-ts-120-practicekgclaimsoptions",
+          "line": 155,
+          "anchor": "packages-law-practice-server-src-practicekg-claims-ts-155-practicekgclaimsoptions",
           "currentTags": [
             "@category",
             "@since"
@@ -12610,8 +12632,8 @@
           "exportKind": "class",
           "filePath": "src/PracticeKg.claims.ts",
           "repoPath": "packages/law-practice/server/src/PracticeKg.claims.ts",
-          "line": 149,
-          "anchor": "packages-law-practice-server-src-practicekg-claims-ts-149-practicekgclaimssummary",
+          "line": 189,
+          "anchor": "packages-law-practice-server-src-practicekg-claims-ts-189-practicekgclaimssummary",
           "currentTags": [
             "@category",
             "@since"
@@ -12632,8 +12654,8 @@
           "exportKind": "class",
           "filePath": "src/PracticeKg.claims.ts",
           "repoPath": "packages/law-practice/server/src/PracticeKg.claims.ts",
-          "line": 173,
-          "anchor": "packages-law-practice-server-src-practicekg-claims-ts-173-practicekgclaimserror",
+          "line": 213,
+          "anchor": "packages-law-practice-server-src-practicekg-claims-ts-213-practicekgclaimserror",
           "currentTags": [
             "@category",
             "@since"
@@ -12654,8 +12676,8 @@
           "exportKind": "const",
           "filePath": "src/PracticeKg.claims.ts",
           "repoPath": "packages/law-practice/server/src/PracticeKg.claims.ts",
-          "line": 255,
-          "anchor": "packages-law-practice-server-src-practicekg-claims-ts-255-runpracticekgclaimsbatch",
+          "line": 295,
+          "anchor": "packages-law-practice-server-src-practicekg-claims-ts-295-runpracticekgclaimsbatch",
           "currentTags": [
             "@effects",
             "@category",
@@ -38994,9 +39016,9 @@
       "status": "needs-remediation",
       "sourceCoverage": {
         "srcDir": "src",
-        "sourceFileCount": 218,
-        "publicModuleCount": 216,
-        "publicExportCount": 1704
+        "sourceFileCount": 223,
+        "publicModuleCount": 221,
+        "publicExportCount": 1758
       },
       "docgenCoverage": {
         "hasDocgenConfig": true,
@@ -39006,14 +39028,14 @@
       },
       "counts": {
         "openModules": 46,
-        "openExports": 9,
+        "openExports": 10,
         "missingExportExamples": 0,
         "missingExportCategories": 0,
         "missingExportSince": 0,
         "missingExportSummaries": 0,
         "forbiddenTagFindings": 0,
         "malformedConditionalTagFindings": 0,
-        "exampleImportFindings": 0,
+        "exampleImportFindings": 1,
         "unsafeExampleFindings": 0,
         "schemaAnnotationFindings": 0,
         "documentationRuleFindings": {
@@ -39394,6 +39416,72 @@
         },
         {
           "docKind": "packageDocumentation",
+          "filePath": "src/commands/Cache/Cache.command.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Cache/Cache.command.ts",
+          "line": 1,
+          "anchor": "packages-tooling-tool-cli-src-commands-cache-cache-command-ts-1-module",
+          "currentTags": [
+            "@packageDocumentation",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "exportCount": 5,
+          "remediationStatus": "resolved"
+        },
+        {
+          "docKind": "packageDocumentation",
+          "filePath": "src/commands/Cache/Cache.schemas.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Cache/Cache.schemas.ts",
+          "line": 1,
+          "anchor": "packages-tooling-tool-cli-src-commands-cache-cache-schemas-ts-1-module",
+          "currentTags": [
+            "@packageDocumentation",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "exportCount": 10,
+          "remediationStatus": "resolved"
+        },
+        {
+          "docKind": "packageDocumentation",
+          "filePath": "src/commands/Cache/index.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Cache/index.ts",
+          "line": 1,
+          "anchor": "packages-tooling-tool-cli-src-commands-cache-index-ts-1-module",
+          "currentTags": [
+            "@packageDocumentation",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "exportCount": 2,
+          "remediationStatus": "resolved"
+        },
+        {
+          "docKind": "packageDocumentation",
           "filePath": "src/commands/Ci/Ci.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Ci/Ci.command.ts",
           "line": 1,
@@ -39459,7 +39547,7 @@
               "rule": "multiple-description-paragraphs"
             }
           ],
-          "exportCount": 24,
+          "exportCount": 25,
           "remediationStatus": "open"
         },
         {
@@ -39943,7 +40031,7 @@
           "schemaAnnotationGaps": [],
           "categoryViolations": [],
           "documentationShapeViolations": [],
-          "exportCount": 5,
+          "exportCount": 12,
           "remediationStatus": "resolved"
         },
         {
@@ -39987,7 +40075,7 @@
           "schemaAnnotationGaps": [],
           "categoryViolations": [],
           "documentationShapeViolations": [],
-          "exportCount": 7,
+          "exportCount": 8,
           "remediationStatus": "resolved"
         },
         {
@@ -40009,7 +40097,7 @@
           "schemaAnnotationGaps": [],
           "categoryViolations": [],
           "documentationShapeViolations": [],
-          "exportCount": 12,
+          "exportCount": 16,
           "remediationStatus": "resolved"
         },
         {
@@ -40032,7 +40120,7 @@
           "schemaAnnotationGaps": [],
           "categoryViolations": [],
           "documentationShapeViolations": [],
-          "exportCount": 5,
+          "exportCount": 7,
           "remediationStatus": "resolved"
         },
         {
@@ -40423,6 +40511,28 @@
         },
         {
           "docKind": "packageDocumentation",
+          "filePath": "src/commands/Explore/Atlas.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Explore/Atlas.ts",
+          "line": 1,
+          "anchor": "packages-tooling-tool-cli-src-commands-explore-atlas-ts-1-module",
+          "currentTags": [
+            "@packageDocumentation",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "exportCount": 16,
+          "remediationStatus": "resolved"
+        },
+        {
+          "docKind": "packageDocumentation",
           "filePath": "src/commands/Explore/Check.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Explore/Check.ts",
           "line": 1,
@@ -40484,7 +40594,7 @@
           "schemaAnnotationGaps": [],
           "categoryViolations": [],
           "documentationShapeViolations": [],
-          "exportCount": 2,
+          "exportCount": 3,
           "remediationStatus": "resolved"
         },
         {
@@ -42768,7 +42878,7 @@
           "schemaAnnotationGaps": [],
           "categoryViolations": [],
           "documentationShapeViolations": [],
-          "exportCount": 27,
+          "exportCount": 29,
           "remediationStatus": "resolved"
         },
         {
@@ -43776,6 +43886,28 @@
           "remediationStatus": "open"
         },
         {
+          "docKind": "jsdoc",
+          "filePath": "src/commands/Worktree/Worktree.constants.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Worktree/Worktree.constants.ts",
+          "line": 1,
+          "anchor": "packages-tooling-tool-cli-src-commands-worktree-worktree-constants-ts-1-module",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "exportCount": 1,
+          "remediationStatus": "resolved"
+        },
+        {
           "docKind": "packageDocumentation",
           "filePath": "src/commands/Worktree/Worktree.errors.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Worktree/Worktree.errors.ts",
@@ -43842,7 +43974,7 @@
           "schemaAnnotationGaps": [],
           "categoryViolations": [],
           "documentationShapeViolations": [],
-          "exportCount": 5,
+          "exportCount": 6,
           "remediationStatus": "resolved"
         },
         {
@@ -43982,7 +44114,7 @@
               "rule": "multiple-description-paragraphs"
             }
           ],
-          "exportCount": 27,
+          "exportCount": 28,
           "remediationStatus": "open"
         }
       ],
@@ -45624,6 +45756,381 @@
           "remediationStatus": "resolved"
         },
         {
+          "symbolName": "runCacheWarm",
+          "exportKind": "const",
+          "filePath": "src/commands/Cache/Cache.command.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Cache/Cache.command.ts",
+          "line": 223,
+          "anchor": "packages-tooling-tool-cli-src-commands-cache-cache-command-ts-223-runcachewarm",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "runCacheWarmForTesting",
+          "exportKind": "const",
+          "filePath": "src/commands/Cache/Cache.command.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Cache/Cache.command.ts",
+          "line": 249,
+          "anchor": "packages-tooling-tool-cli-src-commands-cache-cache-command-ts-249-runcachewarmfortesting",
+          "currentTags": [
+            "@internal",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "buildCacheDashboard",
+          "exportKind": "const",
+          "filePath": "src/commands/Cache/Cache.command.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Cache/Cache.command.ts",
+          "line": 383,
+          "anchor": "packages-tooling-tool-cli-src-commands-cache-cache-command-ts-383-buildcachedashboard",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "runCacheRestorationProbe",
+          "exportKind": "const",
+          "filePath": "src/commands/Cache/Cache.command.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Cache/Cache.command.ts",
+          "line": 438,
+          "anchor": "packages-tooling-tool-cli-src-commands-cache-cache-command-ts-438-runcacherestorationprobe",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "cacheCommand",
+          "exportKind": "const",
+          "filePath": "src/commands/Cache/Cache.command.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Cache/Cache.command.ts",
+          "line": 518,
+          "anchor": "packages-tooling-tool-cli-src-commands-cache-cache-command-ts-518-cachecommand",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "CacheRunMode",
+          "exportKind": "const",
+          "filePath": "src/commands/Cache/Cache.schemas.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Cache/Cache.schemas.ts",
+          "line": 29,
+          "anchor": "packages-tooling-tool-cli-src-commands-cache-cache-schemas-ts-29-cacherunmode",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "CacheRunMode",
+          "exportKind": "type",
+          "filePath": "src/commands/Cache/Cache.schemas.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Cache/Cache.schemas.ts",
+          "line": 39,
+          "anchor": "packages-tooling-tool-cli-src-commands-cache-cache-schemas-ts-39-cacherunmode",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "CacheWallTime",
+          "exportKind": "class",
+          "filePath": "src/commands/Cache/Cache.schemas.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Cache/Cache.schemas.ts",
+          "line": 56,
+          "anchor": "packages-tooling-tool-cli-src-commands-cache-cache-schemas-ts-56-cachewalltime",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "CacheLambdaSummary",
+          "exportKind": "class",
+          "filePath": "src/commands/Cache/Cache.schemas.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Cache/Cache.schemas.ts",
+          "line": 81,
+          "anchor": "packages-tooling-tool-cli-src-commands-cache-cache-schemas-ts-81-cachelambdasummary",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "CacheDashboardReport",
+          "exportKind": "class",
+          "filePath": "src/commands/Cache/Cache.schemas.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Cache/Cache.schemas.ts",
+          "line": 105,
+          "anchor": "packages-tooling-tool-cli-src-commands-cache-cache-schemas-ts-105-cachedashboardreport",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "CacheWarmLane",
+          "exportKind": "class",
+          "filePath": "src/commands/Cache/Cache.schemas.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Cache/Cache.schemas.ts",
+          "line": 138,
+          "anchor": "packages-tooling-tool-cli-src-commands-cache-cache-schemas-ts-138-cachewarmlane",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "CacheWarmReceipt",
+          "exportKind": "class",
+          "filePath": "src/commands/Cache/Cache.schemas.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Cache/Cache.schemas.ts",
+          "line": 161,
+          "anchor": "packages-tooling-tool-cli-src-commands-cache-cache-schemas-ts-161-cachewarmreceipt",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "CacheCommandError",
+          "exportKind": "class",
+          "filePath": "src/commands/Cache/Cache.schemas.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Cache/Cache.schemas.ts",
+          "line": 188,
+          "anchor": "packages-tooling-tool-cli-src-commands-cache-cache-schemas-ts-188-cachecommanderror",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "CacheDashboardReportJson",
+          "exportKind": "const",
+          "filePath": "src/commands/Cache/Cache.schemas.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Cache/Cache.schemas.ts",
+          "line": 232,
+          "anchor": "packages-tooling-tool-cli-src-commands-cache-cache-schemas-ts-232-cachedashboardreportjson",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "CacheWarmReceiptJson",
+          "exportKind": "const",
+          "filePath": "src/commands/Cache/Cache.schemas.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Cache/Cache.schemas.ts",
+          "line": 249,
+          "anchor": "packages-tooling-tool-cli-src-commands-cache-cache-schemas-ts-249-cachewarmreceiptjson",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "export { buildCacheDashboard, cacheCommand, runCacheRestorationProbe, runCacheWarm } from \"./Cache.command.ts\";",
+          "exportKind": "re-export",
+          "filePath": "src/commands/Cache/index.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Cache/index.ts",
+          "line": 13,
+          "anchor": "packages-tooling-tool-cli-src-commands-cache-index-ts-13-export-buildcachedashboard-cachecommand-runcacherestorationprobe-runcachewarm-from-cache-command-ts",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "export {\n  CacheCommandError,\n  CacheDashboardReport,\n  CacheDashboardReportJson,\n  CacheLambdaSummary,\n  CacheRunMode,\n  CacheWallTime,\n  CacheWarmLane,\n  CacheWarmReceipt,\n  CacheWarmReceiptJson,\n} from \"./Cache.schemas.ts\";",
+          "exportKind": "re-export",
+          "filePath": "src/commands/Cache/index.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Cache/index.ts",
+          "line": 20,
+          "anchor": "packages-tooling-tool-cli-src-commands-cache-index-ts-20-export-cachecommanderror-cachedashboardreport-cachedashboardreportjson-cachelambdasummary-cacherunmode-cachewalltime-cachewarmlane-cachewarmreceipt-cachewarmreceiptjson-from-cache-schemas-ts",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
           "symbolName": "appendTurboSummary",
           "exportKind": "const",
           "filePath": "src/commands/Ci/Ci.command.ts",
@@ -46031,8 +46538,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Ci/CiLane.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Ci/CiLane.ts",
-          "line": 762,
-          "anchor": "packages-tooling-tool-cli-src-commands-ci-cilane-ts-762-docteststepfortesting",
+          "line": 774,
+          "anchor": "packages-tooling-tool-cli-src-commands-ci-cilane-ts-774-docteststepfortesting",
           "currentTags": [
             "@param",
             "@returns",
@@ -46055,8 +46562,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Ci/CiLane.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Ci/CiLane.ts",
-          "line": 903,
-          "anchor": "packages-tooling-tool-cli-src-commands-ci-cilane-ts-903-cilanestepsfortesting",
+          "line": 916,
+          "anchor": "packages-tooling-tool-cli-src-commands-ci-cilane-ts-916-cilanestepsfortesting",
           "currentTags": [
             "@param",
             "@returns",
@@ -46079,12 +46586,36 @@
           "remediationStatus": "open"
         },
         {
+          "symbolName": "docgenLaneModeForChangedPaths",
+          "exportKind": "const",
+          "filePath": "src/commands/Ci/CiLane.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Ci/CiLane.ts",
+          "line": 1216,
+          "anchor": "packages-tooling-tool-cli-src-commands-ci-cilane-ts-1216-docgenlanemodeforchangedpaths",
+          "currentTags": [
+            "@param",
+            "@returns",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
           "symbolName": "runCiLane",
           "exportKind": "const",
           "filePath": "src/commands/Ci/CiLane.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Ci/CiLane.ts",
-          "line": 1448,
-          "anchor": "packages-tooling-tool-cli-src-commands-ci-cilane-ts-1448-runcilane",
+          "line": 1522,
+          "anchor": "packages-tooling-tool-cli-src-commands-ci-cilane-ts-1522-runcilane",
           "currentTags": [
             "@param",
             "@returns",
@@ -46107,8 +46638,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Ci/CiLane.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Ci/CiLane.ts",
-          "line": 1499,
-          "anchor": "packages-tooling-tool-cli-src-commands-ci-cilane-ts-1499-cilanecommand",
+          "line": 1573,
+          "anchor": "packages-tooling-tool-cli-src-commands-ci-cilane-ts-1573-cilanecommand",
           "currentTags": [
             "@category",
             "@since"
@@ -46129,8 +46660,8 @@
           "exportKind": "class",
           "filePath": "src/commands/Ci/CiLane.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Ci/CiLane.ts",
-          "line": 1693,
-          "anchor": "packages-tooling-tool-cli-src-commands-ci-cilane-ts-1693-cilocalstepplan",
+          "line": 1767,
+          "anchor": "packages-tooling-tool-cli-src-commands-ci-cilane-ts-1767-cilocalstepplan",
           "currentTags": [
             "@category",
             "@since"
@@ -46151,8 +46682,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Ci/CiLane.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Ci/CiLane.ts",
-          "line": 1767,
-          "anchor": "packages-tooling-tool-cli-src-commands-ci-cilane-ts-1767-cilanedispatchstep",
+          "line": 1841,
+          "anchor": "packages-tooling-tool-cli-src-commands-ci-cilane-ts-1841-cilanedispatchstep",
           "currentTags": [
             "@param",
             "@returns",
@@ -46175,8 +46706,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Ci/CiLane.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Ci/CiLane.ts",
-          "line": 1805,
-          "anchor": "packages-tooling-tool-cli-src-commands-ci-cilane-ts-1805-cilocalstepsfortesting",
+          "line": 1879,
+          "anchor": "packages-tooling-tool-cli-src-commands-ci-cilane-ts-1879-cilocalstepsfortesting",
           "currentTags": [
             "@param",
             "@returns",
@@ -46199,8 +46730,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Ci/CiLane.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Ci/CiLane.ts",
-          "line": 1838,
-          "anchor": "packages-tooling-tool-cli-src-commands-ci-cilane-ts-1838-runcilocal",
+          "line": 1912,
+          "anchor": "packages-tooling-tool-cli-src-commands-ci-cilane-ts-1912-runcilocal",
           "currentTags": [
             "@param",
             "@returns",
@@ -46223,8 +46754,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Ci/CiLane.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Ci/CiLane.ts",
-          "line": 1874,
-          "anchor": "packages-tooling-tool-cli-src-commands-ci-cilane-ts-1874-cilocalcommand",
+          "line": 1948,
+          "anchor": "packages-tooling-tool-cli-src-commands-ci-cilane-ts-1948-cilocalcommand",
           "currentTags": [
             "@category",
             "@since"
@@ -49296,8 +49827,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Corpus/Corpus.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/Corpus.command.ts",
-          "line": 332,
-          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-command-ts-332-corpuscommand",
+          "line": 411,
+          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-command-ts-411-corpuscommand",
           "currentTags": [
             "@category",
             "@since"
@@ -49336,12 +49867,166 @@
           "remediationStatus": "resolved"
         },
         {
+          "symbolName": "PreservationPreflightMissingError",
+          "exportKind": "class",
+          "filePath": "src/commands/Corpus/Corpus.errors.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/Corpus.errors.ts",
+          "line": 69,
+          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-errors-ts-69-preservationpreflightmissingerror",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "PreservationPreflightUnapprovedError",
+          "exportKind": "class",
+          "filePath": "src/commands/Corpus/Corpus.errors.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/Corpus.errors.ts",
+          "line": 94,
+          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-errors-ts-94-preservationpreflightunapprovederror",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "PreservationCeilingExceededError",
+          "exportKind": "class",
+          "filePath": "src/commands/Corpus/Corpus.errors.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/Corpus.errors.ts",
+          "line": 124,
+          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-errors-ts-124-preservationceilingexceedederror",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "PreservationArchiveIoError",
+          "exportKind": "class",
+          "filePath": "src/commands/Corpus/Corpus.errors.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/Corpus.errors.ts",
+          "line": 153,
+          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-errors-ts-153-preservationarchiveioerror",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "PreservationVerificationFailure",
+          "exportKind": "class",
+          "filePath": "src/commands/Corpus/Corpus.errors.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/Corpus.errors.ts",
+          "line": 187,
+          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-errors-ts-187-preservationverificationfailure",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "PreservationUnapprovedRowsError",
+          "exportKind": "class",
+          "filePath": "src/commands/Corpus/Corpus.errors.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/Corpus.errors.ts",
+          "line": 219,
+          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-errors-ts-219-preservationunapprovedrowserror",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "PreservationCommandError",
+          "exportKind": "type",
+          "filePath": "src/commands/Corpus/Corpus.errors.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/Corpus.errors.ts",
+          "line": 238,
+          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-errors-ts-238-preservationcommanderror",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
           "symbolName": "CorpusArchiveMoveUncoveredFileError",
           "exportKind": "class",
           "filePath": "src/commands/Corpus/Corpus.errors.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/Corpus.errors.ts",
-          "line": 73,
-          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-errors-ts-73-corpusarchivemoveuncoveredfileerror",
+          "line": 265,
+          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-errors-ts-265-corpusarchivemoveuncoveredfileerror",
           "currentTags": [
             "@category",
             "@since"
@@ -49362,8 +50047,8 @@
           "exportKind": "class",
           "filePath": "src/commands/Corpus/Corpus.errors.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/Corpus.errors.ts",
-          "line": 110,
-          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-errors-ts-110-corpusarchivemovedigestmismatcherror",
+          "line": 302,
+          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-errors-ts-302-corpusarchivemovedigestmismatcherror",
           "currentTags": [
             "@category",
             "@since"
@@ -49384,8 +50069,8 @@
           "exportKind": "class",
           "filePath": "src/commands/Corpus/Corpus.errors.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/Corpus.errors.ts",
-          "line": 146,
-          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-errors-ts-146-corpusarchivemovedestinationconflicterror",
+          "line": 338,
+          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-errors-ts-338-corpusarchivemovedestinationconflicterror",
           "currentTags": [
             "@category",
             "@since"
@@ -49406,8 +50091,8 @@
           "exportKind": "type",
           "filePath": "src/commands/Corpus/Corpus.errors.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/Corpus.errors.ts",
-          "line": 181,
-          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-errors-ts-181-corpusarchivemoveerror",
+          "line": 373,
+          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-errors-ts-373-corpusarchivemoveerror",
           "currentTags": [
             "@category",
             "@since"
@@ -49605,12 +50290,34 @@
           "remediationStatus": "resolved"
         },
         {
-          "symbolName": "export * from \"./internal/RecycleBin.schemas.ts\";",
+          "symbolName": "export * from \"./internal/Preservation.schemas.ts\";",
           "exportKind": "re-export",
           "filePath": "src/commands/Corpus/Corpus.schemas.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/Corpus.schemas.ts",
           "line": 49,
-          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-schemas-ts-49-export-from-internal-recyclebin-schemas-ts",
+          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-schemas-ts-49-export-from-internal-preservation-schemas-ts",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "export * from \"./internal/RecycleBin.schemas.ts\";",
+          "exportKind": "re-export",
+          "filePath": "src/commands/Corpus/Corpus.schemas.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/Corpus.schemas.ts",
+          "line": 56,
+          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-schemas-ts-56-export-from-internal-recyclebin-schemas-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -49631,8 +50338,8 @@
           "exportKind": "re-export",
           "filePath": "src/commands/Corpus/Corpus.schemas.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/Corpus.schemas.ts",
-          "line": 56,
-          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-schemas-ts-56-export-from-internal-salvage-schemas-ts",
+          "line": 63,
+          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-schemas-ts-63-export-from-internal-salvage-schemas-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -49653,8 +50360,8 @@
           "exportKind": "re-export",
           "filePath": "src/commands/Corpus/Corpus.service.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/Corpus.service.ts",
-          "line": 52,
-          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-service-ts-52-export-extractcorpusdocket-from-internal-docket-ts",
+          "line": 62,
+          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-service-ts-62-export-extractcorpusdocket-from-internal-docket-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -49675,8 +50382,8 @@
           "exportKind": "interface",
           "filePath": "src/commands/Corpus/Corpus.service.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/Corpus.service.ts",
-          "line": 77,
-          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-service-ts-77-corpuscommandserviceshape",
+          "line": 87,
+          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-service-ts-87-corpuscommandserviceshape",
           "currentTags": [
             "@category",
             "@since"
@@ -49697,8 +50404,8 @@
           "exportKind": "class",
           "filePath": "src/commands/Corpus/Corpus.service.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/Corpus.service.ts",
-          "line": 150,
-          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-service-ts-150-corpuscommandservice",
+          "line": 181,
+          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-service-ts-181-corpuscommandservice",
           "currentTags": [
             "@category",
             "@since"
@@ -49719,8 +50426,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Corpus/Corpus.service.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/Corpus.service.ts",
-          "line": 197,
-          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-service-ts-197-corpuscommandservicelive",
+          "line": 241,
+          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-service-ts-241-corpuscommandservicelive",
           "currentTags": [
             "@category",
             "@since"
@@ -49741,8 +50448,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Corpus/Corpus.service.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/Corpus.service.ts",
-          "line": 224,
-          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-service-ts-224-archivemovecorpus",
+          "line": 268,
+          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-service-ts-268-archivemovecorpus",
           "currentTags": [
             "@param",
             "@returns",
@@ -49766,8 +50473,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Corpus/Corpus.service.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/Corpus.service.ts",
-          "line": 251,
-          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-service-ts-251-catalogcorpus",
+          "line": 295,
+          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-service-ts-295-catalogcorpus",
           "currentTags": [
             "@param",
             "@returns",
@@ -49791,8 +50498,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Corpus/Corpus.service.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/Corpus.service.ts",
-          "line": 284,
-          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-service-ts-284-extractcorpus",
+          "line": 328,
+          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-service-ts-328-extractcorpus",
           "currentTags": [
             "@param",
             "@returns",
@@ -49816,8 +50523,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Corpus/Corpus.service.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/Corpus.service.ts",
-          "line": 311,
-          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-service-ts-311-enrichcorpus",
+          "line": 355,
+          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-service-ts-355-enrichcorpus",
           "currentTags": [
             "@param",
             "@returns",
@@ -49841,8 +50548,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Corpus/Corpus.service.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/Corpus.service.ts",
-          "line": 338,
-          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-service-ts-338-organizecorpus",
+          "line": 382,
+          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-service-ts-382-organizecorpus",
           "currentTags": [
             "@param",
             "@returns",
@@ -49866,8 +50573,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Corpus/Corpus.service.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/Corpus.service.ts",
-          "line": 368,
-          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-service-ts-368-salvagecorpus",
+          "line": 412,
+          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-service-ts-412-salvagecorpus",
           "currentTags": [
             "@param",
             "@returns",
@@ -49891,8 +50598,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Corpus/Corpus.service.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/Corpus.service.ts",
-          "line": 395,
-          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-service-ts-395-verifysalvage",
+          "line": 439,
+          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-service-ts-439-verifysalvage",
           "currentTags": [
             "@param",
             "@returns",
@@ -49912,12 +50619,100 @@
           "remediationStatus": "resolved"
         },
         {
+          "symbolName": "preflightT7Preservation",
+          "exportKind": "const",
+          "filePath": "src/commands/Corpus/Corpus.service.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/Corpus.service.ts",
+          "line": 461,
+          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-service-ts-461-preflightt7preservation",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "approveT7Preservation",
+          "exportKind": "const",
+          "filePath": "src/commands/Corpus/Corpus.service.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/Corpus.service.ts",
+          "line": 482,
+          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-service-ts-482-approvet7preservation",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "runT7Preservation",
+          "exportKind": "const",
+          "filePath": "src/commands/Corpus/Corpus.service.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/Corpus.service.ts",
+          "line": 505,
+          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-service-ts-505-runt7preservation",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "verifyT7Preservation",
+          "exportKind": "const",
+          "filePath": "src/commands/Corpus/Corpus.service.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/Corpus.service.ts",
+          "line": 526,
+          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-service-ts-526-verifyt7preservation",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
           "symbolName": "printCorpusIndex",
           "exportKind": "const",
           "filePath": "src/commands/Corpus/Corpus.service.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/Corpus.service.ts",
-          "line": 417,
-          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-service-ts-417-printcorpusindex",
+          "line": 547,
+          "anchor": "packages-tooling-tool-cli-src-commands-corpus-corpus-service-ts-547-printcorpusindex",
           "currentTags": [
             "@effects",
             "@category",
@@ -50029,6 +50824,50 @@
           "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/index.ts",
           "line": 43,
           "anchor": "packages-tooling-tool-cli-src-commands-corpus-index-ts-43-export-from-corpus-service-ts",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "export * from \"./internal/Preservation.contracts.ts\";",
+          "exportKind": "re-export",
+          "filePath": "src/commands/Corpus/index.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/index.ts",
+          "line": 50,
+          "anchor": "packages-tooling-tool-cli-src-commands-corpus-index-ts-50-export-from-internal-preservation-contracts-ts",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "export {\n  ArchiveWriterLive,\n  CapacityPreflightServiceLive,\n  makeArchiveWriterLive,\n  PreservationManifestStoreLive,\n  PreservationVerifierLive,\n  StreamingHasherLive,\n} from \"./internal/Preservation.ts\";",
+          "exportKind": "re-export",
+          "filePath": "src/commands/Corpus/index.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Corpus/index.ts",
+          "line": 57,
+          "anchor": "packages-tooling-tool-cli-src-commands-corpus-index-ts-57-export-archivewriterlive-capacitypreflightservicelive-makearchivewriterlive-preservationmanifeststorelive-preservationverifierlive-streaminghasherlive-from-internal-preservation-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -51953,6 +52792,371 @@
           "remediationStatus": "resolved"
         },
         {
+          "symbolName": "EXPLORATION_ATLAS_PATH",
+          "exportKind": "const",
+          "filePath": "src/commands/Explore/Atlas.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Explore/Atlas.ts",
+          "line": 50,
+          "anchor": "packages-tooling-tool-cli-src-commands-explore-atlas-ts-50-exploration-atlas-path",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "ExplorationStatus",
+          "exportKind": "const",
+          "filePath": "src/commands/Explore/Atlas.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Explore/Atlas.ts",
+          "line": 66,
+          "anchor": "packages-tooling-tool-cli-src-commands-explore-atlas-ts-66-explorationstatus",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "ExplorationStatus",
+          "exportKind": "type",
+          "filePath": "src/commands/Explore/Atlas.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Explore/Atlas.ts",
+          "line": 77,
+          "anchor": "packages-tooling-tool-cli-src-commands-explore-atlas-ts-77-explorationstatus",
+          "currentTags": [
+            "@see",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "ExplorationStage",
+          "exportKind": "const",
+          "filePath": "src/commands/Explore/Atlas.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Explore/Atlas.ts",
+          "line": 93,
+          "anchor": "packages-tooling-tool-cli-src-commands-explore-atlas-ts-93-explorationstage",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "ExplorationStage",
+          "exportKind": "type",
+          "filePath": "src/commands/Explore/Atlas.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Explore/Atlas.ts",
+          "line": 104,
+          "anchor": "packages-tooling-tool-cli-src-commands-explore-atlas-ts-104-explorationstage",
+          "currentTags": [
+            "@see",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "ExplorationProjectionAuthority",
+          "exportKind": "const",
+          "filePath": "src/commands/Explore/Atlas.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Explore/Atlas.ts",
+          "line": 127,
+          "anchor": "packages-tooling-tool-cli-src-commands-explore-atlas-ts-127-explorationprojectionauthority",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "ExplorationProjectionAuthority",
+          "exportKind": "type",
+          "filePath": "src/commands/Explore/Atlas.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Explore/Atlas.ts",
+          "line": 140,
+          "anchor": "packages-tooling-tool-cli-src-commands-explore-atlas-ts-140-explorationprojectionauthority",
+          "currentTags": [
+            "@see",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "ExplorationProjectionState",
+          "exportKind": "class",
+          "filePath": "src/commands/Explore/Atlas.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Explore/Atlas.ts",
+          "line": 185,
+          "anchor": "packages-tooling-tool-cli-src-commands-explore-atlas-ts-185-explorationprojectionstate",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "ExplorationAtlasRow",
+          "exportKind": "class",
+          "filePath": "src/commands/Explore/Atlas.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Explore/Atlas.ts",
+          "line": 221,
+          "anchor": "packages-tooling-tool-cli-src-commands-explore-atlas-ts-221-explorationatlasrow",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "ExplorationProjection",
+          "exportKind": "class",
+          "filePath": "src/commands/Explore/Atlas.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Explore/Atlas.ts",
+          "line": 271,
+          "anchor": "packages-tooling-tool-cli-src-commands-explore-atlas-ts-271-explorationprojection",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "renderExplorationAtlas",
+          "exportKind": "const",
+          "filePath": "src/commands/Explore/Atlas.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Explore/Atlas.ts",
+          "line": 388,
+          "anchor": "packages-tooling-tool-cli-src-commands-explore-atlas-ts-388-renderexplorationatlas",
+          "currentTags": [
+            "@param",
+            "@returns",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "buildExplorationProjection",
+          "exportKind": "const",
+          "filePath": "src/commands/Explore/Atlas.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Explore/Atlas.ts",
+          "line": 515,
+          "anchor": "packages-tooling-tool-cli-src-commands-explore-atlas-ts-515-buildexplorationprojection",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "buildExplorationAtlasContent",
+          "exportKind": "const",
+          "filePath": "src/commands/Explore/Atlas.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Explore/Atlas.ts",
+          "line": 627,
+          "anchor": "packages-tooling-tool-cli-src-commands-explore-atlas-ts-627-buildexplorationatlascontent",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "explorationProjectionDriftPaths",
+          "exportKind": "const",
+          "filePath": "src/commands/Explore/Atlas.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Explore/Atlas.ts",
+          "line": 659,
+          "anchor": "packages-tooling-tool-cli-src-commands-explore-atlas-ts-659-explorationprojectiondriftpaths",
+          "currentTags": [
+            "@param",
+            "@returns",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [
+            {
+              "example": 1,
+              "rule": "wrong-required-namespace-alias",
+              "detail": "Examples importing effect/Option must use the O namespace alias."
+            }
+          ],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "open"
+        },
+        {
+          "symbolName": "writeExplorationAtlas",
+          "exportKind": "const",
+          "filePath": "src/commands/Explore/Atlas.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Explore/Atlas.ts",
+          "line": 704,
+          "anchor": "packages-tooling-tool-cli-src-commands-explore-atlas-ts-704-writeexplorationatlas",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "exploreAtlasCommand",
+          "exportKind": "const",
+          "filePath": "src/commands/Explore/Atlas.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Explore/Atlas.ts",
+          "line": 737,
+          "anchor": "packages-tooling-tool-cli-src-commands-explore-atlas-ts-737-exploreatlascommand",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
           "symbolName": "packetForkFindingKey",
           "exportKind": "const",
           "filePath": "src/commands/Explore/Check.ts",
@@ -52003,8 +53207,30 @@
           "exportKind": "const",
           "filePath": "src/commands/Explore/Explore.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Explore/Explore.command.ts",
-          "line": 39,
-          "anchor": "packages-tooling-tool-cli-src-commands-explore-explore-command-ts-39-explorecommand",
+          "line": 40,
+          "anchor": "packages-tooling-tool-cli-src-commands-explore-explore-command-ts-40-explorecommand",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "export * from \"./Atlas.ts\";",
+          "exportKind": "re-export",
+          "filePath": "src/commands/Explore/index.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Explore/index.ts",
+          "line": 14,
+          "anchor": "packages-tooling-tool-cli-src-commands-explore-index-ts-14-export-from-atlas-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -52025,8 +53251,8 @@
           "exportKind": "re-export",
           "filePath": "src/commands/Explore/index.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Explore/index.ts",
-          "line": 14,
-          "anchor": "packages-tooling-tool-cli-src-commands-explore-index-ts-14-export-from-check-ts",
+          "line": 21,
+          "anchor": "packages-tooling-tool-cli-src-commands-explore-index-ts-21-export-from-check-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -52047,8 +53273,8 @@
           "exportKind": "re-export",
           "filePath": "src/commands/Explore/index.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Explore/index.ts",
-          "line": 21,
-          "anchor": "packages-tooling-tool-cli-src-commands-explore-index-ts-21-export-from-explore-command-ts",
+          "line": 28,
+          "anchor": "packages-tooling-tool-cli-src-commands-explore-index-ts-28-export-from-explore-command-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -59711,8 +60937,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Goals/PortfolioIndex.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Goals/PortfolioIndex.ts",
-          "line": 193,
-          "anchor": "packages-tooling-tool-cli-src-commands-goals-portfolioindex-ts-193-buildportfolioindexcontent",
+          "line": 192,
+          "anchor": "packages-tooling-tool-cli-src-commands-goals-portfolioindex-ts-192-buildportfolioindexcontent",
           "currentTags": [
             "@category",
             "@since"
@@ -59733,8 +60959,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Goals/PortfolioIndex.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Goals/PortfolioIndex.ts",
-          "line": 247,
-          "anchor": "packages-tooling-tool-cli-src-commands-goals-portfolioindex-ts-247-writeportfolioindex",
+          "line": 246,
+          "anchor": "packages-tooling-tool-cli-src-commands-goals-portfolioindex-ts-246-writeportfolioindex",
           "currentTags": [
             "@effects",
             "@category",
@@ -59756,8 +60982,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Goals/PortfolioIndex.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Goals/PortfolioIndex.ts",
-          "line": 316,
-          "anchor": "packages-tooling-tool-cli-src-commands-goals-portfolioindex-ts-316-goalsindexcommand",
+          "line": 321,
+          "anchor": "packages-tooling-tool-cli-src-commands-goals-portfolioindex-ts-321-goalsindexcommand",
           "currentTags": [
             "@category",
             "@since"
@@ -63231,8 +64457,8 @@
           "exportKind": "re-export",
           "filePath": "src/commands/Knowledge/Knowledge.service.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.service.ts",
-          "line": 87,
-          "anchor": "packages-tooling-tool-cli-src-commands-knowledge-knowledge-service-ts-87-export-type-knowledgetreeoracle-from-knowledge-refs-ts",
+          "line": 89,
+          "anchor": "packages-tooling-tool-cli-src-commands-knowledge-knowledge-service-ts-89-export-type-knowledgetreeoracle-from-knowledge-refs-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -63253,8 +64479,8 @@
           "exportKind": "interface",
           "filePath": "src/commands/Knowledge/Knowledge.service.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.service.ts",
-          "line": 174,
-          "anchor": "packages-tooling-tool-cli-src-commands-knowledge-knowledge-service-ts-174-knowledgearchiveoracle",
+          "line": 177,
+          "anchor": "packages-tooling-tool-cli-src-commands-knowledge-knowledge-service-ts-177-knowledgearchiveoracle",
           "currentTags": [
             "@see",
             "@category",
@@ -63276,8 +64502,8 @@
           "exportKind": "interface",
           "filePath": "src/commands/Knowledge/Knowledge.service.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.service.ts",
-          "line": 207,
-          "anchor": "packages-tooling-tool-cli-src-commands-knowledge-knowledge-service-ts-207-knowledgepairedoracleinput",
+          "line": 210,
+          "anchor": "packages-tooling-tool-cli-src-commands-knowledge-knowledge-service-ts-210-knowledgepairedoracleinput",
           "currentTags": [
             "@see",
             "@category",
@@ -63299,8 +64525,8 @@
           "exportKind": "interface",
           "filePath": "src/commands/Knowledge/Knowledge.service.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.service.ts",
-          "line": 230,
-          "anchor": "packages-tooling-tool-cli-src-commands-knowledge-knowledge-service-ts-230-knowledgeserviceshape",
+          "line": 233,
+          "anchor": "packages-tooling-tool-cli-src-commands-knowledge-knowledge-service-ts-233-knowledgeserviceshape",
           "currentTags": [
             "@see",
             "@category",
@@ -63322,8 +64548,8 @@
           "exportKind": "class",
           "filePath": "src/commands/Knowledge/Knowledge.service.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.service.ts",
-          "line": 264,
-          "anchor": "packages-tooling-tool-cli-src-commands-knowledge-knowledge-service-ts-264-knowledgeservice",
+          "line": 267,
+          "anchor": "packages-tooling-tool-cli-src-commands-knowledge-knowledge-service-ts-267-knowledgeservice",
           "currentTags": [
             "@see",
             "@category",
@@ -63345,8 +64571,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Knowledge/Knowledge.service.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.service.ts",
-          "line": 302,
-          "anchor": "packages-tooling-tool-cli-src-commands-knowledge-knowledge-service-ts-302-makeknowledgefindingid",
+          "line": 305,
+          "anchor": "packages-tooling-tool-cli-src-commands-knowledge-knowledge-service-ts-305-makeknowledgefindingid",
           "currentTags": [
             "@param",
             "@category",
@@ -63368,8 +64594,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Knowledge/Knowledge.service.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.service.ts",
-          "line": 827,
-          "anchor": "packages-tooling-tool-cli-src-commands-knowledge-knowledge-service-ts-827-scanknowledgepair",
+          "line": 836,
+          "anchor": "packages-tooling-tool-cli-src-commands-knowledge-knowledge-service-ts-836-scanknowledgepair",
           "currentTags": [
             "@see",
             "@category",
@@ -63391,8 +64617,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Knowledge/Knowledge.service.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.service.ts",
-          "line": 924,
-          "anchor": "packages-tooling-tool-cli-src-commands-knowledge-knowledge-service-ts-924-guardknowledgecloneattributes",
+          "line": 933,
+          "anchor": "packages-tooling-tool-cli-src-commands-knowledge-knowledge-service-ts-933-guardknowledgecloneattributes",
           "currentTags": [
             "@param",
             "@returns",
@@ -63415,8 +64641,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Knowledge/Knowledge.service.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.service.ts",
-          "line": 1185,
-          "anchor": "packages-tooling-tool-cli-src-commands-knowledge-knowledge-service-ts-1185-makeknowledgearchiveoracle",
+          "line": 1194,
+          "anchor": "packages-tooling-tool-cli-src-commands-knowledge-knowledge-service-ts-1194-makeknowledgearchiveoracle",
           "currentTags": [
             "@internal",
             "@param",
@@ -63440,8 +64666,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Knowledge/Knowledge.service.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.service.ts",
-          "line": 1410,
-          "anchor": "packages-tooling-tool-cli-src-commands-knowledge-knowledge-service-ts-1410-resolveknowledgeprobepolicy",
+          "line": 1421,
+          "anchor": "packages-tooling-tool-cli-src-commands-knowledge-knowledge-service-ts-1421-resolveknowledgeprobepolicy",
           "currentTags": [
             "@param",
             "@returns",
@@ -63465,8 +64691,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Knowledge/Knowledge.service.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.service.ts",
-          "line": 1533,
-          "anchor": "packages-tooling-tool-cli-src-commands-knowledge-knowledge-service-ts-1533-makeknowledgetreeoracle",
+          "line": 1544,
+          "anchor": "packages-tooling-tool-cli-src-commands-knowledge-knowledge-service-ts-1544-makeknowledgetreeoracle",
           "currentTags": [
             "@param",
             "@returns",
@@ -63489,8 +64715,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Knowledge/Knowledge.service.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.service.ts",
-          "line": 1618,
-          "anchor": "packages-tooling-tool-cli-src-commands-knowledge-knowledge-service-ts-1618-knowledgeservicelive",
+          "line": 1629,
+          "anchor": "packages-tooling-tool-cli-src-commands-knowledge-knowledge-service-ts-1629-knowledgeservicelive",
           "currentTags": [
             "@see",
             "@category",
@@ -65412,8 +66638,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Lint/PackageTestImports.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Lint/PackageTestImports.ts",
-          "line": 344,
-          "anchor": "packages-tooling-tool-cli-src-commands-lint-packagetestimports-ts-344-lintpackagetestimportscommand",
+          "line": 357,
+          "anchor": "packages-tooling-tool-cli-src-commands-lint-packagetestimports-ts-357-lintpackagetestimportscommand",
           "currentTags": [
             "@category",
             "@since"
@@ -65772,8 +66998,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Lint/RoadmapRefs.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Lint/RoadmapRefs.ts",
-          "line": 295,
-          "anchor": "packages-tooling-tool-cli-src-commands-lint-roadmaprefs-ts-295-runroadmaprefslint",
+          "line": 298,
+          "anchor": "packages-tooling-tool-cli-src-commands-lint-roadmaprefs-ts-298-runroadmaprefslint",
           "currentTags": [
             "@category",
             "@since"
@@ -65794,8 +67020,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Lint/RoadmapRefs.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Lint/RoadmapRefs.ts",
-          "line": 357,
-          "anchor": "packages-tooling-tool-cli-src-commands-lint-roadmaprefs-ts-357-lintroadmaprefscommand",
+          "line": 362,
+          "anchor": "packages-tooling-tool-cli-src-commands-lint-roadmaprefs-ts-362-lintroadmaprefscommand",
           "currentTags": [
             "@category",
             "@since"
@@ -71506,8 +72732,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Quality/Quality.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts",
-          "line": 659,
-          "anchor": "packages-tooling-tool-cli-src-commands-quality-quality-command-ts-659-runbunaudit",
+          "line": 663,
+          "anchor": "packages-tooling-tool-cli-src-commands-quality-quality-command-ts-663-runbunaudit",
           "currentTags": [
             "@param",
             "@returns",
@@ -71534,8 +72760,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Quality/Quality.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts",
-          "line": 785,
-          "anchor": "packages-tooling-tool-cli-src-commands-quality-quality-command-ts-785-devqualitystepsfortesting",
+          "line": 789,
+          "anchor": "packages-tooling-tool-cli-src-commands-quality-quality-command-ts-789-devqualitystepsfortesting",
           "currentTags": [
             "@param",
             "@returns",
@@ -71558,8 +72784,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Quality/Quality.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts",
-          "line": 853,
-          "anchor": "packages-tooling-tool-cli-src-commands-quality-quality-command-ts-853-reviewfixdocgenlocalargsfortesting",
+          "line": 857,
+          "anchor": "packages-tooling-tool-cli-src-commands-quality-quality-command-ts-857-reviewfixdocgenlocalargsfortesting",
           "currentTags": [
             "@param",
             "@returns",
@@ -71582,8 +72808,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Quality/Quality.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts",
-          "line": 1078,
-          "anchor": "packages-tooling-tool-cli-src-commands-quality-quality-command-ts-1078-rungithubchecks",
+          "line": 1082,
+          "anchor": "packages-tooling-tool-cli-src-commands-quality-quality-command-ts-1082-rungithubchecks",
           "currentTags": [
             "@param",
             "@returns",
@@ -71606,8 +72832,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Quality/Quality.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts",
-          "line": 1390,
-          "anchor": "packages-tooling-tool-cli-src-commands-quality-quality-command-ts-1390-collecteffecttsgodiagnosticlines",
+          "line": 1394,
+          "anchor": "packages-tooling-tool-cli-src-commands-quality-quality-command-ts-1394-collecteffecttsgodiagnosticlines",
           "currentTags": [
             "@param",
             "@returns",
@@ -71630,8 +72856,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Quality/Quality.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts",
-          "line": 1617,
-          "anchor": "packages-tooling-tool-cli-src-commands-quality-quality-command-ts-1617-collecttsgopluginprofilediagnosticsfortesting",
+          "line": 1621,
+          "anchor": "packages-tooling-tool-cli-src-commands-quality-quality-command-ts-1621-collecttsgopluginprofilediagnosticsfortesting",
           "currentTags": [
             "@category",
             "@since"
@@ -71652,8 +72878,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Quality/Quality.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts",
-          "line": 1745,
-          "anchor": "packages-tooling-tool-cli-src-commands-quality-quality-command-ts-1745-runtsgorulescheck",
+          "line": 1749,
+          "anchor": "packages-tooling-tool-cli-src-commands-quality-quality-command-ts-1749-runtsgorulescheck",
           "currentTags": [
             "@returns",
             "@category",
@@ -71675,8 +72901,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Quality/Quality.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts",
-          "line": 1896,
-          "anchor": "packages-tooling-tool-cli-src-commands-quality-quality-command-ts-1896-runtesttsgochecks",
+          "line": 1900,
+          "anchor": "packages-tooling-tool-cli-src-commands-quality-quality-command-ts-1900-runtesttsgochecks",
           "currentTags": [
             "@param",
             "@returns",
@@ -71699,8 +72925,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Quality/Quality.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts",
-          "line": 1994,
-          "anchor": "packages-tooling-tool-cli-src-commands-quality-quality-command-ts-1994-runtsgosmokecheck",
+          "line": 1998,
+          "anchor": "packages-tooling-tool-cli-src-commands-quality-quality-command-ts-1998-runtsgosmokecheck",
           "currentTags": [
             "@returns",
             "@category",
@@ -71722,8 +72948,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Quality/Quality.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts",
-          "line": 2104,
-          "anchor": "packages-tooling-tool-cli-src-commands-quality-quality-command-ts-2104-ismoduletagscannedpathfortesting",
+          "line": 2108,
+          "anchor": "packages-tooling-tool-cli-src-commands-quality-quality-command-ts-2108-ismoduletagscannedpathfortesting",
           "currentTags": [
             "@param",
             "@returns",
@@ -71746,8 +72972,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Quality/Quality.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts",
-          "line": 2125,
-          "anchor": "packages-tooling-tool-cli-src-commands-quality-quality-command-ts-2125-runjsdocmoduletagscheck",
+          "line": 2129,
+          "anchor": "packages-tooling-tool-cli-src-commands-quality-quality-command-ts-2129-runjsdocmoduletagscheck",
           "currentTags": [
             "@returns",
             "@category",
@@ -71769,8 +72995,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Quality/Quality.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts",
-          "line": 2202,
-          "anchor": "packages-tooling-tool-cli-src-commands-quality-quality-command-ts-2202-runjsdocinventory",
+          "line": 2206,
+          "anchor": "packages-tooling-tool-cli-src-commands-quality-quality-command-ts-2206-runjsdocinventory",
           "currentTags": [
             "@returns",
             "@category",
@@ -71792,9 +73018,57 @@
           "exportKind": "const",
           "filePath": "src/commands/Quality/Quality.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts",
-          "line": 2255,
-          "anchor": "packages-tooling-tool-cli-src-commands-quality-quality-command-ts-2255-runjsdocquality",
+          "line": 2259,
+          "anchor": "packages-tooling-tool-cli-src-commands-quality-quality-command-ts-2259-runjsdocquality",
           "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "renderAdmissionSnapshotLinesForTesting",
+          "exportKind": "const",
+          "filePath": "src/commands/Quality/Quality.command.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts",
+          "line": 2745,
+          "anchor": "packages-tooling-tool-cli-src-commands-quality-quality-command-ts-2745-renderadmissionsnapshotlinesfortesting",
+          "currentTags": [
+            "@param",
+            "@returns",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "renderTmpfsReportLinesForTesting",
+          "exportKind": "const",
+          "filePath": "src/commands/Quality/Quality.command.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts",
+          "line": 2851,
+          "anchor": "packages-tooling-tool-cli-src-commands-quality-quality-command-ts-2851-rendertmpfsreportlinesfortesting",
+          "currentTags": [
+            "@param",
+            "@returns",
             "@category",
             "@since"
           ],
@@ -71814,8 +73088,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Quality/Quality.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts",
-          "line": 2814,
-          "anchor": "packages-tooling-tool-cli-src-commands-quality-quality-command-ts-2814-qualitycommand",
+          "line": 2895,
+          "anchor": "packages-tooling-tool-cli-src-commands-quality-quality-command-ts-2895-qualitycommand",
           "currentTags": [
             "@category",
             "@since"
@@ -74364,8 +75638,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Root.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Root.ts",
-          "line": 67,
-          "anchor": "packages-tooling-tool-cli-src-commands-root-ts-67-rootcommand",
+          "line": 68,
+          "anchor": "packages-tooling-tool-cli-src-commands-root-ts-68-rootcommand",
           "currentTags": [
             "@internal",
             "@category",
@@ -79857,8 +81131,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Worktree/Worktree.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Worktree/Worktree.command.ts",
-          "line": 52,
-          "anchor": "packages-tooling-tool-cli-src-commands-worktree-worktree-command-ts-52-worktree-local-file-entries",
+          "line": 51,
+          "anchor": "packages-tooling-tool-cli-src-commands-worktree-worktree-command-ts-51-worktree-local-file-entries",
           "currentTags": [
             "@category",
             "@since"
@@ -79879,8 +81153,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Worktree/Worktree.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Worktree/Worktree.command.ts",
-          "line": 76,
-          "anchor": "packages-tooling-tool-cli-src-commands-worktree-worktree-command-ts-76-defaultworktreebranch",
+          "line": 75,
+          "anchor": "packages-tooling-tool-cli-src-commands-worktree-worktree-command-ts-75-defaultworktreebranch",
           "currentTags": [
             "@param",
             "@returns",
@@ -79903,8 +81177,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Worktree/Worktree.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Worktree/Worktree.command.ts",
-          "line": 97,
-          "anchor": "packages-tooling-tool-cli-src-commands-worktree-worktree-command-ts-97-worktreeaddargs",
+          "line": 96,
+          "anchor": "packages-tooling-tool-cli-src-commands-worktree-worktree-command-ts-96-worktreeaddargs",
           "currentTags": [
             "@param",
             "@returns",
@@ -79927,8 +81201,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Worktree/Worktree.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Worktree/Worktree.command.ts",
-          "line": 124,
-          "anchor": "packages-tooling-tool-cli-src-commands-worktree-worktree-command-ts-124-worktreeremoveargs",
+          "line": 123,
+          "anchor": "packages-tooling-tool-cli-src-commands-worktree-worktree-command-ts-123-worktreeremoveargs",
           "currentTags": [
             "@param",
             "@returns",
@@ -79951,8 +81225,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Worktree/Worktree.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Worktree/Worktree.command.ts",
-          "line": 149,
-          "anchor": "packages-tooling-tool-cli-src-commands-worktree-worktree-command-ts-149-branchdeletecommand",
+          "line": 148,
+          "anchor": "packages-tooling-tool-cli-src-commands-worktree-worktree-command-ts-148-branchdeletecommand",
           "currentTags": [
             "@param",
             "@returns",
@@ -79975,8 +81249,8 @@
           "exportKind": "class",
           "filePath": "src/commands/Worktree/Worktree.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Worktree/Worktree.command.ts",
-          "line": 176,
-          "anchor": "packages-tooling-tool-cli-src-commands-worktree-worktree-command-ts-176-worktreecontext",
+          "line": 175,
+          "anchor": "packages-tooling-tool-cli-src-commands-worktree-worktree-command-ts-175-worktreecontext",
           "currentTags": [
             "@category",
             "@since"
@@ -79997,8 +81271,8 @@
           "exportKind": "class",
           "filePath": "src/commands/Worktree/Worktree.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Worktree/Worktree.command.ts",
-          "line": 215,
-          "anchor": "packages-tooling-tool-cli-src-commands-worktree-worktree-command-ts-215-worktreecopyoutcome",
+          "line": 214,
+          "anchor": "packages-tooling-tool-cli-src-commands-worktree-worktree-command-ts-214-worktreecopyoutcome",
           "currentTags": [
             "@category",
             "@since"
@@ -80019,8 +81293,8 @@
           "exportKind": "class",
           "filePath": "src/commands/Worktree/Worktree.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Worktree/Worktree.command.ts",
-          "line": 257,
-          "anchor": "packages-tooling-tool-cli-src-commands-worktree-worktree-command-ts-257-worktreedoctorentry",
+          "line": 256,
+          "anchor": "packages-tooling-tool-cli-src-commands-worktree-worktree-command-ts-256-worktreedoctorentry",
           "currentTags": [
             "@category",
             "@since"
@@ -80041,8 +81315,8 @@
           "exportKind": "class",
           "filePath": "src/commands/Worktree/Worktree.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Worktree/Worktree.command.ts",
-          "line": 301,
-          "anchor": "packages-tooling-tool-cli-src-commands-worktree-worktree-command-ts-301-worktreedoctorreport",
+          "line": 300,
+          "anchor": "packages-tooling-tool-cli-src-commands-worktree-worktree-command-ts-300-worktreedoctorreport",
           "currentTags": [
             "@category",
             "@since"
@@ -80063,8 +81337,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Worktree/Worktree.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Worktree/Worktree.command.ts",
-          "line": 382,
-          "anchor": "packages-tooling-tool-cli-src-commands-worktree-worktree-command-ts-382-resolveworktreecontext",
+          "line": 381,
+          "anchor": "packages-tooling-tool-cli-src-commands-worktree-worktree-command-ts-381-resolveworktreecontext",
           "currentTags": [
             "@category",
             "@since"
@@ -80085,8 +81359,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Worktree/Worktree.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Worktree/Worktree.command.ts",
-          "line": 438,
-          "anchor": "packages-tooling-tool-cli-src-commands-worktree-worktree-command-ts-438-addworktree",
+          "line": 437,
+          "anchor": "packages-tooling-tool-cli-src-commands-worktree-worktree-command-ts-437-addworktree",
           "currentTags": [
             "@category",
             "@since"
@@ -80107,8 +81381,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Worktree/Worktree.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Worktree/Worktree.command.ts",
-          "line": 485,
-          "anchor": "packages-tooling-tool-cli-src-commands-worktree-worktree-command-ts-485-copylocalfiles",
+          "line": 484,
+          "anchor": "packages-tooling-tool-cli-src-commands-worktree-worktree-command-ts-484-copylocalfiles",
           "currentTags": [
             "@category",
             "@since"
@@ -80129,8 +81403,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Worktree/Worktree.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Worktree/Worktree.command.ts",
-          "line": 576,
-          "anchor": "packages-tooling-tool-cli-src-commands-worktree-worktree-command-ts-576-worktreedoctorreportforcontext",
+          "line": 575,
+          "anchor": "packages-tooling-tool-cli-src-commands-worktree-worktree-command-ts-575-worktreedoctorreportforcontext",
           "currentTags": [
             "@category",
             "@since"
@@ -80151,8 +81425,30 @@
           "exportKind": "const",
           "filePath": "src/commands/Worktree/Worktree.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Worktree/Worktree.command.ts",
-          "line": 849,
-          "anchor": "packages-tooling-tool-cli-src-commands-worktree-worktree-command-ts-849-worktreecommand",
+          "line": 848,
+          "anchor": "packages-tooling-tool-cli-src-commands-worktree-worktree-command-ts-848-worktreecommand",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "WORKTREES_ROOT_SUFFIX",
+          "exportKind": "const",
+          "filePath": "src/commands/Worktree/Worktree.constants.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Worktree/Worktree.constants.ts",
+          "line": 15,
+          "anchor": "packages-tooling-tool-cli-src-commands-worktree-worktree-constants-ts-15-worktrees-root-suffix",
           "currentTags": [
             "@category",
             "@since"
@@ -80897,12 +82193,34 @@
           "remediationStatus": "resolved"
         },
         {
-          "symbolName": "export * from \"./Worktree.errors.ts\";",
+          "symbolName": "export * from \"./Worktree.constants.ts\";",
           "exportKind": "re-export",
           "filePath": "src/commands/Worktree/index.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Worktree/index.ts",
           "line": 34,
-          "anchor": "packages-tooling-tool-cli-src-commands-worktree-index-ts-34-export-from-worktree-errors-ts",
+          "anchor": "packages-tooling-tool-cli-src-commands-worktree-index-ts-34-export-from-worktree-constants-ts",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "export * from \"./Worktree.errors.ts\";",
+          "exportKind": "re-export",
+          "filePath": "src/commands/Worktree/index.ts",
+          "repoPath": "packages/tooling/tool/cli/src/commands/Worktree/index.ts",
+          "line": 41,
+          "anchor": "packages-tooling-tool-cli-src-commands-worktree-index-ts-41-export-from-worktree-errors-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -80923,8 +82241,8 @@
           "exportKind": "re-export",
           "filePath": "src/commands/Worktree/index.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Worktree/index.ts",
-          "line": 41,
-          "anchor": "packages-tooling-tool-cli-src-commands-worktree-index-ts-41-export-from-worktree-schemas-ts",
+          "line": 48,
+          "anchor": "packages-tooling-tool-cli-src-commands-worktree-index-ts-48-export-from-worktree-schemas-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -80945,8 +82263,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Yeet/Yeet.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts",
-          "line": 509,
-          "anchor": "packages-tooling-tool-cli-src-commands-yeet-yeet-command-ts-509-yeetmonitorcommandroute",
+          "line": 537,
+          "anchor": "packages-tooling-tool-cli-src-commands-yeet-yeet-command-ts-537-yeetmonitorcommandroute",
           "currentTags": [
             "@param",
             "@returns",
@@ -80969,8 +82287,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Yeet/Yeet.command.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts",
-          "line": 632,
-          "anchor": "packages-tooling-tool-cli-src-commands-yeet-yeet-command-ts-632-yeetcommand",
+          "line": 664,
+          "anchor": "packages-tooling-tool-cli-src-commands-yeet-yeet-command-ts-664-yeetcommand",
           "currentTags": [
             "@category",
             "@since"
@@ -81325,8 +82643,8 @@
           "exportKind": "class",
           "filePath": "src/commands/Yeet/Yeet.schemas.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Yeet/Yeet.schemas.ts",
-          "line": 375,
-          "anchor": "packages-tooling-tool-cli-src-commands-yeet-yeet-schemas-ts-375-yeetrunoptions",
+          "line": 376,
+          "anchor": "packages-tooling-tool-cli-src-commands-yeet-yeet-schemas-ts-376-yeetrunoptions",
           "currentTags": [
             "@category",
             "@since"
@@ -81347,8 +82665,8 @@
           "exportKind": "class",
           "filePath": "src/commands/Yeet/Yeet.schemas.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Yeet/Yeet.schemas.ts",
-          "line": 428,
-          "anchor": "packages-tooling-tool-cli-src-commands-yeet-yeet-schemas-ts-428-yeetrunresult",
+          "line": 430,
+          "anchor": "packages-tooling-tool-cli-src-commands-yeet-yeet-schemas-ts-430-yeetrunresult",
           "currentTags": [
             "@category",
             "@since"
@@ -81369,8 +82687,8 @@
           "exportKind": "class",
           "filePath": "src/commands/Yeet/Yeet.schemas.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Yeet/Yeet.schemas.ts",
-          "line": 456,
-          "anchor": "packages-tooling-tool-cli-src-commands-yeet-yeet-schemas-ts-456-yeetstagedpublishintent",
+          "line": 458,
+          "anchor": "packages-tooling-tool-cli-src-commands-yeet-yeet-schemas-ts-458-yeetstagedpublishintent",
           "currentTags": [
             "@category",
             "@since"
@@ -81391,8 +82709,8 @@
           "exportKind": "class",
           "filePath": "src/commands/Yeet/Yeet.schemas.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Yeet/Yeet.schemas.ts",
-          "line": 482,
-          "anchor": "packages-tooling-tool-cli-src-commands-yeet-yeet-schemas-ts-482-yeetexistingcommitpublishintent",
+          "line": 484,
+          "anchor": "packages-tooling-tool-cli-src-commands-yeet-yeet-schemas-ts-484-yeetexistingcommitpublishintent",
           "currentTags": [
             "@category",
             "@since"
@@ -81413,8 +82731,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Yeet/Yeet.schemas.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Yeet/Yeet.schemas.ts",
-          "line": 512,
-          "anchor": "packages-tooling-tool-cli-src-commands-yeet-yeet-schemas-ts-512-yeetpublishintent",
+          "line": 514,
+          "anchor": "packages-tooling-tool-cli-src-commands-yeet-yeet-schemas-ts-514-yeetpublishintent",
           "currentTags": [
             "@category",
             "@since"
@@ -81435,8 +82753,8 @@
           "exportKind": "type",
           "filePath": "src/commands/Yeet/Yeet.schemas.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Yeet/Yeet.schemas.ts",
-          "line": 526,
-          "anchor": "packages-tooling-tool-cli-src-commands-yeet-yeet-schemas-ts-526-yeetpublishintent",
+          "line": 528,
+          "anchor": "packages-tooling-tool-cli-src-commands-yeet-yeet-schemas-ts-528-yeetpublishintent",
           "currentTags": [
             "@see",
             "@category",
@@ -81458,8 +82776,8 @@
           "exportKind": "const",
           "filePath": "src/commands/Yeet/Yeet.schemas.ts",
           "repoPath": "packages/tooling/tool/cli/src/commands/Yeet/Yeet.schemas.ts",
-          "line": 544,
-          "anchor": "packages-tooling-tool-cli-src-commands-yeet-yeet-schemas-ts-544-defaultyeetrunoptions",
+          "line": 546,
+          "anchor": "packages-tooling-tool-cli-src-commands-yeet-yeet-schemas-ts-546-defaultyeetrunoptions",
           "currentTags": [
             "@param",
             "@returns",
@@ -81610,12 +82928,34 @@
           "remediationStatus": "resolved"
         },
         {
-          "symbolName": "export {\n  /**\n   * CI helper command group.\n   *\n   * @category cli-commands\n   * @since 0.0.0\n   */\n  ciCommand,\n} from \"./commands/Ci/index.ts\";",
+          "symbolName": "export {\n  /**\n   * Turbo cache recovery and evidence command group.\n   *\n   * @category cli-commands\n   * @since 0.0.0\n   */\n  cacheCommand,\n} from \"./commands/Cache/index.ts\";",
           "exportKind": "re-export",
           "filePath": "src/index.ts",
           "repoPath": "packages/tooling/tool/cli/src/index.ts",
           "line": 36,
-          "anchor": "packages-tooling-tool-cli-src-index-ts-36-export-ci-helper-command-group-category-cli-commands-since-0-0-0-cicommand-from-commands-ci-index-ts",
+          "anchor": "packages-tooling-tool-cli-src-index-ts-36-export-turbo-cache-recovery-and-evidence-command-group-category-cli-commands-since-0-0-0-cachecommand-from-commands-cache-index-ts",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "export {\n  /**\n   * CI helper command group.\n   *\n   * @category cli-commands\n   * @since 0.0.0\n   */\n  ciCommand,\n} from \"./commands/Ci/index.ts\";",
+          "exportKind": "re-export",
+          "filePath": "src/index.ts",
+          "repoPath": "packages/tooling/tool/cli/src/index.ts",
+          "line": 51,
+          "anchor": "packages-tooling-tool-cli-src-index-ts-51-export-ci-helper-command-group-category-cli-commands-since-0-0-0-cicommand-from-commands-ci-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -81636,8 +82976,8 @@
           "exportKind": "re-export",
           "filePath": "src/index.ts",
           "repoPath": "packages/tooling/tool/cli/src/index.ts",
-          "line": 51,
-          "anchor": "packages-tooling-tool-cli-src-index-ts-51-export-code-generation-command-for-workspace-barrels-and-exports-category-cli-commands-since-0-0-0-codegencommand-from-commands-codegen-index-ts",
+          "line": 66,
+          "anchor": "packages-tooling-tool-cli-src-index-ts-66-export-code-generation-command-for-workspace-barrels-and-exports-category-cli-commands-since-0-0-0-codegencommand-from-commands-codegen-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -81658,8 +82998,8 @@
           "exportKind": "re-export",
           "filePath": "src/index.ts",
           "repoPath": "packages/tooling/tool/cli/src/index.ts",
-          "line": 66,
-          "anchor": "packages-tooling-tool-cli-src-index-ts-66-export-codex-helper-command-group-category-cli-commands-since-0-0-0-codexcommand-from-commands-codex-index-ts",
+          "line": 81,
+          "anchor": "packages-tooling-tool-cli-src-index-ts-81-export-codex-helper-command-group-category-cli-commands-since-0-0-0-codexcommand-from-commands-codex-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -81680,8 +83020,8 @@
           "exportKind": "re-export",
           "filePath": "src/index.ts",
           "repoPath": "packages/tooling/tool/cli/src/index.ts",
-          "line": 81,
-          "anchor": "packages-tooling-tool-cli-src-index-ts-81-export-corpus-curation-command-group-category-cli-commands-since-0-0-0-corpuscommand-from-commands-corpus-index-ts",
+          "line": 96,
+          "anchor": "packages-tooling-tool-cli-src-index-ts-96-export-corpus-curation-command-group-category-cli-commands-since-0-0-0-corpuscommand-from-commands-corpus-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -81702,8 +83042,8 @@
           "exportKind": "re-export",
           "filePath": "src/index.ts",
           "repoPath": "packages/tooling/tool/cli/src/index.ts",
-          "line": 96,
-          "anchor": "packages-tooling-tool-cli-src-index-ts-96-export-package-scaffolding-command-for-creating-new-workspace-packages-category-cli-commands-since-0-0-0-createpackagecommand-from-commands-createpackage-index-ts",
+          "line": 111,
+          "anchor": "packages-tooling-tool-cli-src-index-ts-111-export-package-scaffolding-command-for-creating-new-workspace-packages-category-cli-commands-since-0-0-0-createpackagecommand-from-commands-createpackage-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -81724,8 +83064,8 @@
           "exportKind": "re-export",
           "filePath": "src/index.ts",
           "repoPath": "packages/tooling/tool/cli/src/index.ts",
-          "line": 111,
-          "anchor": "packages-tooling-tool-cli-src-index-ts-111-export-deletepackagecommand-from-commands-deletepackage-index-ts",
+          "line": 126,
+          "anchor": "packages-tooling-tool-cli-src-index-ts-126-export-deletepackagecommand-from-commands-deletepackage-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -81746,8 +83086,8 @@
           "exportKind": "re-export",
           "filePath": "src/index.ts",
           "repoPath": "packages/tooling/tool/cli/src/index.ts",
-          "line": 118,
-          "anchor": "packages-tooling-tool-cli-src-index-ts-118-export-human-first-docgen-command-group-category-cli-commands-since-0-0-0-docgencommand-from-commands-docgen-index-ts",
+          "line": 133,
+          "anchor": "packages-tooling-tool-cli-src-index-ts-133-export-human-first-docgen-command-group-category-cli-commands-since-0-0-0-docgencommand-from-commands-docgen-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -81768,8 +83108,8 @@
           "exportKind": "re-export",
           "filePath": "src/index.ts",
           "repoPath": "packages/tooling/tool/cli/src/index.ts",
-          "line": 133,
-          "anchor": "packages-tooling-tool-cli-src-index-ts-133-export-command-first-docs-discovery-command-tree-category-cli-commands-since-0-0-0-docscommand-from-commands-docs-index-ts",
+          "line": 148,
+          "anchor": "packages-tooling-tool-cli-src-index-ts-148-export-command-first-docs-discovery-command-tree-category-cli-commands-since-0-0-0-docscommand-from-commands-docs-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -81790,8 +83130,8 @@
           "exportKind": "re-export",
           "filePath": "src/index.ts",
           "repoPath": "packages/tooling/tool/cli/src/index.ts",
-          "line": 148,
-          "anchor": "packages-tooling-tool-cli-src-index-ts-148-export-fallow-quality-tooling-command-group-category-cli-commands-since-0-0-0-fallowcommand-from-commands-fallow-index-ts",
+          "line": 163,
+          "anchor": "packages-tooling-tool-cli-src-index-ts-163-export-fallow-quality-tooling-command-group-category-cli-commands-since-0-0-0-fallowcommand-from-commands-fallow-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -81812,8 +83152,8 @@
           "exportKind": "re-export",
           "filePath": "src/index.ts",
           "repoPath": "packages/tooling/tool/cli/src/index.ts",
-          "line": 163,
-          "anchor": "packages-tooling-tool-cli-src-index-ts-163-export-dataset-file-curation-command-group-category-cli-commands-since-0-0-0-filescommand-from-commands-files-index-ts",
+          "line": 178,
+          "anchor": "packages-tooling-tool-cli-src-index-ts-178-export-dataset-file-curation-command-group-category-cli-commands-since-0-0-0-filescommand-from-commands-files-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -81834,8 +83174,8 @@
           "exportKind": "re-export",
           "filePath": "src/index.ts",
           "repoPath": "packages/tooling/tool/cli/src/index.ts",
-          "line": 178,
-          "anchor": "packages-tooling-tool-cli-src-index-ts-178-export-image-and-video-curation-command-group-category-cli-commands-since-0-0-0-imagecommand-from-commands-image-index-ts",
+          "line": 193,
+          "anchor": "packages-tooling-tool-cli-src-index-ts-193-export-image-and-video-curation-command-group-category-cli-commands-since-0-0-0-imagecommand-from-commands-image-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -81856,8 +83196,8 @@
           "exportKind": "re-export",
           "filePath": "src/index.ts",
           "repoPath": "packages/tooling/tool/cli/src/index.ts",
-          "line": 193,
-          "anchor": "packages-tooling-tool-cli-src-index-ts-193-export-knowledge-surface-verification-command-group-category-cli-commands-since-0-0-0-knowledgecommand-from-commands-knowledge-index-ts",
+          "line": 208,
+          "anchor": "packages-tooling-tool-cli-src-index-ts-208-export-knowledge-surface-verification-command-group-category-cli-commands-since-0-0-0-knowledgecommand-from-commands-knowledge-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -81878,8 +83218,8 @@
           "exportKind": "re-export",
           "filePath": "src/index.ts",
           "repoPath": "packages/tooling/tool/cli/src/index.ts",
-          "line": 208,
-          "anchor": "packages-tooling-tool-cli-src-index-ts-208-export-lab-app-lifecycle-command-group-category-cli-commands-since-0-0-0-labscommand-from-commands-labs-index-ts",
+          "line": 223,
+          "anchor": "packages-tooling-tool-cli-src-index-ts-223-export-lab-app-lifecycle-command-group-category-cli-commands-since-0-0-0-labscommand-from-commands-labs-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -81900,8 +83240,8 @@
           "exportKind": "re-export",
           "filePath": "src/index.ts",
           "repoPath": "packages/tooling/tool/cli/src/index.ts",
-          "line": 223,
-          "anchor": "packages-tooling-tool-cli-src-index-ts-223-export-effect-laws-command-group-category-cli-commands-since-0-0-0-lawscommand-from-commands-laws-index-ts",
+          "line": 238,
+          "anchor": "packages-tooling-tool-cli-src-index-ts-238-export-effect-laws-command-group-category-cli-commands-since-0-0-0-lawscommand-from-commands-laws-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -81922,8 +83262,8 @@
           "exportKind": "re-export",
           "filePath": "src/index.ts",
           "repoPath": "packages/tooling/tool/cli/src/index.ts",
-          "line": 238,
-          "anchor": "packages-tooling-tool-cli-src-index-ts-238-export-lint-policy-command-group-category-cli-commands-since-0-0-0-lintcommand-from-commands-lint-index-ts",
+          "line": 253,
+          "anchor": "packages-tooling-tool-cli-src-index-ts-253-export-lint-policy-command-group-category-cli-commands-since-0-0-0-lintcommand-from-commands-lint-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -81944,8 +83284,8 @@
           "exportKind": "re-export",
           "filePath": "src/index.ts",
           "repoPath": "packages/tooling/tool/cli/src/index.ts",
-          "line": 253,
-          "anchor": "packages-tooling-tool-cli-src-index-ts-253-export-purge-command-for-removing-root-workspace-build-artifacts-category-cli-commands-since-0-0-0-purgecommand-from-commands-purge-index-ts",
+          "line": 268,
+          "anchor": "packages-tooling-tool-cli-src-index-ts-268-export-purge-command-for-removing-root-workspace-build-artifacts-category-cli-commands-since-0-0-0-purgecommand-from-commands-purge-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -81966,8 +83306,8 @@
           "exportKind": "re-export",
           "filePath": "src/index.ts",
           "repoPath": "packages/tooling/tool/cli/src/index.ts",
-          "line": 268,
-          "anchor": "packages-tooling-tool-cli-src-index-ts-268-export-recorded-ui-verification-command-group-category-cli-commands-since-0-0-0-qacommand-from-commands-qa-index-ts",
+          "line": 283,
+          "anchor": "packages-tooling-tool-cli-src-index-ts-283-export-recorded-ui-verification-command-group-category-cli-commands-since-0-0-0-qacommand-from-commands-qa-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -81988,8 +83328,8 @@
           "exportKind": "re-export",
           "filePath": "src/index.ts",
           "repoPath": "packages/tooling/tool/cli/src/index.ts",
-          "line": 283,
-          "anchor": "packages-tooling-tool-cli-src-index-ts-283-export-repository-operational-quality-command-group-category-cli-commands-since-0-0-0-qualitycommand-from-commands-quality-index-ts",
+          "line": 298,
+          "anchor": "packages-tooling-tool-cli-src-index-ts-298-export-repository-operational-quality-command-group-category-cli-commands-since-0-0-0-qualitycommand-from-commands-quality-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -82010,8 +83350,8 @@
           "exportKind": "re-export",
           "filePath": "src/index.ts",
           "repoPath": "packages/tooling/tool/cli/src/index.ts",
-          "line": 298,
-          "anchor": "packages-tooling-tool-cli-src-index-ts-298-export-root-cli-command-that-composes-subcommands-category-cli-commands-since-0-0-0-rootcommand-from-commands-root-ts",
+          "line": 313,
+          "anchor": "packages-tooling-tool-cli-src-index-ts-313-export-root-cli-command-that-composes-subcommands-category-cli-commands-since-0-0-0-rootcommand-from-commands-root-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -82032,8 +83372,8 @@
           "exportKind": "re-export",
           "filePath": "src/index.ts",
           "repoPath": "packages/tooling/tool/cli/src/index.ts",
-          "line": 313,
-          "anchor": "packages-tooling-tool-cli-src-index-ts-313-export-runnerscommand-from-commands-runners-index-ts",
+          "line": 328,
+          "anchor": "packages-tooling-tool-cli-src-index-ts-328-export-runnerscommand-from-commands-runners-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -82054,8 +83394,8 @@
           "exportKind": "re-export",
           "filePath": "src/index.ts",
           "repoPath": "packages/tooling/tool/cli/src/index.ts",
-          "line": 320,
-          "anchor": "packages-tooling-tool-cli-src-index-ts-320-export-official-data-sync-command-for-checked-in-generated-typescript-modules-category-cli-commands-since-0-0-0-syncdatatotscommand-from-commands-syncdatatots-index-ts",
+          "line": 335,
+          "anchor": "packages-tooling-tool-cli-src-index-ts-335-export-official-data-sync-command-for-checked-in-generated-typescript-modules-category-cli-commands-since-0-0-0-syncdatatotscommand-from-commands-syncdatatots-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -82076,8 +83416,8 @@
           "exportKind": "re-export",
           "filePath": "src/index.ts",
           "repoPath": "packages/tooling/tool/cli/src/index.ts",
-          "line": 335,
-          "anchor": "packages-tooling-tool-cli-src-index-ts-335-export-dependency-topological-sort-command-category-cli-commands-since-0-0-0-toposortcommand-from-commands-toposort-index-ts",
+          "line": 350,
+          "anchor": "packages-tooling-tool-cli-src-index-ts-350-export-dependency-topological-sort-command-category-cli-commands-since-0-0-0-toposortcommand-from-commands-toposort-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -82098,8 +83438,8 @@
           "exportKind": "re-export",
           "filePath": "src/index.ts",
           "repoPath": "packages/tooling/tool/cli/src/index.ts",
-          "line": 350,
-          "anchor": "packages-tooling-tool-cli-src-index-ts-350-export-tsconfig-sync-command-for-workspace-tsconfig-references-and-root-aliases-category-cli-commands-since-0-0-0-tsconfigsynccommand-from-commands-tsconfigsync-index-ts",
+          "line": 365,
+          "anchor": "packages-tooling-tool-cli-src-index-ts-365-export-tsconfig-sync-command-for-workspace-tsconfig-references-and-root-aliases-category-cli-commands-since-0-0-0-tsconfigsynccommand-from-commands-tsconfigsync-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -82120,8 +83460,8 @@
           "exportKind": "re-export",
           "filePath": "src/index.ts",
           "repoPath": "packages/tooling/tool/cli/src/index.ts",
-          "line": 365,
-          "anchor": "packages-tooling-tool-cli-src-index-ts-365-export-version-sync-command-for-detecting-and-fixing-version-drift-category-cli-commands-since-0-0-0-versionsynccommand-from-commands-versionsync-index-ts",
+          "line": 380,
+          "anchor": "packages-tooling-tool-cli-src-index-ts-380-export-version-sync-command-for-detecting-and-fixing-version-drift-category-cli-commands-since-0-0-0-versionsynccommand-from-commands-versionsync-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -82142,8 +83482,8 @@
           "exportKind": "re-export",
           "filePath": "src/index.ts",
           "repoPath": "packages/tooling/tool/cli/src/index.ts",
-          "line": 380,
-          "anchor": "packages-tooling-tool-cli-src-index-ts-380-export-sibling-git-worktree-management-command-category-cli-commands-since-0-0-0-worktreecommand-from-commands-worktree-index-ts",
+          "line": 395,
+          "anchor": "packages-tooling-tool-cli-src-index-ts-395-export-sibling-git-worktree-management-command-category-cli-commands-since-0-0-0-worktreecommand-from-commands-worktree-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -82164,8 +83504,8 @@
           "exportKind": "re-export",
           "filePath": "src/index.ts",
           "repoPath": "packages/tooling/tool/cli/src/index.ts",
-          "line": 395,
-          "anchor": "packages-tooling-tool-cli-src-index-ts-395-export-yeet-quality-feedback-and-publish-command-category-cli-commands-since-0-0-0-yeetcommand-from-commands-yeet-index-ts",
+          "line": 410,
+          "anchor": "packages-tooling-tool-cli-src-index-ts-410-export-yeet-quality-feedback-and-publish-command-category-cli-commands-since-0-0-0-yeetcommand-from-commands-yeet-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -96512,9 +97852,9 @@
       "status": "needs-remediation",
       "sourceCoverage": {
         "srcDir": "src",
-        "sourceFileCount": 207,
-        "publicModuleCount": 207,
-        "publicExportCount": 582
+        "sourceFileCount": 214,
+        "publicModuleCount": 214,
+        "publicExportCount": 648
       },
       "docgenCoverage": {
         "hasDocgenConfig": true,
@@ -98561,6 +99901,94 @@
         },
         {
           "docKind": "packageDocumentation",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.compatibility.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.compatibility.ts",
+          "line": 1,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-compatibility-ts-1-module",
+          "currentTags": [
+            "@packageDocumentation",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "exportCount": 2,
+          "remediationStatus": "resolved"
+        },
+        {
+          "docKind": "packageDocumentation",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.data.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.data.ts",
+          "line": 1,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-data-ts-1-module",
+          "currentTags": [
+            "@packageDocumentation",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "exportCount": 8,
+          "remediationStatus": "resolved"
+        },
+        {
+          "docKind": "packageDocumentation",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 1,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-1-module",
+          "currentTags": [
+            "@packageDocumentation",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "exportCount": 33,
+          "remediationStatus": "resolved"
+        },
+        {
+          "docKind": "packageDocumentation",
+          "filePath": "src/values/CourtReporterVocabulary/index.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/index.ts",
+          "line": 1,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-index-ts-1-module",
+          "currentTags": [
+            "@packageDocumentation",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "exportCount": 3,
+          "remediationStatus": "resolved"
+        },
+        {
+          "docKind": "packageDocumentation",
           "filePath": "src/values/DocketCitation/DocketCitation.model.ts",
           "repoPath": "packages/law-practice/domain/src/values/DocketCitation/DocketCitation.model.ts",
           "line": 1,
@@ -99922,6 +101350,72 @@
         },
         {
           "docKind": "packageDocumentation",
+          "filePath": "src/values/PatentDocument/PatentDocument.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/PatentDocument/PatentDocument.model.ts",
+          "line": 1,
+          "anchor": "packages-law-practice-domain-src-values-patentdocument-patentdocument-model-ts-1-module",
+          "currentTags": [
+            "@packageDocumentation",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "exportCount": 15,
+          "remediationStatus": "resolved"
+        },
+        {
+          "docKind": "packageDocumentation",
+          "filePath": "src/values/PatentDocument/PatentDocument.normalizer.ts",
+          "repoPath": "packages/law-practice/domain/src/values/PatentDocument/PatentDocument.normalizer.ts",
+          "line": 1,
+          "anchor": "packages-law-practice-domain-src-values-patentdocument-patentdocument-normalizer-ts-1-module",
+          "currentTags": [
+            "@packageDocumentation",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "exportCount": 2,
+          "remediationStatus": "resolved"
+        },
+        {
+          "docKind": "packageDocumentation",
+          "filePath": "src/values/PatentDocument/index.ts",
+          "repoPath": "packages/law-practice/domain/src/values/PatentDocument/index.ts",
+          "line": 1,
+          "anchor": "packages-law-practice-domain-src-values-patentdocument-index-ts-1-module",
+          "currentTags": [
+            "@packageDocumentation",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "exportCount": 2,
+          "remediationStatus": "resolved"
+        },
+        {
+          "docKind": "packageDocumentation",
           "filePath": "src/values/PatentDocumentTriplet/PatentDocumentTriplet.model.ts",
           "repoPath": "packages/law-practice/domain/src/values/PatentDocumentTriplet/PatentDocumentTriplet.model.ts",
           "line": 1,
@@ -101254,7 +102748,7 @@
           "schemaAnnotationGaps": [],
           "categoryViolations": [],
           "documentationShapeViolations": [],
-          "exportCount": 76,
+          "exportCount": 77,
           "remediationStatus": "resolved"
         }
       ],
@@ -107499,6 +108993,1028 @@
           "remediationStatus": "resolved"
         },
         {
+          "symbolName": "CourtReporterCompatibilityPolicy",
+          "exportKind": "const",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.compatibility.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.compatibility.ts",
+          "line": 66,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-compatibility-ts-66-courtreportercompatibilitypolicy",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "classifyCourtReporterArtifactCompatibility",
+          "exportKind": "const",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.compatibility.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.compatibility.ts",
+          "line": 472,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-compatibility-ts-472-classifycourtreporterartifactcompatibility",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "CourtVocabulary",
+          "exportKind": "const",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.data.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.data.ts",
+          "line": 36,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-data-ts-36-courtvocabulary",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "ReporterVocabulary",
+          "exportKind": "const",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.data.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.data.ts",
+          "line": 52,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-data-ts-52-reportervocabulary",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "CourtReporterArtifact",
+          "exportKind": "const",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.data.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.data.ts",
+          "line": 68,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-data-ts-68-courtreporterartifact",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "isCurrentCourtReporterArtifactVersion",
+          "exportKind": "const",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.data.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.data.ts",
+          "line": 99,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-data-ts-99-iscurrentcourtreporterartifactversion",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "findCourtById",
+          "exportKind": "const",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.data.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.data.ts",
+          "line": 156,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-data-ts-156-findcourtbyid",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "findReporterById",
+          "exportKind": "const",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.data.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.data.ts",
+          "line": 174,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-data-ts-174-findreporterbyid",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "findCourtsByAlias",
+          "exportKind": "const",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.data.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.data.ts",
+          "line": 190,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-data-ts-190-findcourtsbyalias",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "findReportersByAlias",
+          "exportKind": "const",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.data.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.data.ts",
+          "line": 212,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-data-ts-212-findreportersbyalias",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "CourtId",
+          "exportKind": "const",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 35,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-35-courtid",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "CourtId",
+          "exportKind": "type",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 49,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-49-courtid",
+          "currentTags": [
+            "@see",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "ReporterId",
+          "exportKind": "const",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 71,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-71-reporterid",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "ReporterId",
+          "exportKind": "type",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 85,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-85-reporterid",
+          "currentTags": [
+            "@see",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "CourtReporterArtifactVersion",
+          "exportKind": "const",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 102,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-102-courtreporterartifactversion",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "CourtReporterArtifactVersion",
+          "exportKind": "type",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 116,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-116-courtreporterartifactversion",
+          "currentTags": [
+            "@see",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "CourtSystem",
+          "exportKind": "const",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 149,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-149-courtsystem",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "CourtSystem",
+          "exportKind": "type",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 163,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-163-courtsystem",
+          "currentTags": [
+            "@see",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "CourtType",
+          "exportKind": "const",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 190,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-190-courttype",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "CourtType",
+          "exportKind": "type",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 204,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-204-courttype",
+          "currentTags": [
+            "@see",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "CourtHierarchyLevel",
+          "exportKind": "const",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 227,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-227-courthierarchylevel",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "CourtHierarchyLevel",
+          "exportKind": "type",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 241,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-241-courthierarchylevel",
+          "currentTags": [
+            "@see",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "ReporterCiteType",
+          "exportKind": "const",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 273,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-273-reportercitetype",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "ReporterCiteType",
+          "exportKind": "type",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 287,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-287-reportercitetype",
+          "currentTags": [
+            "@see",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "VocabularyEntryStatus",
+          "exportKind": "const",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 305,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-305-vocabularyentrystatus",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "VocabularyEntryStatus",
+          "exportKind": "type",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 319,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-319-vocabularyentrystatus",
+          "currentTags": [
+            "@see",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "ArtifactCompatibilityStatus",
+          "exportKind": "const",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 337,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-337-artifactcompatibilitystatus",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "ArtifactCompatibilityStatus",
+          "exportKind": "type",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 351,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-351-artifactcompatibilitystatus",
+          "currentTags": [
+            "@see",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "ArtifactDriftChangeKind",
+          "exportKind": "const",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 384,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-384-artifactdriftchangekind",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "ArtifactDriftChangeKind",
+          "exportKind": "type",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 398,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-398-artifactdriftchangekind",
+          "currentTags": [
+            "@see",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "ContextualAlias",
+          "exportKind": "class",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 420,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-420-contextualalias",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "EffectiveRange",
+          "exportKind": "class",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 445,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-445-effectiverange",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "CourtVocabularyRecord",
+          "exportKind": "class",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 469,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-469-courtvocabularyrecord",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "ReporterEdition",
+          "exportKind": "class",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 510,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-510-reporteredition",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "ReporterVocabularyRecord",
+          "exportKind": "class",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 535,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-535-reportervocabularyrecord",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "VocabularySourceProvenance",
+          "exportKind": "class",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 576,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-576-vocabularysourceprovenance",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "CourtVocabularyArtifact",
+          "exportKind": "class",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 609,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-609-courtvocabularyartifact",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "ReporterVocabularyArtifact",
+          "exportKind": "class",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 637,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-637-reportervocabularyartifact",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "ArtifactCompatibilityPolicy",
+          "exportKind": "class",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 665,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-665-artifactcompatibilitypolicy",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "CourtReporterArtifactContract",
+          "exportKind": "class",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 705,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-705-courtreporterartifactcontract",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "CourtReporterArtifactComparison",
+          "exportKind": "class",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 778,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-778-courtreporterartifactcomparison",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "ArtifactDriftChange",
+          "exportKind": "class",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 815,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-815-artifactdriftchange",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "ArtifactDriftReport",
+          "exportKind": "class",
+          "filePath": "src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/CourtReporterVocabulary.model.ts",
+          "line": 842,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-courtreportervocabulary-model-ts-842-artifactdriftreport",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "export * from \"./CourtReporterVocabulary.compatibility.ts\";",
+          "exportKind": "re-export",
+          "filePath": "src/values/CourtReporterVocabulary/index.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/index.ts",
+          "line": 20,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-index-ts-20-export-from-courtreportervocabulary-compatibility-ts",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "export * from \"./CourtReporterVocabulary.data.ts\";",
+          "exportKind": "re-export",
+          "filePath": "src/values/CourtReporterVocabulary/index.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/index.ts",
+          "line": 33,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-index-ts-33-export-from-courtreportervocabulary-data-ts",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "export * from \"./CourtReporterVocabulary.model.ts\";",
+          "exportKind": "re-export",
+          "filePath": "src/values/CourtReporterVocabulary/index.ts",
+          "repoPath": "packages/law-practice/domain/src/values/CourtReporterVocabulary/index.ts",
+          "line": 46,
+          "anchor": "packages-law-practice-domain-src-values-courtreportervocabulary-index-ts-46-export-from-courtreportervocabulary-model-ts",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
           "symbolName": "DocketCitation",
           "exportKind": "class",
           "filePath": "src/values/DocketCitation/DocketCitation.model.ts",
@@ -109948,6 +112464,434 @@
           "anchor": "packages-law-practice-domain-src-values-partykind-index-ts-9-export-from-partykind-model-ts",
           "currentTags": [
             "@packageDocumentation",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "PatentApplicationSectionRole",
+          "exportKind": "const",
+          "filePath": "src/values/PatentDocument/PatentDocument.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/PatentDocument/PatentDocument.model.ts",
+          "line": 42,
+          "anchor": "packages-law-practice-domain-src-values-patentdocument-patentdocument-model-ts-42-patentapplicationsectionrole",
+          "currentTags": [
+            "@see",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "PatentApplicationSectionRole",
+          "exportKind": "type",
+          "filePath": "src/values/PatentDocument/PatentDocument.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/PatentDocument/PatentDocument.model.ts",
+          "line": 69,
+          "anchor": "packages-law-practice-domain-src-values-patentdocument-patentdocument-model-ts-69-patentapplicationsectionrole",
+          "currentTags": [
+            "@see",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "PatentClaimTransition",
+          "exportKind": "const",
+          "filePath": "src/values/PatentDocument/PatentDocument.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/PatentDocument/PatentDocument.model.ts",
+          "line": 87,
+          "anchor": "packages-law-practice-domain-src-values-patentdocument-patentdocument-model-ts-87-patentclaimtransition",
+          "currentTags": [
+            "@see",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "PatentClaimTransition",
+          "exportKind": "type",
+          "filePath": "src/values/PatentDocument/PatentDocument.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/PatentDocument/PatentDocument.model.ts",
+          "line": 107,
+          "anchor": "packages-law-practice-domain-src-values-patentdocument-patentdocument-model-ts-107-patentclaimtransition",
+          "currentTags": [
+            "@see",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "PatentClaim",
+          "exportKind": "const",
+          "filePath": "src/values/PatentDocument/PatentDocument.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/PatentDocument/PatentDocument.model.ts",
+          "line": 165,
+          "anchor": "packages-law-practice-domain-src-values-patentdocument-patentdocument-model-ts-165-patentclaim",
+          "currentTags": [
+            "@see",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "PatentClaim",
+          "exportKind": "type",
+          "filePath": "src/values/PatentDocument/PatentDocument.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/PatentDocument/PatentDocument.model.ts",
+          "line": 188,
+          "anchor": "packages-law-practice-domain-src-values-patentdocument-patentdocument-model-ts-188-patentclaim",
+          "currentTags": [
+            "@see",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "PatentClaimDependencyIssue",
+          "exportKind": "const",
+          "filePath": "src/values/PatentDocument/PatentDocument.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/PatentDocument/PatentDocument.model.ts",
+          "line": 218,
+          "anchor": "packages-law-practice-domain-src-values-patentdocument-patentdocument-model-ts-218-patentclaimdependencyissue",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "PatentClaimDependencyIssue",
+          "exportKind": "type",
+          "filePath": "src/values/PatentDocument/PatentDocument.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/PatentDocument/PatentDocument.model.ts",
+          "line": 253,
+          "anchor": "packages-law-practice-domain-src-values-patentdocument-patentdocument-model-ts-253-patentclaimdependencyissue",
+          "currentTags": [
+            "@see",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "inspectPatentClaimDependencies",
+          "exportKind": "const",
+          "filePath": "src/values/PatentDocument/PatentDocument.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/PatentDocument/PatentDocument.model.ts",
+          "line": 335,
+          "anchor": "packages-law-practice-domain-src-values-patentdocument-patentdocument-model-ts-335-inspectpatentclaimdependencies",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "PatentClaims",
+          "exportKind": "const",
+          "filePath": "src/values/PatentDocument/PatentDocument.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/PatentDocument/PatentDocument.model.ts",
+          "line": 429,
+          "anchor": "packages-law-practice-domain-src-values-patentdocument-patentdocument-model-ts-429-patentclaims",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "PatentClaims",
+          "exportKind": "type",
+          "filePath": "src/values/PatentDocument/PatentDocument.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/PatentDocument/PatentDocument.model.ts",
+          "line": 444,
+          "anchor": "packages-law-practice-domain-src-values-patentdocument-patentdocument-model-ts-444-patentclaims",
+          "currentTags": [
+            "@see",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "PatentApplicationSection",
+          "exportKind": "class",
+          "filePath": "src/values/PatentDocument/PatentDocument.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/PatentDocument/PatentDocument.model.ts",
+          "line": 468,
+          "anchor": "packages-law-practice-domain-src-values-patentdocument-patentdocument-model-ts-468-patentapplicationsection",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "PatentApplicationSections",
+          "exportKind": "const",
+          "filePath": "src/values/PatentDocument/PatentDocument.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/PatentDocument/PatentDocument.model.ts",
+          "line": 573,
+          "anchor": "packages-law-practice-domain-src-values-patentdocument-patentdocument-model-ts-573-patentapplicationsections",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "PatentApplicationSections",
+          "exportKind": "type",
+          "filePath": "src/values/PatentDocument/PatentDocument.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/PatentDocument/PatentDocument.model.ts",
+          "line": 588,
+          "anchor": "packages-law-practice-domain-src-values-patentdocument-patentdocument-model-ts-588-patentapplicationsections",
+          "currentTags": [
+            "@see",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "PatentApplicationDocument",
+          "exportKind": "class",
+          "filePath": "src/values/PatentDocument/PatentDocument.model.ts",
+          "repoPath": "packages/law-practice/domain/src/values/PatentDocument/PatentDocument.model.ts",
+          "line": 661,
+          "anchor": "packages-law-practice-domain-src-values-patentdocument-patentdocument-model-ts-661-patentapplicationdocument",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "PatentDocumentNormalizationError",
+          "exportKind": "class",
+          "filePath": "src/values/PatentDocument/PatentDocument.normalizer.ts",
+          "repoPath": "packages/law-practice/domain/src/values/PatentDocument/PatentDocument.normalizer.ts",
+          "line": 65,
+          "anchor": "packages-law-practice-domain-src-values-patentdocument-patentdocument-normalizer-ts-65-patentdocumentnormalizationerror",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "normalizePatentApplicationDocument",
+          "exportKind": "const",
+          "filePath": "src/values/PatentDocument/PatentDocument.normalizer.ts",
+          "repoPath": "packages/law-practice/domain/src/values/PatentDocument/PatentDocument.normalizer.ts",
+          "line": 473,
+          "anchor": "packages-law-practice-domain-src-values-patentdocument-patentdocument-normalizer-ts-473-normalizepatentapplicationdocument",
+          "currentTags": [
+            "@effects",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "export * from \"./PatentDocument.model.ts\";",
+          "exportKind": "re-export",
+          "filePath": "src/values/PatentDocument/index.ts",
+          "repoPath": "packages/law-practice/domain/src/values/PatentDocument/index.ts",
+          "line": 14,
+          "anchor": "packages-law-practice-domain-src-values-patentdocument-index-ts-14-export-from-patentdocument-model-ts",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "export * from \"./PatentDocument.normalizer.ts\";",
+          "exportKind": "re-export",
+          "filePath": "src/values/PatentDocument/index.ts",
+          "repoPath": "packages/law-practice/domain/src/values/PatentDocument/index.ts",
+          "line": 21,
+          "anchor": "packages-law-practice-domain-src-values-patentdocument-index-ts-21-export-from-patentdocument-normalizer-ts",
+          "currentTags": [
             "@category",
             "@since"
           ],
@@ -113566,12 +116510,34 @@
           "remediationStatus": "resolved"
         },
         {
-          "symbolName": "export * from \"./PatentDocumentTriplet/index.ts\";",
+          "symbolName": "export * from \"./PatentDocument/index.ts\";",
           "exportKind": "re-export",
           "filePath": "src/values/index.ts",
           "repoPath": "packages/law-practice/domain/src/values/index.ts",
           "line": 564,
-          "anchor": "packages-law-practice-domain-src-values-index-ts-564-export-from-patentdocumenttriplet-index-ts",
+          "anchor": "packages-law-practice-domain-src-values-index-ts-564-export-from-patentdocument-index-ts",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "export * from \"./PatentDocumentTriplet/index.ts\";",
+          "exportKind": "re-export",
+          "filePath": "src/values/index.ts",
+          "repoPath": "packages/law-practice/domain/src/values/index.ts",
+          "line": 571,
+          "anchor": "packages-law-practice-domain-src-values-index-ts-571-export-from-patentdocumenttriplet-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -113592,8 +116558,8 @@
           "exportKind": "re-export",
           "filePath": "src/values/index.ts",
           "repoPath": "packages/law-practice/domain/src/values/index.ts",
-          "line": 571,
-          "anchor": "packages-law-practice-domain-src-values-index-ts-571-export-from-patentmetadata-index-ts",
+          "line": 578,
+          "anchor": "packages-law-practice-domain-src-values-index-ts-578-export-from-patentmetadata-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -113614,8 +116580,8 @@
           "exportKind": "re-export",
           "filePath": "src/values/index.ts",
           "repoPath": "packages/law-practice/domain/src/values/index.ts",
-          "line": 578,
-          "anchor": "packages-law-practice-domain-src-values-index-ts-578-export-from-patentnumber-index-ts",
+          "line": 585,
+          "anchor": "packages-law-practice-domain-src-values-index-ts-585-export-from-patentnumber-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -113636,8 +116602,8 @@
           "exportKind": "re-export",
           "filePath": "src/values/index.ts",
           "repoPath": "packages/law-practice/domain/src/values/index.ts",
-          "line": 585,
-          "anchor": "packages-law-practice-domain-src-values-index-ts-585-export-from-patentoffice-index-ts",
+          "line": 592,
+          "anchor": "packages-law-practice-domain-src-values-index-ts-592-export-from-patentoffice-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -113658,8 +116624,8 @@
           "exportKind": "re-export",
           "filePath": "src/values/index.ts",
           "repoPath": "packages/law-practice/domain/src/values/index.ts",
-          "line": 598,
-          "anchor": "packages-law-practice-domain-src-values-index-ts-598-export-from-permissionstatus-index-ts",
+          "line": 605,
+          "anchor": "packages-law-practice-domain-src-values-index-ts-605-export-from-permissionstatus-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -113680,8 +116646,8 @@
           "exportKind": "re-export",
           "filePath": "src/values/index.ts",
           "repoPath": "packages/law-practice/domain/src/values/index.ts",
-          "line": 611,
-          "anchor": "packages-law-practice-domain-src-values-index-ts-611-export-from-pinciteinfo-index-ts",
+          "line": 618,
+          "anchor": "packages-law-practice-domain-src-values-index-ts-618-export-from-pinciteinfo-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -113702,8 +116668,8 @@
           "exportKind": "re-export",
           "filePath": "src/values/index.ts",
           "repoPath": "packages/law-practice/domain/src/values/index.ts",
-          "line": 618,
-          "anchor": "packages-law-practice-domain-src-values-index-ts-618-export-from-practicekgepistemicstatus-index-ts",
+          "line": 625,
+          "anchor": "packages-law-practice-domain-src-values-index-ts-625-export-from-practicekgepistemicstatus-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -113724,8 +116690,8 @@
           "exportKind": "re-export",
           "filePath": "src/values/index.ts",
           "repoPath": "packages/law-practice/domain/src/values/index.ts",
-          "line": 625,
-          "anchor": "packages-law-practice-domain-src-values-index-ts-625-export-from-practicekgprovenancekind-index-ts",
+          "line": 632,
+          "anchor": "packages-law-practice-domain-src-values-index-ts-632-export-from-practicekgprovenancekind-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -113746,8 +116712,8 @@
           "exportKind": "re-export",
           "filePath": "src/values/index.ts",
           "repoPath": "packages/law-practice/domain/src/values/index.ts",
-          "line": 632,
-          "anchor": "packages-law-practice-domain-src-values-index-ts-632-export-from-prioritybasis-index-ts",
+          "line": 639,
+          "anchor": "packages-law-practice-domain-src-values-index-ts-639-export-from-prioritybasis-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -113768,8 +116734,8 @@
           "exportKind": "re-export",
           "filePath": "src/values/index.ts",
           "repoPath": "packages/law-practice/domain/src/values/index.ts",
-          "line": 645,
-          "anchor": "packages-law-practice-domain-src-values-index-ts-645-export-from-publiclawcitation-index-ts",
+          "line": 652,
+          "anchor": "packages-law-practice-domain-src-values-index-ts-652-export-from-publiclawcitation-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -113790,8 +116756,8 @@
           "exportKind": "re-export",
           "filePath": "src/values/index.ts",
           "repoPath": "packages/law-practice/domain/src/values/index.ts",
-          "line": 658,
-          "anchor": "packages-law-practice-domain-src-values-index-ts-658-export-from-regulationcitation-index-ts",
+          "line": 665,
+          "anchor": "packages-law-practice-domain-src-values-index-ts-665-export-from-regulationcitation-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -113812,8 +116778,8 @@
           "exportKind": "re-export",
           "filePath": "src/values/index.ts",
           "repoPath": "packages/law-practice/domain/src/values/index.ts",
-          "line": 671,
-          "anchor": "packages-law-practice-domain-src-values-index-ts-671-export-from-resolutionresult-index-ts",
+          "line": 678,
+          "anchor": "packages-law-practice-domain-src-values-index-ts-678-export-from-resolutionresult-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -113834,8 +116800,8 @@
           "exportKind": "re-export",
           "filePath": "src/values/index.ts",
           "repoPath": "packages/law-practice/domain/src/values/index.ts",
-          "line": 684,
-          "anchor": "packages-law-practice-domain-src-values-index-ts-684-export-from-restatementcitation-index-ts",
+          "line": 691,
+          "anchor": "packages-law-practice-domain-src-values-index-ts-691-export-from-restatementcitation-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -113856,8 +116822,8 @@
           "exportKind": "re-export",
           "filePath": "src/values/index.ts",
           "repoPath": "packages/law-practice/domain/src/values/index.ts",
-          "line": 697,
-          "anchor": "packages-law-practice-domain-src-values-index-ts-697-export-from-segment-index-ts",
+          "line": 704,
+          "anchor": "packages-law-practice-domain-src-values-index-ts-704-export-from-segment-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -113878,8 +116844,8 @@
           "exportKind": "re-export",
           "filePath": "src/values/index.ts",
           "repoPath": "packages/law-practice/domain/src/values/index.ts",
-          "line": 710,
-          "anchor": "packages-law-practice-domain-src-values-index-ts-710-export-from-segmentmap-index-ts",
+          "line": 717,
+          "anchor": "packages-law-practice-domain-src-values-index-ts-717-export-from-segmentmap-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -113900,8 +116866,8 @@
           "exportKind": "re-export",
           "filePath": "src/values/index.ts",
           "repoPath": "packages/law-practice/domain/src/values/index.ts",
-          "line": 717,
-          "anchor": "packages-law-practice-domain-src-values-index-ts-717-export-from-senioritytier-index-ts",
+          "line": 724,
+          "anchor": "packages-law-practice-domain-src-values-index-ts-724-export-from-senioritytier-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -113922,8 +116888,8 @@
           "exportKind": "re-export",
           "filePath": "src/values/index.ts",
           "repoPath": "packages/law-practice/domain/src/values/index.ts",
-          "line": 730,
-          "anchor": "packages-law-practice-domain-src-values-index-ts-730-export-from-sessionlawcitation-index-ts",
+          "line": 737,
+          "anchor": "packages-law-practice-domain-src-values-index-ts-737-export-from-sessionlawcitation-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -113944,8 +116910,8 @@
           "exportKind": "re-export",
           "filePath": "src/values/index.ts",
           "repoPath": "packages/law-practice/domain/src/values/index.ts",
-          "line": 743,
-          "anchor": "packages-law-practice-domain-src-values-index-ts-743-export-from-shortformcitationtype-index-ts",
+          "line": 750,
+          "anchor": "packages-law-practice-domain-src-values-index-ts-750-export-from-shortformcitationtype-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -113966,8 +116932,8 @@
           "exportKind": "re-export",
           "filePath": "src/values/index.ts",
           "repoPath": "packages/law-practice/domain/src/values/index.ts",
-          "line": 756,
-          "anchor": "packages-law-practice-domain-src-values-index-ts-756-export-from-sourcenormref-index-ts",
+          "line": 763,
+          "anchor": "packages-law-practice-domain-src-values-index-ts-763-export-from-sourcenormref-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -113988,8 +116954,8 @@
           "exportKind": "re-export",
           "filePath": "src/values/index.ts",
           "repoPath": "packages/law-practice/domain/src/values/index.ts",
-          "line": 769,
-          "anchor": "packages-law-practice-domain-src-values-index-ts-769-export-from-span-index-ts",
+          "line": 776,
+          "anchor": "packages-law-practice-domain-src-values-index-ts-776-export-from-span-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -114010,8 +116976,8 @@
           "exportKind": "re-export",
           "filePath": "src/values/index.ts",
           "repoPath": "packages/law-practice/domain/src/values/index.ts",
-          "line": 782,
-          "anchor": "packages-law-practice-domain-src-values-index-ts-782-export-from-staterulecitation-index-ts",
+          "line": 789,
+          "anchor": "packages-law-practice-domain-src-values-index-ts-789-export-from-staterulecitation-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -114032,8 +116998,8 @@
           "exportKind": "re-export",
           "filePath": "src/values/index.ts",
           "repoPath": "packages/law-practice/domain/src/values/index.ts",
-          "line": 795,
-          "anchor": "packages-law-practice-domain-src-values-index-ts-795-export-from-statutecitation-index-ts",
+          "line": 802,
+          "anchor": "packages-law-practice-domain-src-values-index-ts-802-export-from-statutecitation-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -114054,8 +117020,8 @@
           "exportKind": "re-export",
           "filePath": "src/values/index.ts",
           "repoPath": "packages/law-practice/domain/src/values/index.ts",
-          "line": 808,
-          "anchor": "packages-law-practice-domain-src-values-index-ts-808-export-from-statutesatlargecitation-index-ts",
+          "line": 815,
+          "anchor": "packages-law-practice-domain-src-values-index-ts-815-export-from-statutesatlargecitation-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -114076,8 +117042,8 @@
           "exportKind": "re-export",
           "filePath": "src/values/index.ts",
           "repoPath": "packages/law-practice/domain/src/values/index.ts",
-          "line": 821,
-          "anchor": "packages-law-practice-domain-src-values-index-ts-821-export-from-stringcitationgroup-index-ts",
+          "line": 828,
+          "anchor": "packages-law-practice-domain-src-values-index-ts-828-export-from-stringcitationgroup-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -114098,8 +117064,8 @@
           "exportKind": "re-export",
           "filePath": "src/values/index.ts",
           "repoPath": "packages/law-practice/domain/src/values/index.ts",
-          "line": 834,
-          "anchor": "packages-law-practice-domain-src-values-index-ts-834-export-from-structureddate-index-ts",
+          "line": 841,
+          "anchor": "packages-law-practice-domain-src-values-index-ts-841-export-from-structureddate-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -114120,8 +117086,8 @@
           "exportKind": "re-export",
           "filePath": "src/values/index.ts",
           "repoPath": "packages/law-practice/domain/src/values/index.ts",
-          "line": 847,
-          "anchor": "packages-law-practice-domain-src-values-index-ts-847-export-from-subsequenthistoryentry-index-ts",
+          "line": 854,
+          "anchor": "packages-law-practice-domain-src-values-index-ts-854-export-from-subsequenthistoryentry-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -114142,8 +117108,8 @@
           "exportKind": "re-export",
           "filePath": "src/values/index.ts",
           "repoPath": "packages/law-practice/domain/src/values/index.ts",
-          "line": 860,
-          "anchor": "packages-law-practice-domain-src-values-index-ts-860-export-from-surroundingcontext-index-ts",
+          "line": 867,
+          "anchor": "packages-law-practice-domain-src-values-index-ts-867-export-from-surroundingcontext-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -114164,8 +117130,8 @@
           "exportKind": "re-export",
           "filePath": "src/values/index.ts",
           "repoPath": "packages/law-practice/domain/src/values/index.ts",
-          "line": 873,
-          "anchor": "packages-law-practice-domain-src-values-index-ts-873-export-from-treatisecitation-index-ts",
+          "line": 880,
+          "anchor": "packages-law-practice-domain-src-values-index-ts-880-export-from-treatisecitation-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -114186,8 +117152,8 @@
           "exportKind": "re-export",
           "filePath": "src/values/index.ts",
           "repoPath": "packages/law-practice/domain/src/values/index.ts",
-          "line": 886,
-          "anchor": "packages-law-practice-domain-src-values-index-ts-886-export-from-treatycitation-index-ts",
+          "line": 893,
+          "anchor": "packages-law-practice-domain-src-values-index-ts-893-export-from-treatycitation-index-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -152621,9 +155587,9 @@
       "status": "clean",
       "sourceCoverage": {
         "srcDir": "src",
-        "sourceFileCount": 25,
-        "publicModuleCount": 25,
-        "publicExportCount": 102
+        "sourceFileCount": 26,
+        "publicModuleCount": 26,
+        "publicExportCount": 125
       },
       "docgenCoverage": {
         "hasDocgenConfig": true,
@@ -153098,7 +156064,7 @@
           "schemaAnnotationGaps": [],
           "categoryViolations": [],
           "documentationShapeViolations": [],
-          "exportCount": 5,
+          "exportCount": 7,
           "remediationStatus": "resolved"
         },
         {
@@ -153164,7 +156130,29 @@
           "schemaAnnotationGaps": [],
           "categoryViolations": [],
           "documentationShapeViolations": [],
-          "exportCount": 5,
+          "exportCount": 22,
+          "remediationStatus": "resolved"
+        },
+        {
+          "docKind": "packageDocumentation",
+          "filePath": "src/VerifiedSpan/VerifiedSpan.normalization.ts",
+          "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.normalization.ts",
+          "line": 1,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-normalization-ts-1-module",
+          "currentTags": [
+            "@packageDocumentation",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "exportCount": 3,
           "remediationStatus": "resolved"
         },
         {
@@ -153186,7 +156174,7 @@
           "schemaAnnotationGaps": [],
           "categoryViolations": [],
           "documentationShapeViolations": [],
-          "exportCount": 4,
+          "exportCount": 5,
           "remediationStatus": "resolved"
         },
         {
@@ -154888,34 +157876,12 @@
           "remediationStatus": "resolved"
         },
         {
-          "symbolName": "normalizeTextLocator",
-          "exportKind": "const",
-          "filePath": "src/VerifiedSpan/VerifiedSpan.behavior.ts",
-          "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.behavior.ts",
-          "line": 219,
-          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-behavior-ts-219-normalizetextlocator",
-          "currentTags": [
-            "@category",
-            "@since"
-          ],
-          "missingRequiredTags": [],
-          "forbiddenTags": [],
-          "missingSummary": false,
-          "malformedConditionalTags": [],
-          "exampleImportViolations": [],
-          "unsafeExampleViolations": [],
-          "schemaAnnotationGaps": [],
-          "categoryViolations": [],
-          "documentationShapeViolations": [],
-          "remediationStatus": "resolved"
-        },
-        {
           "symbolName": "locateRawText",
           "exportKind": "const",
           "filePath": "src/VerifiedSpan/VerifiedSpan.behavior.ts",
           "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.behavior.ts",
-          "line": 458,
-          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-behavior-ts-458-locaterawtext",
+          "line": 311,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-behavior-ts-311-locaterawtext",
           "currentTags": [
             "@category",
             "@since"
@@ -154936,8 +157902,8 @@
           "exportKind": "const",
           "filePath": "src/VerifiedSpan/VerifiedSpan.behavior.ts",
           "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.behavior.ts",
-          "line": 539,
-          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-behavior-ts-539-converttextoffsetrange",
+          "line": 392,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-behavior-ts-392-converttextoffsetrange",
           "currentTags": [
             "@category",
             "@since"
@@ -154958,8 +157924,8 @@
           "exportKind": "const",
           "filePath": "src/VerifiedSpan/VerifiedSpan.behavior.ts",
           "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.behavior.ts",
-          "line": 585,
-          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-behavior-ts-585-reconstructsourcetext",
+          "line": 438,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-behavior-ts-438-reconstructsourcetext",
           "currentTags": [
             "@category",
             "@since"
@@ -154980,9 +157946,78 @@
           "exportKind": "const",
           "filePath": "src/VerifiedSpan/VerifiedSpan.behavior.ts",
           "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.behavior.ts",
-          "line": 641,
-          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-behavior-ts-641-locategroundedextractions",
+          "line": 494,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-behavior-ts-494-locategroundedextractions",
           "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "beginVerifiedSpanHistory",
+          "exportKind": "const",
+          "filePath": "src/VerifiedSpan/VerifiedSpan.behavior.ts",
+          "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.behavior.ts",
+          "line": 729,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-behavior-ts-729-beginverifiedspanhistory",
+          "currentTags": [
+            "@effects",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "verifyCurrentSpanHistory",
+          "exportKind": "const",
+          "filePath": "src/VerifiedSpan/VerifiedSpan.behavior.ts",
+          "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.behavior.ts",
+          "line": 763,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-behavior-ts-763-verifycurrentspanhistory",
+          "currentTags": [
+            "@effects",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "reanchorVerifiedSpanHistory",
+          "exportKind": "const",
+          "filePath": "src/VerifiedSpan/VerifiedSpan.behavior.ts",
+          "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.behavior.ts",
+          "line": 820,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-behavior-ts-820-reanchorverifiedspanhistory",
+          "currentTags": [
+            "@effects",
             "@category",
             "@since"
           ],
@@ -155090,8 +158125,8 @@
           "exportKind": "type",
           "filePath": "src/VerifiedSpan/VerifiedSpan.errors.ts",
           "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.errors.ts",
-          "line": 56,
-          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-errors-ts-56-verifiedspanerrorreason",
+          "line": 58,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-errors-ts-58-verifiedspanerrorreason",
           "currentTags": [
             "@category",
             "@since"
@@ -155112,8 +158147,8 @@
           "exportKind": "class",
           "filePath": "src/VerifiedSpan/VerifiedSpan.errors.ts",
           "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.errors.ts",
-          "line": 72,
-          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-errors-ts-72-verifiedspanerror",
+          "line": 74,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-errors-ts-74-verifiedspanerror",
           "currentTags": [
             "@category",
             "@since"
@@ -155134,8 +158169,8 @@
           "exportKind": "const",
           "filePath": "src/VerifiedSpan/VerifiedSpan.model.ts",
           "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.model.ts",
-          "line": 28,
-          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-model-ts-28-textoffsetunit",
+          "line": 40,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-model-ts-40-textoffsetunit",
           "currentTags": [
             "@category",
             "@since"
@@ -155156,8 +158191,8 @@
           "exportKind": "type",
           "filePath": "src/VerifiedSpan/VerifiedSpan.model.ts",
           "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.model.ts",
-          "line": 49,
-          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-model-ts-49-textoffsetunit",
+          "line": 61,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-model-ts-61-textoffsetunit",
           "currentTags": [
             "@category",
             "@since"
@@ -155178,8 +158213,8 @@
           "exportKind": "class",
           "filePath": "src/VerifiedSpan/VerifiedSpan.model.ts",
           "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.model.ts",
-          "line": 115,
-          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-model-ts-115-textoffsetrange",
+          "line": 127,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-model-ts-127-textoffsetrange",
           "currentTags": [
             "@category",
             "@since"
@@ -155200,8 +158235,8 @@
           "exportKind": "class",
           "filePath": "src/VerifiedSpan/VerifiedSpan.model.ts",
           "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.model.ts",
-          "line": 182,
-          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-model-ts-182-utf16textrange",
+          "line": 194,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-model-ts-194-utf16textrange",
           "currentTags": [
             "@category",
             "@since"
@@ -155222,8 +158257,450 @@
           "exportKind": "class",
           "filePath": "src/VerifiedSpan/VerifiedSpan.model.ts",
           "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.model.ts",
-          "line": 212,
-          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-model-ts-212-rawtextchunk",
+          "line": 224,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-model-ts-224-rawtextchunk",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "VerifiedSpanAttemptId",
+          "exportKind": "const",
+          "filePath": "src/VerifiedSpan/VerifiedSpan.model.ts",
+          "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.model.ts",
+          "line": 252,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-model-ts-252-verifiedspanattemptid",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "VerifiedSpanAttemptId",
+          "exportKind": "type",
+          "filePath": "src/VerifiedSpan/VerifiedSpan.model.ts",
+          "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.model.ts",
+          "line": 265,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-model-ts-265-verifiedspanattemptid",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "VerifiedSpanEngine",
+          "exportKind": "class",
+          "filePath": "src/VerifiedSpan/VerifiedSpan.model.ts",
+          "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.model.ts",
+          "line": 283,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-model-ts-283-verifiedspanengine",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "VerifiedSpanAttemptKind",
+          "exportKind": "const",
+          "filePath": "src/VerifiedSpan/VerifiedSpan.model.ts",
+          "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.model.ts",
+          "line": 312,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-model-ts-312-verifiedspanattemptkind",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "VerifiedSpanAttemptKind",
+          "exportKind": "type",
+          "filePath": "src/VerifiedSpan/VerifiedSpan.model.ts",
+          "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.model.ts",
+          "line": 324,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-model-ts-324-verifiedspanattemptkind",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "VerifiedSpanAttemptFailureStage",
+          "exportKind": "const",
+          "filePath": "src/VerifiedSpan/VerifiedSpan.model.ts",
+          "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.model.ts",
+          "line": 340,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-model-ts-340-verifiedspanattemptfailurestage",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "VerifiedSpanAttemptFailureStage",
+          "exportKind": "type",
+          "filePath": "src/VerifiedSpan/VerifiedSpan.model.ts",
+          "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.model.ts",
+          "line": 352,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-model-ts-352-verifiedspanattemptfailurestage",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "VerifiedSpanAttemptFailureReason",
+          "exportKind": "const",
+          "filePath": "src/VerifiedSpan/VerifiedSpan.model.ts",
+          "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.model.ts",
+          "line": 369,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-model-ts-369-verifiedspanattemptfailurereason",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "VerifiedSpanAttemptFailureReason",
+          "exportKind": "type",
+          "filePath": "src/VerifiedSpan/VerifiedSpan.model.ts",
+          "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.model.ts",
+          "line": 381,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-model-ts-381-verifiedspanattemptfailurereason",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "VerifiedSpanAttemptFailure",
+          "exportKind": "class",
+          "filePath": "src/VerifiedSpan/VerifiedSpan.model.ts",
+          "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.model.ts",
+          "line": 436,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-model-ts-436-verifiedspanattemptfailure",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "VerifiedSpanCandidateAnchorReceipt",
+          "exportKind": "class",
+          "filePath": "src/VerifiedSpan/VerifiedSpan.model.ts",
+          "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.model.ts",
+          "line": 463,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-model-ts-463-verifiedspancandidateanchorreceipt",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "VerifiedSpanAttemptOutcome",
+          "exportKind": "const",
+          "filePath": "src/VerifiedSpan/VerifiedSpan.model.ts",
+          "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.model.ts",
+          "line": 531,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-model-ts-531-verifiedspanattemptoutcome",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "VerifiedSpanAttemptOutcome",
+          "exportKind": "type",
+          "filePath": "src/VerifiedSpan/VerifiedSpan.model.ts",
+          "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.model.ts",
+          "line": 550,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-model-ts-550-verifiedspanattemptoutcome",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "VerifiedSpanAttemptRecord",
+          "exportKind": "class",
+          "filePath": "src/VerifiedSpan/VerifiedSpan.model.ts",
+          "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.model.ts",
+          "line": 750,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-model-ts-750-verifiedspanattemptrecord",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "VerifiedSpanHistory",
+          "exportKind": "class",
+          "filePath": "src/VerifiedSpan/VerifiedSpan.model.ts",
+          "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.model.ts",
+          "line": 843,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-model-ts-843-verifiedspanhistory",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "BeginVerifiedSpanHistoryInput",
+          "exportKind": "class",
+          "filePath": "src/VerifiedSpan/VerifiedSpan.model.ts",
+          "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.model.ts",
+          "line": 909,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-model-ts-909-beginverifiedspanhistoryinput",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "ContinueVerifiedSpanHistoryInput",
+          "exportKind": "class",
+          "filePath": "src/VerifiedSpan/VerifiedSpan.model.ts",
+          "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.model.ts",
+          "line": 938,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-model-ts-938-continueverifiedspanhistoryinput",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "NormalizedTextWithRawOffsets",
+          "exportKind": "class",
+          "filePath": "src/VerifiedSpan/VerifiedSpan.normalization.ts",
+          "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.normalization.ts",
+          "line": 51,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-normalization-ts-51-normalizedtextwithrawoffsets",
+          "currentTags": [
+            "@category",
+            "@since",
+            "@internal"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "normalizeWithRawOffsets",
+          "exportKind": "const",
+          "filePath": "src/VerifiedSpan/VerifiedSpan.normalization.ts",
+          "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.normalization.ts",
+          "line": 191,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-normalization-ts-191-normalizewithrawoffsets",
+          "currentTags": [
+            "@category",
+            "@since",
+            "@internal"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "normalizeTextLocator",
+          "exportKind": "const",
+          "filePath": "src/VerifiedSpan/VerifiedSpan.normalization.ts",
+          "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/VerifiedSpan.normalization.ts",
+          "line": 237,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-verifiedspan-normalization-ts-237-normalizetextlocator",
           "currentTags": [
             "@category",
             "@since"
@@ -155312,6 +158789,28 @@
           "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/index.ts",
           "line": 26,
           "anchor": "packages-foundation-capability-langextract-src-verifiedspan-index-ts-26-export-from-verifiedspan-model-ts",
+          "currentTags": [
+            "@since",
+            "@category"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "export { normalizeTextLocator } from \"./VerifiedSpan.normalization.ts\";",
+          "exportKind": "re-export",
+          "filePath": "src/VerifiedSpan/index.ts",
+          "repoPath": "packages/foundation/capability/langextract/src/VerifiedSpan/index.ts",
+          "line": 31,
+          "anchor": "packages-foundation-capability-langextract-src-verifiedspan-index-ts-31-export-normalizetextlocator-from-verifiedspan-normalization-ts",
           "currentTags": [
             "@since",
             "@category"
@@ -268709,9 +272208,9 @@
       "status": "needs-remediation",
       "sourceCoverage": {
         "srcDir": "src",
-        "sourceFileCount": 31,
-        "publicModuleCount": 30,
-        "publicExportCount": 108
+        "sourceFileCount": 33,
+        "publicModuleCount": 32,
+        "publicExportCount": 113
       },
       "docgenCoverage": {
         "hasDocgenConfig": true,
@@ -269321,6 +272820,50 @@
         },
         {
           "docKind": "packageDocumentation",
+          "filePath": "src/PatentClaimCandidate/PatentClaimCandidate.ts",
+          "repoPath": "packages/law-practice/use-cases/src/PatentClaimCandidate/PatentClaimCandidate.ts",
+          "line": 1,
+          "anchor": "packages-law-practice-use-cases-src-patentclaimcandidate-patentclaimcandidate-ts-1-module",
+          "currentTags": [
+            "@packageDocumentation",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "exportCount": 3,
+          "remediationStatus": "resolved"
+        },
+        {
+          "docKind": "packageDocumentation",
+          "filePath": "src/PatentClaimCandidate/index.ts",
+          "repoPath": "packages/law-practice/use-cases/src/PatentClaimCandidate/index.ts",
+          "line": 1,
+          "anchor": "packages-law-practice-use-cases-src-patentclaimcandidate-index-ts-1-module",
+          "currentTags": [
+            "@packageDocumentation",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "exportCount": 1,
+          "remediationStatus": "resolved"
+        },
+        {
+          "docKind": "packageDocumentation",
           "filePath": "src/PracticeKg.tools.ts",
           "repoPath": "packages/law-practice/use-cases/src/PracticeKg.tools.ts",
           "line": 1,
@@ -269410,7 +272953,7 @@
           "schemaAnnotationGaps": [],
           "categoryViolations": [],
           "documentationShapeViolations": [],
-          "exportCount": 4,
+          "exportCount": 5,
           "remediationStatus": "resolved"
         },
         {
@@ -271101,6 +274644,95 @@
           "remediationStatus": "resolved"
         },
         {
+          "symbolName": "PatentClaimCandidateInput",
+          "exportKind": "class",
+          "filePath": "src/PatentClaimCandidate/PatentClaimCandidate.ts",
+          "repoPath": "packages/law-practice/use-cases/src/PatentClaimCandidate/PatentClaimCandidate.ts",
+          "line": 49,
+          "anchor": "packages-law-practice-use-cases-src-patentclaimcandidate-patentclaimcandidate-ts-49-patentclaimcandidateinput",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "PatentClaimCandidateError",
+          "exportKind": "class",
+          "filePath": "src/PatentClaimCandidate/PatentClaimCandidate.ts",
+          "repoPath": "packages/law-practice/use-cases/src/PatentClaimCandidate/PatentClaimCandidate.ts",
+          "line": 107,
+          "anchor": "packages-law-practice-use-cases-src-patentclaimcandidate-patentclaimcandidate-ts-107-patentclaimcandidateerror",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "patentClaimCandidateFrom",
+          "exportKind": "const",
+          "filePath": "src/PatentClaimCandidate/PatentClaimCandidate.ts",
+          "repoPath": "packages/law-practice/use-cases/src/PatentClaimCandidate/PatentClaimCandidate.ts",
+          "line": 212,
+          "anchor": "packages-law-practice-use-cases-src-patentclaimcandidate-patentclaimcandidate-ts-212-patentclaimcandidatefrom",
+          "currentTags": [
+            "@effects",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "export * from \"./PatentClaimCandidate.ts\";",
+          "exportKind": "re-export",
+          "filePath": "src/PatentClaimCandidate/index.ts",
+          "repoPath": "packages/law-practice/use-cases/src/PatentClaimCandidate/index.ts",
+          "line": 14,
+          "anchor": "packages-law-practice-use-cases-src-patentclaimcandidate-index-ts-14-export-from-patentclaimcandidate-ts",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
           "symbolName": "PracticeKgToolError",
           "exportKind": "class",
           "filePath": "src/PracticeKg.tools.ts",
@@ -271739,12 +275371,34 @@
           "remediationStatus": "resolved"
         },
         {
+          "symbolName": "export * from \"./PatentClaimCandidate/index.ts\";",
+          "exportKind": "re-export",
+          "filePath": "src/server.ts",
+          "repoPath": "packages/law-practice/use-cases/src/server.ts",
+          "line": 45,
+          "anchor": "packages-law-practice-use-cases-src-server-ts-45-export-from-patentclaimcandidate-index-ts",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
           "symbolName": "export * from \"./PracticeKg.tools.ts\";",
           "exportKind": "re-export",
           "filePath": "src/server.ts",
           "repoPath": "packages/law-practice/use-cases/src/server.ts",
-          "line": 53,
-          "anchor": "packages-law-practice-use-cases-src-server-ts-53-export-from-practicekg-tools-ts",
+          "line": 60,
+          "anchor": "packages-law-practice-use-cases-src-server-ts-60-export-from-practicekg-tools-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -271765,8 +275419,8 @@
           "exportKind": "re-export",
           "filePath": "src/server.ts",
           "repoPath": "packages/law-practice/use-cases/src/server.ts",
-          "line": 60,
-          "anchor": "packages-law-practice-use-cases-src-server-ts-60-export-from-tools-ts",
+          "line": 67,
+          "anchor": "packages-law-practice-use-cases-src-server-ts-67-export-from-tools-ts",
           "currentTags": [
             "@category",
             "@since"
@@ -294356,7 +298010,7 @@
         "srcDir": "src",
         "sourceFileCount": 8,
         "publicModuleCount": 8,
-        "publicExportCount": 225
+        "publicExportCount": 226
       },
       "docgenCoverage": {
         "hasDocgenConfig": true,
@@ -294567,7 +298221,7 @@
           "schemaAnnotationGaps": [],
           "categoryViolations": [],
           "documentationShapeViolations": [],
-          "exportCount": 140,
+          "exportCount": 141,
           "remediationStatus": "resolved"
         }
       ],
@@ -296489,12 +300143,34 @@
           "remediationStatus": "resolved"
         },
         {
-          "symbolName": "$SemanticaId",
+          "symbolName": "$LejeuneBoltWorkbenchId",
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
           "line": 241,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-241-semanticaid",
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-241-lejeuneboltworkbenchid",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "$SemanticaId",
+          "exportKind": "const",
+          "filePath": "src/packages.ts",
+          "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
+          "line": 259,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-259-semanticaid",
           "currentTags": [
             "@category",
             "@since"
@@ -296515,8 +300191,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 258,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-258-trustgraphworkbenchid",
+          "line": 276,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-276-trustgraphworkbenchid",
           "currentTags": [
             "@category",
             "@since"
@@ -296537,8 +300213,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 278,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-278-dataid",
+          "line": 296,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-296-dataid",
           "currentTags": [
             "@category",
             "@since"
@@ -296559,8 +300235,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 294,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-294-identityid",
+          "line": 312,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-312-identityid",
           "currentTags": [
             "@category",
             "@since"
@@ -296581,8 +300257,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 310,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-310-schemaid",
+          "line": 328,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-328-schemaid",
           "currentTags": [
             "@category",
             "@since"
@@ -296603,8 +300279,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 326,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-326-provenanceid",
+          "line": 344,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-344-provenanceid",
           "currentTags": [
             "@category",
             "@since"
@@ -296625,8 +300301,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 342,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-342-rdfid",
+          "line": 360,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-360-rdfid",
           "currentTags": [
             "@category",
             "@since"
@@ -296647,8 +300323,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 358,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-358-ontologyid",
+          "line": 376,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-376-ontologyid",
           "currentTags": [
             "@category",
             "@since"
@@ -296669,8 +300345,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 374,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-374-semanticfoundationid",
+          "line": 392,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-392-semanticfoundationid",
           "currentTags": [
             "@category",
             "@since"
@@ -296691,8 +300367,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 390,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-390-typesid",
+          "line": 408,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-408-typesid",
           "currentTags": [
             "@category",
             "@since"
@@ -296713,8 +300389,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 406,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-406-utilsid",
+          "line": 424,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-424-utilsid",
           "currentTags": [
             "@category",
             "@since"
@@ -296735,8 +300411,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 424,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-424-uiid",
+          "line": 442,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-442-uiid",
           "currentTags": [
             "@category",
             "@since"
@@ -296757,8 +300433,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 442,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-442-repoaimetricsid",
+          "line": 460,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-460-repoaimetricsid",
           "currentTags": [
             "@category",
             "@since"
@@ -296779,8 +300455,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 458,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-458-repocliid",
+          "line": 476,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-476-repocliid",
           "currentTags": [
             "@category",
             "@since"
@@ -296801,8 +300477,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 474,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-474-repoconfigsid",
+          "line": 492,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-492-repoconfigsid",
           "currentTags": [
             "@category",
             "@since"
@@ -296823,8 +300499,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 490,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-490-repoutilsid",
+          "line": 508,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-508-repoutilsid",
           "currentTags": [
             "@category",
             "@since"
@@ -296845,8 +300521,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 506,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-506-testutilsid",
+          "line": 524,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-524-testutilsid",
           "currentTags": [
             "@category",
             "@since"
@@ -296867,8 +300543,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 524,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-524-shareddomainid",
+          "line": 542,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-542-shareddomainid",
           "currentTags": [
             "@category",
             "@since"
@@ -296889,8 +300565,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 541,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-541-sharedusecasesid",
+          "line": 559,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-559-sharedusecasesid",
           "currentTags": [
             "@category",
             "@since"
@@ -296911,8 +300587,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 557,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-557-sharedtablesid",
+          "line": 575,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-575-sharedtablesid",
           "currentTags": [
             "@category",
             "@since"
@@ -296933,8 +300609,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 573,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-573-semanticwebid",
+          "line": 591,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-591-semanticwebid",
           "currentTags": [
             "@category",
             "@since"
@@ -296955,8 +300631,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 589,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-589-nlpid",
+          "line": 607,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-607-nlpid",
           "currentTags": [
             "@category",
             "@since"
@@ -296977,8 +300653,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 605,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-605-nlpprocessingid",
+          "line": 623,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-623-nlpprocessingid",
           "currentTags": [
             "@category",
             "@since"
@@ -296999,8 +300675,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 621,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-621-langextractid",
+          "line": 639,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-639-langextractid",
           "currentTags": [
             "@category",
             "@since"
@@ -297021,8 +300697,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 637,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-637-observabilityid",
+          "line": 655,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-655-observabilityid",
           "currentTags": [
             "@category",
             "@since"
@@ -297043,8 +300719,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 653,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-653-colorsid",
+          "line": 671,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-671-colorsid",
           "currentTags": [
             "@category",
             "@since"
@@ -297065,8 +300741,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 669,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-669-chalkid",
+          "line": 687,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-687-chalkid",
           "currentTags": [
             "@category",
             "@since"
@@ -297087,8 +300763,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 685,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-685-repodocgenid",
+          "line": 703,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-703-repodocgenid",
           "currentTags": [
             "@category",
             "@since"
@@ -297109,8 +300785,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 701,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-701-infraid",
+          "line": 719,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-719-infraid",
           "currentTags": [
             "@category",
             "@since"
@@ -297131,8 +300807,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 719,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-719-workspacedomainid",
+          "line": 737,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-737-workspacedomainid",
           "currentTags": [
             "@category",
             "@since"
@@ -297153,8 +300829,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 735,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-735-epistemicdomainid",
+          "line": 753,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-753-epistemicdomainid",
           "currentTags": [
             "@category",
             "@since"
@@ -297175,8 +300851,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 752,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-752-epistemicusecasesid",
+          "line": 770,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-770-epistemicusecasesid",
           "currentTags": [
             "@category",
             "@since"
@@ -297197,8 +300873,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 769,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-769-agentsdomainid",
+          "line": 787,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-787-agentsdomainid",
           "currentTags": [
             "@category",
             "@since"
@@ -297219,8 +300895,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 785,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-785-agentsserverid",
+          "line": 803,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-803-agentsserverid",
           "currentTags": [
             "@category",
             "@since"
@@ -297241,8 +300917,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 801,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-801-agentsusecasesid",
+          "line": 819,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-819-agentsusecasesid",
           "currentTags": [
             "@category",
             "@since"
@@ -297263,8 +300939,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 817,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-817-agentsclientid",
+          "line": 835,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-835-agentsclientid",
           "currentTags": [
             "@category",
             "@since"
@@ -297285,8 +300961,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 833,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-833-lawpracticedomainid",
+          "line": 851,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-851-lawpracticedomainid",
           "currentTags": [
             "@category",
             "@since"
@@ -297307,8 +300983,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 851,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-851-lawpracticeusecasesid",
+          "line": 869,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-869-lawpracticeusecasesid",
           "currentTags": [
             "@category",
             "@since"
@@ -297329,8 +301005,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 869,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-869-lawpracticeserverid",
+          "line": 887,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-887-lawpracticeserverid",
           "currentTags": [
             "@category",
             "@since"
@@ -297351,8 +301027,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 886,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-886-professionaldesktopid",
+          "line": 904,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-904-professionaldesktopid",
           "currentTags": [
             "@category",
             "@since"
@@ -297373,8 +301049,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 903,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-903-repopkgs",
+          "line": 921,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-921-repopkgs",
           "currentTags": [
             "@category",
             "@since"
@@ -297395,8 +301071,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 919,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-919-mdid",
+          "line": 937,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-937-mdid",
           "currentTags": [
             "@category",
             "@since"
@@ -297417,8 +301093,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 935,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-935-oipwebid",
+          "line": 953,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-953-oipwebid",
           "currentTags": [
             "@category",
             "@since"
@@ -297439,8 +301115,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 951,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-951-drizzleid",
+          "line": 969,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-969-drizzleid",
           "currentTags": [
             "@category",
             "@since"
@@ -297461,8 +301137,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 967,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-967-duckdbid",
+          "line": 985,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-985-duckdbid",
           "currentTags": [
             "@category",
             "@since"
@@ -297483,8 +301159,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 983,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-983-facedetectionid",
+          "line": 1001,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1001-facedetectionid",
           "currentTags": [
             "@category",
             "@since"
@@ -297505,8 +301181,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 999,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-999-ffmpegid",
+          "line": 1017,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1017-ffmpegid",
           "currentTags": [
             "@category",
             "@since"
@@ -297527,8 +301203,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1015,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1015-postgresid",
+          "line": 1033,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1033-postgresid",
           "currentTags": [
             "@category",
             "@since"
@@ -297549,8 +301225,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1032,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1032-anthropicid",
+          "line": 1050,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1050-anthropicid",
           "currentTags": [
             "@category",
             "@since"
@@ -297571,8 +301247,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1048,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1048-veniceaiid",
+          "line": 1066,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1066-veniceaiid",
           "currentTags": [
             "@category",
             "@since"
@@ -297593,8 +301269,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1064,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1064-xaiid",
+          "line": 1082,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1082-xaiid",
           "currentTags": [
             "@category",
             "@since"
@@ -297615,8 +301291,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1081,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1081-acpid",
+          "line": 1099,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1099-acpid",
           "currentTags": [
             "@category",
             "@since"
@@ -297637,8 +301313,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1098,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1098-openaicompatid",
+          "line": 1116,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1116-openaicompatid",
           "currentTags": [
             "@category",
             "@since"
@@ -297659,8 +301335,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1115,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1115-workspacetablesid",
+          "line": 1133,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1133-workspacetablesid",
           "currentTags": [
             "@category",
             "@since"
@@ -297681,8 +301357,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1132,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1132-workspaceusecasesid",
+          "line": 1150,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1150-workspaceusecasesid",
           "currentTags": [
             "@category",
             "@since"
@@ -297703,8 +301379,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1150,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1150-workspaceserverid",
+          "line": 1168,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1168-workspaceserverid",
           "currentTags": [
             "@category",
             "@since"
@@ -297725,8 +301401,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1167,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1167-documentsdomainid",
+          "line": 1185,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1185-documentsdomainid",
           "currentTags": [
             "@category",
             "@since"
@@ -297747,8 +301423,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1184,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1184-documentsusecasesid",
+          "line": 1202,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1202-documentsusecasesid",
           "currentTags": [
             "@category",
             "@since"
@@ -297769,8 +301445,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1202,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1202-documentsserverid",
+          "line": 1220,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1220-documentsserverid",
           "currentTags": [
             "@category",
             "@since"
@@ -297791,8 +301467,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1219,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1219-architecturelabdomainid",
+          "line": 1237,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1237-architecturelabdomainid",
           "currentTags": [
             "@category",
             "@since"
@@ -297813,8 +301489,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1237,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1237-architecturelabusecasesid",
+          "line": 1255,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1255-architecturelabusecasesid",
           "currentTags": [
             "@category",
             "@since"
@@ -297835,8 +301511,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1255,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1255-architecturelabconfigid",
+          "line": 1273,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1273-architecturelabconfigid",
           "currentTags": [
             "@category",
             "@since"
@@ -297857,8 +301533,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1273,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1273-architecturelabserverid",
+          "line": 1291,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1291-architecturelabserverid",
           "currentTags": [
             "@category",
             "@since"
@@ -297879,8 +301555,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1291,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1291-architecturelabtablesid",
+          "line": 1309,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1309-architecturelabtablesid",
           "currentTags": [
             "@category",
             "@since"
@@ -297901,8 +301577,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1309,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1309-architecturelabclientid",
+          "line": 1327,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1327-architecturelabclientid",
           "currentTags": [
             "@category",
             "@since"
@@ -297923,8 +301599,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1327,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1327-architecturelabuiid",
+          "line": 1345,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1345-architecturelabuiid",
           "currentTags": [
             "@category",
             "@since"
@@ -297945,8 +301621,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1345,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1345-architecturelabproofid",
+          "line": 1363,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1363-architecturelabproofid",
           "currentTags": [
             "@category",
             "@since"
@@ -297967,8 +301643,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1363,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1363-runpodid",
+          "line": 1381,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1381-runpodid",
           "currentTags": [
             "@category",
             "@since"
@@ -297989,8 +301665,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1380,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1380-onepasswordcliid",
+          "line": 1398,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1398-onepasswordcliid",
           "currentTags": [
             "@category",
             "@since"
@@ -298011,8 +301687,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1397,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1397-discordid",
+          "line": 1415,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1415-discordid",
           "currentTags": [
             "@category",
             "@since"
@@ -298033,8 +301709,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1414,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1414-aiprovidercliid",
+          "line": 1432,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1432-aiprovidercliid",
           "currentTags": [
             "@category",
             "@since"
@@ -298055,8 +301731,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1431,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1431-sanityid",
+          "line": 1449,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1449-sanityid",
           "currentTags": [
             "@category",
             "@since"
@@ -298077,8 +301753,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1448,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1448-hubspotid",
+          "line": 1466,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1466-hubspotid",
           "currentTags": [
             "@category",
             "@since"
@@ -298099,8 +301775,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1465,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1465-phoenixid",
+          "line": 1483,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1483-phoenixid",
           "currentTags": [
             "@category",
             "@since"
@@ -298121,8 +301797,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1482,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1482-aisyncid",
+          "line": 1500,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1500-aisyncid",
           "currentTags": [
             "@category",
             "@since"
@@ -298143,8 +301819,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1499,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1499-boxid",
+          "line": 1517,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1517-boxid",
           "currentTags": [
             "@category",
             "@since"
@@ -298165,8 +301841,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1516,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1516-nlpmcpid",
+          "line": 1534,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1534-nlpmcpid",
           "currentTags": [
             "@category",
             "@since"
@@ -298187,8 +301863,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1533,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1533-rdfcanonizeid",
+          "line": 1551,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1551-rdfcanonizeid",
           "currentTags": [
             "@category",
             "@since"
@@ -298209,8 +301885,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1550,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1550-winkid",
+          "line": 1568,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1568-winkid",
           "currentTags": [
             "@category",
             "@since"
@@ -298231,8 +301907,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1567,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1567-fileprocessingid",
+          "line": 1585,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1585-fileprocessingid",
           "currentTags": [
             "@category",
             "@since"
@@ -298253,8 +301929,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1584,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1584-tikaid",
+          "line": 1602,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1602-tikaid",
           "currentTags": [
             "@category",
             "@since"
@@ -298275,8 +301951,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1601,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1601-libpffid",
+          "line": 1619,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1619-libpffid",
           "currentTags": [
             "@category",
             "@since"
@@ -298297,8 +301973,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1618,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1618-firecrawlid",
+          "line": 1636,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1636-firecrawlid",
           "currentTags": [
             "@category",
             "@since"
@@ -298319,8 +301995,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1635,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1635-usptoid",
+          "line": 1653,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1653-usptoid",
           "currentTags": [
             "@category",
             "@since"
@@ -298341,8 +302017,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1652,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1652-lexicalschemaid",
+          "line": 1670,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1670-lexicalschemaid",
           "currentTags": [
             "@category",
             "@since"
@@ -298363,8 +302039,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1669,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1669-editorid",
+          "line": 1687,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1687-editorid",
           "currentTags": [
             "@category",
             "@since"
@@ -298385,8 +302061,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1686,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1686-scratchpadid",
+          "line": 1704,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1704-scratchpadid",
           "currentTags": [
             "@category",
             "@since"
@@ -298407,8 +302083,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1703,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1703-htmlid",
+          "line": 1721,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1721-htmlid",
           "currentTags": [
             "@category",
             "@since"
@@ -298429,8 +302105,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1720,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1720-pandocastid",
+          "line": 1738,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1738-pandocastid",
           "currentTags": [
             "@category",
             "@since"
@@ -298451,8 +302127,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1737,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1737-pgliteid",
+          "line": 1755,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1755-pgliteid",
           "currentTags": [
             "@category",
             "@since"
@@ -298473,8 +302149,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1754,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1754-m365id",
+          "line": 1772,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1772-m365id",
           "currentTags": [
             "@category",
             "@since"
@@ -298495,8 +302171,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1771,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1771-m365mcpid",
+          "line": 1789,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1789-m365mcpid",
           "currentTags": [
             "@category",
             "@since"
@@ -298517,8 +302193,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1788,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1788-govinfoid",
+          "line": 1806,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1806-govinfoid",
           "currentTags": [
             "@category",
             "@since"
@@ -298539,8 +302215,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1805,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1805-ecfrid",
+          "line": 1823,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1823-ecfrid",
           "currentTags": [
             "@category",
             "@since"
@@ -298561,8 +302237,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1822,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1822-apitransportid",
+          "line": 1840,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1840-apitransportid",
           "currentTags": [
             "@category",
             "@since"
@@ -298583,8 +302259,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1839,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1839-mcpkitid",
+          "line": 1857,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1857-mcpkitid",
           "currentTags": [
             "@category",
             "@since"
@@ -298605,8 +302281,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1856,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1856-usptomcpid",
+          "line": 1874,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1874-usptomcpid",
           "currentTags": [
             "@category",
             "@since"
@@ -298627,8 +302303,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1873,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1873-pacerid",
+          "line": 1891,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1891-pacerid",
           "currentTags": [
             "@category",
             "@since"
@@ -298649,8 +302325,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1890,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1890-fcrunsid",
+          "line": 1908,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1908-fcrunsid",
           "currentTags": [
             "@category",
             "@since"
@@ -298671,8 +302347,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1907,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1907-cosmosid",
+          "line": 1925,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1925-cosmosid",
           "currentTags": [
             "@category",
             "@since"
@@ -298693,8 +302369,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1924,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1924-dbadminid",
+          "line": 1942,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1942-dbadminid",
           "currentTags": [
             "@category",
             "@since"
@@ -298715,8 +302391,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1941,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1941-epistemicserverid",
+          "line": 1959,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1959-epistemicserverid",
           "currentTags": [
             "@category",
             "@since"
@@ -298737,8 +302413,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1958,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1958-epistemictablesid",
+          "line": 1976,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1976-epistemictablesid",
           "currentTags": [
             "@category",
             "@since"
@@ -298759,8 +302435,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1975,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1975-lintrulesid",
+          "line": 1993,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1993-lintrulesid",
           "currentTags": [
             "@category",
             "@since"
@@ -298781,8 +302457,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 1992,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-1992-n3id",
+          "line": 2010,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2010-n3id",
           "currentTags": [
             "@category",
             "@since"
@@ -298803,8 +302479,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 2009,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2009-pretextid",
+          "line": 2027,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2027-pretextid",
           "currentTags": [
             "@category",
             "@since"
@@ -298825,8 +302501,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 2026,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2026-graph3did",
+          "line": 2044,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2044-graph3did",
           "currentTags": [
             "@category",
             "@since"
@@ -298847,8 +302523,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 2043,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2043-dockid",
+          "line": 2061,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2061-dockid",
           "currentTags": [
             "@category",
             "@since"
@@ -298869,8 +302545,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 2060,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2060-dockreactid",
+          "line": 2078,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2078-dockreactid",
           "currentTags": [
             "@category",
             "@since"
@@ -298891,8 +302567,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 2077,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2077-ontologyclientid",
+          "line": 2095,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2095-ontologyclientid",
           "currentTags": [
             "@category",
             "@since"
@@ -298913,8 +302589,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 2094,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2094-ontologyconfigid",
+          "line": 2112,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2112-ontologyconfigid",
           "currentTags": [
             "@category",
             "@since"
@@ -298935,8 +302611,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 2111,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2111-ontologydomainid",
+          "line": 2129,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2129-ontologydomainid",
           "currentTags": [
             "@category",
             "@since"
@@ -298957,8 +302633,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 2128,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2128-ontologyserverid",
+          "line": 2146,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2146-ontologyserverid",
           "currentTags": [
             "@category",
             "@since"
@@ -298979,8 +302655,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 2145,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2145-ontologyuiid",
+          "line": 2163,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2163-ontologyuiid",
           "currentTags": [
             "@category",
             "@since"
@@ -299001,8 +302677,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 2162,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2162-ontologyusecasesid",
+          "line": 2180,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2180-ontologyusecasesid",
           "currentTags": [
             "@category",
             "@since"
@@ -299023,8 +302699,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 2179,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2179-oxigraphid",
+          "line": 2197,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2197-oxigraphid",
           "currentTags": [
             "@category",
             "@since"
@@ -299045,8 +302721,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 2196,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2196-shaclid",
+          "line": 2214,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2214-shaclid",
           "currentTags": [
             "@category",
             "@since"
@@ -299067,8 +302743,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 2213,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2213-storybookid",
+          "line": 2231,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2231-storybookid",
           "currentTags": [
             "@category",
             "@since"
@@ -299089,8 +302765,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 2230,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2230-tsgoshimid",
+          "line": 2248,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2248-tsgoshimid",
           "currentTags": [
             "@category",
             "@since"
@@ -299111,8 +302787,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 2247,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2247-doctextid",
+          "line": 2265,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2265-doctextid",
           "currentTags": [
             "@category",
             "@since"
@@ -299133,8 +302809,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 2264,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2264-documentstablesid",
+          "line": 2282,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2282-documentstablesid",
           "currentTags": [
             "@category",
             "@since"
@@ -299155,8 +302831,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 2281,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2281-tailscaleid",
+          "line": 2299,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2299-tailscaleid",
           "currentTags": [
             "@category",
             "@since"
@@ -299177,8 +302853,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 2298,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2298-agentstablesid",
+          "line": 2316,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2316-agentstablesid",
           "currentTags": [
             "@category",
             "@since"
@@ -299199,8 +302875,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 2315,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2315-epistemicconfigid",
+          "line": 2333,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2333-epistemicconfigid",
           "currentTags": [
             "@category",
             "@since"
@@ -299221,8 +302897,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 2332,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2332-lawpracticetablesid",
+          "line": 2350,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2350-lawpracticetablesid",
           "currentTags": [
             "@category",
             "@since"
@@ -299243,8 +302919,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 2350,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2350-practicekgmcpid",
+          "line": 2368,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2368-practicekgmcpid",
           "currentTags": [
             "@category",
             "@since"
@@ -299265,8 +302941,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 2367,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2367-openclawid",
+          "line": 2385,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2385-openclawid",
           "currentTags": [
             "@category",
             "@since"
@@ -299287,8 +302963,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 2384,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2384-obsid",
+          "line": 2402,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2402-obsid",
           "currentTags": [
             "@category",
             "@since"
@@ -299309,8 +302985,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 2401,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2401-exiftoolid",
+          "line": 2419,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2419-exiftoolid",
           "currentTags": [
             "@category",
             "@since"
@@ -299331,8 +303007,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 2418,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2418-qacaptureid",
+          "line": 2436,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2436-qacaptureid",
           "currentTags": [
             "@category",
             "@since"
@@ -299353,8 +303029,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 2435,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2435-govlegalmcpid",
+          "line": 2453,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2453-govlegalmcpid",
           "currentTags": [
             "@category",
             "@since"
@@ -299375,8 +303051,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 2451,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2451-epistemicclientid",
+          "line": 2469,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2469-epistemicclientid",
           "currentTags": [
             "@category",
             "@since"
@@ -299397,8 +303073,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 2467,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2467-epistemicuiid",
+          "line": 2485,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2485-epistemicuiid",
           "currentTags": [
             "@category",
             "@since"
@@ -299419,8 +303095,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 2483,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2483-effectdrizzleid",
+          "line": 2501,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2501-effectdrizzleid",
           "currentTags": [
             "@category",
             "@since"
@@ -299441,8 +303117,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 2500,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2500-skillcontractid",
+          "line": 2518,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2518-skillcontractid",
           "currentTags": [
             "@category",
             "@since"
@@ -299463,8 +303139,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 2517,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2517-codegenkitid",
+          "line": 2535,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2535-codegenkitid",
           "currentTags": [
             "@category",
             "@since"
@@ -299485,8 +303161,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 2534,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2534-brandid",
+          "line": 2552,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2552-brandid",
           "currentTags": [
             "@category",
             "@since"
@@ -299507,8 +303183,8 @@
           "exportKind": "const",
           "filePath": "src/packages.ts",
           "repoPath": "packages/foundation/modeling/identity/src/packages.ts",
-          "line": 2551,
-          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2551-openaiid",
+          "line": 2569,
+          "anchor": "packages-foundation-modeling-identity-src-packages-ts-2569-openaiid",
           "currentTags": [
             "@category",
             "@since"
@@ -515842,7 +519518,7 @@
         "srcDir": "src",
         "sourceFileCount": 4,
         "publicModuleCount": 4,
-        "publicExportCount": 22
+        "publicExportCount": 28
       },
       "docgenCoverage": {
         "hasDocgenConfig": true,
@@ -515947,7 +519623,7 @@
           "schemaAnnotationGaps": [],
           "categoryViolations": [],
           "documentationShapeViolations": [],
-          "exportCount": 9,
+          "exportCount": 15,
           "remediationStatus": "resolved"
         },
         {
@@ -516199,8 +519875,8 @@
           "exportKind": "const",
           "filePath": "src/VerifiedTextAnchor.ts",
           "repoPath": "packages/foundation/modeling/provenance/src/VerifiedTextAnchor.ts",
-          "line": 37,
-          "anchor": "packages-foundation-modeling-provenance-src-verifiedtextanchor-ts-37-verifiedtextanchorerrorreason",
+          "line": 71,
+          "anchor": "packages-foundation-modeling-provenance-src-verifiedtextanchor-ts-71-verifiedtextanchorerrorreason",
           "currentTags": [
             "@category",
             "@since"
@@ -516221,8 +519897,8 @@
           "exportKind": "type",
           "filePath": "src/VerifiedTextAnchor.ts",
           "repoPath": "packages/foundation/modeling/provenance/src/VerifiedTextAnchor.ts",
-          "line": 63,
-          "anchor": "packages-foundation-modeling-provenance-src-verifiedtextanchor-ts-63-verifiedtextanchorerrorreason",
+          "line": 97,
+          "anchor": "packages-foundation-modeling-provenance-src-verifiedtextanchor-ts-97-verifiedtextanchorerrorreason",
           "currentTags": [
             "@category",
             "@since"
@@ -516243,8 +519919,96 @@
           "exportKind": "class",
           "filePath": "src/VerifiedTextAnchor.ts",
           "repoPath": "packages/foundation/modeling/provenance/src/VerifiedTextAnchor.ts",
-          "line": 80,
-          "anchor": "packages-foundation-modeling-provenance-src-verifiedtextanchor-ts-80-verifiedtextanchorerror",
+          "line": 114,
+          "anchor": "packages-foundation-modeling-provenance-src-verifiedtextanchor-ts-114-verifiedtextanchorerror",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "VerifySourceTextIdentityInput",
+          "exportKind": "class",
+          "filePath": "src/VerifiedTextAnchor.ts",
+          "repoPath": "packages/foundation/modeling/provenance/src/VerifiedTextAnchor.ts",
+          "line": 154,
+          "anchor": "packages-foundation-modeling-provenance-src-verifiedtextanchor-ts-154-verifysourcetextidentityinput",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "VerifiedSourceText",
+          "exportKind": "type",
+          "filePath": "src/VerifiedTextAnchor.ts",
+          "repoPath": "packages/foundation/modeling/provenance/src/VerifiedTextAnchor.ts",
+          "line": 212,
+          "anchor": "packages-foundation-modeling-provenance-src-verifiedtextanchor-ts-212-verifiedsourcetext",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "VerifiedSourceText",
+          "exportKind": "const",
+          "filePath": "src/VerifiedTextAnchor.ts",
+          "repoPath": "packages/foundation/modeling/provenance/src/VerifiedTextAnchor.ts",
+          "line": 229,
+          "anchor": "packages-foundation-modeling-provenance-src-verifiedtextanchor-ts-229-verifiedsourcetext",
+          "currentTags": [
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "VerifyTextAnchorAgainstVerifiedSourceInput",
+          "exportKind": "class",
+          "filePath": "src/VerifiedTextAnchor.ts",
+          "repoPath": "packages/foundation/modeling/provenance/src/VerifiedTextAnchor.ts",
+          "line": 249,
+          "anchor": "packages-foundation-modeling-provenance-src-verifiedtextanchor-ts-249-verifytextanchoragainstverifiedsourceinput",
           "currentTags": [
             "@category",
             "@since"
@@ -516265,8 +520029,8 @@
           "exportKind": "class",
           "filePath": "src/VerifiedTextAnchor.ts",
           "repoPath": "packages/foundation/modeling/provenance/src/VerifiedTextAnchor.ts",
-          "line": 126,
-          "anchor": "packages-foundation-modeling-provenance-src-verifiedtextanchor-ts-126-verifytextanchorinput",
+          "line": 282,
+          "anchor": "packages-foundation-modeling-provenance-src-verifiedtextanchor-ts-282-verifytextanchorinput",
           "currentTags": [
             "@category",
             "@since"
@@ -516287,8 +520051,8 @@
           "exportKind": "class",
           "filePath": "src/VerifiedTextAnchor.ts",
           "repoPath": "packages/foundation/modeling/provenance/src/VerifiedTextAnchor.ts",
-          "line": 161,
-          "anchor": "packages-foundation-modeling-provenance-src-verifiedtextanchor-ts-161-textanchorverificationreceipt",
+          "line": 317,
+          "anchor": "packages-foundation-modeling-provenance-src-verifiedtextanchor-ts-317-textanchorverificationreceipt",
           "currentTags": [
             "@category",
             "@since"
@@ -516309,8 +520073,8 @@
           "exportKind": "type",
           "filePath": "src/VerifiedTextAnchor.ts",
           "repoPath": "packages/foundation/modeling/provenance/src/VerifiedTextAnchor.ts",
-          "line": 215,
-          "anchor": "packages-foundation-modeling-provenance-src-verifiedtextanchor-ts-215-verifiedtextanchor",
+          "line": 379,
+          "anchor": "packages-foundation-modeling-provenance-src-verifiedtextanchor-ts-379-verifiedtextanchor",
           "currentTags": [
             "@category",
             "@since"
@@ -516331,8 +520095,8 @@
           "exportKind": "const",
           "filePath": "src/VerifiedTextAnchor.ts",
           "repoPath": "packages/foundation/modeling/provenance/src/VerifiedTextAnchor.ts",
-          "line": 238,
-          "anchor": "packages-foundation-modeling-provenance-src-verifiedtextanchor-ts-238-verifiedtextanchor",
+          "line": 402,
+          "anchor": "packages-foundation-modeling-provenance-src-verifiedtextanchor-ts-402-verifiedtextanchor",
           "currentTags": [
             "@category",
             "@since"
@@ -516353,8 +520117,55 @@
           "exportKind": "const",
           "filePath": "src/VerifiedTextAnchor.ts",
           "repoPath": "packages/foundation/modeling/provenance/src/VerifiedTextAnchor.ts",
-          "line": 306,
-          "anchor": "packages-foundation-modeling-provenance-src-verifiedtextanchor-ts-306-totextanchorverificationreceipt",
+          "line": 470,
+          "anchor": "packages-foundation-modeling-provenance-src-verifiedtextanchor-ts-470-totextanchorverificationreceipt",
+          "currentTags": [
+            "@param",
+            "@returns",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "verifySourceTextIdentity",
+          "exportKind": "const",
+          "filePath": "src/VerifiedTextAnchor.ts",
+          "repoPath": "packages/foundation/modeling/provenance/src/VerifiedTextAnchor.ts",
+          "line": 528,
+          "anchor": "packages-foundation-modeling-provenance-src-verifiedtextanchor-ts-528-verifysourcetextidentity",
+          "currentTags": [
+            "@effects",
+            "@category",
+            "@since"
+          ],
+          "missingRequiredTags": [],
+          "forbiddenTags": [],
+          "missingSummary": false,
+          "malformedConditionalTags": [],
+          "exampleImportViolations": [],
+          "unsafeExampleViolations": [],
+          "schemaAnnotationGaps": [],
+          "categoryViolations": [],
+          "documentationShapeViolations": [],
+          "remediationStatus": "resolved"
+        },
+        {
+          "symbolName": "verifyTextAnchorAgainstVerifiedSource",
+          "exportKind": "const",
+          "filePath": "src/VerifiedTextAnchor.ts",
+          "repoPath": "packages/foundation/modeling/provenance/src/VerifiedTextAnchor.ts",
+          "line": 578,
+          "anchor": "packages-foundation-modeling-provenance-src-verifiedtextanchor-ts-578-verifytextanchoragainstverifiedsource",
           "currentTags": [
             "@param",
             "@returns",
@@ -516377,8 +520188,8 @@
           "exportKind": "const",
           "filePath": "src/VerifiedTextAnchor.ts",
           "repoPath": "packages/foundation/modeling/provenance/src/VerifiedTextAnchor.ts",
-          "line": 370,
-          "anchor": "packages-foundation-modeling-provenance-src-verifiedtextanchor-ts-370-verifytextanchor",
+          "line": 656,
+          "anchor": "packages-foundation-modeling-provenance-src-verifiedtextanchor-ts-656-verifytextanchor",
           "currentTags": [
             "@effects",
             "@category",

--- a/standards/jsdoc-documentation.inventory.md
+++ b/standards/jsdoc-documentation.inventory.md
@@ -1,6 +1,6 @@
 # JSDoc Documentation Compliance Inventory
 
-Generated: 2026-08-30T00:14:38.060Z
+Generated: 2026-08-30T11:19:29.667Z
 
 ## Scope
 
@@ -14,16 +14,16 @@ The package universe is the current `bun run topo-sort` output. This inventory c
 | cleanPackages | 73 |
 | packagesWithoutPublicSrcSurface | 3 |
 | packagesNeedingRemediation | 58 |
-| publicModules | 2935 |
-| publicExports | 20407 |
+| publicModules | 2950 |
+| publicExports | 20563 |
 | openModules | 347 |
-| openExports | 98 |
+| openExports | 99 |
 | missingExportExamples | 4 |
 | missingExportCategories | 0 |
 | missingExportSince | 0 |
 | forbiddenTagFindings | 0 |
 | malformedConditionalTagFindings | 0 |
-| exampleImportFindings | 0 |
+| exampleImportFindings | 1 |
 | unsafeExampleFindings | 0 |
 | schemaAnnotationFindings | 0 |
 | undescribed-see | 12 |
@@ -64,7 +64,7 @@ The package universe is the current `bun run topo-sort` output. This inventory c
 | 7 | `@beep/pacer` | `packages/drivers/pacer` | needs-remediation | 13 | 89 | 12 | 0 |
 | 8 | `@beep/workspace-tables` | `packages/workspace/tables` | clean | 19 | 48 | 0 | 0 |
 | 9 | `@beep/mcp-kit` | `packages/foundation/capability/mcp-kit` | needs-remediation | 9 | 62 | 8 | 4 |
-| 10 | `@beep/law-practice-server` | `packages/law-practice/server` | needs-remediation | 22 | 80 | 1 | 0 |
+| 10 | `@beep/law-practice-server` | `packages/law-practice/server` | needs-remediation | 22 | 81 | 1 | 0 |
 | 11 | `@beep/db-admin` | `packages/_internal/db-admin` | needs-remediation | 13 | 46 | 2 | 0 |
 | 12 | `@beep/shared-domain` | `packages/shared/domain` | needs-remediation | 104 | 368 | 3 | 2 |
 | 13 | `@beep/discord` | `packages/drivers/discord` | clean | 4 | 15 | 0 | 0 |
@@ -73,14 +73,14 @@ The package universe is the current `bun run topo-sort` output. This inventory c
 | 16 | `@beep/ontology-use-cases` | `packages/ontology/use-cases` | needs-remediation | 23 | 214 | 1 | 3 |
 | 17 | `@beep/architecture-lab-client` | `packages/architecture-lab/client` | clean | 3 | 7 | 0 | 0 |
 | 18 | `@beep/dock` | `packages/foundation/ui-system/dock` | clean | 20 | 212 | 0 | 0 |
-| 19 | `@beep/repo-cli` | `packages/tooling/tool/cli` | needs-remediation | 216 | 1704 | 46 | 9 |
+| 19 | `@beep/repo-cli` | `packages/tooling/tool/cli` | needs-remediation | 221 | 1758 | 46 | 10 |
 | 20 | `@beep/pglite` | `packages/drivers/pglite` | needs-remediation | 4 | 11 | 3 | 0 |
 | 21 | `@beep/ai-sync` | `packages/tooling/library/ai-sync` | clean | 10 | 86 | 0 | 0 |
 | 22 | `@beep/agents-server` | `packages/agents/server` | needs-remediation | 11 | 39 | 2 | 0 |
 | 23 | `@beep/workspace-use-cases` | `packages/workspace/use-cases` | needs-remediation | 12 | 46 | 1 | 0 |
 | 24 | `@beep/editor` | `packages/foundation/ui-system/editor` | needs-remediation | 36 | 241 | 14 | 0 |
 | 25 | `@beep/nlp-mcp` | `packages/drivers/nlp-mcp` | needs-remediation | 9 | 123 | 8 | 1 |
-| 26 | `@beep/law-practice-domain` | `packages/law-practice/domain` | needs-remediation | 207 | 582 | 9 | 4 |
+| 26 | `@beep/law-practice-domain` | `packages/law-practice/domain` | needs-remediation | 214 | 648 | 9 | 4 |
 | 27 | `@beep/repo-docgen` | `packages/tooling/tool/docgen` | clean | 10 | 86 | 0 | 0 |
 | 28 | `@beep/file-processing` | `packages/foundation/capability/file-processing` | clean | 26 | 130 | 0 | 0 |
 | 29 | `@beep/ontology-config` | `packages/ontology/config` | needs-remediation | 7 | 19 | 1 | 0 |
@@ -109,13 +109,13 @@ The package universe is the current `bun run topo-sort` output. This inventory c
 | 52 | `@beep/agents-tables` | `packages/agents/tables` | clean | 6 | 14 | 0 | 0 |
 | 53 | `@beep/ontology-domain` | `packages/ontology/domain` | clean | 6 | 41 | 0 | 0 |
 | 54 | `@beep/lexical-schema` | `packages/foundation/modeling/lexical` | needs-remediation | 5 | 119 | 4 | 4 |
-| 55 | `@beep/langextract` | `packages/foundation/capability/langextract` | clean | 25 | 102 | 0 | 0 |
+| 55 | `@beep/langextract` | `packages/foundation/capability/langextract` | clean | 26 | 125 | 0 | 0 |
 | 56 | `@beep/shared-tables` | `packages/shared/tables` | clean | 9 | 12 | 0 | 0 |
 | 57 | `@beep/scratchpad` | `scratchpad` | clean | 469 | 4233 | 0 | 0 |
 | 58 | `@beep/md` | `packages/foundation/modeling/md` | needs-remediation | 8 | 256 | 4 | 0 |
 | 59 | `@beep/practice-kg-mcp` | `apps/practice-kg-mcp` | clean | 7 | 14 | 0 | 0 |
 | 60 | `@beep/tailscale` | `packages/drivers/tailscale` | clean | 5 | 29 | 0 | 0 |
-| 61 | `@beep/law-practice-use-cases` | `packages/law-practice/use-cases` | needs-remediation | 30 | 108 | 4 | 0 |
+| 61 | `@beep/law-practice-use-cases` | `packages/law-practice/use-cases` | needs-remediation | 32 | 113 | 4 | 0 |
 | 62 | `@beep/epistemic-ui` | `packages/epistemic/ui` | clean | 5 | 12 | 0 | 0 |
 | 63 | `@beep/workspace-domain` | `packages/workspace/domain` | clean | 30 | 58 | 0 | 0 |
 | 64 | `@beep/semantic-web` | `packages/foundation/capability/semantic-web` | clean | 8 | 56 | 0 | 0 |
@@ -126,7 +126,7 @@ The package universe is the current `bun run topo-sort` output. This inventory c
 | 69 | `@beep/libpff` | `packages/drivers/libpff` | needs-remediation | 7 | 40 | 4 | 1 |
 | 70 | `@beep/venice-ai` | `packages/drivers/venice-ai` | clean | 3 | 35 | 0 | 0 |
 | 71 | `@beep/graph-3d` | `packages/drivers/graph-3d` | needs-remediation | 7 | 17 | 2 | 0 |
-| 72 | `@beep/identity` | `packages/foundation/modeling/identity` | clean | 8 | 225 | 0 | 0 |
+| 72 | `@beep/identity` | `packages/foundation/modeling/identity` | clean | 8 | 226 | 0 | 0 |
 | 73 | `@beep/drizzle` | `packages/drivers/drizzle` | clean | 3 | 11 | 0 | 0 |
 | 74 | `@beep/ontology-ui` | `packages/ontology/ui` | clean | 15 | 28 | 0 | 0 |
 | 75 | `@beep/api-transport` | `packages/foundation/capability/api-transport` | needs-remediation | 3 | 10 | 2 | 0 |
@@ -183,7 +183,7 @@ The package universe is the current `bun run topo-sort` output. This inventory c
 | 126 | `@beep/codegen-kit` | `packages/tooling/library/codegen-kit` | clean | 5 | 37 | 0 | 0 |
 | 127 | `@beep/architecture-lab-domain` | `packages/architecture-lab/domain` | clean | 15 | 48 | 0 | 0 |
 | 128 | `@beep/pretext` | `packages/drivers/pretext` | needs-remediation | 6 | 36 | 6 | 0 |
-| 129 | `@beep/provenance` | `packages/foundation/modeling/provenance` | needs-remediation | 4 | 22 | 1 | 0 |
+| 129 | `@beep/provenance` | `packages/foundation/modeling/provenance` | needs-remediation | 4 | 28 | 1 | 0 |
 | 130 | `@beep/epistemic-tables` | `packages/epistemic/tables` | needs-remediation | 28 | 87 | 4 | 0 |
 | 131 | `@beep/qa-capture` | `packages/tooling/library/qa-capture` | needs-remediation | 11 | 155 | 10 | 0 |
 | 132 | `@beep/doc-text` | `packages/drivers/doc-text` | clean | 3 | 12 | 0 | 0 |
@@ -358,14 +358,15 @@ Module findings:
 
 Export findings:
 - `src/commands/Ci/CiLane.ts:339` `CI_LANE_DESCRIPTORS` (const) - 1 documentation section/link violation(s)
-- `src/commands/Ci/CiLane.ts:903` `ciLaneStepsForTesting` (const) - 1 documentation section/link violation(s)
+- `src/commands/Ci/CiLane.ts:916` `ciLaneStepsForTesting` (const) - 1 documentation section/link violation(s)
 - `src/commands/CreatePackage/CreatePackage.command.ts:107` `resolveCreatePackageTemplateDir` (const) - 1 documentation section/link violation(s)
+- `src/commands/Explore/Atlas.ts:659` `explorationProjectionDriftPaths` (const) - 1 example import violation(s)
 - `src/commands/Laws/FrozenGrantSet.ts:328` `runFrozenGrantSetRules` (const) - 1 documentation section/link violation(s)
 - `src/commands/Laws/NoNativeRuntime.ts:570` `runNoNativeRuntimeRules` (const) - 1 documentation section/link violation(s)
 - `src/commands/Qa/JudgeCheck.ts:512` `extractLastJsonBlock` (const) - 1 documentation section/link violation(s)
 - `src/commands/Qa/JudgePack.ts:541` `renderTimeline` (const) - 1 documentation section/link violation(s)
 - `src/commands/Qa/JudgePack.ts:642` `selectJudgeEvidence` (const) - 1 documentation section/link violation(s)
-- `src/commands/Quality/Quality.command.ts:659` `runBunAudit` (const) - 1 documentation section/link violation(s)
+- `src/commands/Quality/Quality.command.ts:663` `runBunAudit` (const) - 1 documentation section/link violation(s)
 
 ### @beep/pglite
 

--- a/standards/jsdoc-totals.regression-baseline.jsonc
+++ b/standards/jsdoc-totals.regression-baseline.jsonc
@@ -8,7 +8,7 @@
   "regeneration_command": "bun run beep quality jsdoc-inventory",
   "snapshot_command": "bun run beep quality jsdoc-ratchet --write-baseline",
   "comparison": "fail-on-growth: generated inventory totals must not exceed this committed baseline",
-  "generated_at": "2026-08-30T00:19:07.754Z",
+  "generated_at": "2026-08-30T11:24:33.018Z",
   "tracked_totals": {
     "packagesNeedingRemediation": 58,
     "missingExportExamples": 4,


### PR DESCRIPTION
## feat(repo-cli): walk every scratch root and classify vitest and worktree-stub leaks

The tmpfs janitor now walks /tmp plus a distinct, canonical, absolute TMPDIR, rejecting /,
HOME, and ancestors of HOME or the checkout with a report warning, and gains two fail-closed
reap classes. vitest-forks-tmp matches 21-char nanoid directories whose children are only
ssr or client, uses the newest child mtime as its idle clock with a 24h threshold, and is
skipped while any vitest runner is alive. dangling-worktree-stub matches <x>-worktrees/<name>
whose gitfile target and parent repository are both NotFound, canonicalized and confined to
the scratch root, and removes the emptied container afterwards. worktree-command.test.ts keeps
its main checkout inside the temp root so its sibling -worktrees directory no longer leaks.
Report fields stay additive on tmpfs-reap/v1.

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/feat_tmpfs-reap-classes-e8bf11048585/verdict.json

---

## Provenance

- Branch: <code>feat/tmpfs-reap-classes</code>
- Harness: `codex`

<!-- yeet-provenance
{
  "schemaVersion": 1,
  "branch": "feat/tmpfs-reap-classes",
  "harness": "codex"
}
-->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790672282&installation_model_id=424656&pr_number=893&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F893&signature=e3eac4a620be0f4e356e915499b7fd8237e58af9e03a9d630a9b71adc67744b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->