### PR TITLE
test(repo-cli): stabilize restoration mutation timing

### DIFF
--- a/packages/tooling/tool/cli/test/corpus-command.test.ts
+++ b/packages/tooling/tool/cli/test/corpus-command.test.ts
@@ -1341,19 +1341,12 @@ const measurePreservationDenominators = Effect.fn("CorpusTest.measurePreservatio
 
 const collectorManifestJson = S.fromJsonString(CollectorManifestRecord);
 
-const waitForOpenProcessFile = Effect.fn("CorpusTest.waitForOpenProcessFile")(function* (
+const waitForPathToExist = Effect.fn("CorpusTest.waitForPathToExist")(function* (
   filePath: string
 ): Effect.fn.Return<boolean, never, FileSystem.FileSystem> {
   const fs = yield* FileSystem.FileSystem;
-  const descriptorRoot = `/proc/${process.pid}/fd`;
   for (let attempt = 0; attempt < 5_000; attempt += 1) {
-    const descriptors = yield* fs.readDirectory(descriptorRoot).pipe(Effect.orDie);
-    const targets = yield* Effect.forEach(
-      descriptors,
-      (descriptor) => fs.readLink(`${descriptorRoot}/${descriptor}`).pipe(Effect.option),
-      { concurrency: "unbounded" }
-    );
-    if (A.some(targets, (target) => O.exists(target, (value) => value === filePath))) return true;
+    if (yield* fs.exists(filePath).pipe(Effect.orDie)) return true;
     yield* Effect.yieldNow;
   }
   return false;
@@ -1532,6 +1525,15 @@ describe("corpus restoration preservation", () => {
         const path = yield* Path.Path;
         const fixture = yield* makeRestorationFixture();
         const sourcePath = path.join(fixture.sourceRoot, "nested", "large.bin");
+        const partialPath = path.join(
+          fixture.corpusRoot,
+          "raw",
+          "synthetic-restoration",
+          "payload",
+          "tree",
+          "nested",
+          "large.bin.partial"
+        );
         const sourceBytes = new Uint8Array(2 * 1024 * 1024);
         sourceBytes.fill(0x31);
         const stableReplacement = new Uint8Array(sourceBytes.length);
@@ -1559,8 +1561,8 @@ describe("corpus restoration preservation", () => {
         });
         yield* Effect.forkChild(
           Effect.gen(function* () {
-            const sourceOpened = yield* waitForOpenProcessFile(sourcePath);
-            if (!sourceOpened) return yield* Effect.die("Preservation source was not observably open for mutation.");
+            const partialExists = yield* waitForPathToExist(partialPath);
+            if (!partialExists) return yield* Effect.die("Partial archive was not observable for mutation.");
             yield* fs.rename(replacementPath, sourcePath);
           })
         );
@@ -1602,6 +1604,15 @@ describe("corpus restoration preservation", () => {
         const path = yield* Path.Path;
         const fixture = yield* makeRestorationFixture();
         const sourcePath = path.join(fixture.sourceRoot, "nested", "large.bin");
+        const partialPath = path.join(
+          fixture.corpusRoot,
+          "raw",
+          "synthetic-restoration",
+          "payload",
+          "tree",
+          "nested",
+          "large.bin.partial"
+        );
         const sourceBytes = new Uint8Array(2 * 1024 * 1024);
         sourceBytes.fill(0x41);
         const stableReplacement = new Uint8Array(sourceBytes.length);
@@ -1629,8 +1640,8 @@ describe("corpus restoration preservation", () => {
         });
         yield* Effect.forkChild(
           Effect.gen(function* () {
-            const sourceOpened = yield* waitForOpenProcessFile(sourcePath);
-            if (!sourceOpened) return yield* Effect.die("Preservation source was not observably open for mutation.");
+            const partialExists = yield* waitForPathToExist(partialPath);
+            if (!partialExists) return yield* Effect.die("Partial archive was not observable for mutation.");
             yield* fs.rename(replacementPath, sourcePath);
             yield* fs.writeFileString(path.join(fixture.sourceRoot, "unrelated-added.bin"), "unexpected drift");
           })


### PR DESCRIPTION
## test(repo-cli): stabilize restoration mutation timing

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/fix_issue-898-property-laws-53a07bf8d6e7/verdict.json

---

## Provenance

- Branch: <code>fix/issue-898-property-laws</code>
- Harness: `codex`

<!-- yeet-provenance
{
  "schemaVersion": 1,
  "branch": "fix/issue-898-property-laws",
  "harness": "codex"
}
-->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/922"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790727915&installation_model_id=424656&pr_number=922&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F922&signature=5187ad9ea87dd2c23c5e0226a210d734400952cee44293d307ae10b717129360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

Closes #898
