### PR TITLE
fix(repo-cli): make runtime root invariant

### DIFF
--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/ArtifactPaths.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/ArtifactPaths.ts
@@ -134,9 +134,9 @@ const artifactNameHash = (value: string): string => createHash("sha256").update(
 
 const effectiveUserId = (): number => userInfo().uid;
 
-// Locks keep their historical leaf directly under the base root; resolving the
-// base independently of XDG_RUNTIME_DIR makes configured and scrubbed siblings
-// converge on the same coordinator.
+// Locks keep their historical UID-scoped leaf directly under literal /tmp, so
+// launcher environment and transient runtime-directory probes cannot split
+// sibling sessions across coordinators.
 const proofCoordinatorRuntimeRoot = Effect.fnUntraced(function* (): Effect.fn.Return<
   string,
   never,
@@ -157,10 +157,8 @@ const proofCoordinatorDirectoryName = (): string =>
  * path. Equivalent SCP, SSH, HTTPS, and Git URLs therefore share a lock. The
  * normalized identity is hashed before it reaches the path, so a
  * credential-bearing remote URL never appears in a filename. Lock files live
- * under the shared per-user coordination root. Resolution probes
- * `/run/user/<uid>` by creating a child directory and otherwise uses the
- * uid-suffixed system-temporary fallback. The namespace includes opaque machine
- * identity plus the effective UID.
+ * under literal `/tmp` with no environment-dependent or fallible root choice.
+ * The namespace includes opaque machine identity plus the effective UID.
  *
  * **Example** (Share a coordinator across checkouts)
  *

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/ArtifactPaths.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/ArtifactPaths.ts
@@ -134,9 +134,9 @@ const artifactNameHash = (value: string): string => createHash("sha256").update(
 
 const effectiveUserId = (): number => userInfo().uid;
 
-// Locks keep their historical UID-scoped leaf directly under literal /tmp, so
-// launcher environment and transient runtime-directory probes cannot split
-// sibling sessions across coordinators.
+// Locks keep their historical scoped leaf directly under the invariant
+// platform base, so launcher environment and transient runtime-directory probes
+// cannot split sibling sessions across coordinators.
 const proofCoordinatorRuntimeRoot = Effect.fnUntraced(function* (): Effect.fn.Return<
   string,
   never,
@@ -157,8 +157,9 @@ const proofCoordinatorDirectoryName = (): string =>
  * path. Equivalent SCP, SSH, HTTPS, and Git URLs therefore share a lock. The
  * normalized identity is hashed before it reaches the path, so a
  * credential-bearing remote URL never appears in a filename. Lock files live
- * under literal `/tmp` with no environment-dependent or fallible root choice.
- * The namespace includes opaque machine identity plus the effective UID.
+ * under the invariant platform base with no environment-dependent or fallible
+ * root choice. The namespace includes opaque machine identity plus the
+ * effective UID.
  *
  * **Example** (Share a coordinator across checkouts)
  *

--- a/packages/tooling/tool/cli/src/internal/repo-run/QualityScheduler.ts
+++ b/packages/tooling/tool/cli/src/internal/repo-run/QualityScheduler.ts
@@ -17,7 +17,7 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { freemem, tmpdir, totalmem, userInfo } from "node:os";
+import { freemem, totalmem } from "node:os";
 import { $RepoCliId } from "@beep/identity/packages";
 import * as OptionUtils from "@beep/utils/Option";
 import {
@@ -61,7 +61,6 @@ import {
 } from "./RunScope.ts";
 import { admissionRootFor, perUserRuntimeRoot } from "./RuntimeRoot.ts";
 import type { ChildProcessSpawner } from "effect/unstable/process";
-import type { RuntimeRootKind } from "./RuntimeRoot.schemas.ts";
 
 const $I = $RepoCliId.create("internal/repo-run/QualityScheduler");
 
@@ -106,44 +105,6 @@ export interface MemoryStatsShape {
  * @since 0.0.0
  */
 export class MemoryStats extends Context.Service<MemoryStats, MemoryStatsShape>()($I`MemoryStats`) {}
-
-class LegacyAdmissionRootsTestOverride extends Context.Service<
-  LegacyAdmissionRootsTestOverride,
-  ReadonlyArray<string>
->()($I`LegacyAdmissionRootsTestOverride`) {}
-
-/**
- * Inject explicit legacy admission roots into an Effect for isolated migration tests.
- *
- * **Example** (Avoid host admission state in a migration test)
- *
- * ```ts
- * import { provideLegacyAdmissionRootsForTesting } from "@beep/repo-cli/test/RepoRun"
- * import { Effect } from "effect"
- *
- * const program = Effect.succeed("isolated").pipe(provideLegacyAdmissionRootsForTesting(["/tmp/test-legacy"]))
- * console.log(Effect.runSync(program)) // "isolated"
- * ```
- *
- * @internal
- * @category testing
- * @since 0.0.0
- */
-export const provideLegacyAdmissionRootsForTesting: {
-  <Value, Error2, Requirements>(
-    roots: ReadonlyArray<string>
-  ): (self: Effect.Effect<Value, Error2, Requirements>) => Effect.Effect<Value, Error2, Requirements>;
-  <Value, Error2, Requirements>(
-    self: Effect.Effect<Value, Error2, Requirements>,
-    roots: ReadonlyArray<string>
-  ): Effect.Effect<Value, Error2, Requirements>;
-} = dual(
-  2,
-  <Value, Error2, Requirements>(
-    self: Effect.Effect<Value, Error2, Requirements>,
-    roots: ReadonlyArray<string>
-  ): Effect.Effect<Value, Error2, Requirements> => Effect.provideService(self, LegacyAdmissionRootsTestOverride, roots)
-);
 
 const parseMeminfoFieldGib = (meminfo: string, field: string): O.Option<number> =>
   pipe(
@@ -321,16 +282,10 @@ interface AdmissionDirectories {
   readonly quarantine: string;
   readonly queue: string;
   readonly root: string;
-  readonly runtimeKind: typeof RuntimeRootKind.Type;
 }
 
-const admissionDirectoriesFor = (
-  path: Path.Path,
-  root: string,
-  runtimeKind: typeof RuntimeRootKind.Type
-): AdmissionDirectories => ({
+const admissionDirectoriesFor = (path: Path.Path, root: string): AdmissionDirectories => ({
   root,
-  runtimeKind,
   leases: path.join(root, "leases"),
   queue: path.join(root, "queue"),
   quarantine: path.join(root, "quarantine"),
@@ -439,7 +394,7 @@ const ensureAdmissionDirectories = Effect.fnUntraced(function* (): Effect.fn.Ret
   // The base root is shared with the proof-lock coordinator (RuntimeRoot.ts),
   // so every session on the machine coordinates under one tree.
   const choice = yield* perUserRuntimeRoot();
-  const directories = admissionDirectoriesFor(path, admissionRootFor(path, choice), choice.kind);
+  const directories = admissionDirectoriesFor(path, admissionRootFor(path, choice));
   yield* Effect.forEach(
     [directories.root, directories.leases, directories.queue, directories.quarantine],
     (directory) =>
@@ -1437,9 +1392,9 @@ const derivedRunScopeUnitName = (lease: YeetAdmissionLease): ReadonlyArray<strin
 const recordedRunScopeUnitName = (lease: YeetAdmissionLease): ReadonlyArray<string> =>
   pipe(O.fromUndefinedOr(lease.runScope), O.match({ onNone: A.empty<string>, onSome: (scope) => [scope.unitName] }));
 
-// Only scopes that record this reaper's admission root as owner are candidates:
-// a scope from another root (another XDG_RUNTIME_DIR, an env-scrubbed session,
-// a test fixture) is someone else's live work, never a leak from here.
+// Only scopes that record this reaper's admission root as owner are candidates.
+// Production now has one invariant root; a scope from an isolated test fixture
+// is someone else's live work, never a leak from here.
 const ownedByRoot = (ownerRoot: string) =>
   Effect.fnUntraced(function* (
     unitName: string
@@ -1469,73 +1424,6 @@ const stopLeakedRunScopes = Effect.fnUntraced(function* (
   yield* Effect.forEach(targets, stopRunScopeForReap, { concurrency: 4, discard: true });
 });
 
-const reapLegacyAdmissionRoots = Effect.fnUntraced(function* (
-  roots: ReadonlyArray<string>
-): Effect.fn.Return<void, never, FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner> {
-  const fs = yield* FileSystem.FileSystem;
-  const path = yield* Path.Path;
-  yield* Effect.forEach(
-    roots,
-    (root) =>
-      Effect.gen(function* () {
-        if (!(yield* fs.exists(root))) {
-          return;
-        }
-        const directories = admissionDirectoriesFor(path, root, "tmpdir");
-        if (!(yield* fs.exists(directories.leases)) || !(yield* fs.exists(directories.queue))) {
-          return;
-        }
-        // A legacy root is only eligible after the same private-directory
-        // validation as the active root. If it is unreadable or unsafe, leave
-        // its scopes untouched rather than guessing ownership.
-        yield* validateAdmissionDirectory(root);
-        yield* stopLeakedRunScopes(yield* scanAdmissionState(directories, true), root);
-      }).pipe(
-        Effect.catch((error) =>
-          Console.warn(`[yeet] legacy admission root ${root} could not be reconciled safely: ${error.message}`)
-        )
-      ),
-    { discard: true }
-  );
-});
-
-/**
- * Reconcile run scopes recorded under explicit legacy admission roots.
- *
- * **Example** (Reference the migration seam)
- *
- * ```ts
- * import { reapLegacyAdmissionRootsForTesting } from "@beep/repo-cli/test/RepoRun"
- *
- * console.log(typeof reapLegacyAdmissionRootsForTesting) // "function"
- * ```
- *
- * @internal
- * @category testing
- * @since 0.0.0
- */
-export const reapLegacyAdmissionRootsForTesting = reapLegacyAdmissionRoots;
-
-const legacyAdmissionRootsFor: {
-  (path: Path.Path, currentRoot: string): ReadonlyArray<string>;
-  (currentRoot: string): (path: Path.Path) => ReadonlyArray<string>;
-} = dual(2, (path: Path.Path, currentRoot: string): ReadonlyArray<string> => {
-  const leaf = `beep-admit-uid-${userInfo().uid}`;
-  return pipe(
-    A.dedupe([path.join(tmpdir(), leaf), path.join("/tmp", leaf)]),
-    A.filter((root) => root !== currentRoot)
-  );
-});
-
-/**
- * Derive the legacy tmpdir admission roots considered during migration.
- *
- * @internal
- * @category testing
- * @since 0.0.0
- */
-export const legacyAdmissionRootsForTesting = legacyAdmissionRootsFor;
-
 /**
  * Reap dead admission state (dead pid or `/proc` start-time mismatch).
  *
@@ -1564,15 +1452,6 @@ export const reapAdmissionState = Effect.fn("QualityScheduler.reapAdmissionState
   const directories = yield* ensureAdmissionDirectories();
   if (options.apply) {
     yield* stopLeakedRunScopes(yield* scanAdmissionState(directories, false), directories.root);
-    if (directories.runtimeKind === "run-user") {
-      const path = yield* Path.Path;
-      const override = yield* Effect.serviceOption(LegacyAdmissionRootsTestOverride);
-      const legacyRoots = pipe(
-        override,
-        O.getOrElse(() => legacyAdmissionRootsFor(path, directories.root))
-      );
-      yield* reapLegacyAdmissionRoots(legacyRoots);
-    }
   }
   return yield* snapshotAdmissionState(directories, AdmissionConfig.make({}), options.apply);
 });

--- a/packages/tooling/tool/cli/src/internal/repo-run/RunScope.ts
+++ b/packages/tooling/tool/cli/src/internal/repo-run/RunScope.ts
@@ -171,8 +171,8 @@ export const detectRunScopeSupport = Effect.fn("RunScope.detectRunScopeSupport")
  * ```
  *
  * The unit description records the admission root that owns the scope, so a
- * reaper running against a different root (another `XDG_RUNTIME_DIR`, a test
- * fixture, an env-scrubbed session) never mistakes it for a leak.
+ * reaper running against an isolated test root never mistakes its scope for a
+ * leak. Production sessions all use the invariant canonical root.
  *
  * @param ticketId - Admission ticket nonce used to generate a safe unit name.
  * @param ownerRoot - Admission root directory whose lease owns the scope.

--- a/packages/tooling/tool/cli/src/internal/repo-run/RuntimeRoot.schemas.ts
+++ b/packages/tooling/tool/cli/src/internal/repo-run/RuntimeRoot.schemas.ts
@@ -12,34 +12,34 @@ const $I = $RepoCliId.create("internal/repo-run/RuntimeRoot.schemas");
 /**
  * How the per-user runtime root was chosen.
  *
- * **Example** (Recognise the temporary fallback)
+ * **Example** (Recognise the canonical host root)
  *
  * ```ts
  * import { RuntimeRootKind } from "@beep/repo-cli/test/RepoRun"
  *
- * console.log(RuntimeRootKind.is.tmpdir("tmpdir")) // true
+ * console.log(RuntimeRootKind.is.canonical("canonical")) // true
  * ```
  *
  * @category models
  * @since 0.0.0
  */
-export const RuntimeRootKind = LiteralKit(["run-user", "tmpdir", "test-override"]).pipe(
+export const RuntimeRootKind = LiteralKit(["canonical", "test-override"]).pipe(
   $I.annoteSchema("RuntimeRootKind", {
     description:
-      "Origin of the chosen runtime root: a usable /run/user/<uid>, the system temporary directory, or an injected test override.",
+      "Origin of the chosen runtime root: the invariant host coordination root or an injected test override.",
   })
 );
 
 /**
  * The chosen per-user base root plus its origin.
  *
- * **Example** (Construct a run-user choice)
+ * **Example** (Construct the canonical choice)
  *
  * ```ts
  * import { RuntimeRootChoice } from "@beep/repo-cli/test/RepoRun"
  *
- * const choice = RuntimeRootChoice.make({ kind: "run-user", root: "/run/user/1000" })
- * console.log(choice.root) // "/run/user/1000"
+ * const choice = RuntimeRootChoice.make({ kind: "canonical", root: "/tmp" })
+ * console.log(choice.root) // "/tmp"
  * ```
  *
  * @category models

--- a/packages/tooling/tool/cli/src/internal/repo-run/RuntimeRoot.ts
+++ b/packages/tooling/tool/cli/src/internal/repo-run/RuntimeRoot.ts
@@ -4,7 +4,8 @@
  * Both coordinators used to choose between launcher-specific environment state,
  * `/run/user/<uid>`, and the system temporary directory. Any fallible choice can
  * split sibling sessions across separate trees. This module instead fixes the
- * host base at POSIX `/tmp`; each consumer appends its existing UID-scoped leaf.
+ * POSIX base at `/tmp`; Windows uses the effective user's home-backed
+ * `.beep/runtime` directory. Each consumer appends its existing scoped leaf.
  *
  * This change is a hard cutover, not a mixed-version migration. Before adopting
  * it, operators must drain every Yeet process, admission lease or ticket,
@@ -22,7 +23,30 @@ import { dual } from "effect/Function";
 import { RuntimeRootChoice, RuntimeRootKind } from "./RuntimeRoot.schemas.ts";
 import type { Path } from "effect";
 
-const CANONICAL_RUNTIME_ROOT = "/tmp";
+/**
+ * Resolve the invariant production base for an explicit platform and user home.
+ *
+ * **Example** (Resolve the Windows base)
+ *
+ * ```ts
+ * import { canonicalRuntimeRootForTesting } from "@beep/repo-cli/test/RepoRun"
+ *
+ * console.log(canonicalRuntimeRootForTesting("win32", "C:\\Users\\alice"))
+ * // "C:\\Users\\alice\\.beep\\runtime"
+ * ```
+ *
+ * @internal
+ * @category testing
+ * @since 0.0.0
+ */
+export const canonicalRuntimeRootForTesting: {
+  (platform: NodeJS.Platform, userHome: string): string;
+  (userHome: string): (platform: NodeJS.Platform) => string;
+} = dual(2, (platform: NodeJS.Platform, userHome: string): string =>
+  platform === "win32" ? `${userHome.replace(/[\\/]+$/u, "")}\\.beep\\runtime` : "/tmp"
+);
+
+const CANONICAL_RUNTIME_ROOT = canonicalRuntimeRootForTesting(process.platform, userInfo().homedir);
 
 class RuntimeRootTestOverride extends Context.Service<RuntimeRootTestOverride, RuntimeRootChoice>()(
   "@beep/repo-cli/internal/repo-run/RuntimeRoot/RuntimeRootTestOverride"
@@ -69,10 +93,11 @@ export const provideRuntimeRootForTesting: {
  *
  * **Details**
  *
- * Production always returns literal `/tmp`. It does not consult
- * `XDG_RUNTIME_DIR`, `TMPDIR`, or a fallible `/run/user/<uid>` probe, so sibling
- * sessions cannot independently select different coordination trees. Admission
- * and proof consumers retain their existing UID-scoped leaves below this base.
+ * Production returns literal `/tmp` on POSIX and a stable directory below the
+ * effective user's home on Windows. It does not consult `XDG_RUNTIME_DIR`,
+ * `TMPDIR`, `TEMP`, or a fallible `/run/user/<uid>` probe, so sibling sessions
+ * cannot independently select different coordination trees. Admission and
+ * proof consumers retain their existing scoped leaves below this base.
  * Deployment must follow the module-level hard-cutover procedure; mixed-version
  * coordination with the prior `/run/user/<uid>` scheme is intentionally refused
  * as an operational rollout shape.
@@ -83,7 +108,7 @@ export const provideRuntimeRootForTesting: {
  * import { perUserRuntimeRoot } from "@beep/repo-cli/test/RepoRun"
  * import { Effect } from "effect"
  *
- * Effect.runPromise(perUserRuntimeRoot()).then((resolved) => console.log(resolved.root)) // "/tmp"
+ * Effect.runPromise(perUserRuntimeRoot()).then((resolved) => console.log(resolved.kind)) // "canonical"
  * ```
  *
  * @returns The chosen base root and how it was chosen.

--- a/packages/tooling/tool/cli/src/internal/repo-run/RuntimeRoot.ts
+++ b/packages/tooling/tool/cli/src/internal/repo-run/RuntimeRoot.ts
@@ -6,6 +6,13 @@
  * split sibling sessions across separate trees. This module instead fixes the
  * host base at POSIX `/tmp`; each consumer appends its existing UID-scoped leaf.
  *
+ * This change is a hard cutover, not a mixed-version migration. Before adopting
+ * it, operators must drain every Yeet process, admission lease or ticket,
+ * proof-lock file, and `agent-run-*.scope` created by a version that coordinates
+ * under `/run/user/<uid>`. Running the two root schemes concurrently is not
+ * supported: an old process cannot observe a compatibility lock introduced only
+ * in the new process, so a one-sided bridge would provide false safety.
+ *
  * @since 0.0.0
  */
 import { userInfo } from "node:os";
@@ -66,6 +73,9 @@ export const provideRuntimeRootForTesting: {
  * `XDG_RUNTIME_DIR`, `TMPDIR`, or a fallible `/run/user/<uid>` probe, so sibling
  * sessions cannot independently select different coordination trees. Admission
  * and proof consumers retain their existing UID-scoped leaves below this base.
+ * Deployment must follow the module-level hard-cutover procedure; mixed-version
+ * coordination with the prior `/run/user/<uid>` scheme is intentionally refused
+ * as an operational rollout shape.
  *
  * **Example** (Resolve the invariant host base)
  *

--- a/packages/tooling/tool/cli/src/internal/repo-run/RuntimeRoot.ts
+++ b/packages/tooling/tool/cli/src/internal/repo-run/RuntimeRoot.ts
@@ -1,43 +1,25 @@
 /**
  * One per-user runtime root shared by admission and proof coordination.
  *
- * Both coordinators used to pick their root by testing whether
- * `XDG_RUNTIME_DIR` was configured, so a session launched with a scrubbed
- * environment coordinated under a different root than its siblings and ran
- * proofs unserialised. This module ignores launcher-specific environment state,
- * chooses the base root once, and lets each consumer append its own leaf.
+ * Both coordinators used to choose between launcher-specific environment state,
+ * `/run/user/<uid>`, and the system temporary directory. Any fallible choice can
+ * split sibling sessions across separate trees. This module instead fixes the
+ * host base at POSIX `/tmp`; each consumer appends its existing UID-scoped leaf.
  *
  * @since 0.0.0
  */
-import { tmpdir, userInfo } from "node:os";
+import { userInfo } from "node:os";
 import * as O from "@beep/utils/Option";
-import { Console, Context, Effect, FileSystem, MutableRef, Path } from "effect";
+import { Context, Effect } from "effect";
 import { dual } from "effect/Function";
 import { RuntimeRootChoice, RuntimeRootKind } from "./RuntimeRoot.schemas.ts";
+import type { Path } from "effect";
 
-// The fallback notice is diagnostic; one line per process is enough, and it
-// goes to stderr so `--json` stdout streams stay machine-parseable.
-const fallbackNoticed = MutableRef.make(false);
+const CANONICAL_RUNTIME_ROOT = "/tmp";
 
 class RuntimeRootTestOverride extends Context.Service<RuntimeRootTestOverride, RuntimeRootChoice>()(
   "@beep/repo-cli/internal/repo-run/RuntimeRoot/RuntimeRootTestOverride"
 ) {}
-
-const canCreateChildDirectory = Effect.fnUntraced(function* (
-  directory: string
-): Effect.fn.Return<boolean, never, FileSystem.FileSystem> {
-  const fs = yield* FileSystem.FileSystem;
-  const info = yield* fs.stat(directory).pipe(Effect.option);
-  if (!O.exists(info, (entry) => entry.type === "Directory")) {
-    return false;
-  }
-  const probe = yield* fs.makeTempDirectory({ directory, prefix: ".beep-runtime-root-probe-" }).pipe(Effect.option);
-  if (O.isNone(probe)) {
-    return false;
-  }
-  yield* fs.remove(probe.value, { recursive: true, force: true }).pipe(Effect.ignore);
-  return true;
-});
 
 /**
  * Inject a runtime-root choice into an Effect for isolated scheduler tests.
@@ -80,23 +62,18 @@ export const provideRuntimeRootForTesting: {
  *
  * **Details**
  *
- * Resolution order: `/run/user/<uid>` when the `FileSystem` service can create
- * and remove a child directory there; otherwise the system temporary directory,
- * announced once per process on stderr. `XDG_RUNTIME_DIR` is deliberately not
- * consulted, so configured and env-scrubbed sibling sessions converge.
+ * Production always returns literal `/tmp`. It does not consult
+ * `XDG_RUNTIME_DIR`, `TMPDIR`, or a fallible `/run/user/<uid>` probe, so sibling
+ * sessions cannot independently select different coordination trees. Admission
+ * and proof consumers retain their existing UID-scoped leaves below this base.
  *
- * **Example** (Resolve with a temporary fallback)
+ * **Example** (Resolve the invariant host base)
  *
  * ```ts
  * import { perUserRuntimeRoot } from "@beep/repo-cli/test/RepoRun"
- * import * as NodePath from "@effect/platform-node/NodePath"
- * import { Effect, FileSystem } from "effect"
+ * import { Effect } from "effect"
  *
- * const choice = perUserRuntimeRoot().pipe(
- *   Effect.provide(FileSystem.layerNoop({})),
- *   Effect.provide(NodePath.layer)
- * )
- * Effect.runPromise(choice).then((resolved) => console.log(resolved.kind)) // "tmpdir"
+ * Effect.runPromise(perUserRuntimeRoot()).then((resolved) => console.log(resolved.root)) // "/tmp"
  * ```
  *
  * @returns The chosen base root and how it was chosen.
@@ -106,23 +83,13 @@ export const provideRuntimeRootForTesting: {
 export const perUserRuntimeRoot = Effect.fn("RuntimeRoot.perUserRuntimeRoot")(function* (): Effect.fn.Return<
   RuntimeRootChoice,
   never,
-  FileSystem.FileSystem | Path.Path
+  never
 > {
   const override = yield* Effect.serviceOption(RuntimeRootTestOverride);
   if (O.isSome(override)) {
     return override.value;
   }
-  const path = yield* Path.Path;
-  const runUserDirectory = path.join("/run/user", `${userInfo().uid}`);
-  if (yield* canCreateChildDirectory(runUserDirectory)) {
-    return RuntimeRootChoice.make({ kind: "run-user", root: runUserDirectory });
-  }
-  const root = tmpdir();
-  if (!MutableRef.get(fallbackNoticed)) {
-    MutableRef.set(fallbackNoticed, true);
-    yield* Console.warn(`[yeet] runtime root: ${runUserDirectory} unavailable; using ${root}`);
-  }
-  return RuntimeRootChoice.make({ kind: "tmpdir", root });
+  return RuntimeRootChoice.make({ kind: "canonical", root: CANONICAL_RUNTIME_ROOT });
 });
 
 /**
@@ -130,9 +97,9 @@ export const perUserRuntimeRoot = Effect.fn("RuntimeRoot.perUserRuntimeRoot")(fu
  *
  * **Details**
  *
- * Per-user roots get `beep/admit`; the shared temporary directory gets the
- * uid-suffixed `beep-admit-uid-<uid>` leaf it has always used, because
- * `tmpdir()` is not per-user.
+ * The canonical host base gets the historical uid-suffixed
+ * `beep-admit-uid-<uid>` leaf. Test overrides get `beep/admit`, keeping isolated
+ * fixtures self-contained.
  *
  * **Example** (Derive the admission root)
  *
@@ -142,9 +109,9 @@ export const perUserRuntimeRoot = Effect.fn("RuntimeRoot.perUserRuntimeRoot")(fu
  * import { Effect, Path } from "effect"
  *
  * const root = Effect.map(Path.Path, (path) =>
- *   admissionRootFor(path, RuntimeRootChoice.make({ kind: "run-user", root: "/run/user/1000" }))
+ *   admissionRootFor(path, RuntimeRootChoice.make({ kind: "canonical", root: "/tmp" }))
  * ).pipe(Effect.provide(NodePath.layer))
- * Effect.runPromise(root).then(console.log) // "/run/user/1000/beep/admit"
+ * Effect.runPromise(root).then(console.log) // "/tmp/beep-admit-uid-1000"
  * ```
  *
  * @param path - Platform path service.
@@ -157,7 +124,7 @@ export const admissionRootFor: {
   (path: Path.Path, choice: RuntimeRootChoice): string;
   (choice: RuntimeRootChoice): (path: Path.Path) => string;
 } = dual(2, (path: Path.Path, choice: RuntimeRootChoice): string =>
-  RuntimeRootKind.is.tmpdir(choice.kind)
+  RuntimeRootKind.is.canonical(choice.kind)
     ? path.join(choice.root, `beep-admit-uid-${userInfo().uid}`)
     : path.join(choice.root, "beep", "admit")
 );

--- a/packages/tooling/tool/cli/test/quality-scheduler.test.ts
+++ b/packages/tooling/tool/cli/test/quality-scheduler.test.ts
@@ -12,11 +12,9 @@ import {
   appendAdmissionJournalEvent,
   decodeAdmissionJournalEvent,
   isOvershootLoserForTesting,
-  legacyAdmissionRootsForTesting,
   MemoryStats,
   noAdmissionOriginGate,
   parseAdmissionProcStatStartTime,
-  provideLegacyAdmissionRootsForTesting,
   provideRuntimeRootForTesting,
   RunScopeRecord,
   RuntimeRootChoice,
@@ -1087,82 +1085,6 @@ describe("quality-scheduler", () => {
                 expect(captured).not.toContain("stop\nagent-run-legacy.scope");
               })
             );
-          })
-        );
-      })
-    ));
-
-  it("reconciles dead scopes under a safe legacy admission root without stopping live legacy work", () =>
-    Effect.runPromise(
-      Effect.gen(function* () {
-        const gibRef = yield* Ref.make(50);
-        yield* withAdmissionTempRoot(gibRef, (tempRoot) =>
-          Effect.gen(function* () {
-            const fs = yield* FileSystem.FileSystem;
-            const path = yield* Path.Path;
-            const runtimeDirectory = path.dirname(path.dirname(tempRoot.root));
-            const legacyRoot: AdmissionTempRoot = {
-              root: path.join(runtimeDirectory, "legacy", "beep-admit-uid-1000"),
-              leases: path.join(runtimeDirectory, "legacy", "beep-admit-uid-1000", "leases"),
-              queue: path.join(runtimeDirectory, "legacy", "beep-admit-uid-1000", "queue"),
-              quarantine: path.join(runtimeDirectory, "legacy", "beep-admit-uid-1000", "quarantine"),
-            };
-            yield* Effect.forEach(
-              [legacyRoot.root, legacyRoot.leases, legacyRoot.queue, legacyRoot.quarantine],
-              (directory) => fs.makeDirectory(directory, { recursive: true, mode: 0o700 }),
-              { discard: true }
-            );
-            const missingRoot = path.join(runtimeDirectory, "legacy", "missing-root");
-            const incompleteRoot = path.join(runtimeDirectory, "legacy", "incomplete-root");
-            const unsafeRoot = path.join(runtimeDirectory, "legacy", "unsafe-root");
-            yield* fs.makeDirectory(incompleteRoot, { recursive: true, mode: 0o700 });
-            yield* Effect.forEach(
-              [unsafeRoot, path.join(unsafeRoot, "leases"), path.join(unsafeRoot, "queue")],
-              (directory) => fs.makeDirectory(directory, { recursive: true, mode: 0o700 }),
-              { discard: true }
-            );
-            yield* fs.chmod(unsafeRoot, 0o755);
-            const liveLeasePath = yield* writeFakeLease(legacyRoot, {
-              originKey: "legacy-live",
-              runScope: RunScopeRecord.make({
-                unitName: "agent-run-legacy-live.scope",
-                support: "active",
-                attachedPid: process.pid,
-                attachedAt: "2026-08-30T00:00:01Z",
-              }),
-            });
-            const deadLeasePath = yield* writeFakeLease(legacyRoot, {
-              pid: DEAD_PID,
-              procStart: "0",
-              originKey: "legacy-dead",
-              runScope: RunScopeRecord.make({
-                unitName: "agent-run-legacy-dead.scope",
-                support: "active",
-                attachedPid: DEAD_PID,
-                attachedAt: "2026-08-30T00:00:01Z",
-              }),
-            });
-            const binDirectory = path.join(runtimeDirectory, "legacy-bin");
-            const capturePath = path.join(runtimeDirectory, "legacy-systemctl.argv");
-            yield* fs.makeDirectory(binDirectory, { recursive: true });
-            yield* writeExecutable(
-              path.join(binDirectory, "systemctl"),
-              `#!/bin/sh\nprintf '%s\\n' "$@" >> '${capturePath}'\ncase "$2" in\n  list-units) printf 'agent-run-legacy-live.scope loaded active running\\nagent-run-legacy-dead.scope loaded active running\\n' ;;\n  show) printf 'Description=beep-yeet-lease nonce=legacy root=${legacyRoot.root}\\n' ;;\nesac\nexit 0\n`
-            );
-
-            expect(legacyAdmissionRootsForTesting(path, legacyRoot.root)).not.toContain(legacyRoot.root);
-            yield* withPrependedPath(
-              binDirectory,
-              reapAdmissionState({ apply: true }).pipe(
-                provideRuntimeRootForTesting(RuntimeRootChoice.make({ kind: "run-user", root: runtimeDirectory })),
-                provideLegacyAdmissionRootsForTesting([missingRoot, incompleteRoot, unsafeRoot, legacyRoot.root])
-              )
-            );
-            const captured = yield* fs.readFileString(capturePath);
-            expect(captured).toContain("--user\nstop\nagent-run-legacy-dead.scope\n");
-            expect(captured).not.toContain("stop\nagent-run-legacy-live.scope");
-            expect(yield* fs.exists(liveLeasePath)).toBe(true);
-            expect(yield* fs.exists(deadLeasePath)).toBe(false);
           })
         );
       })

--- a/packages/tooling/tool/cli/test/runtime-root.test.ts
+++ b/packages/tooling/tool/cli/test/runtime-root.test.ts
@@ -1,4 +1,4 @@
-import { tmpdir, userInfo } from "node:os";
+import { userInfo } from "node:os";
 import {
   admissionRootFor,
   perUserRuntimeRoot,
@@ -9,107 +9,40 @@ import { proofCoordinatorLockPath } from "@beep/repo-cli/test/Yeet";
 import { provideScopedLayer } from "@beep/test-utils";
 import * as NodePath from "@effect/platform-node/NodePath";
 import { describe, expect, it } from "@effect/vitest";
-import { ConfigProvider, Effect, FileSystem, Layer, Path } from "effect";
-import * as O from "effect/Option";
+import { ConfigProvider, Effect, FileSystem, Path } from "effect";
 
 const uid = userInfo().uid;
-const runUserDirectory = `/run/user/${uid}`;
+const canonical = RuntimeRootChoice.make({ kind: "canonical", root: "/tmp" });
 
-const directoryInfo: FileSystem.File.Info = {
-  type: "Directory",
-  mtime: O.none(),
-  atime: O.none(),
-  birthtime: O.none(),
-  dev: 1,
-  ino: O.none(),
-  mode: 0o700,
-  nlink: O.none(),
-  uid: O.some(uid),
-  gid: O.none(),
-  rdev: O.none(),
-  size: FileSystem.Size(0),
-  blksize: O.none(),
-  blocks: O.none(),
-};
-
-const writableRunUser = FileSystem.layerNoop({
-  stat: (path) =>
-    path === runUserDirectory
-      ? Effect.succeed(directoryInfo)
-      : Effect.fail(new Error(`unexpected stat ${path}`) as never),
-  makeTempDirectory: () => Effect.succeed(`${runUserDirectory}/.beep-runtime-root-probe-test`),
-  remove: () => Effect.void,
-});
-
-const unwritableRunUser = FileSystem.layerNoop({
-  stat: () => Effect.succeed(directoryInfo),
-  makeTempDirectory: () => Effect.fail(new Error("unwritable") as never),
-});
-
-const fileAtRunUser = FileSystem.layerNoop({
-  stat: () => Effect.succeed({ ...directoryInfo, type: "File" }),
-});
-
-const resolveWith = (fileSystem: Layer.Layer<FileSystem.FileSystem>, environment: Readonly<Record<string, string>>) =>
+const resolveWith = (environment: Readonly<Record<string, string>>) =>
   perUserRuntimeRoot().pipe(
-    Effect.provideService(ConfigProvider.ConfigProvider, ConfigProvider.fromUnknown(environment)),
-    provideScopedLayer(Layer.mergeAll(fileSystem, NodePath.layer))
+    Effect.provideService(ConfigProvider.ConfigProvider, ConfigProvider.fromUnknown(environment))
   );
 
 describe("per-user runtime root", () => {
-  it.effect("ignores arbitrary XDG_RUNTIME_DIR values and chooses the run-user root", () =>
+  it.effect("uses one literal host root across launcher environment variants", () =>
     Effect.gen(function* () {
-      const configured = yield* resolveWith(writableRunUser, { XDG_RUNTIME_DIR: "/configured/runtime" });
-      const scrubbed = yield* resolveWith(writableRunUser, {});
-      expect(configured).toStrictEqual(RuntimeRootChoice.make({ kind: "run-user", root: runUserDirectory }));
+      const configured = yield* resolveWith({ XDG_RUNTIME_DIR: "/configured/runtime", TMPDIR: "/custom/tmp" });
+      const relative = yield* resolveWith({ XDG_RUNTIME_DIR: "relative/runtime" });
+      const empty = yield* resolveWith({ XDG_RUNTIME_DIR: "", TMPDIR: "" });
+      const scrubbed = yield* resolveWith({});
+      expect(configured).toStrictEqual(canonical);
+      expect(relative).toStrictEqual(canonical);
+      expect(empty).toStrictEqual(canonical);
       expect(scrubbed).toStrictEqual(configured);
     })
   );
 
-  it.effect("ignores relative and empty XDG_RUNTIME_DIR values", () =>
+  it.effect("does not require a fallible filesystem probe", () =>
     Effect.gen(function* () {
-      const relative = yield* resolveWith(writableRunUser, { XDG_RUNTIME_DIR: "relative/runtime" });
-      const empty = yield* resolveWith(writableRunUser, { XDG_RUNTIME_DIR: "" });
-      expect(relative).toStrictEqual(RuntimeRootChoice.make({ kind: "run-user", root: runUserDirectory }));
-      expect(empty).toStrictEqual(relative);
-    })
-  );
-
-  it.effect("uses /run/user/<uid> when a child directory can be created and removed", () =>
-    Effect.gen(function* () {
-      const choice = yield* resolveWith(writableRunUser, {});
-      expect(choice).toStrictEqual(RuntimeRootChoice.make({ kind: "run-user", root: runUserDirectory }));
-    })
-  );
-
-  it.effect("falls back to the temporary directory when /run/user/<uid> is absent", () =>
-    Effect.gen(function* () {
-      const choice = yield* resolveWith(FileSystem.layerNoop({}), {});
-      expect(choice).toStrictEqual(RuntimeRootChoice.make({ kind: "tmpdir", root: tmpdir() }));
-    })
-  );
-
-  it.effect("falls back to the temporary directory when /run/user/<uid> exists but is not writable", () =>
-    Effect.gen(function* () {
-      const choice = yield* resolveWith(unwritableRunUser, {});
-      expect(choice).toStrictEqual(RuntimeRootChoice.make({ kind: "tmpdir", root: tmpdir() }));
-    })
-  );
-
-  it.effect("falls back to the temporary directory when /run/user/<uid> is not a directory", () =>
-    Effect.gen(function* () {
-      const choice = yield* resolveWith(fileAtRunUser, {});
-      expect(choice).toStrictEqual(RuntimeRootChoice.make({ kind: "tmpdir", root: tmpdir() }));
+      expect(yield* perUserRuntimeRoot()).toStrictEqual(canonical);
     })
   );
 
   it.effect("accepts an explicit isolated test override", () =>
     Effect.gen(function* () {
       const override = RuntimeRootChoice.make({ kind: "test-override", root: "/isolated/runtime" });
-      const choice = yield* perUserRuntimeRoot().pipe(
-        provideRuntimeRootForTesting(override),
-        provideScopedLayer(Layer.mergeAll(FileSystem.layerNoop({}), NodePath.layer))
-      );
+      const choice = yield* perUserRuntimeRoot().pipe(provideRuntimeRootForTesting(override));
       expect(choice).toStrictEqual(override);
     })
   );
@@ -118,9 +51,8 @@ describe("per-user runtime root", () => {
     Effect.gen(function* () {
       const path = yield* Path.Path;
       const configured = RuntimeRootChoice.make({ kind: "test-override", root: "/configured/runtime" });
-      const temporary = RuntimeRootChoice.make({ kind: "tmpdir", root: tmpdir() });
       expect(admissionRootFor(path, configured)).toBe("/configured/runtime/beep/admit");
-      expect(admissionRootFor(path, temporary)).toBe(path.join(tmpdir(), `beep-admit-uid-${uid}`));
+      expect(admissionRootFor(path, canonical)).toBe(path.join("/tmp", `beep-admit-uid-${uid}`));
 
       const lock = yield* proofCoordinatorLockPath("https://github.com/acme/repo.git").pipe(
         provideRuntimeRootForTesting(configured),

--- a/packages/tooling/tool/cli/test/runtime-root.test.ts
+++ b/packages/tooling/tool/cli/test/runtime-root.test.ts
@@ -1,6 +1,7 @@
 import { userInfo } from "node:os";
 import {
   admissionRootFor,
+  canonicalRuntimeRootForTesting,
   perUserRuntimeRoot,
   provideRuntimeRootForTesting,
   RuntimeRootChoice,
@@ -12,7 +13,8 @@ import { describe, expect, it } from "@effect/vitest";
 import { ConfigProvider, Effect, FileSystem, Path } from "effect";
 
 const uid = userInfo().uid;
-const canonical = RuntimeRootChoice.make({ kind: "canonical", root: "/tmp" });
+const canonicalRoot = canonicalRuntimeRootForTesting(process.platform, userInfo().homedir);
+const canonical = RuntimeRootChoice.make({ kind: "canonical", root: canonicalRoot });
 
 const resolveWith = (environment: Readonly<Record<string, string>>) =>
   perUserRuntimeRoot().pipe(
@@ -20,7 +22,12 @@ const resolveWith = (environment: Readonly<Record<string, string>>) =>
   );
 
 describe("per-user runtime root", () => {
-  it.effect("uses one literal host root across launcher environment variants", () =>
+  it("uses a stable user-writable Windows base without consulting TEMP", () => {
+    expect(canonicalRuntimeRootForTesting("win32", "C:\\Users\\alice")).toBe("C:\\Users\\alice\\.beep\\runtime");
+    expect(canonicalRuntimeRootForTesting("linux", "/home/alice")).toBe("/tmp");
+  });
+
+  it.effect("uses one invariant host root across launcher environment variants", () =>
     Effect.gen(function* () {
       const configured = yield* resolveWith({ XDG_RUNTIME_DIR: "/configured/runtime", TMPDIR: "/custom/tmp" });
       const relative = yield* resolveWith({ XDG_RUNTIME_DIR: "relative/runtime" });
@@ -52,7 +59,7 @@ describe("per-user runtime root", () => {
       const path = yield* Path.Path;
       const configured = RuntimeRootChoice.make({ kind: "test-override", root: "/configured/runtime" });
       expect(admissionRootFor(path, configured)).toBe("/configured/runtime/beep/admit");
-      expect(admissionRootFor(path, canonical)).toBe(path.join("/tmp", `beep-admit-uid-${uid}`));
+      expect(admissionRootFor(path, canonical)).toBe(path.join(canonicalRoot, `beep-admit-uid-${uid}`));
 
       const lock = yield* proofCoordinatorLockPath("https://github.com/acme/repo.git").pipe(
         provideRuntimeRootForTesting(configured),

--- a/packages/tooling/tool/cli/test/yeet-review-fixes.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-review-fixes.test.ts
@@ -1,4 +1,10 @@
-import { MemoryStats, provideRuntimeRootForTesting, RuntimeRootChoice } from "@beep/repo-cli/test/RepoRun";
+import { userInfo } from "node:os";
+import {
+  canonicalRuntimeRootForTesting,
+  MemoryStats,
+  provideRuntimeRootForTesting,
+  RuntimeRootChoice,
+} from "@beep/repo-cli/test/RepoRun";
 import {
   emptyTurboPlanSnapshot,
   loadYeetInboxView,
@@ -278,8 +284,14 @@ describe("yeet review fixes", () => {
             Effect.provideService(ConfigProvider.ConfigProvider, ConfigProvider.fromUnknown(environment)),
             provideScopedLayer(FileSystem.layerNoop({}))
           );
-        const canonicalPrefix = path.join("/tmp", "beep-yeet-proof-locks-");
-        const configuredRoot = path.join("/tmp", "configured-yeet-runtime");
+        const canonicalPrefix = path.join(
+          canonicalRuntimeRootForTesting(process.platform, userInfo().homedir),
+          "beep-yeet-proof-locks-"
+        );
+        const configuredRoot = path.join(
+          canonicalRuntimeRootForTesting(process.platform, userInfo().homedir),
+          "configured-yeet-runtime"
+        );
 
         const missing = yield* resolveWithEnvironment({});
         const relative = yield* resolveWithEnvironment({ XDG_RUNTIME_DIR: "relative-runtime" });

--- a/packages/tooling/tool/cli/test/yeet-review-fixes.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-review-fixes.test.ts
@@ -1,4 +1,3 @@
-import { tmpdir } from "node:os";
 import { MemoryStats, provideRuntimeRootForTesting, RuntimeRootChoice } from "@beep/repo-cli/test/RepoRun";
 import {
   emptyTurboPlanSnapshot,
@@ -269,7 +268,7 @@ describe("yeet review fixes", () => {
       }).pipe(provideScopedLayer(PlatformLayer))
     ));
 
-  it("uses only absolute runtime roots and an ephemeral fallback", () =>
+  it("uses one canonical runtime root and supports an isolated override", () =>
     Effect.runPromise(
       Effect.gen(function* () {
         const path = yield* Path.Path;
@@ -279,16 +278,16 @@ describe("yeet review fixes", () => {
             Effect.provideService(ConfigProvider.ConfigProvider, ConfigProvider.fromUnknown(environment)),
             provideScopedLayer(FileSystem.layerNoop({}))
           );
-        const fallbackPrefix = path.join(tmpdir(), "beep-yeet-proof-locks-");
-        const configuredRoot = path.join(tmpdir(), "configured-yeet-runtime");
+        const canonicalPrefix = path.join("/tmp", "beep-yeet-proof-locks-");
+        const configuredRoot = path.join("/tmp", "configured-yeet-runtime");
 
         const missing = yield* resolveWithEnvironment({});
         const relative = yield* resolveWithEnvironment({ XDG_RUNTIME_DIR: "relative-runtime" });
         const configured = yield* resolveWithEnvironment({ XDG_RUNTIME_DIR: configuredRoot });
 
-        expect(missing).toContain(fallbackPrefix);
-        expect(relative).toContain(fallbackPrefix);
-        expect(configured).toContain(fallbackPrefix);
+        expect(missing).toContain(canonicalPrefix);
+        expect(relative).toContain(canonicalPrefix);
+        expect(configured).toContain(canonicalPrefix);
 
         const overridden = yield* proofCoordinatorLockPath(repositoryIdentity).pipe(
           provideRuntimeRootForTesting(RuntimeRootChoice.make({ kind: "test-override", root: configuredRoot })),


### PR DESCRIPTION
## Summary

Follow-up to #891 and its final Greptile P1 review finding.

- make the production runtime coordination base an invariant literal `/tmp`
- use the effective user's home-backed `.beep/runtime` directory on Windows, where `/tmp` is not a writable system location
- preserve the historical UID-scoped admission and proof-lock leaf paths
- remove the now-unnecessary fallible `/run/user/<uid>` probe and legacy-root migration surface
- keep an explicit test-only runtime-root override for isolated fixtures

This removes all environment-dependent and fallible production root selection, so same-user sibling sessions cannot split admission or proof coordination across separate trees.

## Rollout constraint

This is a hard cutover rather than a mixed-version migration. Before #894 is merged or deployed, every Yeet process, admission lease or ticket, proof-lock file, and `agent-run-*.scope` created by #891's `/run/user/<uid>` scheme must be drained. A one-sided compatibility lock would be misleading because an already-running old process cannot observe a lock protocol introduced only by the new code.

The merge host was checked after #891 completed: both the legacy and canonical admission roots contain no leases or tickets, neither proof-lock root contains a lock file, and there are no `agent-run-*.scope` units. The verified host is therefore already at the required cutover boundary; do not reintroduce an old-version Yeet process before merging this follow-up.

## Review finding

Addresses https://github.com/beep-effect/beep-effect/pull/891#discussion_r3888903809.

## Local proof

- `bunx vitest run test/runtime-root.test.ts test/quality-scheduler.test.ts test/yeet-review-fixes.test.ts test/yeet.test.ts` — 182/182 passed
- `bun run beep quality test-tsgo` — 947 files across 135 packages passed
- `bunx turbo run check --filter=@beep/repo-cli` — 33/33 tasks passed
- coverage summary passed the repository ratchet comparator for `@beep/repo-cli` with epsilon `0.001`

<!-- yeet-provenance
{
  "schemaVersion": 1,
  "branch": "fix/runtime-root-shared",
  "harness": "codex"
}
-->
