### PR TITLE
fix(explorations): restore beep-ci-ops frozen adapter bytes and exempt run evidence

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -52,6 +52,14 @@
       "!standards/repo-exports.catalog.jsonc",
       "!**/fixtures/f1/documents",
       "!scratchpad",
+      // beep-ci-operational-ontology §4b: digest-locked run evidence. The
+      // adapter engine bytes are pinned by a sha256 sidecar and the archived
+      // run manifest, and the runs/ tree (manifest, observations, vendored
+      // judging engine incl. JSON contract bytes) is captured provenance —
+      // a format sweep rewriting any of it falsifies the recorded run
+      // (PR #865 reformatted the adapter and broke its engine check).
+      "!explorations/beep-ci-operational-ontology/ontology/extraction/s4/beep-ci-ops/adapters",
+      "!explorations/beep-ci-operational-ontology/ontology/extraction/s4/beep-ci-ops/runs",
       "!**/modeling/html/data"
     ]
   },

--- a/explorations/beep-ci-operational-ontology/DECISIONS.md
+++ b/explorations/beep-ci-operational-ontology/DECISIONS.md
@@ -392,3 +392,27 @@ then (c) S4 lane launch.
   re-open every row.
 - All 31 submittable proposals ACCEPTED (rat-001..031); 216 conceded referents stand withdrawn;
   149 unresolved rows + 104-entry LEDGER = the S5 queue.
+
+## 2026-08-30 — S5 design grill (eight rulings, rounds 1–2, steward: Benjamin)
+
+- **Home:** S5 outputs live at `ontology/extraction/s5/` (stage-N continuity; the
+  taxonomy graduates to the formal T-Box only at S8).
+- **Engine:** bespoke `s5-taxonomy-contract.md` + a `validate_packet.py --s5` gate
+  (disposition totality over 104 LEDGER + 337 candidates + every fact key,
+  join-integrity against rat-001..031, lattice soundness, parked-row protection) —
+  not a rerun of the foundational auditor (its unit is the referent, not the lattice).
+- **Facts:** the 1,038 FACTS rule in bulk classes keyed by (predicate,
+  subject-term disposition); only orphans and conflicts get individual rulings.
+- **Parked rows:** the 149 waiver-parked dispositions auto-rule `parked-run-2`
+  citing the ratified 57.75% waiver; auditor run 2 re-opens them after the
+  journal/verdict corpus extension.
+- **Seat budget:** one round, ~6 seats — assembly lanes per kind cluster (codex
+  Sol max), one independent adversary (codex max), one blinded alternative
+  (grok xhigh) — plus re-review; the §4b join pass shrinks the open surface first.
+- **Literal-domain members:** all 89 appear in TAXONOMY.yaml as leaf records under
+  their ratified domains (membership-check refs), giving S6 its enumerations.
+- **Merges:** duplicate candidates mapping onto one ratified term get a distinct
+  `merged-into` ruling (alias provenance is first-class for S6/KPI projection),
+  never folded into `accepted-via`.
+- **Sitting log:** steward sittings land in DECISIONS.md only (the §4b precedent);
+  DISPOSITIONS.yaml carries the machine-readable outcome per row.

--- a/explorations/beep-ci-operational-ontology/README.md
+++ b/explorations/beep-ci-operational-ontology/README.md
@@ -100,6 +100,15 @@ graduation. Full plan with locked decisions: [`DECISIONS.md`](./DECISIONS.md).
 
 ## Trail
 
+- 2026-08-30 (twelfth stint): frozen-evidence integrity repair + S5 design grill.
+  PR #865's repo-wide Biome write sweep had rewritten the digest-locked §4b
+  adapter engine and its golden input without the sidecar (engine check broken
+  on main); restored to the pinned bytes and exempted the packet's `adapters/`
+  and `runs/` trees from Biome (PR #899; receipt in the ledger). S5 grill
+  rounds 1–2 settled — eight rulings recorded in DECISIONS.md; next session
+  authors `ontology/docs/s5-taxonomy-contract.md` + the `--s5` gate and runs
+  the join pass before any seat launches.
+
 - 2026-08-29 (eleventh stint): §4b NORMALIZATION GATE COMPLETE + RATIFIED. The
   ontology-foundational-auditor ran AS WRITTEN in a dedicated worktree
   (branch ontology-s4b-normalization, pin c1558f6ca9b1): 1,112 observations

--- a/explorations/beep-ci-operational-ontology/ontology/extraction/s4/beep-ci-ops/adapters/adapter-typescript.ts
+++ b/explorations/beep-ci-operational-ontology/ontology/extraction/s4/beep-ci-ops/adapters/adapter-typescript.ts
@@ -126,7 +126,9 @@ const KIND_NAMES: Partial<Record<ts.SyntaxKind, string>> = {
 };
 
 const isExported = (node: ts.Node): boolean =>
-  ts.canHaveModifiers(node) ? (ts.getModifiers(node) ?? []).some((m) => m.kind === ts.SyntaxKind.ExportKeyword) : false;
+  ts.canHaveModifiers(node)
+    ? (ts.getModifiers(node) ?? []).some((m) => m.kind === ts.SyntaxKind.ExportKeyword)
+    : false;
 
 /** Leftmost dotted-name of an expression: S.Class<X>()("X", {...}) -> "S.Class". */
 const leftmostName = (e: ts.Expression): string | undefined => {
@@ -178,10 +180,10 @@ const literalKitMembers = (root: ts.Node): string[] => {
 };
 
 interface Decl {
-  facts: Fact[];
-  kind: string;
-  name: string;
   node: ts.Node;
+  name: string;
+  kind: string;
+  facts: Fact[];
 }
 
 const declFacts = (node: ts.Node): Decl[] => {
@@ -192,7 +194,10 @@ const declFacts = (node: ts.Node): Decl[] => {
   };
   const heritage = (n: ts.ClassDeclaration | ts.InterfaceDeclaration, facts: Fact[]): void => {
     for (const h of n.heritageClauses ?? []) {
-      const pred = h.token === ts.SyntaxKind.ExtendsKeyword ? "extends_syntactically" : "implements_syntactically";
+      const pred =
+        h.token === ts.SyntaxKind.ExtendsKeyword
+          ? "extends_syntactically"
+          : "implements_syntactically";
       for (const t of h.types) {
         const nm = leftmostName(t.expression);
         if (nm !== undefined) facts.push({ predicate: pred, object: nm });
@@ -370,13 +375,15 @@ const main = (): void => {
     // Golden mode: fixed commit "GOLDEN", path = provided relative path,
     // bytes read directly from the fixture file.
     const path = args.get("--golden-path") ?? "golden/input.ts";
-    const text = new TextDecoder().decode(new Uint8Array(require("node:fs").readFileSync(goldenInput)));
+    const text = new TextDecoder().decode(
+      new Uint8Array(require("node:fs").readFileSync(goldenInput)),
+    );
     for (const r of extractFile("GOLDEN", path, text)) console.log(JSON.stringify(r));
     return;
   }
   if (repo === undefined || commit === undefined) {
     console.error(
-      "usage: bun adapter-typescript.ts --repo <root> --commit <sha> | --golden-input <file> --golden-path <rel>"
+      "usage: bun adapter-typescript.ts --repo <root> --commit <sha> | --golden-input <file> --golden-path <rel>",
     );
     process.exit(2);
   }
@@ -390,7 +397,7 @@ const main = (): void => {
       : a.repository.path > b.repository.path
         ? 1
         : a.source_span.start_line - b.source_span.start_line ||
-          (a.symbol.lexical_name < b.symbol.lexical_name ? -1 : 1)
+          (a.symbol.lexical_name < b.symbol.lexical_name ? -1 : 1),
   );
   for (const r of all) console.log(JSON.stringify(r));
 };

--- a/explorations/beep-ci-operational-ontology/ontology/extraction/s4/beep-ci-ops/adapters/golden/typescript/input.ts
+++ b/explorations/beep-ci-operational-ontology/ontology/extraction/s4/beep-ci-ops/adapters/golden/typescript/input.ts
@@ -1,7 +1,6 @@
 /** Golden fixture for adapter-typescript — exercises every emitted shape. */
-
-import { LiteralKit } from "@beep/schema";
 import * as S from "effect/Schema";
+import { LiteralKit } from "@beep/schema";
 
 export const GoldenPriority = LiteralKit("publish", "verify");
 

--- a/explorations/beep-ci-operational-ontology/ops/manifest.json
+++ b/explorations/beep-ci-operational-ontology/ops/manifest.json
@@ -15,6 +15,6 @@
       "supersededBy": null
     },
     "created": "2026-08-27",
-    "updated": "2026-08-29"
+    "updated": "2026-08-30"
   }
 }

--- a/explorations/beep-ci-operational-ontology/research/OPPORTUNITIES.md
+++ b/explorations/beep-ci-operational-ontology/research/OPPORTUNITIES.md
@@ -43,3 +43,18 @@
   content-addressed path (for example `work/proposals/history/<sha256>.yaml`) and the validator
   should verify each round's `target_sha256` against it; commit `work/` at every round boundary
   so git history keeps the bytes even before the skill does.
+
+## 2026-08-30: an unrelated format sweep rewrote digest-locked run evidence
+
+- **Work:** starting the S5 stint on fresh main after the §4b packet merged (PR #889).
+- **Evidence:** PR #865 (court-reporter vocabulary) carried a repo-wide Biome write sweep that
+  reformatted `ontology/extraction/s4/beep-ci-ops/adapters/adapter-typescript.ts` (line joins,
+  interface key sorting) and `adapters/golden/typescript/input.ts` without touching the
+  `adapter-typescript.ts.sha256` sidecar — on main the frozen adapter failed its own engine
+  check (tree sha `ee276c25…` vs sidecar `fc6dec09…`).
+- **Cost:** the committed copy of the run's engine diverged from the archived manifest and the
+  pin; anyone replaying the adapter got a hard verify_engine refusal until the bytes were
+  restored from the retention tag lineage.
+- **Prevention:** Biome `files.includes` now excludes the packet's `adapters/` and `runs/`
+  trees (this change); frozen evidence must always ship with a formatter exemption in the same
+  PR that freezes it, since a digest lock can only detect corruption, not stop a write sweep.


### PR DESCRIPTION
## Summary

PR #865 carried a repo-wide Biome write sweep that reformatted the §4b digest-locked adapter
engine (`…/beep-ci-ops/adapters/adapter-typescript.ts` — line joins, interface key sorting) and
its golden input, without updating the `adapter-typescript.ts.sha256` sidecar. On main the frozen
adapter therefore failed its own engine check (tree sha `ee276c25…` vs sidecar `fc6dec09…`),
falsifying the archived run's recorded engine identity — exactly the hazard PR #889's review
flagged.

- Restore both files to the pinned bytes (verified equal to the sidecar and to the
  `evidence/beep-ci-ops/orun-2026-08-29T08-20-55Z-pin` tag lineage).
- Exempt the packet's `adapters/` and `runs/` evidence trees in Biome `files.includes` so a
  future write sweep cannot rewrite captured provenance (proven: `biome check --write` over the
  dir now leaves the bytes untouched).
- Record the friction receipt in the packet ledger.

## Verification

Local `yeet verify`: every lane green except `quality:coverage`, which reproduces the identical
environment-only signature from PR #889 (`LaneProofReuse.ts` 86.84 < 92.1, `Planner.ts`
90.54 < 91.89 in `@beep/repo-cli` — a package this 4-file diff does not touch; the full fallback
fires only because root `biome.jsonc` has no workspace owner). Hosted
`Heavy / Coverage Regression` passed these exact rows on #889 hours ago.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790699799&installation_model_id=424656&pr_number=899&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F899&signature=ea8bb729c000989b3676f321c58a93b68402ea01a70edea9f2c98d920c38d303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->