### PR TITLE
fix(goals): recover packet convention closeout

### DIFF
--- a/.changeset/calm-oranges-smile.md
+++ b/.changeset/calm-oranges-smile.md
@@ -1,0 +1,6 @@
+---
+"@beep/repo-ai-metrics": patch
+---
+
+Keep privacy-sensitive agent-effectiveness fixtures independent of a managed
+home-based `TMPDIR` while preserving production private-path rejection.

--- a/explorations/packet-system-redesign/DECISIONS.md
+++ b/explorations/packet-system-redesign/DECISIONS.md
@@ -621,3 +621,35 @@ that is reverified after the implementation head reaches merge-ready. *Rejected:
 preserve the docs-only split after the operator requested one PR (contradicts
 the current delivery instruction); silently ignore D19 (erases why the changed
 delivery shape is valid).
+
+## 2026-08-30 — D27: A bounded recovery PR closes the already-merged candidate-6 packet
+
+**Question.** PR #855 merged before candidate 6's reflection, lifecycle flip,
+and parent-exploration graduation landed, and its terminal head did not produce
+the declared strict Yeet closeout. May a separate recovery PR perform P4, or
+must the packet remain indefinitely active because D26 required one PR?
+
+**Answer.** The operator authorizes one bounded recovery PR. It repairs and
+re-proves the packet's canonical empty-preview command, records the Codex
+reflection, reconciles the goal to `completed-retained`, and graduates this
+exploration for the candidate-6 wave. The recovery PR itself must be driven to
+exact-head merge-ready through Yeet before the lifecycle and graduation claims
+are accepted.
+
+This is an explicit exception to D26's same-PR closeout shape, not a claim that
+PR #855 satisfied it. PR #855 remains the implementation artifact at head
+`94c7966fa18c5482b6445b5f0ead558822ba866e`: all 17 review threads were
+resolved, but its final wave had failed Fallow Advisory Envelopes and Vercel
+contexts and no scored Greptile verdict. `completionGate.grandfathered` remains
+false.
+
+**Rationale.** A merged PR and deleted branch cannot receive the missing P4
+commit. Leaving the packet `active` presents executable P3 work that no longer
+exists, while calling merged state equivalent to merge-ready would erase the
+exact-head evidence gap. A separately proven recovery PR is the smallest
+auditable correction: it preserves the historical failure, restores the
+canonical preview, supplies the required reflection, and makes current packet
+state truthful. *Rejected:* reopen or rewrite #855 (impossible and
+history-destroying); infer merge-ready from merged state (false); grandfather
+the packet (the gate predates this work); leave P3 active forever (misleading
+and unactionable).

--- a/explorations/packet-system-redesign/MAP.md
+++ b/explorations/packet-system-redesign/MAP.md
@@ -196,6 +196,18 @@ D25 fixes candidate 6's first slice as the fork-repair applier alone. D26
 supersedes D19's unexecuted docs-only leg and carries the rulings, campaign,
 migration, and closeout in one PR.
 
+## Candidate-6 closeout recovery (2026-08-30)
+
+Candidate 6 shipped its implementation in PR #855, but that PR merged before
+the D26 same-PR reflection and lifecycle closure and did not retain a strict
+final-head Yeet verdict. D27 authorizes one bounded recovery PR to repair and
+prove the canonical empty preview, record the reflection, close the goal, and
+graduate this exploration. D26 remains the historical delivery decision; D27
+supersedes only its now-impossible closeout mechanism.
+
+Sequencing step 3 is complete through that recovery. Candidates 2–5 remain
+gated and unchanged.
+
 ## Candidate Goal Packets
 
 | Order | Proposed slug | Mission | Dependencies | Live capability composition |
@@ -205,7 +217,7 @@ migration, and closeout in one PR.
 | 3 | `packet-projection-migration` (D6 navigation slice shipped 2026-08-27; goal not yet created) | Finish migrating packet control state onto the event fold and generated projections. Ship-velocity P5 already landed wholesale local ATLAS generation and marked README status regions with an explicit manifest-adoption boundary; this packet retains fleet stream adoption, the by-state tree, guarded exploration status writes, and the remaining ratchet. | `packet-control-plane-core`; `packet-convention-migration` must lift Amendment G's stream freeze before fleet event authority; design-gate fields from `packet-design-approval-gate` where tier requires them; KSA Workstream D projection contract. | Reuse the shipped `Explore/Atlas.ts` D3 projector, `packages/tooling/tool/cli/src/commands/Goals/PortfolioIndex.ts`, `Inventory.ts`, `Doctor.ts`, and KSA Workstream D's deterministic projector contract. REMAINING NET-NEW: fleet exploration event migration, by-state tree, golden/upcaster migration fixtures, guarded exploration writers, fork-repair flow, and the wider advisory-to-blocking ratchet. |
 | 4 | `packet-evidence-closure` (not yet created) | Make landed-versus-closed derivable: schema-valid digest-bound evidence receipts, proof-cache keys, systemic OPPORTUNITIES receipts/roll-up, and the four observational flow metrics. | `packet-control-plane-core`; projection consumers from `packet-projection-migration`; lands after the initial self-hosting slice exposes real friction. | Reuse docgen proof-manifest verification/memoization in `packages/tooling/tool/cli/src/commands/Docgen/internal/Targets.ts` and `Local.ts`, the existing reflection/Yeet evidence surfaces, and per-packet `research/OPPORTUNITIES.md`. NET-NEW: canonical receipt schema, merged-commit subject sealing, landed/closed derivation, opportunity schema/roll-up/mechanical drafts, and approval-wait/parked-age/gate-wall-cache/amendment-rate projections. |
 | 5 | `packets-app-react-v2` (not yet created) | If daily use of KSA’s static v1 proves an interaction gap, ship a read-only React packets viewer over the same projector: pulse first, then kanban/DAG/roadmap/markdown drill-in, with scoped reproject push and ETag-poll fallback. | KSA Workstream D static self-contained HTML v1 must ship and daily-use evidence must identify a concrete interaction gap; `packet-projection-migration` supplies the shared projector and `sourceTip`. | Reuse the KSA projector contract and existing app Vite/portless conventions. NET-NEW: a packets app workspace, read-only React views, custom `packets:projection` HMR invalidation, ETag fallback, and visible source-tip/version/age staleness chrome. No write endpoint, drag-and-drop, or client-side frontier derivation. |
-| 6 | `packet-convention-migration` (created 2026-08-26) | Ship the single-packet fork-repair applier (Amendment G rung 0), then migrate every non-v2 goal manifest onto the canonical v2 convention through a translate-review-amend-rerun loop, lifting the `ops/events/` opt-in freeze. | `packet-control-plane-core` (closed); Amendment G's applier staging; Amendment E's genesis seeder and no-backfill law. | Reuse the shipped `planForkRepair` derivation, PacketCore fold/store/writer, and `beep explore --check`; extend the Goals CLI with actual-shape manifest translation, Violation/Warning severity, breaking/additive/cosmetic drift, fleet lint, and honest genesis seeding. |
+| 6 | `packet-convention-migration` (created 2026-08-26; closed under D27 2026-08-30) | Shipped the single-packet fork-repair applier (Amendment G rung 0), migrated every non-v2 goal manifest onto the canonical v2 convention through a translate-review-amend-rerun loop, and lifted the `ops/events/` opt-in freeze. | `packet-control-plane-core` (closed); Amendment G's applier staging; Amendment E's genesis seeder and no-backfill law. | Reused the shipped `planForkRepair` derivation, PacketCore fold/store/writer, and `beep explore --check`; extended the Goals CLI with actual-shape manifest translation, Violation/Warning severity, breaking/additive/cosmetic drift, fleet lint, and honest genesis seeding. Implementation PR #855 plus the D27 recovery are the retained evidence. |
 
 ## D5 Design-Gate Inventory
 
@@ -220,7 +232,7 @@ seeds; implementation may amend them only through the ratified amendment path.
 | `packet-projection-migration` (D6 navigation slice shipped; goal not yet created) | Extend the shipped Atlas/README projector into fleet event adoption and the Goals/Explore doctor/index surfaces; add migration/upcaster/golden-stream fixtures and the generated by-state tree; add the typed work-plan module and Goals-local sidecar renderer (Amendment H, D20) with render-and-diff migration fixtures. | Shipped: `ExplorationProjectionState`, `ExplorationProjection`, `ExplorationAtlasRow`, README generated regions. Remaining: `PacketProjector`, `PacketProjection`, `sourceTip`, `projectorVersion`, `PacketUpcaster`, `ForkRepairPlan`, `PacketByStateTree`, `PacketWorkPlan`, `WorkPlanStep`, `ResponsibleAgent`, `WorkPlanSidecar`, adoption/migration plan. |
 | `packet-evidence-closure` (not yet created) | Add receipt/closure/opportunity/metric modules under packet-core; extend Yeet/reflection evidence adapters and packet doctor projections; add per-packet opportunity-schema and fleet-roll-up fixtures. | `EvidenceSubject`, `EvidenceReceipt`, `ProofCacheKey`, `LandedState`, `ClosedState`, `OpportunityReceipt`, `FlowMetricSnapshot`, merged-commit seal verifier. |
 | `packets-app-react-v2` (not yet created) | Create the `packets` app under `apps/` (not yet created) through `bun run beep create-package` only after the gate fires; consume the shared projection JSON/API adapter; add pulse, secondary views, staleness chrome, scoped watch/HMR, ETag poll, and browser-QA fixtures. | `PacketProjectionClient`, `PacketPulseView`, `OperatorQueueView`, `PacketStaleness`, `packets:projection` event contract, scoped reproject service, ETag poll fallback. |
-| `packet-convention-migration` (created 2026-08-26) | Add a `Migration/` module beside PacketCore inside the Goals command tree; extend the Explore check with fleet-wide lint results; extend goal-manifest translation fixtures with actual legacy and half-migrated shapes; add applier, translator, seeder, and fleet-lint tests. Packet docs change only through the migration's deterministic output. | `PacketForkRepairApplier`, `ManifestTranslation`, `TranslationReport`, `TranslationAssumption`, `ManifestShapeProbe`, `MigrationSeverity`, `DriftClassification`, `FleetLintFinding`, `PacketGenesisSeed`. |
+| `packet-convention-migration` (closed under D27 2026-08-30) | Shipped a `Migration/` module beside PacketCore inside the Goals command tree; extended Explore check with fleet-wide lint results and goal-manifest translation fixtures with actual legacy and half-migrated shapes; added applier, translator, seeder, fleet-lint, and registered-command runtime tests. | `PacketForkRepairApplier`, `ManifestTranslation`, `TranslationReport`, `TranslationAssumption`, `ManifestShapeProbe`, `MigrationSeverity`, `DriftClassification`, `FleetLintFinding`, `PacketGenesisSeed`. |
 
 The React candidate’s exact home is the future `packets` app under `apps/` (not yet created), resolving D12’s deferred
 home question. That path is a proposal only: the app and goal do not yet exist,
@@ -256,14 +268,13 @@ than guessed telemetry.
 
 ## Sequencing
 
-**Status 2026-08-26 (Session B):** steps 1 and 2 are complete —
+**Status 2026-08-30 (D27 recovery):** steps 1–3 are complete —
 `packet-control-plane-core` shipped the core, self-hosted its own stream, and
 closed `completed-retained` through its guarded writer (#848, #850). D17
-inserts the fleet convention-migration campaign (candidate 6) ahead of step 3:
-the design gate and fleet migration both presuppose packets carrying streams,
-and the Amendment G opt-in freeze holds the fleet at the single pilot stream
-until candidate 6's repair applier ships. The numbered sequence below is
-preserved as the ratified record.
+inserted the fleet convention-migration campaign (candidate 6) ahead of the
+remaining gated packets. PR #855 shipped the migration; D27's bounded recovery
+closed the missed reflection/lifecycle leg and graduated this exploration.
+The numbered sequence below is preserved as the ratified record.
 
 **Projection update 2026-08-27:** ship-velocity P5 pulled D6's Atlas/README
 navigation slice forward without lifting Amendment G's fleet stream freeze.
@@ -278,9 +289,10 @@ This does not reorder candidate 6 ahead of the remaining candidate-3 work.
 2. **Self-hosting adoption slice.** Use the core in advisory mode on these
    graduated candidate goals, evolve `set-status` into the guarded writer,
    and project this campaign’s state without changing canonical authored prose.
-3. **Convention migration.** Prove the fork applier alone, then probe and
-   translate every non-v2 goal manifest, seed honest genesis events, and run
-   the fleet lint plus `beep explore --check` before the campaign closes.
+3. **Convention migration — complete under D27.** Proved the fork applier,
+   translated every non-v2 goal manifest, seeded honest genesis events, and
+   closed with an empty migration preview plus zero `beep explore --check`
+   findings.
 4. **Design approval and projection migration.** Add tiered DESIGN/approval
    gates, then migrate generated ATLAS and README status blocks under an
    advisory-to-blocking ratchet.

--- a/explorations/packet-system-redesign/README.md
+++ b/explorations/packet-system-redesign/README.md
@@ -3,18 +3,20 @@
 ## Status
 
 <!-- BEGIN GENERATED: EXPLORATION STATUS -->
-Stage: `decompose`
-Status: `active`
+Stage: `graduate`
+Status: `graduated`
 <!-- END GENERATED: EXPLORATION STATUS -->
 
-Graduated 2026-08-17 with `packet-control-plane-core` as the sole promised-now
-candidate. **Reopened at `decompose` 2026-08-26** on the ratified convention:
-the candidate-2/3 gate condition was satisfied on main evidence and the core
-closed `completed-retained`. Session B then chartered
-[`goals/packet-convention-migration`](../../goals/packet-convention-migration/README.md)
-as candidate 6 and the first reopener, and ruled on H, I, and J (D17–D26).
-Candidates 2–4 remain gated re-entry candidates; the React viewer stays gated
-on KSA static-v1 daily-use evidence.
+Graduated for the candidate-6 wave on 2026-08-30. The convention migration
+implementation shipped in PR #855; D27 authorized a bounded recovery PR for
+the reflection, public empty-preview repair, goal lifecycle reconciliation,
+and this graduation after the original PR merged before its promised same-PR
+closeout.
+
+Candidates 2–4 remain gated re-entry candidates, the React viewer remains gated
+on KSA static-v1 daily-use evidence, and Amendment J remains with
+`typed-agent-skill-contracts`. A fired gate reopens this packet at `decompose`;
+there is no active open question for the completed candidate-6 wave.
 
 Source: [`ops/manifest.json`](./ops/manifest.json)
 
@@ -29,11 +31,9 @@ BDUF ceremony.
 
 ## Next Open Question
 
-None for this wave. D24 routes Amendment J through the existing
-`typed-agent-skill-contracts` exploration, D25 starts candidate 6 with the
-fork-repair applier alone, and D26 combines the rulings, implementation,
-migration, and closeout in one PR. The active work is the graduated
-`packet-convention-migration` goal.
+None. Candidate 6 is closed under D27. Candidates 2–5 retain their existing
+re-entry gates; when one fires, reopen this exploration at `decompose` rather
+than treating the present graduation as authorization to scaffold it.
 
 ## Read This First
 
@@ -48,6 +48,14 @@ migration, and closeout in one PR. The active work is the graduated
 
 ## Trail
 
+- 2026-08-30 (candidate-6 recovery closeout): PR #855 had already merged the
+  packet-convention implementation when P3 resumed, so its promised same-PR P4
+  was impossible. The final implementation head had all 17 review threads
+  resolved but retained two failed contexts and no scored Greptile verdict.
+  D27 authorized one bounded recovery PR, which repaired and re-proved the
+  canonical empty-preview command, added the Codex reflection, closed the goal
+  `completed-retained`, and graduated this exploration for the wave without
+  rewriting #855 as merge-ready.
 - 2026-08-27 (D6 navigation migration): ship-velocity P5 landed the ignored
   whole-file Atlas and marked README status projections. No exploration
   streams were fabricated: manifests are explicit adoption snapshots until

--- a/explorations/packet-system-redesign/ops/manifest.json
+++ b/explorations/packet-system-redesign/ops/manifest.json
@@ -3,8 +3,8 @@
   "exploration": {
     "slug": "packet-system-redesign",
     "title": "Exploration & Goal Packet System Redesign",
-    "status": "active",
-    "stage": "decompose",
+    "status": "graduated",
+    "stage": "graduate",
     "openQuestions": [],
     "sources": ["research/SOURCES.md"],
     "links": {
@@ -16,6 +16,6 @@
       "supersededBy": null
     },
     "created": "2026-08-10",
-    "updated": "2026-08-26"
+    "updated": "2026-08-30"
   }
 }

--- a/goals/README.md
+++ b/goals/README.md
@@ -83,14 +83,13 @@ New manifests must index launchers near the agent asset metadata:
 }
 ```
 
-Some existing manifests still use compatibility schema names such as
-`initiative-manifest/v1`, `1.0.0`, or custom legacy shapes. A dedicated
-fleet migration **is planned** (2026-08-17): once
-`goals/packet-control-plane-core` lands, an adversarial quality loop
-migrates every non-`completed-retained` packet to this standard and zeroes
-the doctor baseline (see `docs/ROADMAP.md`, Machinery lane). Until that
-campaign runs, preserve existing wire shapes; do not hand-migrate
-piecemeal — partial migration is how majority-pattern gravity persists.
+The fleet convention migration completed through PR #855 and its D27 recovery
+closeout. All 160 tracked goal packets plus `_template` now use
+`initiative-manifest/v2`; the retained apply report is
+[`packet-convention-migration/history/fleet-migration-report.md`](./packet-convention-migration/history/fleet-migration-report.md).
+Use `bun run beep goals migrate-conventions --preview` and
+`bun run beep explore --check` as drift checks. Do not restore legacy wire
+shapes or infer a convention from historical packet examples.
 
 ## Lifecycle
 

--- a/goals/court-reporter-vocabulary/ops/manifest.json
+++ b/goals/court-reporter-vocabulary/ops/manifest.json
@@ -12,6 +12,7 @@
   "lifecycle": "completed-retained",
   "mission": "Deliver deterministic versioned courts-db and reporters-db artifacts with stable public IDs, lifecycle-safe drift, and a machine-readable compatibility contract.",
   "statusNote": "P0-P3 complete: deterministic ingestion, public stable vocabulary, lifecycle compatibility, evidence, reflection, and Yeet PR-to-mergeable proof.",
+  "mergedPullRequest": 865,
   "executionCapable": true,
   "reflectionRequired": true,
   "provenance": {

--- a/goals/gov-legal-data-driver-delivery/ops/manifest.json
+++ b/goals/gov-legal-data-driver-delivery/ops/manifest.json
@@ -117,5 +117,6 @@
     "A committed spec drifts beyond what the bespoke renderer can express; record the delta and fallback decision under research/ first.",
     "Verification requires unnamed credentials, cost, destructive side effects, or policy approval.",
     "The same blocker repeats after reasonable investigation."
-  ]
+  ],
+  "mission": "Deliver the research foundation and first product-pulled driver on the substrate the predecessor proved: committed source/terms research plus `@beep/ecfr` at 15-operation parity. Federal Register, DOL, and CourtListener resume individually only when a product feature pulls that driver."
 }

--- a/goals/packet-convention-migration/GOAL.md
+++ b/goals/packet-convention-migration/GOAL.md
@@ -1,41 +1,31 @@
-# GOAL: packet convention migration
+# GOAL: packet convention migration (retained)
 
 Repo root is the current `beep-effect` checkout. Do not assume an absolute
 path; several checkouts exist. All paths below are repo-relative.
 
-Outcome: prove a staged single-packet fork repair, then migrate every legacy
-goal manifest to the canonical v2 convention with explicit reports, honest
-genesis events, fleet lint, and zero `beep explore --check` findings.
+This packet is closed evidence, not an active migration launcher. PR #855
+shipped the fork-repair applier, v2 translator, genesis seeder, and fleet lint.
+D27 authorized one later recovery PR because #855 merged before its promised
+same-PR reflection and lifecycle flip and without a strict final-head Yeet
+verdict.
 
-Read first:
+Read:
 
-- `goals/packet-convention-migration/{README,SPEC,DESIGN,PLAN}.md`
-- `goals/packet-convention-migration/ops/manifest.json`
-- `explorations/packet-system-redesign/{MAP,DECISIONS}.md` D17–D26
-- `AGENTS.md`, schema-first, effect-first, JSDoc, explore, and Yeet guidance
+- `README.md`, `SPEC.md`, `PLAN.md`, and `ops/manifest.json`
+- `history/fleet-migration-report.md` and `history/reflections/`
+- `research/OPPORTUNITIES.md`
+- `explorations/packet-system-redesign/DECISIONS.md` D17–D27
 
-Scope:
+Do not resume, amend, or reapply the merged #855 branch. For regression work,
+run the public preview and fleet checks read-only:
 
-- In: the existing Goals/Explore CLI command trees, focused tests, the packet
-  core fork fixture, deterministic goal-manifest/event/trace migration output,
-  and this goal plus its parent exploration.
-- Out: exploration-manifest migration, generated ATLAS/README regions,
-  candidates 2–5, Amendment J implementation, signing, and fabricated history.
+1. `bun run beep goals set-status --migrate` must plan zero edits.
+2. `bun run beep goals migrate-conventions --preview` must report zero
+   translations, seeds, issues, assumptions, and fleet findings.
+3. `bun run beep explore --check` must report `findings=0`.
+4. `bun run beep goals doctor` must report zero blockers and advisories.
 
-Workflow:
-
-1. Keep `PLAN.md` current and preserve unrelated worktree changes.
-2. Implement schemas before services. Reuse PacketCore's fold, digest, store,
-   and projector; do not create a parallel event format.
-3. Land the repair applier proof before the translator/seeder slice.
-4. Preview the fleet. Any violation blocks apply; warnings and assumptions are
-   explicit. Preserve unknown manifest keys.
-5. Apply once, prove a second preview is empty, and run
-   `bun run beep explore --check` to zero findings.
-6. Publish through Yeet. At P4 use `/reflect`, flip packet state in this PR,
-   and re-prove the final head.
-
-Acceptance is exactly `SPEC.md`. Stop instead of improvising if translation
-would invent meaning, repair would lose a branch, seeding would overwrite a
-stream, or requested proof needs unnamed credentials, cost, or destructive
-state.
+Any new finding is drift to repair in its owning packet or Goals command, not
+authorization to recreate legacy manifests or fabricate event history.
+Candidates 2–5 remain gated work in the parent exploration; they are outside
+this retained goal.

--- a/goals/packet-convention-migration/PLAN.md
+++ b/goals/packet-convention-migration/PLAN.md
@@ -29,18 +29,25 @@ findings. Census: all 161 manifests including the template are v2; 66 goal
 streams fold with fresh traces. Focused checks, package typecheck/lint, doctor,
 index, explore check, and the full 2,328-test repo-cli suite pass.
 
-## P3 — Yeet: PR to mergeable (IN PROGRESS)
+## P3 — Implementation delivery (COMPLETE BY D27 RECOVERY 2026-08-30)
 
-Publish the single PR and monitor until the implementation head is merge-ready
-with no unresolved review threads. Address every actionable review finding.
+PR #855 merged the implementation at
+`94c7966fa18c5482b6445b5f0ead558822ba866e`, and all 17 review threads were
+resolved. Its final hosted wave did not establish the packet's strict
+exact-head merge-readiness contract: Fallow Advisory Envelopes and Vercel were
+red, and Greptile produced no score. D27 preserves that gap and authorizes the
+separate recovery PR; P3 is terminal under that explicit exception, not by
+retroactive reinterpretation of #855.
 
-## P4 — Close (PENDING)
+## P4 — Close (COMPLETE 2026-08-30)
 
-After the implementation head proves merge-ready, write the `/reflect`
-closeout, mark this goal `completed-retained`, mark the parent exploration
-graduated for this wave, regenerate packet projections, and drive the final
-same-PR head back to merge-ready.
+The recovery PR repaired the public convention-preview runtime, proved a second
+preview empty, added the Codex closeout reflection, marked this goal
+`completed-retained`, and graduated the parent exploration for the candidate-6
+wave. The recovery head itself is accepted only through the current exact-head
+Yeet closeout contract.
 
 ## Current blockers
 
-None.
+None. Candidates 2–5 remain gated re-entry work in the parent exploration and
+are not owned by this closed goal.

--- a/goals/packet-convention-migration/README.md
+++ b/goals/packet-convention-migration/README.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Lifecycle: `active`
+Lifecycle: `completed-retained`
 
 Source: [`ops/manifest.json`](./ops/manifest.json)
 
@@ -12,7 +12,7 @@ Repair forked packet streams, then migrate every legacy goal manifest onto the
 canonical v2 convention with honest genesis events and fleet-wide integrity
 reports.
 
-## Launch
+## Retained Regression Entry Point
 
 ```text
 /goal follow the instructions in goals/packet-convention-migration/GOAL.md
@@ -20,21 +20,32 @@ reports.
 
 ## Read This First
 
-1. [`GOAL.md`](./GOAL.md) — compact execution launcher.
+1. [`GOAL.md`](./GOAL.md) — retained closeout and read-only regression guidance.
 2. [`SPEC.md`](./SPEC.md) — normative contract and acceptance criteria.
 3. [`DESIGN.md`](./DESIGN.md) — mutation boundaries and significant symbols.
-4. [`PLAN.md`](./PLAN.md) — active phased plan.
+4. [`PLAN.md`](./PLAN.md) — terminal execution and recovery record.
 5. [`ops/manifest.json`](./ops/manifest.json) — machine-readable routing.
 6. [`research/SOURCES.md`](./research/SOURCES.md) — inherited evidence.
 
 ## Current Phase
 
-P3 Yeet — implementation and fleet application are complete; drive the
-single PR to merge-ready before the same-PR closeout flip.
+Closed through the operator-authorized D27 recovery exception. Implementation
+shipped in PR #855, but that PR merged before the same-PR P4 reflection and
+state flip and did not retain a strict final-head Yeet closeout. The recovery
+PR restored the canonical empty-preview proof, recorded the historical gap,
+and carried this packet to `completed-retained`.
 
 ## Latest Evidence
 
-The fleet apply translated 65 manifests and seeded 65 honest one-event streams.
-Its post-apply preview reports zero remaining translations, seeds, issues, or
-fleet findings; all 66 opted-in streams pass `beep explore --check`. The full
-repo-cli suite passes 2,328 tests.
+PR #855 merged the fork-repair applier, convention translator, fleet lint, and
+genesis seeder at implementation head
+`94c7966fa18c5482b6445b5f0ead558822ba866e`. The migration translated 65
+manifests, seeded 65 honest streams, and reported no remaining translations,
+seeds, issues, or fleet findings. All 17 review threads were resolved.
+
+The implementation PR is not described as exact-head merge-ready: its final
+wave had failures in Fallow Advisory Envelopes and Vercel, while Greptile ended
+without a score. D27 authorized the separate recovery PR that repaired and
+re-proved the canonical empty preview, supplied the required Codex reflection,
+and reconciled the goal and parent exploration. Current main already superseded
+the historical Fallow hotspot through commit `2ce7525d5a`.

--- a/goals/packet-convention-migration/SPEC.md
+++ b/goals/packet-convention-migration/SPEC.md
@@ -3,7 +3,7 @@
 Normative contract. Packet anchor document. Seeded 2026-08-26 from candidate 6
 of the ratified
 [`packet-system-redesign`](../../explorations/packet-system-redesign/MAP.md)
-MAP and Session B decisions D17–D26.
+MAP, Session B decisions D17–D26, and the D27 post-merge recovery ruling.
 
 ## Mission
 
@@ -58,6 +58,15 @@ assumptions and issues explicitly, and prove the resulting fleet with
 - The operation is idempotent: a second preview after apply has no edits or
   seeds, and `bun run beep explore --check` is clean.
 
+## Post-merge recovery ruling
+
+D27 authorizes a separate recovery PR because implementation PR #855 merged
+before the required same-PR reflection and lifecycle changes. The exception is
+bounded to repairing the canonical empty-preview command, recording the
+reflection, reconciling fleet drift and goal/exploration state, and proving the
+recovery head through Yeet. It does not grandfather the goal and does not
+assert that #855's final head was merge-ready.
+
 ## Acceptance
 
 - [x] `beep goals repair-fork <slug> --root <root> --preview|--apply` repairs
@@ -73,8 +82,11 @@ assumptions and issues explicitly, and prove the resulting fleet with
       and a fresh tip-only trace; already-streamed packets are not reseeded.
 - [x] A second migration preview is empty and `bun run beep explore --check`
       reports zero findings.
-- [ ] Focused tests, typecheck, repo verification, reflection lint, and Yeet's
-      exact-head merge-readiness proof pass.
+- [x] Focused tests, typecheck, repo verification, and reflection lint pass for
+      the shipped implementation and recovery; the recovery head carries the
+      lifecycle closeout and is accepted through Yeet's exact-head
+      merge-readiness proof. PR #855's historical final-head check and Greptile
+      gaps remain explicitly recorded under D27.
 
 ## Stop conditions
 

--- a/goals/packet-convention-migration/history/reflections/2026-08-30-codex.md
+++ b/goals/packet-convention-migration/history/reflections/2026-08-30-codex.md
@@ -1,0 +1,90 @@
+---
+goal: packet-convention-migration
+agent: codex
+date: "2026-08-30"
+trigger: closeout
+confidence: high
+findings:
+  - category: tooling-friction
+    confidence: high
+    instruction: Exercise every registered mutation command through its public CLI runtime before declaring the command reusable.
+    explanation: The internal migration services and focused suites passed, but the later canonical preview failed before planning because the registered command did not provide PacketEventStore.
+  - category: goal-critique
+    confidence: high
+    instruction: Validate the referenced PR state before presenting a same-PR closeout phase as executable, and define an explicit recovery path for terminal PR drift.
+    explanation: The launcher still instructed P3 monitoring and same-PR P4 after PR 855 had merged and its branch had been deleted.
+  - category: codification-todo
+    confidence: high
+    instruction: Make reflection and lifecycle closure a blocking pre-merge packet check when a goal promises a same-PR flip.
+    explanation: PR 855 merged with the packet still active, two terminal failed contexts, and no scored Greptile closeout, leaving prose state detached from hosted reality.
+  - category: implementation-improvement
+    confidence: medium
+    instruction: Require failure injection and ownership checks at every multi-file promotion and rollback boundary.
+    explanation: Review repeatedly found concurrent-writer loss windows after initial local proof; the final implementation hardened these boundaries only through successive adversarial findings.
+todos:
+  - Add a registered-command runtime smoke test for each Goals mutation command.
+  - Add a packet closeout guard that compares planned same-PR lifecycle changes with the live PR before merge.
+---
+
+# Reflection — packet-convention-migration (2026-08-30, codex)
+
+## Summary
+
+The packet shipped the fork-repair applier, actual-shape v2 translation, fleet
+lint, and honest genesis adoption in PR #855. Sixty-five manifests and streams
+migrated, the post-apply plan was empty at delivery, and all 17 review threads
+closed. The packet required an operator-authorized recovery PR because #855
+merged before the reflection and state flips, with two failed final contexts
+and no scored Greptile verdict.
+
+## Tooling experience
+
+- **Worked:** Schema-first reports, deterministic preview/apply output,
+  failure-injection tests, GraphQL review-thread inspection, and Yeet's
+  exact-head model exposed concrete mutation and hosted-state defects.
+- **Didn't:** The public convention-preview command lacked its event-store
+  service at recovery time even though internal tests passed.
+- **Frustrating:** The launcher and PLAN described an open same-PR closeout
+  three days after the PR had merged and its branch disappeared. The fleet
+  check commands also exited successfully while reporting acceptance findings.
+- **Wished existed:** A pre-merge packet guard requiring the reflection,
+  lifecycle flip, strict closeout artifact, and live PR-state agreement on the
+  exact head.
+
+## Implementation improvement opportunities
+
+- Test command registration and Layer composition as a runtime boundary, not
+  only the underlying planner and services.
+- Keep the promotion/rollback failure matrix as a reusable mutation-campaign
+  law: stage, re-read, publish atomically, verify ownership, preserve foreign
+  bytes, and report retained recovery artifacts.
+- Make check-mode exit status agree with violation-level findings so automation
+  cannot confuse process success with zero-finding acceptance.
+
+## Goal & prompt critique
+
+The launcher should not say “drive the single PR” without naming the PR and
+first checking its live state. It should define the recovery disposition when
+the PR becomes terminal before P4: stop, record exact-head facts, obtain an
+explicit exception, and use a separately proven closeout PR without rewriting
+history.
+
+## TODOs worth codifying
+
+- Add a registered-command smoke test for every Goals writer or mutator.
+- Add a same-PR closeout pre-merge check covering reflection, lifecycle,
+  unresolved threads, required checks, and scored bot closeout.
+- Fail check mode when blocking or violation findings remain.
+
+## Lessons (confidence-tiered)
+
+- **HIGH — Critical:** Never infer exact-head merge readiness from a later
+  `MERGED` state — terminal check and review evidence must be retained
+  independently.
+- **HIGH — Critical:** Test the public command's dependency graph — green
+  internal services do not prove a registered CLI can construct them.
+- **MEDIUM — Best practice:** Treat rollback ownership and concurrent-writer
+  preservation as first-class acceptance for every multi-file mutator.
+- **LOW — Consideration:** A bounded recovery exception is preferable to
+  permanently false active state, provided it is explicit and does not
+  retroactively upgrade the original PR's evidence.

--- a/goals/packet-convention-migration/ops/manifest.json
+++ b/goals/packet-convention-migration/ops/manifest.json
@@ -4,17 +4,18 @@
     "id": "packet-convention-migration",
     "packetId": "goal-packet/v1:4e5241728af3683113e81ea4a35c101c589aa1a0b8a5921754f3f915d90b5a58",
     "title": "Packet Convention Migration",
-    "status": "active",
+    "status": "completed-retained",
     "created": "2026-08-26",
-    "updated": "2026-08-26",
+    "updated": "2026-08-30",
     "packetAnchorDocument": "SPEC.md"
   },
   "packetPath": "goals/packet-convention-migration",
-  "lifecycle": "active",
+  "lifecycle": "completed-retained",
   "mission": "Repair forked packet streams and migrate the goal fleet onto the canonical v2 manifest and honest genesis convention.",
-  "statusNote": "P0-P2 are complete in the single packet-convention-migration PR; P3 is driving that implementation head through Yeet before the same-PR P4 closeout.",
+  "statusNote": "Implementation shipped in merged PR #855 at 94c7966fa18c, but its final head did not demonstrate strict Yeet merge readiness and merged before P4. D27 authorizes the separately Yeet-proven recovery PR that restores the public empty-preview command, reflection, lifecycle closeout, and parent graduation.",
   "executionCapable": true,
   "reflectionRequired": true,
+  "mergedPullRequest": 855,
   "provenance": {
     "exploration": "explorations/packet-system-redesign",
     "graduated": "2026-08-26"
@@ -23,7 +24,7 @@
     "operator": "yeet",
     "requiresPullRequest": true,
     "requiresMergeable": true,
-    "statement": "Not achieved until this goal's work ships as a PR driven to mergeable via /yeet (bun run beep yeet: repair -> verify -> publish --pr -> monitor).",
+    "statement": "D27 recovery exception: implementation is retained in merged PR #855, while the separate PR carrying the missing reflection, lifecycle reconciliation, parent graduation, and canonical empty-preview repair must be driven to exact-head merge-ready via Yeet. This does not assert that PR #855 itself reached that state.",
     "grandfathered": false
   },
   "currentSourceOfTruth": [
@@ -52,8 +53,8 @@
     { "id": "P0", "name": "Research and rulings", "status": "complete" },
     { "id": "P1", "name": "Implement", "status": "complete" },
     { "id": "P2", "name": "Fleet apply and verify", "status": "complete" },
-    { "id": "P3", "name": "Yeet: PR to mergeable", "status": "in-progress" },
-    { "id": "P4", "name": "Close", "status": "pending" }
+    { "id": "P3", "name": "Yeet: PR to mergeable", "status": "complete" },
+    { "id": "P4", "name": "Close", "status": "complete" }
   ],
   "verificationCommands": [
     "test \"$(wc -m < goals/packet-convention-migration/GOAL.md)\" -le 4000",

--- a/goals/packet-convention-migration/research/OPPORTUNITIES.md
+++ b/goals/packet-convention-migration/research/OPPORTUNITIES.md
@@ -474,3 +474,21 @@
 - **Disposition:** publication-command construction friction; retry through a
   literal stdin body and keep the already authoritative exact-head proof.
 - **Owner:** agent shell-command construction and PR publication wrappers.
+
+## 2026-08-30 — Yeet monitor treats deployment quota failures as repairable source defects
+
+- **What happened:** the required hosted `beep yeet monitor` invocation exited
+  on three Vercel status failures and opened a local repair session even though
+  each failure was an external deployment-account quota condition, not a defect
+  in the PR head.
+- **Evidence:** `bun run beep yeet monitor --watch --until-event --summary`
+  reported first-red capsules for `Vercel – oip-web`, `Vercel –
+  oip-web-staging`, and `Vercel – todox`; every status target identified
+  `upgradeToPro=build-rate-limit`, while the GitHub Actions checks continued.
+- **What would have prevented it:** classify external deployment quota and
+  account-status contexts separately from repairable source checks, and let
+  monitor wake only on required checks or explicitly actionable providers.
+- **Disposition:** hosted-environment noise; do not run repair or retry the
+  Vercel contexts, and continue monitoring exact-head required checks and
+  review state.
+- **Owner:** Yeet hosted-monitor classification and deployment integrations.

--- a/goals/packet-convention-migration/research/OPPORTUNITIES.md
+++ b/goals/packet-convention-migration/research/OPPORTUNITIES.md
@@ -196,3 +196,263 @@
   unit or get reviewer sign-off on `--write-baseline`," not "raise the
   percentage."
 - **Owner:** coverage-ratchet lane maintainers.
+
+## 2026-08-30 — Supplied checkout path omits the repository container directory
+
+- **What happened:** the P3 closeout session opened in the supplied
+  `YeeBois/project/beep-effect2` directory, where the packet was absent and Git
+  reported `not a git repository`. The live checkout was instead under the
+  sibling `YeeBois/projects/beep-effect2` path.
+- **Evidence:** reading `goals/packet-convention-migration/GOAL.md` failed with
+  `No such file or directory`, and `git status --short --branch` failed with
+  `fatal: not a git repository (or any parent up to mount point /)`.
+- **What would have prevented it:** resolve the requested packet relative to a
+  verified Git root before starting the task, or generate the session working
+  directory from the exact owning checkout rather than a hand-entered path.
+- **Disposition:** session-routing friction; work continued only in the
+  verified sibling checkout, without modifying the empty supplied directory.
+- **Owner:** session-launch and checkout-routing maintainers.
+
+## 2026-08-30 — Scheduler status usage requires an undocumented JSON flag
+
+- **What happened:** the operator-prescribed admission probe, `bun run beep
+  quality scheduler status`, failed before reporting lane ownership because
+  the live CLI requires `--json`.
+- **Evidence:** the command printed `ERROR Missing required flag: --json` and
+  exited with code 1, although the Yeet/operator guidance names the unflagged
+  command as the canonical human-readable status probe.
+- **What would have prevented it:** keep the human-readable default accepted,
+  or update the operator and Yeet guidance atomically when the JSON flag becomes
+  mandatory.
+- **Disposition:** CLI/documentation drift; use the explicit `--json` form for
+  the live scheduler snapshot.
+- **Owner:** quality scheduler CLI and Yeet guidance maintainers.
+
+## 2026-08-30 — Packet launcher requests a same-PR closeout after the PR merged
+
+- **What happened:** P3 was resumed with instructions to monitor the open
+  packet PR to merge-ready and then perform P4 on that same PR, but the live
+  repository has no open packet-convention PR. The implementation PR had
+  already merged while the packet remained marked P3 in progress.
+- **Evidence:** `gh pr list --state open` returned only unrelated PR #896;
+  `gh pr view 855` reports `state: MERGED`, head
+  `feat/packet-convention-migration`, merged on 2026-08-27, while
+  `goals/packet-convention-migration/PLAN.md` still says P3 is in progress and
+  P4 is pending.
+- **What would have prevented it:** make the same-PR closeout flip a blocking
+  pre-merge check, and have packet resume validate the referenced PR state
+  before presenting P3 as executable.
+- **Disposition:** closeout-state drift requiring an explicit recovery ruling;
+  a merged PR cannot accept the mandated P4 commit.
+- **Owner:** packet closeout and Yeet merge-gate maintainers.
+
+## 2026-08-30 — Merge protection allowed the packet PR past its declared closeout gates
+
+- **What happened:** the historical implementation PR was merged even though
+  its final head never reached the packet's declared exact-head merge-readiness
+  state. The later closeout session therefore cannot honestly infer P3 success
+  from the merged state alone.
+- **Evidence:** `gh pr checks 855` reports 28 terminal contexts with failures in
+  `Fallow Advisory Envelopes` and `Vercel – oip-web`; the terminal Greptile
+  context is neutral/skipped after an internal review error, so the final-head
+  score and issue count are unknown. The PR did nevertheless merge at head
+  `94c7966fa1`, and all 17 GraphQL review threads are resolved.
+- **What would have prevented it:** make the packet completion contract's
+  required checks and strict Greptile closeout branch-protection gates, and
+  require the same-PR lifecycle flip before merge is enabled.
+- **Disposition:** hosted policy gap; merged status is not a substitute for
+  terminal green checks and a scored review-bot verdict.
+- **Owner:** repository branch protection and Yeet closeout maintainers.
+
+## 2026-08-30 — Isolated recovery worktree cannot run the repo CLI before dependency linking
+
+- **What happened:** the dedicated closeout worktree was created from the
+  verified Git head, but its first scheduler probe could not load the repo CLI
+  because workspace dependencies were unavailable in that worktree.
+- **Evidence:** `bun run beep quality scheduler status --json` failed with
+  `Cannot find module '@beep/utils'` from the repo CLI entrypoint.
+- **What would have prevented it:** have the worktree bootstrap path link or
+  install the owning checkout's verified dependency tree before advertising the
+  worktree as command-ready, or make the scheduler probe available outside the
+  workspace dependency graph.
+- **Disposition:** worktree-bootstrap friction; reuse the existing verified
+  dependency tree before running packet checks.
+- **Owner:** worktree setup and quality scheduler maintainers.
+
+## 2026-08-30 — Post-merge hook runs before an isolated worktree is command-ready
+
+- **What happened:** fast-forwarding the newly attached recovery branch invoked
+  the repository's post-merge version-sync hook before the worktree dependency
+  link had been provisioned. The Git update completed, but its validation hook
+  could not execute.
+- **Evidence:** `git merge --ff-only origin/main` fast-forwarded successfully,
+  then `version-sync-check` failed with `Cannot find module '@beep/utils'` from
+  the repo CLI entrypoint. The same command surface worked after linking the
+  existing verified dependency tree.
+- **What would have prevented it:** provision worktree dependencies as part of
+  worktree creation, before any checkout/switch/merge operation capable of
+  firing repository hooks, or make the hook bootstrap-independent.
+- **Disposition:** worktree/hook ordering friction; rerun the affected
+  validation through the canonical quality path after provisioning.
+- **Owner:** worktree setup and Git-hook maintainers.
+
+## 2026-08-30 — Convention-migration preview cannot construct its PacketEventStore dependency
+
+- **What happened:** the recovery census invoked the packet's canonical second
+  preview to prove that no legacy convention work remained. The command failed
+  before reporting a plan because its runtime layer did not provide the packet
+  event store.
+- **Evidence:** `bun run beep goals migrate-conventions --preview` exited 1 with
+  `Service not found: @beep/repo-cli/commands/Goals/PacketCore/PacketEventStore/PacketEventStore`.
+  In the same checkout, `bun run beep goals set-status --migrate` completed and
+  still planned one manifest repair for `gov-legal-data-driver-delivery`.
+- **What would have prevented it:** exercise the registered CLI command through
+  a runtime-layer smoke test, and compose every PacketCore dependency into the
+  migration command's public provider before declaring the campaign reusable.
+- **Disposition:** repaired in the recovery branch by providing the shared
+  migration layer at the registered command boundary and adding a root-command
+  smoke test. The focused suite passes 60 tests, and the live second preview
+  now reports zero translations, seeds, issues, assumptions, or fleet findings.
+- **Owner:** Goals migration command and PacketCore layer maintainers.
+
+## 2026-08-30 — Reusing a checkout-wide dependency tree crosses worktree source boundaries
+
+- **What happened:** linking the parent checkout's complete `node_modules`
+  tree made the isolated worktree command-capable, but workspace-package links
+  inside that tree still targeted the parent checkout. A scoped repo-cli check
+  therefore compiled a mixture of recovery-worktree and parent-checkout source.
+- **Evidence:** `bunx turbo run check --filter=@beep/repo-cli` resolved
+  foundation source through the sibling `beep-effect2` checkout and failed an
+  unrelated `@beep/duckdb` dependency build on missing runtime types, while the
+  worktree's focused migration suite passed 60 tests.
+- **What would have prevented it:** bootstrap each worktree with a local frozen
+  install whose workspace links target that worktree; reserve a whole-tree
+  dependency symlink for read-only commands that cannot traverse workspace
+  package links.
+- **Disposition:** environment-only mixed-checkout proof failure; replace the
+  validated symlink with a worktree-local frozen install and rerun the scoped
+  check before attributing source failures.
+- **Owner:** worktree dependency-bootstrap maintainers.
+
+## 2026-08-30 — Fleet checks exit successfully while reporting acceptance findings
+
+- **What happened:** both fleet inspection commands completed with exit code 0
+  even though their reports still contained findings that block the packet's
+  literal zero-finding acceptance contract.
+- **Evidence:** `bun run beep explore --check` reported `findings=5`, and the
+  repaired `bun run beep goals migrate-conventions --preview` reported three
+  violation-severity unreachable references, while both processes exited 0.
+- **What would have prevented it:** make `--check` and preview return nonzero
+  when blocking or violation findings are present, or add an explicit
+  `--fail-on-findings` mode and use it in packet/CI acceptance.
+- **Disposition:** proof parsing hazard; this recovery validates the literal
+  report counts instead of treating process success as acceptance. After the
+  reconciliation, both commands report zero findings.
+- **Owner:** Explore check and Goals convention-migration CLI maintainers.
+
+## 2026-08-30 — Package verification exposes opaque failures in unrelated CLI command fixtures
+
+- **What happened:** the required full `@beep/repo-cli` package verifier passed
+  build, typecheck, lint setup, and 2,692 tests, but two agent-effectiveness
+  command tests failed without printing the underlying fixture command output.
+  Diagnosis showed their temp-directory helpers inherited a `TMPDIR` below the
+  user cache, which the production private-home-path scanner correctly rejects.
+- **Evidence:** `bun run beep quality package-verify @beep/repo-cli` reported
+  failures in `agent-effectiveness-command.test.ts` for `emits report-only
+  annotation check JSON` and `defaults Phoenix sync to dry-run JSON`; both
+  surfaced only `CliReportedExit` messages from the command boundary.
+- **What would have prevented it:** have command-fixture failures attach the
+  captured stdout/stderr and resolved fixture path to `CliReportedExit`, and
+  make privacy-sensitive test fixtures allocate below an explicit safe scratch
+  root instead of inheriting an arbitrary `TMPDIR`.
+- **Disposition:** reproduced unchanged on the clean current `origin/main`
+  checkout and isolated by unsetting `TMPDIR`, so it was an
+  environment-sensitive baseline fixture defect rather than a migration
+  regression. Both test-only helpers now allocate beneath `/tmp` with cleanup
+  unchanged; the CLI and AI-metrics suites pass 25/25 tests under both the
+  actual managed `TMPDIR` and an unset `TMPDIR`.
+- **Owner:** Agent Effectiveness command tests and package-verification
+  diagnostics maintainers.
+
+## 2026-08-30 — Lifecycle closeout left executable framing in the packet README
+
+- **What happened:** the goal launcher itself was converted to retained,
+  read-only regression guidance, but the packet README still labeled its
+  command block `Launch`, described `GOAL.md` as an execution launcher, and
+  called `PLAN.md` active.
+- **Evidence:** final-diff review found the stale labels in
+  `goals/packet-convention-migration/README.md` after the canonical lifecycle
+  had already become `completed-retained`.
+- **What would have prevented it:** make lifecycle closeout lint README
+  orientation language, not only the generated lifecycle line, and flag active
+  launcher or plan labels in retained packets.
+- **Disposition:** fixed in the recovery diff by relabeling the command as a
+  retained regression entry point and both documents as terminal/read-only
+  guidance.
+- **Owner:** packet closeout lint and README template maintainers.
+
+## 2026-08-30 — Dirty-worktree cheap gates miss a required product changeset
+
+- **What happened:** the edit-loop cheap-gate proof reported no changed product
+  workspaces, but the first authoritative staged publish committed the same
+  candidate and then failed because `@beep/repo-ai-metrics` lacked a changeset.
+- **Evidence:** before commit, `quality:changeset-status` printed
+  `product_workspaces=0`; during `yeet publish --staged-only --pr --monitor`, it
+  printed `product_workspaces=2` and `changed product workspaces missing an
+  in-range changeset: @beep/repo-ai-metrics`.
+- **What would have prevented it:** have dirty-worktree changeset detection
+  include staged and unstaged paths relative to the base, or make cheap-gates
+  reject an uncommitted candidate instead of returning an incomplete green
+  product-workspace census.
+- **Disposition:** publish stopped before push. The required AI-metrics patch
+  changeset was added and the unpushed recovery commit amended; re-run the
+  authoritative publish proof on the corrected head.
+- **Owner:** changeset-status and Yeet dirty-worktree preflight maintainers.
+
+## 2026-08-30 — Full coverage proof regresses untouched Yeet branch floors
+
+- **What happened:** the corrected committed-head Yeet proof passed every
+  preflight, build, lint, Effect/tsgo, unit, integration, JSDoc, and docgen lane,
+  but its repository CLI coverage shard measured two untouched Yeet internals
+  below their committed branch floors.
+- **Evidence:** `bun run beep yeet verify --collect-all` completed 28 of 29
+  lanes and failed only `quality:coverage`; the ratchet reported
+  `LaneProofReuse.ts` at `86.84 < 92.1` branches and `Planner.ts` at
+  `90.54 < 91.89`, although the CLI shard itself passed 143 test files and
+  2,689 tests plus 5 skips.
+- **What would have prevented it:** ensure per-file coverage floors are derived
+  from a deterministic test/worker configuration, and report whether a
+  regressed row belongs to the changed path set so unrelated baseline drift is
+  distinguishable from a candidate regression.
+- **Disposition:** diagnosed as deterministic inherited-environment drift: the
+  full proof injects lane-proof mode and base variables, so the nested coverage
+  run did not take the three default branches measured by direct baseline
+  generation. Tests now delete those ambient variables around default-contract
+  assertions. A focused coverage run under the injected environment observed
+  every repaired branch, so the higher committed floors remain intact.
+- **Owner:** coverage-ratchet and repository CLI test maintainers.
+
+## 2026-08-30 — Same-origin admission wait is reported as token backpressure
+
+- **What happened:** the repaired exact-head full proof remained first in the
+  admission queue even after available capacity was sufficient, because a
+  publish proof from another checkout of the same origin still held the
+  origin-wide proof lock. The wait message continued to describe machine-budget
+  backpressure instead of the actual same-origin serialization.
+- **Evidence:** `bun run beep quality scheduler status --json` showed capacity
+  recovering from 9 to 10 tokens with 5 active while the queued full proof
+  requested 3, yet `bun run beep yeet verify --collect-all` remained at
+  position 1 through 195 seconds. Both entries had the same `originKey`; the
+  holder was live for roughly 29 minutes, heartbeating, and executing the final
+  `ci local` test-tsgo process. The queued ticket nevertheless reported
+  `blockedOnOriginAtMillis: 0`.
+- **What would have prevented it:** surface the origin lock as an explicit
+  admission blocker in status and wait messages, populate its blocked-since
+  timestamp, and distinguish it from token or memory pressure. Reduce
+  origin-lock hold time by reusing exact-head proof lanes across the serialized
+  cheap-gates, pre-push, and CI-parity batteries where their contracts overlap.
+- **Disposition:** no dead or stale lease was found, so the active holder was
+  left untouched. The not-yet-admitted recovery ticket was canceled to record
+  this evidence before amending and requeueing the exact-head candidate.
+- **Owner:** Yeet admission scheduler, origin-lock observability, and publish
+  proof orchestration maintainers.

--- a/goals/packet-convention-migration/research/OPPORTUNITIES.md
+++ b/goals/packet-convention-migration/research/OPPORTUNITIES.md
@@ -456,3 +456,21 @@
   this evidence before amending and requeueing the exact-head candidate.
 - **Owner:** Yeet admission scheduler, origin-lock observability, and publish
   proof orchestration maintainers.
+
+## 2026-08-30 — PR body interpolation executes Markdown code spans
+
+- **What happened:** the first manual `gh pr create` attempt passed a Markdown
+  body containing backtick code spans through a double-quoted shell argument.
+  The shell interpreted those spans as command substitutions, started a
+  redundant full Yeet proof, and never created the PR.
+- **Evidence:** the command emitted `zsh: command not found` for the exact-head
+  SHA and then launched `bun run beep yeet verify --collect-all`; a subsequent
+  `gh pr list --head docs/packet-convention-closeout-recovery` returned no PR.
+  The accidentally launched proof processes were identified by their exact
+  command and terminated without touching other active checkouts.
+- **What would have prevented it:** pass multiline PR bodies through
+  `gh pr create --body-file -` or another literal stdin/file boundary instead
+  of interpolating Markdown into executable shell text.
+- **Disposition:** publication-command construction friction; retry through a
+  literal stdin body and keep the already authoritative exact-head proof.
+- **Owner:** agent shell-command construction and PR publication wrappers.

--- a/goals/practice-kg-mcp/ops/manifest.json
+++ b/goals/practice-kg-mcp/ops/manifest.json
@@ -10,10 +10,7 @@
   },
   "packetPath": "goals/practice-kg-mcp",
   "lifecycle": "active",
-  "blockedBy": [
-    "AC-2 remains unmet because shipped graph nodes lack provenance (defect B-2).",
-    "Tom's correctness calls on the G-1 through G-5 acceptance questions remain pending."
-  ],
+  "statusNote": "Acceptance remains open: AC-2 is unmet because shipped graph nodes lack provenance (defect B-2), and Tom's correctness calls on the G-1 through G-5 acceptance questions remain pending.",
   "mission": "Ship the first queryable IP-law knowledge graph over the Oppold corpus to Tom's Claude Desktop as a read-only, local-first, .mcpb-packaged stdio MCP server over a portable data bundle, taking live ownership of the orphaned knowledge-graph scope.",
   "executionCapable": true,
   "reflectionRequired": true,

--- a/goals/repo-cli-modularization/ops/events/00002-status-set-11e8642b7aad8414688d2de66509f6a27b1a4f4e00875b6075068f59e268e601.json
+++ b/goals/repo-cli-modularization/ops/events/00002-status-set-11e8642b7aad8414688d2de66509f6a27b1a4f4e00875b6075068f59e268e601.json
@@ -1,0 +1,15 @@
+{
+  "actor": "operator",
+  "at": "2026-08-30T14:33:53.237Z",
+  "body": {
+    "previous": "completed-retained",
+    "status": "paused",
+    "type": "status-set"
+  },
+  "expectedRevision": 1,
+  "packet": "repo-cli-modularization",
+  "parent": "a8e1a2fd8c19dbc51cce6b94145b60372f54e3c836f6fdcda7839682380ce595",
+  "root": "goals",
+  "schemaVersion": "packet-event/v1",
+  "seq": 2
+}

--- a/goals/repo-cli-modularization/ops/manifest.json
+++ b/goals/repo-cli-modularization/ops/manifest.json
@@ -5,7 +5,7 @@
     "title": "@beep/repo-cli Modularization",
     "status": "paused",
     "created": "2026-07-07",
-    "updated": "2026-07-08",
+    "updated": "2026-08-30",
     "packetAnchorDocument": "SPEC.md"
   },
   "packetPath": "goals/repo-cli-modularization",
@@ -130,8 +130,5 @@
     "statement": "Not achieved until the campaign branch ships as a PR driven to mergeable via /yeet (bun run beep yeet: repair -> verify -> publish --message -> monitor).",
     "grandfathered": false
   },
-  "statusNote": "Implementation waves and final local verification are complete, but delivery PR #339 was closed after overlapping standards work landed in #326. Resume for current-main reconciliation, authoritative proof, and a replacement delivery PR.",
-  "blockedBy": [
-    "No merged or mergeable delivery PR exists for the reconciled campaign work."
-  ]
+  "statusNote": "Implementation waves and final local verification are complete, but delivery PR #339 was closed after overlapping standards work landed in #326. Resume for current-main reconciliation, authoritative proof, and a replacement delivery PR. No merged or mergeable delivery PR exists for the reconciled campaign work."
 }

--- a/goals/repo-cli-modularization/ops/trace.json
+++ b/goals/repo-cli-modularization/ops/trace.json
@@ -6,19 +6,19 @@
     "issues": [],
     "packet": "repo-cli-modularization",
     "resumeStage": "P9",
-    "revision": 1,
+    "revision": 2,
     "root": "goals",
-    "status": "completed-retained",
+    "status": "paused",
     "tip": {
-      "id": "a8e1a2fd8c19dbc51cce6b94145b60372f54e3c836f6fdcda7839682380ce595",
-      "seq": 1
+      "id": "11e8642b7aad8414688d2de66509f6a27b1a4f4e00875b6075068f59e268e601",
+      "seq": 2
     }
   },
   "projectorVersion": 2,
   "schemaVersion": "packet-trace/v1",
   "sourceTip": {
-    "id": "a8e1a2fd8c19dbc51cce6b94145b60372f54e3c836f6fdcda7839682380ce595",
-    "seq": 1
+    "id": "11e8642b7aad8414688d2de66509f6a27b1a4f4e00875b6075068f59e268e601",
+    "seq": 2
   },
   "timeline": [
     {
@@ -32,6 +32,17 @@
       },
       "id": "a8e1a2fd8c19dbc51cce6b94145b60372f54e3c836f6fdcda7839682380ce595",
       "seq": 1
+    },
+    {
+      "actor": "operator",
+      "at": "2026-08-30T14:33:53.237Z",
+      "body": {
+        "previous": "completed-retained",
+        "status": "paused",
+        "type": "status-set"
+      },
+      "id": "11e8642b7aad8414688d2de66509f6a27b1a4f4e00875b6075068f59e268e601",
+      "seq": 2
     }
   ]
 }

--- a/goals/semantic-foundation/ops/events/00002-status-set-80edc50ae267b2673866e960a4d79a756aa1fe72c6b3fbf792888e6f6bdc83b7.json
+++ b/goals/semantic-foundation/ops/events/00002-status-set-80edc50ae267b2673866e960a4d79a756aa1fe72c6b3fbf792888e6f6bdc83b7.json
@@ -1,0 +1,15 @@
+{
+  "actor": "operator",
+  "at": "2026-08-30T14:33:55.019Z",
+  "body": {
+    "previous": "active",
+    "status": "completed-retained",
+    "type": "status-set"
+  },
+  "expectedRevision": 1,
+  "packet": "semantic-foundation",
+  "parent": "08395172e4794b7eb75c708ddec5cf2d1ffc953ea6a817a6486504c98ae9caa6",
+  "root": "goals",
+  "schemaVersion": "packet-event/v1",
+  "seq": 2
+}

--- a/goals/semantic-foundation/ops/manifest.json
+++ b/goals/semantic-foundation/ops/manifest.json
@@ -5,7 +5,7 @@
     "title": "Semantic Foundation",
     "status": "completed-retained",
     "created": "2026-07-08",
-    "updated": "2026-08-27",
+    "updated": "2026-08-30",
     "packetAnchorDocument": "SPEC.md"
   },
   "packetPath": "goals/semantic-foundation",

--- a/goals/semantic-foundation/ops/trace.json
+++ b/goals/semantic-foundation/ops/trace.json
@@ -6,19 +6,19 @@
     "issues": [],
     "packet": "semantic-foundation",
     "resumeStage": "M2",
-    "revision": 1,
+    "revision": 2,
     "root": "goals",
-    "status": "active",
+    "status": "completed-retained",
     "tip": {
-      "id": "08395172e4794b7eb75c708ddec5cf2d1ffc953ea6a817a6486504c98ae9caa6",
-      "seq": 1
+      "id": "80edc50ae267b2673866e960a4d79a756aa1fe72c6b3fbf792888e6f6bdc83b7",
+      "seq": 2
     }
   },
   "projectorVersion": 2,
   "schemaVersion": "packet-trace/v1",
   "sourceTip": {
-    "id": "08395172e4794b7eb75c708ddec5cf2d1ffc953ea6a817a6486504c98ae9caa6",
-    "seq": 1
+    "id": "80edc50ae267b2673866e960a4d79a756aa1fe72c6b3fbf792888e6f6bdc83b7",
+    "seq": 2
   },
   "timeline": [
     {
@@ -32,6 +32,17 @@
       },
       "id": "08395172e4794b7eb75c708ddec5cf2d1ffc953ea6a817a6486504c98ae9caa6",
       "seq": 1
+    },
+    {
+      "actor": "operator",
+      "at": "2026-08-30T14:33:55.019Z",
+      "body": {
+        "previous": "active",
+        "status": "completed-retained",
+        "type": "status-set"
+      },
+      "id": "80edc50ae267b2673866e960a4d79a756aa1fe72c6b3fbf792888e6f6bdc83b7",
+      "seq": 2
     }
   ]
 }

--- a/packages/tooling/library/ai-metrics/test/agent-effectiveness.test.ts
+++ b/packages/tooling/library/ai-metrics/test/agent-effectiveness.test.ts
@@ -50,7 +50,7 @@ const withTempDirectory = <A, E, R>(use: (tmpDir: string) => Effect.Effect<A, E,
   Effect.acquireUseRelease(
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
-      return yield* fs.makeTempDirectory();
+      return yield* fs.makeTempDirectory({ directory: "/tmp", prefix: "beep-agent-effectiveness-" });
     }),
     use,
     (tmpDir) =>

--- a/packages/tooling/tool/cli/src/commands/Goals/Migration/Migration.command.ts
+++ b/packages/tooling/tool/cli/src/commands/Goals/Migration/Migration.command.ts
@@ -678,4 +678,7 @@ export const goalsMigrateConventionsCommand = Command.make(
       })
     );
   })
-).pipe(Command.withDescription("Preview or apply the goal-fleet v2 convention migration"));
+).pipe(
+  Command.withDescription("Preview or apply the goal-fleet v2 convention migration"),
+  Command.provide(migrationLayer)
+);

--- a/packages/tooling/tool/cli/test/agent-effectiveness-command.test.ts
+++ b/packages/tooling/tool/cli/test/agent-effectiveness-command.test.ts
@@ -76,7 +76,7 @@ const withTempDirectory = <A, E, R>(use: (tmpDir: string) => Effect.Effect<A, E,
   Effect.acquireUseRelease(
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
-      return yield* fs.makeTempDirectory();
+      return yield* fs.makeTempDirectory({ directory: "/tmp", prefix: "beep-agent-effectiveness-" });
     }),
     use,
     (tmpDir) =>

--- a/packages/tooling/tool/cli/test/goals-packet-convention-migration.test.ts
+++ b/packages/tooling/tool/cli/test/goals-packet-convention-migration.test.ts
@@ -2,6 +2,7 @@ import {
   applyPacketGenesisSeed,
   foldPacketEvents,
   GoalPacketRecord,
+  goalsCommand,
   goalsMigrateConventionsCommand,
   goalsRepairForkCommand,
   isJsonRecord,
@@ -50,6 +51,7 @@ const encodeJsonResult = S.encodeUnknownResult(S.fromJsonString(S.Unknown));
 const encodeJson = (value: unknown): string => Result.getOrThrow(encodeJsonResult(value));
 const runMigration = Command.runWith(goalsMigrateConventionsCommand, { version: "0.0.0" });
 const runRepair = Command.runWith(goalsRepairForkCommand, { version: "0.0.0" });
+const runGoals = Command.runWith(goalsCommand, { version: "0.0.0" });
 
 const record = (slug: string, manifest: Readonly<Record<string, unknown>>): GoalPacketRecord =>
   GoalPacketRecord.make({
@@ -2586,6 +2588,32 @@ layer(testLayer, { timeout: 30_000 })("migration command boundaries", (it) => {
           expect(Exit.isFailure(exit) ? exit.cause.toString() : "").toContain("rollback failed");
           expect(yield* fs.readFileString(manifestPath)).toBe(foreignBytes);
           expect(yield* fs.exists("goals/demo/ops/events")).toBe(false);
+        })
+      );
+    })
+  );
+});
+
+layer(NodeServices.layer, { timeout: 30_000 })("registered migration command boundary", (it) => {
+  it.effect(
+    "provides PacketCore services through the goals command tree",
+    Effect.fnUntraced(function* () {
+      yield* withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeProjectFile(
+            "goals/demo/ops/manifest.json",
+            `${encodeJson({
+              schemaVersion: "initiative-manifest/v2",
+              initiative: { id: "demo", status: "active" },
+              lifecycle: "active",
+              packetPath: "goals/demo",
+              completionGate,
+            })}\n`
+          );
+          const exit = yield* Effect.exit(
+            runGoals(["migrate-conventions", "--preview", "--at", "2026-08-30T00:00:00.000Z"])
+          );
+          expect(Exit.isSuccess(exit)).toBe(true);
         })
       );
     })

--- a/packages/tooling/tool/cli/test/quality-tasks.test.ts
+++ b/packages/tooling/tool/cli/test/quality-tasks.test.ts
@@ -983,15 +983,20 @@ describe("quality task adapter", () => {
       const lane = laneProofTestLane(tempRoot, "proof:test", "preflight", "echo run >> .beep/lane-marker.txt");
       const waves = [GithubCheckLaneWaveSpec.make({ wave: "preflight", lanes: [lane] })];
       const run = collectGithubCheckLaneWavesForTesting("proof", waves, "fail-fast");
+      const runWithLaneProof = withEnvVarEffect(
+        "BEEP_YEET_LANE_PROOF_MODE",
+        "active",
+        withEnvVarEffect("BEEP_YEET_PROOF_BASE", undefined, run)
+      );
 
-      const first = yield* withEnvVarEffect("BEEP_YEET_LANE_PROOF_MODE", "active", run);
+      const first = yield* runWithLaneProof;
       expect(A.map(first.report.lanes, (result) => result.status)).toEqual(["passed"]);
-      const second = yield* withEnvVarEffect("BEEP_YEET_LANE_PROOF_MODE", "active", run);
+      const second = yield* runWithLaneProof;
       expect(A.map(second.report.lanes, (result) => result.status)).toEqual(["reused"]);
       expect(yield* fs.readFileString(markerPath)).toBe("run\n");
 
       yield* fs.writeFileString(path.join(tempRoot, "README.md"), "# changed\n");
-      const invalidated = yield* withEnvVarEffect("BEEP_YEET_LANE_PROOF_MODE", "active", run);
+      const invalidated = yield* runWithLaneProof;
       expect(A.map(invalidated.report.lanes, (result) => result.status)).toEqual(["passed"]);
       expect(yield* fs.readFileString(markerPath)).toBe("run\nrun\n");
     }, provideScopedLayer(PlatformLayer))
@@ -1318,7 +1323,7 @@ describe("quality task adapter", () => {
     return Effect.runPromise(
       withEnvVarEffect(
         "BEEP_YEET_LANE_PROOF_MODE",
-        "off",
+        undefined,
         runGithubChecks("cheap-gates").pipe(
           Effect.tap(
             Effect.fnUntraced(function* () {

--- a/packages/tooling/tool/cli/test/yeet.test.ts
+++ b/packages/tooling/tool/cli/test/yeet.test.ts
@@ -817,7 +817,9 @@ describe("yeet planner", () => {
   });
 
   it("plans collect-all as an explicit override of fail-fast wave scheduling", () => {
-    const plan = buildYeetRunPlanForTesting({ collectAll: true, context, message: O.none(), mode: "verify" });
+    const plan = withEnvVar("BEEP_YEET_LANE_PROOF_MODE", undefined, () =>
+      buildYeetRunPlanForTesting({ collectAll: true, context, message: O.none(), mode: "verify" })
+    );
 
     expect(findStep(plan.steps, "full:pre-push").args).toEqual([
       "run",
@@ -827,6 +829,7 @@ describe("yeet planner", () => {
       "pre-push",
       "--collect-all",
     ]);
+    expect(findStep(plan.steps, "full:pre-push").env?.BEEP_YEET_LANE_PROOF_MODE).toBe("active");
   });
 
   it("builds explicit CI parity as the installed merge-preview CI battery", () => {


### PR DESCRIPTION
## Summary

- close the packet-convention migration as completed-retained after PR #855 merged before its same-PR P4 flip
- reconcile the v2 goal fleet and parent exploration projections, retaining regression-only guidance instead of an active legacy launcher
- fix the public migration command runtime, environment-sensitive agent-effectiveness fixtures, and Yeet coverage tests uncovered during authoritative proof

## Verification

Exact implementation head `8ce2829f39fb4b75e172c4a55b0c9c17d0f25f5c` passed the full 29-lane local Yeet proof. Documentation head `c26059663ad3bf3a1655a26d64d6d233ee821235` additionally passed:

- `bun run beep yeet verify --tier cheap-gates`
- `bun run beep ci lane check --affected --base origin/main --summarize`

Final ledger-only head `d49d0dd2f9c2ff3e82e5cb119f5714b90a913ae6` passed `bun run beep goals doctor`; hosted exact-head checks remain authoritative.

The full local proof used `origin/main` at `19de101c60e7065dee0ef2d1359840a50b87feb5`; hosted merge-preview checks remain authoritative for the newer base.
