### PR TITLE
docs(explorations): flag nested-PST omission in the flat AzCopy form

### DIFF
--- a/explorations/practice-office-provisioning/research/r2-purview-pst-import.md
+++ b/explorations/practice-office-provisioning/research/r2-purview-pst-import.md
@@ -115,8 +115,11 @@ Source: [Use network upload to import PST files](https://learn.microsoft.com/en-
 # every CSV row must then carry FilePath=<directory name>.
 azcopy.exe copy "<Source directory of PST files>" "<SAS URL>" --recursive=true
 
-# Flat form: uploads the directory CONTENTS to the container root —
-# FilePath stays blank in the CSV. Preferred for this runbook.
+# Flat form: uploads the directory's TOP-LEVEL files to the container
+# root — FilePath stays blank in the CSV. Preferred for this runbook,
+# which is why the staging directory must be flat: move any PSTs out of
+# subdirectories first, or they are silently omitted (use the recursive
+# form with FilePath prefixes if nesting must be preserved).
 azcopy.exe copy "<Source directory of PST files>/*" "<SAS URL>"
 ```
 


### PR DESCRIPTION
Follow-up to #915 closing its one post-merge review thread: the runbook's
preferred flat AzCopy form uploads only the staging directory's top-level
files, so the command block now states that nested PSTs must be flattened
first (or the recursive form used with FilePath prefixes) instead of being
silently omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/916"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790716663&installation_model_id=424656&pr_number=916&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F916&signature=e9cd1fc331afbd9aed8c18bc925f1e618ff4cfccc78d767adcecd3daedbf47f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->