### PR TITLE
feat(semantica): add evidence quote relation candidate

### DIFF
--- a/apps/labs/semantica/fixtures/gold/v1/057e356e94f8.relation.json
+++ b/apps/labs/semantica/fixtures/gold/v1/057e356e94f8.relation.json
@@ -14,7 +14,7 @@
       "startChar": 209,
       "endChar": 413,
       "quoteSha256": "dc6f1cfb0368164b7eeba846b7954b1b0a851cf0cae593c179a911ed6d63f987",
-      "verified": false
+      "verified": true
     },
     {
       "predicate": "affiliated with",
@@ -27,7 +27,7 @@
       "startChar": 334,
       "endChar": 449,
       "quoteSha256": "81f825c610aa2ece6d96a099c2398ca4401251b1e8450820473dc0489b4ff3ba",
-      "verified": false
+      "verified": true
     },
     {
       "predicate": "located in",
@@ -40,7 +40,7 @@
       "startChar": 414,
       "endChar": 449,
       "quoteSha256": "0f09509d91df6919c451372c4716e2e3a275567d775a9c26e57a57f496cb1fed",
-      "verified": false
+      "verified": true
     },
     {
       "predicate": "re-evaluates claim due to",
@@ -53,20 +53,7 @@
       "startChar": 714,
       "endChar": 781,
       "quoteSha256": "5bb957c71a676bf7d6a29c8f75d2466c1b6dfc022a8e7b55350a9dba7e6063b1",
-      "verified": false
-    },
-    {
-      "predicate": "published in proceedings of",
-      "subjectStartChar": 19,
-      "subjectEndChar": 79,
-      "subjectSha256": "50b2166abade50b925968f6b877bd51431f22af358a0415ca53ad09a9d7d7636",
-      "objectStartChar": 107,
-      "objectEndChar": 124,
-      "objectSha256": "ccd2892c54be2baf29c21b47c884ceff61ff8665a4849aa2cbe46a109d8cccdd",
-      "startChar": 0,
-      "endChar": 174,
-      "quoteSha256": "d4f65547bc7d33d1021e81ea8af00983e55a139672578cc26610b1803a7bbc3d",
-      "verified": false
+      "verified": true
     }
   ],
   "proposer": {

--- a/apps/labs/semantica/fixtures/gold/v1/057e356e94f8.structure.json
+++ b/apps/labs/semantica/fixtures/gold/v1/057e356e94f8.structure.json
@@ -17,7 +17,7 @@
       "startChar": 478,
       "endChar": 486,
       "quoteSha256": "d21b4a64a2d8656a0fdf7ab2e89a49164ac504686cfa2a3d442e87c209286330",
-      "verified": false
+      "verified": true
     },
     {
       "role": "section",

--- a/apps/labs/semantica/fixtures/gold/v1/05afbbf3e1e9.relation.json
+++ b/apps/labs/semantica/fixtures/gold/v1/05afbbf3e1e9.relation.json
@@ -4,7 +4,7 @@
   "subset": "relation",
   "labels": [
     {
-      "predicate": "affiliated_with",
+      "predicate": "affiliated with",
       "subjectStartChar": 87,
       "subjectEndChar": 184,
       "subjectSha256": "08a230a3916926b388ead21aced92835327fd7630177bb21afa9393462bf9c88",
@@ -14,7 +14,7 @@
       "startChar": 87,
       "endChar": 249,
       "quoteSha256": "321eaa6b88631781d1cadffb803d306a9d55c4f6ad6f09c325873736c7e8645e",
-      "verified": false
+      "verified": true
     },
     {
       "predicate": "selected",
@@ -27,7 +27,7 @@
       "startChar": 789,
       "endChar": 841,
       "quoteSha256": "3b28eccd806b7afa1bee6adbb4be57597f3b527b57f0658e0ea013dccd2da6b5",
-      "verified": false
+      "verified": true
     },
     {
       "predicate": "shows",
@@ -40,7 +40,7 @@
       "startChar": 1348,
       "endChar": 1408,
       "quoteSha256": "d4317b6f0d798b58ecb613fa7c8eb3a84966f4b73ca63d1f4d7ab36aceb8187e",
-      "verified": false
+      "verified": true
     }
   ],
   "proposer": {

--- a/apps/labs/semantica/fixtures/gold/v1/05afbbf3e1e9.structure.json
+++ b/apps/labs/semantica/fixtures/gold/v1/05afbbf3e1e9.structure.json
@@ -17,7 +17,7 @@
       "startChar": 307,
       "endChar": 315,
       "quoteSha256": "d21b4a64a2d8656a0fdf7ab2e89a49164ac504686cfa2a3d442e87c209286330",
-      "verified": false
+      "verified": true
     },
     {
       "role": "section",

--- a/apps/labs/semantica/fixtures/gold/v1/06c93f91ef3d.relation.json
+++ b/apps/labs/semantica/fixtures/gold/v1/06c93f91ef3d.relation.json
@@ -14,7 +14,7 @@
       "startChar": 116,
       "endChar": 154,
       "quoteSha256": "84c559e037ecaec0335a146a1d1cc0726f7dce91a572c8f752632fa3fffa2efd",
-      "verified": false
+      "verified": true
     },
     {
       "predicate": "affiliated with",
@@ -27,7 +27,7 @@
       "startChar": 155,
       "endChar": 193,
       "quoteSha256": "fe222a1615962521e268db22f7b4062123a6e87db688dffbf7b00297baa12184",
-      "verified": false
+      "verified": true
     },
     {
       "predicate": "affiliated with",
@@ -40,7 +40,7 @@
       "startChar": 194,
       "endChar": 236,
       "quoteSha256": "38744657294761cf5dc5e389b7f9355a9029c3f1ee44bd17e10e775716444879",
-      "verified": false
+      "verified": true
     },
     {
       "predicate": "affiliated with",
@@ -53,7 +53,7 @@
       "startChar": 237,
       "endChar": 275,
       "quoteSha256": "4d99f4dcf1b5606ba05c72cb202f944234e320748c7813bd54a0bb2e59d43436",
-      "verified": false
+      "verified": true
     },
     {
       "predicate": "affiliated with",
@@ -66,7 +66,7 @@
       "startChar": 276,
       "endChar": 303,
       "quoteSha256": "d7eafda8e9664339f75962ff91eb8ed98f5a47417c3701d6ba73c075a05e86a2",
-      "verified": false
+      "verified": true
     }
   ],
   "proposer": {

--- a/apps/labs/semantica/fixtures/gold/v1/06c93f91ef3d.structure.json
+++ b/apps/labs/semantica/fixtures/gold/v1/06c93f91ef3d.structure.json
@@ -17,7 +17,7 @@
       "startChar": 937,
       "endChar": 945,
       "quoteSha256": "3d1626989d3e923485561f1e5bdeaa583842a399edaf8cb6df59dbc6f17848f8",
-      "verified": false
+      "verified": true
     },
     {
       "role": "section",

--- a/apps/labs/semantica/fixtures/gold/v1/08e376be5ed2.structure.json
+++ b/apps/labs/semantica/fixtures/gold/v1/08e376be5ed2.structure.json
@@ -30,10 +30,10 @@
     {
       "role": "abstract",
       "depth": 0,
-      "startChar": 2442,
-      "endChar": 3781,
-      "quoteSha256": "0aff6fe4f2c1e38ef75e91c5bc831a2cdadf415678461515129340fb56ecbac0",
-      "verified": false
+      "startChar": 2433,
+      "endChar": 2441,
+      "quoteSha256": "d21b4a64a2d8656a0fdf7ab2e89a49164ac504686cfa2a3d442e87c209286330",
+      "verified": true
     },
     {
       "role": "section",

--- a/apps/labs/semantica/fixtures/gold/v1/0a4ab229f341.structure.json
+++ b/apps/labs/semantica/fixtures/gold/v1/0a4ab229f341.structure.json
@@ -17,7 +17,7 @@
       "startChar": 270,
       "endChar": 278,
       "quoteSha256": "d21b4a64a2d8656a0fdf7ab2e89a49164ac504686cfa2a3d442e87c209286330",
-      "verified": false
+      "verified": true
     },
     {
       "role": "section",

--- a/apps/labs/semantica/fixtures/gold/v1/0a8de1437753.structure.json
+++ b/apps/labs/semantica/fixtures/gold/v1/0a8de1437753.structure.json
@@ -15,9 +15,9 @@
       "role": "abstract",
       "depth": 0,
       "startChar": 372,
-      "endChar": 1879,
-      "quoteSha256": "b06c0f1927cadb770910248e135c98ffbd5e497a5ada0c97d570d2946fbcd92a",
-      "verified": false
+      "endChar": 380,
+      "quoteSha256": "d21b4a64a2d8656a0fdf7ab2e89a49164ac504686cfa2a3d442e87c209286330",
+      "verified": true
     },
     {
       "role": "section",

--- a/apps/labs/semantica/fixtures/gold/v1/0d06c1a2189a.structure.json
+++ b/apps/labs/semantica/fixtures/gold/v1/0d06c1a2189a.structure.json
@@ -17,7 +17,7 @@
       "startChar": 179,
       "endChar": 187,
       "quoteSha256": "d21b4a64a2d8656a0fdf7ab2e89a49164ac504686cfa2a3d442e87c209286330",
-      "verified": false
+      "verified": true
     },
     {
       "role": "section",

--- a/apps/labs/semantica/fixtures/gold/v1/0f75da2dbb9f.structure.json
+++ b/apps/labs/semantica/fixtures/gold/v1/0f75da2dbb9f.structure.json
@@ -17,7 +17,7 @@
       "startChar": 315,
       "endChar": 323,
       "quoteSha256": "d21b4a64a2d8656a0fdf7ab2e89a49164ac504686cfa2a3d442e87c209286330",
-      "verified": false
+      "verified": true
     },
     {
       "role": "section",

--- a/apps/labs/semantica/fixtures/gold/v1/10828be135bf.structure.json
+++ b/apps/labs/semantica/fixtures/gold/v1/10828be135bf.structure.json
@@ -15,9 +15,9 @@
       "role": "abstract",
       "depth": 0,
       "startChar": 209,
-      "endChar": 1377,
-      "quoteSha256": "8fa507aa641d89c94eec541f161785d3bbbf3b3f5c0438a670a1d507f8877b22",
-      "verified": false
+      "endChar": 217,
+      "quoteSha256": "d21b4a64a2d8656a0fdf7ab2e89a49164ac504686cfa2a3d442e87c209286330",
+      "verified": true
     },
     {
       "role": "section",

--- a/apps/labs/semantica/fixtures/gold/v1/gold.json
+++ b/apps/labs/semantica/fixtures/gold/v1/gold.json
@@ -1,6 +1,6 @@
 {
   "version": "gold/v1",
-  "digest": "e94228ce6ce3bf4e597ed282164e4392340548f43f5132c5f803dd6ee52439bc",
+  "digest": "9321c57c92402fba398ff226a178d9bc2922bb48f116f892fd8584a44ad72f29",
   "proposer": {
     "provider": "xai",
     "name": "grok-4.6",
@@ -8,7 +8,7 @@
     "artifactHash": "1bce70d152618aa6b5dcb74a65a42f6b4f375e5cde3df3b9a0cbebdda5f6bd1e",
     "taskType": "gold-proposal"
   },
-  "spotCheckedFraction": 0,
+  "spotCheckedFraction": 0.05570291777188329,
   "subsets": {
     "structure": [
       "057e356e94f8",

--- a/apps/labs/semantica/fixtures/relation-preview.json
+++ b/apps/labs/semantica/fixtures/relation-preview.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "semantica-relation-preview/v1",
+  "cases": [
+    {
+      "paperId": "06c93f91ef3d",
+      "cacheDigest": "5737b31d6d5095afeb0123f9feb8d6e3197f8a284b94096928abce354a0c2955"
+    },
+    {
+      "paperId": "06c93f91ef3d",
+      "cacheDigest": "6bbc2bb81a00c859ba81547fc2b04003671a0e6fd731fa9e4c9dbc6e624d3447"
+    },
+    {
+      "paperId": "057e356e94f8",
+      "cacheDigest": "0ac6007d473c64776b6cc3dbba277dd11096fa387b857381a9c98b2ba8c827e9"
+    }
+  ]
+}

--- a/apps/labs/semantica/src/canary/Command.ts
+++ b/apps/labs/semantica/src/canary/Command.ts
@@ -4,6 +4,7 @@ import * as Bool from "effect/Boolean";
 import * as S from "effect/Schema";
 import { Command, Flag } from "effect/unstable/cli";
 import { GOLD_SUBSETS, proposeGold } from "@/canary/Gold";
+import { RelationPreviewOptions, runRelationPreview } from "@/canary/RelationPreview";
 import { CorpusManifest, ManifestWriteFailed } from "@/corpus/Manifest";
 import { CorpusManifestBuilder } from "@/corpus/ManifestBuilder";
 import { GOLD_PROMPT_ARTIFACT_HASH } from "@/gold/Prompts";
@@ -273,6 +274,20 @@ const GoldCommand = Command.make("gold").pipe(
   ])
 );
 
+const previewCases = Flag.path("cases").pipe(
+  Flag.withDefault("fixtures/relation-preview.json"),
+  Flag.withDescription("Committed E5 manifest of historical provider-cache keys and W1 paper ids.")
+);
+
+const RelationCommand = Command.make("relation").pipe(
+  Command.withDescription("Evidence-quote relation-candidate controls."),
+  Command.withSubcommands([
+    Command.make("preview", { cases: previewCases, manifest: stageManifest }, (options) =>
+      runRelationPreview(RelationPreviewOptions.make(options)).pipe(Effect.asVoid)
+    ).pipe(Command.withDescription("Replay the three breaker responses offline and enforce the E5 grounding floor.")),
+  ])
+);
+
 /**
  * Headless Semantica canary command with manifest, gold, C0, C1, and C2
  * subcommands.
@@ -300,6 +315,7 @@ export const CanaryCommand = Command.make("canary").pipe(
   Command.withSubcommands([
     ManifestCommand,
     GoldCommand,
+    RelationCommand,
     makeStageCommand(CanaryStage.Enum.c0),
     makeStageCommand(CanaryStage.Enum.c1),
     makeStageCommand(CanaryStage.Enum.c2),

--- a/apps/labs/semantica/src/canary/RelationPreview.ts
+++ b/apps/labs/semantica/src/canary/RelationPreview.ts
@@ -1,0 +1,260 @@
+import { $SemanticaId } from "@beep/identity/packages";
+import { AlignmentSource, alignCandidates } from "@beep/langextract/Alignment";
+import { parseModelOutput } from "@beep/langextract/Extraction";
+import { NonNegativeInt, Sha256Hex } from "@beep/schema";
+import { Console, Effect, FileSystem, HashSet, Number as N, Path } from "effect";
+import * as A from "effect/Array";
+import * as O from "effect/Option";
+import * as S from "effect/Schema";
+import * as Str from "effect/String";
+import { CorpusPaperId } from "@/corpus/Manifest";
+import { loadDocumentSelection } from "@/layers/DocumentSourceLive";
+import { groundHostedExtractions, makeHostedExtractionRequest } from "@/layers/ExtractorLive";
+import { LabConfig } from "@/runtime/Config";
+import { Origin } from "@/schema/Document";
+import { RelationPreviewFailed } from "@/schema/Errors";
+import { ProviderCacheEntry } from "@/schema/ProviderCache";
+import { Canonicalizer } from "@/services/Canonicalizer";
+import { Chunker } from "@/services/Chunker";
+import { DocumentSource } from "@/services/DocumentSource";
+import { Parser } from "@/services/Parser";
+import type { SourceDocument } from "@/schema/Document";
+
+const $I = $SemanticaId.create("canary/RelationPreview");
+
+class RelationPreviewCase extends S.Class<RelationPreviewCase>($I`RelationPreviewCase`)(
+  { cacheDigest: Sha256Hex, paperId: CorpusPaperId },
+  $I.annote("RelationPreviewCase", {
+    description: "Historical cache key and W1 paper identity replayed by one zero-spend preview case.",
+  })
+) {}
+
+/**
+ * Versioned set of historical responses required by the E5 preview gate.
+ *
+ * **Example** (Inspect the case field)
+ *
+ * ```ts
+ * import { RelationPreviewManifest } from "@/canary/RelationPreview"
+ *
+ * console.log(RelationPreviewManifest.fields.cases !== undefined) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class RelationPreviewManifest extends S.Class<RelationPreviewManifest>($I`RelationPreviewManifest`)(
+  {
+    cases: S.NonEmptyArray(RelationPreviewCase),
+    schemaVersion: S.Literal("semantica-relation-preview/v1"),
+  },
+  $I.annote("RelationPreviewManifest", {
+    description: "Committed E5 cache-preview case set with a versioned wire contract.",
+  })
+) {}
+
+/**
+ * Command inputs for one offline relation preview.
+ *
+ * **Example** (Create preview options)
+ *
+ * ```ts
+ * import { RelationPreviewOptions } from "@/canary/RelationPreview"
+ *
+ * const options = RelationPreviewOptions.make({
+ *   cases: "fixtures/relation-preview.json",
+ *   manifest: "fixtures/w1.manifest.json"
+ * })
+ * console.log(options.cases) // "fixtures/relation-preview.json"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class RelationPreviewOptions extends S.Class<RelationPreviewOptions>($I`RelationPreviewOptions`)(
+  { cases: S.NonEmptyString, manifest: S.NonEmptyString },
+  $I.annote("RelationPreviewOptions", {
+    description: "Paths to the committed E5 case set and verified W1 manifest.",
+  })
+) {}
+
+class RelationPreviewCaseResult extends S.Class<RelationPreviewCaseResult>($I`RelationPreviewCaseResult`)(
+  {
+    cacheKey: Sha256Hex,
+    candidateCount: NonNegativeInt,
+    degradedRelations: NonNegativeInt,
+    groundedRelations: NonNegativeInt,
+    paperId: CorpusPaperId,
+    relationCandidates: NonNegativeInt,
+  },
+  $I.annote("RelationPreviewCaseResult", {
+    description: "Parsed, relation-candidate, grounded, and degraded counts for one historical response.",
+  })
+) {}
+
+class RelationPreviewReport extends S.Class<RelationPreviewReport>($I`RelationPreviewReport`)(
+  {
+    cases: S.NonEmptyArray(RelationPreviewCaseResult),
+    groundedPapers: NonNegativeInt,
+    groundedRelations: NonNegativeInt,
+    passed: S.Literal(true),
+    schemaVersion: S.Literal("semantica-relation-preview-report/v1"),
+  },
+  $I.annote("RelationPreviewReport", {
+    description: "Successful zero-spend preview with at least one grounded relation on at least one paper.",
+  })
+) {}
+
+const PreviewManifestJson = S.fromJsonString(RelationPreviewManifest);
+const ProviderCacheEntryJson = S.fromJsonString(ProviderCacheEntry);
+const PreviewReportJson = S.fromJsonString(RelationPreviewReport, { space: 2 });
+
+const failed = (reason: RelationPreviewFailed["reason"], message: string): RelationPreviewFailed =>
+  RelationPreviewFailed.make({ message, reason });
+
+const isSelectedPaper =
+  (paperId: CorpusPaperId) =>
+  (document: SourceDocument): boolean =>
+    Origin.match(document.origin, {
+      Fixture: () => false,
+      W1Paper: (origin) => Str.Equivalence(origin.paperId, paperId),
+    });
+
+const loadCanonicalPaper = Effect.fn("RelationPreview.loadCanonicalPaper")(function* (
+  manifestPath: string,
+  paperId: CorpusPaperId
+) {
+  const source = yield* DocumentSource;
+  const parser = yield* Parser;
+  const canonicalizer = yield* Canonicalizer;
+  const chunker = yield* Chunker;
+  const selection = yield* loadDocumentSelection(manifestPath, O.some(paperId), true).pipe(
+    Effect.mapError(() => failed("manifest-invalid", "The E5 W1 manifest did not pass its integrity check."))
+  );
+  const documents = yield* source
+    .list(selection)
+    .pipe(Effect.mapError(() => failed("source-unavailable", "The selected E5 source paper could not be listed.")));
+  const document = yield* A.findFirst(documents, isSelectedPaper(paperId)).pipe(
+    Effect.fromOption,
+    Effect.mapError(() => failed("source-unavailable", "The selected E5 source paper was absent from the listing."))
+  );
+  const bytes = yield* source
+    .read(document)
+    .pipe(Effect.mapError(() => failed("source-unavailable", "The selected E5 source paper could not be read.")));
+  const parsed = yield* parser.parse(document, bytes);
+  if (parsed.outcome === "Degraded") {
+    return yield* failed("parse-degraded", "The selected E5 source paper produced a typed degraded parse.");
+  }
+  const canonical = yield* canonicalizer.identify(document, parsed);
+  return { canonical, canonicalizer, chunks: yield* chunker.chunk(canonical) };
+});
+
+const readPreviewManifest = Effect.fn("RelationPreview.readManifest")(function* (filePath: string) {
+  const fs = yield* FileSystem.FileSystem;
+  return yield* fs.readFileString(filePath).pipe(
+    Effect.flatMap(S.decodeEffect(PreviewManifestJson)),
+    Effect.mapError(() => failed("manifest-invalid", "The E5 preview manifest could not be read or decoded."))
+  );
+});
+
+const readCacheEntry = Effect.fn("RelationPreview.readCacheEntry")(function* (cacheKey: Sha256Hex) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const config = yield* LabConfig;
+  const filePath = path.join(config.providerCacheDirectory, `${cacheKey}.json`);
+  const source = yield* fs
+    .readFileString(filePath)
+    .pipe(Effect.mapError(() => failed("cache-unavailable", "A required E5 provider-cache entry is unavailable.")));
+  const entry = yield* S.decodeEffect(ProviderCacheEntryJson)(source).pipe(
+    Effect.mapError(() => failed("cache-invalid", "A required E5 provider-cache entry failed integrity decoding."))
+  );
+  if (!Str.Equivalence(entry.cacheKey, cacheKey)) {
+    return yield* failed("cache-invalid", "An E5 cache file did not match its selected cache key.");
+  }
+  return entry;
+});
+
+const previewCase = Effect.fn("RelationPreview.previewCase")(function* (
+  manifestPath: string,
+  preview: RelationPreviewCase
+) {
+  const entry = yield* readCacheEntry(preview.cacheDigest);
+  const { canonical, canonicalizer, chunks } = yield* loadCanonicalPaper(manifestPath, preview.paperId);
+  const candidates = yield* parseModelOutput(entry.response).pipe(
+    Effect.mapError(() => failed("response-invalid", "An E5 cached response did not decode as LangExtract output."))
+  );
+  const extractions = alignCandidates(candidates, AlignmentSource.fromRequest(makeHostedExtractionRequest(canonical)));
+  const outcome = yield* groundHostedExtractions(
+    canonicalizer,
+    canonical,
+    chunks,
+    extractions,
+    entry.key.model,
+    O.some(entry.cacheKey)
+  );
+  if (outcome.outcome === "Degraded") {
+    return yield* failed("response-invalid", "The E5 cached response did not produce an extracted evidence batch.");
+  }
+  const relationCandidates = A.length(A.filter(extractions, (item) => Str.Equivalence(item.label, "relation")));
+  const groundedRelations = A.length(A.filter(outcome.batch.claims, (claim) => claim.body.kind === "Relation"));
+  return RelationPreviewCaseResult.make({
+    cacheKey: preview.cacheDigest,
+    candidateCount: NonNegativeInt.make(A.length(extractions)),
+    degradedRelations: NonNegativeInt.make(N.subtract(relationCandidates, groundedRelations)),
+    groundedRelations: NonNegativeInt.make(groundedRelations),
+    paperId: preview.paperId,
+    relationCandidates: NonNegativeInt.make(relationCandidates),
+  });
+});
+
+/**
+ * Replays the committed breaker responses through the production relation
+ * grounding boundary without calling a hosted provider.
+ *
+ * **Example** (Build the preview effect)
+ *
+ * ```ts
+ * import { RelationPreviewOptions, runRelationPreview } from "@/canary/RelationPreview"
+ *
+ * const preview = runRelationPreview(RelationPreviewOptions.make({
+ *   cases: "fixtures/relation-preview.json",
+ *   manifest: "fixtures/w1.manifest.json"
+ * }))
+ * console.log(typeof preview) // "object"
+ * ```
+ *
+ * @effects Reads verified local corpus and cache files and prints a successful report.
+ * @category workflows
+ * @since 0.0.0
+ */
+export const runRelationPreview = Effect.fn("RelationPreview.run")(function* (options: RelationPreviewOptions) {
+  const manifest = yield* readPreviewManifest(options.cases);
+  const cases = yield* Effect.forEach(manifest.cases, (preview) => previewCase(options.manifest, preview), {
+    concurrency: 1,
+  });
+  const groundedRelations = A.reduce(cases, 0, (total, result) => N.sum(total, result.groundedRelations));
+  const groundedPapers = HashSet.size(
+    HashSet.fromIterable(
+      A.map(
+        A.filter(cases, (result) => N.isGreaterThan(result.groundedRelations, 0)),
+        (result) => result.paperId
+      )
+    )
+  );
+  if (N.Equivalence(groundedRelations, 0) || N.Equivalence(groundedPapers, 0)) {
+    return yield* failed(
+      "preview-floor-not-met",
+      "The E5 preview grounded no relation on any selected historical response."
+    );
+  }
+  const report = RelationPreviewReport.make({
+    cases,
+    groundedPapers: NonNegativeInt.make(groundedPapers),
+    groundedRelations: NonNegativeInt.make(groundedRelations),
+    passed: true,
+    schemaVersion: "semantica-relation-preview-report/v1",
+  });
+  const json = yield* S.encodeEffect(PreviewReportJson)(report).pipe(Effect.orDie);
+  yield* Console.log(json);
+  return report;
+});

--- a/apps/labs/semantica/src/layers/ExtractorLive.ts
+++ b/apps/labs/semantica/src/layers/ExtractorLive.ts
@@ -1,5 +1,11 @@
 import { Confidence } from "@beep/epistemic-domain";
-import { GroundedExtraction, LangExtractOptions, LangExtractRequest } from "@beep/langextract/Extraction";
+import { AlignmentSource, alignCandidate } from "@beep/langextract/Alignment";
+import {
+  ExtractionCandidate,
+  GroundedExtraction,
+  LangExtractOptions,
+  LangExtractRequest,
+} from "@beep/langextract/Extraction";
 import {
   allowRemoteExtractionPolicyLayer,
   buildPrompt,
@@ -28,8 +34,10 @@ import {
   EvidenceBatch,
   EvidenceClaim,
   ExtractOutcome,
+  FrozenRelationPredicate,
   makeBatchId,
   makeClaimId,
+  RelationExtractionCandidate,
   StructureRole,
 } from "@/schema/Evidence";
 import { DocumentId } from "@/schema/Ids";
@@ -50,6 +58,10 @@ import type { CanonicalText, Chunk } from "@/schema/Text";
 import type { CanonicalizerShape } from "@/services/Canonicalizer";
 
 const utf8Encoder = new TextEncoder();
+
+const RELATION_CONTRACT_SCHEMA = "semantica-relation-evidence/v1";
+const RELATION_ENDPOINT_POLICY = "evidence-scoped-unique/v1";
+const RELATION_ALIGNMENT_TIERS = ["match_exact", "match_lesser", "match_minimal_fold"] as const;
 
 const HOSTED_TARGETS: A.NonEmptyReadonlyArray<ExtractionTarget> = [
   ExtractionTarget.make({
@@ -83,14 +95,14 @@ const HOSTED_TARGETS: A.NonEmptyReadonlyArray<ExtractionTarget> = [
     name: "relation",
     attributes: ["predicate", "subject", "object"],
     description: O.some(
-      "A relation explicitly stated in the source. Copy one verbatim contiguous source span as the extraction text; never paraphrase or synthesize it. Copy subject and object as exact entity surface strings from that span, and emit matching entity extractions for both endpoints."
+      `A relation explicitly stated in the source. Copy one verbatim contiguous source span as the extraction text; never paraphrase or synthesize it. Copy subject and object as exact entity surface strings from that span. Predicate must be exactly one of: ${A.join(FrozenRelationPredicate.Options, ", ")}.`
     ),
   }),
 ];
 
 const HOSTED_EXAMPLES = [
   ExtractionExample.make({
-    text: "Ada Lovelace developed the Analytical Engine method.",
+    text: "Ada Lovelace is affiliated with the Analytical Engine group.",
     extractions: [
       ExtractionExampleItem.make({
         label: "person",
@@ -98,14 +110,18 @@ const HOSTED_EXAMPLES = [
         attributes: O.some({ cluster: "person-ada-lovelace" }),
       }),
       ExtractionExampleItem.make({
-        label: "method",
-        text: "Analytical Engine",
-        attributes: O.some({ cluster: "method-analytical-engine" }),
+        label: "organization",
+        text: "Analytical Engine group",
+        attributes: O.some({ cluster: "organization-analytical-engine" }),
       }),
       ExtractionExampleItem.make({
         label: "relation",
-        text: "Ada Lovelace developed the Analytical Engine method.",
-        attributes: O.some({ object: "Analytical Engine", predicate: "developed", subject: "Ada Lovelace" }),
+        text: "Ada Lovelace is affiliated with the Analytical Engine group.",
+        attributes: O.some({
+          object: "Analytical Engine group",
+          predicate: "affiliated with",
+          subject: "Ada Lovelace",
+        }),
       }),
     ],
   }),
@@ -124,8 +140,22 @@ const HOSTED_ARTIFACT_REQUEST = LangExtractRequest.make({
   text: Str.empty,
 });
 
+const HostedExtractionCandidateDescriptor = S.Struct({
+  alignmentTiers: S.Tuple([S.Literal("match_exact"), S.Literal("match_lesser"), S.Literal("match_minimal_fold")]),
+  endpointPolicy: S.Literal(RELATION_ENDPOINT_POLICY),
+  relationContract: S.Literal(RELATION_CONTRACT_SCHEMA),
+  renderedPrompt: S.String,
+  schemaVersion: S.Literal("semantica-hosted-extraction-candidate/v1"),
+});
+
 /**
- * Hash of the actual LangExtract prompt rendered from the pinned targets and examples.
+ * Hash of the versioned hosted extraction candidate descriptor.
+ *
+ * **Details**
+ *
+ * The descriptor binds the rendered prompt, relation-contract identifier,
+ * accepted relation alignment tiers, and endpoint policy so a semantic
+ * candidate revision cannot reuse an earlier model identity.
  *
  * **Example** (Inspect the artifact digest)
  *
@@ -140,7 +170,15 @@ const HOSTED_ARTIFACT_REQUEST = LangExtractRequest.make({
  * @since 0.0.0
  */
 export const HOSTED_EXTRACTION_ARTIFACT_HASH = buildPrompt(HOSTED_ARTIFACT_REQUEST).pipe(
-  Effect.flatMap((prompt) => Sha256HexFromBytes.decodeEffect(utf8Encoder.encode(prompt))),
+  Effect.flatMap((renderedPrompt) =>
+    contentDigest(HostedExtractionCandidateDescriptor)({
+      alignmentTiers: RELATION_ALIGNMENT_TIERS,
+      endpointPolicy: RELATION_ENDPOINT_POLICY,
+      relationContract: RELATION_CONTRACT_SCHEMA,
+      renderedPrompt,
+      schemaVersion: "semantica-hosted-extraction-candidate/v1",
+    })
+  ),
   Effect.orDie
 );
 
@@ -258,7 +296,21 @@ const langExtractDegradedKind = (error: LangExtractError): "provider-unavailable
     ? "provider-unavailable"
     : "model-output-invalid";
 
-const requestFor = (canonical: CanonicalText): LangExtractRequest =>
+/**
+ * Builds the exact hosted LangExtract request for one canonical document.
+ *
+ * **Example** (Inspect the request builder)
+ *
+ * ```ts
+ * import { makeHostedExtractionRequest } from "@/layers/ExtractorLive"
+ *
+ * console.log(typeof makeHostedExtractionRequest) // "function"
+ * ```
+ *
+ * @category constructors
+ * @since 0.0.0
+ */
+export const makeHostedExtractionRequest = (canonical: CanonicalText): LangExtractRequest =>
   LangExtractRequest.make({
     documentId: NlpDocumentId.make(canonical.identity.sourceRef),
     examples: HOSTED_EXAMPLES,
@@ -318,41 +370,6 @@ const entityAnchorOf = (claim: EvidenceClaimValue): O.Option<TextAnchor> =>
     Structure: O.none<TextAnchor>,
   });
 
-const exactEntity = (claims: ReadonlyArray<EvidenceClaimValue>, quote: string): O.Option<EvidenceClaimValue> =>
-  A.findFirst(claims, (claim) => entityAnchorOf(claim).pipe(O.exists((body) => Str.Equivalence(body.quote, quote))));
-
-const nearestNfcEntity = (
-  claims: ReadonlyArray<EvidenceClaimValue>,
-  quote: string,
-  before: number
-): O.Option<EvidenceClaimValue> => {
-  const folded = Str.normalize("NFC")(quote);
-  return A.reduce(claims, O.none<EvidenceClaimValue>(), (nearest, claim) =>
-    entityAnchorOf(claim).pipe(
-      O.filter((body) => body.startChar <= before && Str.Equivalence(Str.normalize("NFC")(body.quote), folded)),
-      O.flatMap((body) =>
-        nearest.pipe(
-          O.flatMap(entityAnchorOf),
-          O.match({
-            onNone: () => O.some(claim),
-            onSome: (current) => O.some(body.startChar > current.startChar ? claim : O.getOrThrow(nearest)),
-          })
-        )
-      ),
-      O.orElse(() => nearest)
-    )
-  );
-};
-
-const resolveEndpoint = (
-  claims: ReadonlyArray<EvidenceClaimValue>,
-  quote: O.Option<string>,
-  before: number
-): O.Option<EvidenceClaimValue> =>
-  quote.pipe(
-    O.flatMap((surface) => exactEntity(claims, surface).pipe(O.orElse(() => nearestNfcEntity(claims, surface, before))))
-  );
-
 type AlignedGroundedExtraction = Exclude<GroundedExtraction, { readonly alignmentStatus: "unaligned" }>;
 type LocatedExtraction = readonly [extraction: GroundedExtraction, anchor: TextAnchor];
 
@@ -375,12 +392,252 @@ const locateExtraction = (extraction: GroundedExtraction): Result.Result<Located
     unaligned: () => Result.failVoid,
   });
 
+const locateRelationEvidence = (extraction: GroundedExtraction): Result.Result<LocatedExtraction, void> =>
+  GroundedExtraction.match(extraction, {
+    match_exact: alignedExtraction,
+    match_fuzzy: () => Result.failVoid,
+    match_lesser: alignedExtraction,
+    match_minimal_fold: alignedExtraction,
+    unaligned: () => Result.failVoid,
+  });
+
+const decodeRelationCandidate = (
+  extraction: GroundedExtraction
+): Result.Result<RelationExtractionCandidate, S.SchemaError> =>
+  S.decodeUnknownResult(RelationExtractionCandidate)({
+    evidenceQuote: extraction.text,
+    object: O.getOrUndefined(extractionAttribute(extraction, "object")),
+    predicate: O.getOrUndefined(extractionAttribute(extraction, "predicate")),
+    subject: O.getOrUndefined(extractionAttribute(extraction, "subject")),
+  });
+
+const scopedEndpointAnchor = (evidence: TextAnchor, surface: string): Result.Result<TextAnchor, void> => {
+  const aligned = alignCandidate(
+    ExtractionCandidate.make({ label: "relation-endpoint", text: surface }),
+    AlignmentSource.make({ fuzzyThreshold: UnitInterval.make(1), sourceText: evidence.quote })
+  );
+  return locateRelationEvidence(aligned).pipe(
+    Result.map(([, anchor]) =>
+      TextAnchor.make({
+        endChar: NonNegativeInt.make(N.sum(evidence.startChar, anchor.endChar)),
+        quote: anchor.quote,
+        startChar: NonNegativeInt.make(N.sum(evidence.startChar, anchor.startChar)),
+      })
+    )
+  );
+};
+
+const exactAnchoredEntity = (
+  claims: ReadonlyArray<EvidenceClaimValue>,
+  anchor: TextAnchor
+): O.Option<EvidenceClaimValue> =>
+  A.findFirst(claims, (claim) =>
+    entityAnchorOf(claim).pipe(O.exists((body) => S.toEquivalence(TextAnchor)(body, anchor)))
+  );
+
+const relationDegradation = (
+  chunks: A.NonEmptyReadonlyArray<Chunk>,
+  anchor: O.Option<TextAnchor>,
+  kind: "fabricated-span" | "model-output-invalid" | "relation-unresolved",
+  detail: string
+): DegradedClaim =>
+  DegradedClaim.make({
+    chunk: anchor.pipe(
+      O.map((value) => containingChunk(chunks, value).id),
+      O.getOrElse(() => A.headNonEmpty(chunks).id)
+    ),
+    detail,
+    kind,
+  });
+
+const endpointClaim = Effect.fn("Extractor.endpointClaim")(function* (
+  canonicalizer: CanonicalizerShape,
+  canonical: CanonicalText,
+  chunks: A.NonEmptyReadonlyArray<Chunk>,
+  baseClaims: ReadonlyArray<EvidenceClaimValue>,
+  anchor: TextAnchor,
+  confidence: Confidence,
+  model: ModelIdentity,
+  cacheKey: O.Option<Sha256Hex>
+) {
+  const existing = exactAnchoredEntity(baseClaims, anchor);
+  if (O.isSome(existing)) {
+    return existing.value;
+  }
+  return yield* makeClaim(
+    canonicalizer,
+    canonical,
+    chunks,
+    ClaimBody.cases.Entity.make({
+      ...anchor,
+      cluster: O.none(),
+      entityType: "relation-endpoint",
+      kind: "Entity",
+      label: anchor.quote,
+    }),
+    confidence,
+    "hosted-langextract",
+    model,
+    cacheKey
+  );
+});
+
+const groundRelation = Effect.fn("Extractor.groundRelation")(function* (
+  canonicalizer: CanonicalizerShape,
+  canonical: CanonicalText,
+  chunks: A.NonEmptyReadonlyArray<Chunk>,
+  baseClaims: ReadonlyArray<EvidenceClaimValue>,
+  extraction: GroundedExtraction,
+  model: ModelIdentity,
+  cacheKey: O.Option<Sha256Hex>
+) {
+  const decoded = decodeRelationCandidate(extraction);
+  if (Result.isFailure(decoded)) {
+    return Result.fail(
+      relationDegradation(
+        chunks,
+        O.none(),
+        "model-output-invalid",
+        "A relation candidate did not decode subject, object, predicate, and evidence quote."
+      )
+    );
+  }
+  const located = locateRelationEvidence(extraction);
+  if (Result.isFailure(located)) {
+    return Result.fail(
+      relationDegradation(
+        chunks,
+        O.none(),
+        "fabricated-span",
+        "Relation evidence did not align uniquely through the exact, lesser, or minimal-fold tiers."
+      )
+    );
+  }
+  const [, evidence] = located.success;
+  const subjectAnchor = scopedEndpointAnchor(evidence, decoded.success.subject);
+  const objectAnchor = scopedEndpointAnchor(evidence, decoded.success.object);
+  if (Result.isFailure(subjectAnchor) || Result.isFailure(objectAnchor)) {
+    return Result.fail(
+      relationDegradation(
+        chunks,
+        O.some(evidence),
+        "relation-unresolved",
+        "A relation endpoint did not align uniquely inside its evidence quote."
+      )
+    );
+  }
+  const confidence = evidenceConfidence(extraction.confidence);
+  const subject = yield* endpointClaim(
+    canonicalizer,
+    canonical,
+    chunks,
+    baseClaims,
+    subjectAnchor.success,
+    confidence,
+    model,
+    cacheKey
+  );
+  const object = yield* endpointClaim(
+    canonicalizer,
+    canonical,
+    chunks,
+    baseClaims,
+    objectAnchor.success,
+    confidence,
+    model,
+    cacheKey
+  );
+  const relation = yield* makeClaim(
+    canonicalizer,
+    canonical,
+    chunks,
+    ClaimBody.cases.Relation.make({
+      ...evidence,
+      kind: "Relation",
+      object: object.id,
+      predicate: decoded.success.predicate,
+      subject: subject.id,
+    }),
+    confidence,
+    "hosted-langextract",
+    model,
+    cacheKey
+  );
+  return Result.succeed([subject, object, relation] as const);
+});
+
 const unalignedExtraction = (chunks: A.NonEmptyReadonlyArray<Chunk>): DegradedClaim =>
   DegradedClaim.make({
     chunk: A.headNonEmpty(chunks).id,
     detail: "LangExtract did not align this candidate to the canonical text.",
     kind: "fabricated-span",
   });
+
+/**
+ * Grounds already-aligned hosted candidates through the production evidence
+ * contract.
+ *
+ * **Details**
+ *
+ * The live extractor and E5 cache preview both call this function. Sharing the
+ * boundary prevents the preview from passing through a second implementation
+ * of relation-contract decoding or evidence-scoped endpoint grounding.
+ *
+ * **Example** (Inspect the grounding boundary)
+ *
+ * ```ts
+ * import { groundHostedExtractions } from "@/layers/ExtractorLive"
+ *
+ * console.log(typeof groundHostedExtractions) // "function"
+ * ```
+ *
+ * @internal
+ * @category mapping
+ * @since 0.0.0
+ */
+export const groundHostedExtractions = Effect.fn("Extractor.groundHostedExtractions")(function* (
+  canonicalizer: CanonicalizerShape,
+  canonical: CanonicalText,
+  chunks: A.NonEmptyReadonlyArray<Chunk>,
+  extractions: ReadonlyArray<GroundedExtraction>,
+  model: ModelIdentity,
+  cacheKey: O.Option<Sha256Hex>
+) {
+  const relationExtractions = A.filter(extractions, (extraction) => Str.Equivalence(extraction.label, "relation"));
+  const nonRelationExtractions = A.filter(extractions, (extraction) => !Str.Equivalence(extraction.label, "relation"));
+  const basePairs = A.filterMap(nonRelationExtractions, locateExtraction);
+  const unaligned = A.map(A.filter(nonRelationExtractions, GroundedExtraction.guards.unaligned), () =>
+    unalignedExtraction(chunks)
+  );
+  const baseClaims = yield* Effect.forEach(
+    basePairs,
+    ([extraction, anchor]) =>
+      makeClaim(
+        canonicalizer,
+        canonical,
+        chunks,
+        nonRelationBody(extraction, anchor),
+        evidenceConfidence(extraction.confidence),
+        "hosted-langextract",
+        model,
+        cacheKey
+      ),
+    { concurrency: 1 }
+  );
+  const relations = yield* Effect.forEach(
+    relationExtractions,
+    (extraction) => groundRelation(canonicalizer, canonical, chunks, baseClaims, extraction, model, cacheKey),
+    { concurrency: 1 }
+  );
+  return makeBatch(
+    documentIdOf(canonical),
+    chunks,
+    "hosted-langextract",
+    model,
+    A.appendAll(baseClaims, A.flatten(A.getSuccesses(relations))),
+    A.appendAll(unaligned, A.getFailures(relations))
+  );
+});
 
 const makeHostedExtractor = Effect.gen(function* () {
   const canonicalizer = yield* Canonicalizer;
@@ -390,7 +647,7 @@ const makeHostedExtractor = Effect.gen(function* () {
   return HostedExtractor.of({
     extract: Effect.fn("HostedExtractor.extract")(function* (canonical, chunks) {
       const document = documentIdOf(canonical);
-      const request = requestFor(canonical);
+      const request = makeHostedExtractionRequest(canonical);
       const extracted = yield* langExtract.extract(request).pipe(Effect.result);
       if (Result.isFailure(extracted)) {
         return degradedOutcome(
@@ -402,72 +659,13 @@ const makeHostedExtractor = Effect.gen(function* () {
       }
 
       const cacheKey = O.some(yield* hostedCacheKey(request, model).pipe(Effect.orDie));
-      const pairs = A.filterMap(extracted.success.extractions, locateExtraction);
-      const unaligned = A.map(A.filter(extracted.success.extractions, GroundedExtraction.guards.unaligned), () =>
-        unalignedExtraction(chunks)
-      );
-      const basePairs = A.filter(pairs, ([extraction]) => !Str.Equivalence(extraction.label, "relation"));
-      const relationPairs = A.filter(pairs, ([extraction]) => Str.Equivalence(extraction.label, "relation"));
-      const baseClaims = yield* Effect.forEach(
-        basePairs,
-        ([extraction, anchor]) =>
-          makeClaim(
-            canonicalizer,
-            canonical,
-            chunks,
-            nonRelationBody(extraction, anchor),
-            evidenceConfidence(extraction.confidence),
-            "hosted-langextract",
-            model,
-            cacheKey
-          ),
-        { concurrency: 1 }
-      );
-
-      const relations = yield* Effect.forEach(
-        relationPairs,
-        Effect.fnUntraced(function* ([extraction, anchor]) {
-          const chunk = containingChunk(chunks, anchor);
-          const subject = resolveEndpoint(baseClaims, extractionAttribute(extraction, "subject"), anchor.startChar);
-          const object = resolveEndpoint(baseClaims, extractionAttribute(extraction, "object"), anchor.startChar);
-          const predicate = extractionAttribute(extraction, "predicate");
-          if (O.isNone(subject) || O.isNone(object) || O.isNone(predicate)) {
-            return Result.fail(
-              DegradedClaim.make({
-                chunk: chunk.id,
-                detail: "A relation endpoint or predicate did not resolve to same-batch entity evidence.",
-                kind: "relation-unresolved",
-              })
-            );
-          }
-          const claim = yield* makeClaim(
-            canonicalizer,
-            canonical,
-            chunks,
-            ClaimBody.cases.Relation.make({
-              ...anchor,
-              kind: "Relation",
-              object: object.value.id,
-              predicate: predicate.value,
-              subject: subject.value.id,
-            }),
-            evidenceConfidence(extraction.confidence),
-            "hosted-langextract",
-            model,
-            cacheKey
-          );
-          return Result.succeed(claim);
-        }),
-        { concurrency: 1 }
-      );
-
-      return makeBatch(
-        document,
+      return yield* groundHostedExtractions(
+        canonicalizer,
+        canonical,
         chunks,
-        "hosted-langextract",
+        extracted.success.extractions,
         model,
-        A.appendAll(baseClaims, A.getSuccesses(relations)),
-        A.appendAll(unaligned, A.getFailures(relations))
+        cacheKey
       );
     }),
   });

--- a/apps/labs/semantica/src/schema/Errors.ts
+++ b/apps/labs/semantica/src/schema/Errors.ts
@@ -32,6 +32,20 @@ const ModelRevisionPinSetting = LiteralKit(["AI_ANTHROPIC_MODEL", "SEMANTICA_XAI
   })
 );
 
+const RelationPreviewFailureReason = LiteralKit([
+  "manifest-invalid",
+  "cache-unavailable",
+  "cache-invalid",
+  "source-unavailable",
+  "parse-degraded",
+  "response-invalid",
+  "preview-floor-not-met",
+]).annotate(
+  $I.annote("RelationPreviewFailureReason", {
+    description: "Stable reason codes for the zero-spend evidence-quote preview.",
+  })
+);
+
 /**
  * Reports that a requested source document cannot be listed or read.
  *
@@ -270,5 +284,31 @@ export class C0ExecutionFailed extends S.TaggedError<C0ExecutionFailed>($I`C0Exe
   { message: S.NonEmptyString },
   $I.annoteError<C0ExecutionFailed>("C0ExecutionFailed", {
     description: "Expected failure while acquiring the selected live or replay C0 execution layers.",
+  })
+) {}
+
+/**
+ * Reports a typed failure in the zero-spend relation-candidate preview.
+ *
+ * **Example** (Create a failed preview floor)
+ *
+ * ```ts
+ * import { RelationPreviewFailed } from "@/schema/Errors"
+ *
+ * const error = RelationPreviewFailed.make({
+ *   message: "No cached response grounded a relation.",
+ *   reason: "preview-floor-not-met"
+ * })
+ * console.log(error.reason) // "preview-floor-not-met"
+ * ```
+ *
+ * @category errors
+ * @since 0.0.0
+ */
+export class RelationPreviewFailed extends S.TaggedError<RelationPreviewFailed>($I`RelationPreviewFailed`)(
+  "RelationPreviewFailed",
+  { message: S.NonEmptyString, reason: RelationPreviewFailureReason },
+  $I.annoteError<RelationPreviewFailed>("RelationPreviewFailed", {
+    description: "Expected failure while validating or executing the zero-spend relation-candidate preview.",
   })
 ) {}

--- a/apps/labs/semantica/src/schema/Evidence.ts
+++ b/apps/labs/semantica/src/schema/Evidence.ts
@@ -90,6 +90,78 @@ export const ExtractionMethod = LiteralKit(["hosted-langextract", "pattern-wink"
 export type ExtractionMethod = typeof ExtractionMethod.Type;
 
 /**
+ * Predicate strings frozen by the gold-v1 relation task.
+ *
+ * **Details**
+ *
+ * This vocabulary constrains the hosted extraction target. The relation
+ * candidate contract intentionally accepts any non-empty predicate so the E5
+ * preview can replay responses produced before the vocabulary was frozen.
+ *
+ * **Example** (Check a frozen predicate)
+ *
+ * ```ts
+ * import { FrozenRelationPredicate } from "@/schema/Evidence"
+ *
+ * console.log(FrozenRelationPredicate.is["affiliated with"]("affiliated with")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const FrozenRelationPredicate = LiteralKit([
+  "affiliated with",
+  "authored by",
+  "located in",
+  "re-evaluates claim due to",
+  "selected",
+  "shows",
+]).pipe(
+  $I.annoteSchema("FrozenRelationPredicate", {
+    description: "Exact predicate strings represented by the frozen gold-v1 relation labels.",
+  })
+);
+
+/**
+ * Lab-local relation candidate decoded before relation evidence alignment.
+ *
+ * **Details**
+ *
+ * `evidenceQuote` is the only text allowed to anchor the relation. Subject and
+ * object are surface strings that must each align uniquely inside that quote.
+ * The predicate remains non-empty rather than vocabulary-refined so cached
+ * pre-candidate responses remain measurable by the zero-spend preview.
+ *
+ * **Example** (Create an evidence-quote candidate)
+ *
+ * ```ts
+ * import { RelationExtractionCandidate } from "@/schema/Evidence"
+ *
+ * const candidate = RelationExtractionCandidate.make({
+ *   evidenceQuote: "Ada Lovelace is affiliated with Acme Research.",
+ *   object: "Acme Research",
+ *   predicate: "affiliated with",
+ *   subject: "Ada Lovelace"
+ * })
+ * console.log(candidate.subject) // "Ada Lovelace"
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class RelationExtractionCandidate extends S.Class<RelationExtractionCandidate>($I`RelationExtractionCandidate`)(
+  {
+    evidenceQuote: S.NonEmptyString,
+    object: S.NonEmptyString,
+    predicate: S.NonEmptyString,
+    subject: S.NonEmptyString,
+  },
+  $I.annote("RelationExtractionCandidate", {
+    description: "Relation predicate and endpoint surfaces carried by one source evidence quote.",
+  })
+) {}
+
+/**
  * Structural roles extracted from canonical paper text.
  *
  * **Example** (Check an abstract role)

--- a/apps/labs/semantica/test/C0Slice.test.ts
+++ b/apps/labs/semantica/test/C0Slice.test.ts
@@ -183,7 +183,7 @@ describe("C0 F1 live-to-replay slice", () => {
                 .pipe(Effect.flatMap(S.decodeEffect(EvalTelemetryJson)));
 
               expect(live.reportDigest).toBe(replay.reportDigest);
-              expect(live.reportDigest).toBe("8c6a73fe8d37f45328ee438b5a59365bc5884180b944c8f9e2f2034827cd762c");
+              expect(live.reportDigest).toBe("95cc0a0dbe099ab307d18f36e657b9ab758e95753bb46bbf44e0ecf623c17dc9");
               expect(writtenLive.reportDigest).toBe(writtenReplay.reportDigest);
               expect(writtenLive.reportDigest).toBe(live.reportDigest);
               expect(live.unexpectedDegraded).toBe(0);

--- a/apps/labs/semantica/test/Extractor.test.ts
+++ b/apps/labs/semantica/test/Extractor.test.ts
@@ -14,9 +14,10 @@ import { NLPService } from "@beep/nlp-processing/NLPService";
 import { SourceTextExtractor } from "@beep/provenance";
 import { NonNegativeInt, Sha256Hex } from "@beep/schema";
 import * as BunServices from "@effect/platform-bun/BunServices";
-import { Effect, Layer } from "effect";
+import { Effect, Layer, Result } from "effect";
 import * as A from "effect/Array";
 import * as O from "effect/Option";
+import * as S from "effect/Schema";
 import { describe, expect, it } from "vitest";
 import { F1FixtureId } from "@/fixtures/F1";
 import { CanonicalizerLive } from "@/layers/CanonicalizerLive";
@@ -24,7 +25,7 @@ import { ChunkerLive } from "@/layers/ChunkerLive";
 import { HostedExtractorLive, PatternExtractorLive } from "@/layers/ExtractorLive";
 import { ActiveModelIdentityLive, AnthropicExtractionModelIdentity } from "@/layers/LanguageModelLive";
 import { FixtureDeclaration, Origin, SourceDocument } from "@/schema/Document";
-import { ClaimBody } from "@/schema/Evidence";
+import { ClaimBody, FrozenRelationPredicate, RelationExtractionCandidate } from "@/schema/Evidence";
 import { DocumentId, ProvenanceEventId } from "@/schema/Ids";
 import { ParseOutcome } from "@/schema/Text";
 import { Canonicalizer } from "@/services/Canonicalizer";
@@ -151,6 +152,27 @@ const hostedFailureLayer = (reason: "model-generation-failed" | "model-output-pa
   );
 
 describe("C0 hosted extractor", () => {
+  it("keeps the frozen target vocabulary separate from the legacy-preview relation contract", () => {
+    expect(FrozenRelationPredicate.Options).toEqual([
+      "affiliated with",
+      "authored by",
+      "located in",
+      "re-evaluates claim due to",
+      "selected",
+      "shows",
+    ]);
+    expect(
+      Result.isSuccess(
+        S.decodeResult(RelationExtractionCandidate)({
+          evidenceQuote: "Ada trained Engine.",
+          object: "Engine",
+          predicate: "trained",
+          subject: "Ada",
+        })
+      )
+    ).toBe(true);
+  });
+
   it("preserves hosted coreference cluster assignments on entity claims", () => {
     const text = "Ada wrote notes.";
     const extractions = [grounded("person", "Ada", 0, O.some({ cluster: "person-ada" }))];
@@ -180,21 +202,19 @@ describe("C0 hosted extractor", () => {
     );
   });
 
-  it("resolves NFC-equal relation endpoints to the nearest preceding entity", () => {
-    const decomposed = "Cafe\u0301";
-    const text = `${decomposed} met Engine. Ada praised it.`;
-    const relationStart = text.indexOf("Ada");
+  it("anchors repeated endpoint surfaces inside relation evidence and synthesizes same-batch entities", () => {
+    const text = "Ada wrote notes. Ada selected Engine.";
+    const relationStart = text.lastIndexOf("Ada");
+    const engineStart = text.indexOf("Engine");
     const extractions = [
-      grounded("organization", decomposed, 0),
-      grounded("method", "Engine", text.indexOf("Engine")),
       grounded(
         "relation",
-        "Ada praised it.",
+        "Ada selected Engine.",
         relationStart,
         O.some({
           object: "Engine",
-          predicate: "praised",
-          subject: "Café",
+          predicate: "selected",
+          subject: "Ada",
         })
       ),
     ];
@@ -212,27 +232,28 @@ describe("C0 hosted extractor", () => {
           }
           const entities = A.filter(outcome.batch.claims, (claim) => claim.body.kind === "Entity");
           const relation = A.findFirst(outcome.batch.claims, (claim) => claim.body.kind === "Relation");
-          const nearestSubject = A.findFirst(
-            entities,
-            (claim) => claim.body.startChar === 0 && claim.body.kind === "Entity"
-          );
+          const subject = A.findFirst(entities, (claim) => claim.body.startChar === relationStart);
+          const object = A.findFirst(entities, (claim) => claim.body.startChar === engineStart);
+          expect(entities).toHaveLength(2);
           expect(
             O.map(relation, (claim) =>
               ClaimBody.match(claim.body, {
                 Entity: () => O.none(),
-                Relation: (body) => O.some(body.subject),
+                Relation: (body) => O.some([body.subject, body.object]),
                 Structure: () => O.none(),
               })
             )
-          ).toEqual(O.map(nearestSubject, (claim) => O.some(claim.id)));
+          ).toEqual(
+            O.all([O.map(subject, (claim) => claim.id), O.map(object, (claim) => claim.id)]).pipe(O.map(O.some))
+          );
           expect(outcome.batch.degraded).toEqual([]);
         })
       )
     );
   });
 
-  it("uses an upstream-disambiguated grounded span when surface text repeats", () => {
-    const text = "Ada wrote notes. Ada praised Engine.";
+  it("reuses base entity claims already anchored inside the relation evidence", () => {
+    const text = "Ada wrote notes. Ada selected Engine.";
     const secondAda = text.lastIndexOf("Ada");
     const engine = text.indexOf("Engine");
     const extractions = [
@@ -240,9 +261,9 @@ describe("C0 hosted extractor", () => {
       grounded("method", "Engine", engine),
       grounded(
         "relation",
-        "Ada praised Engine.",
+        "Ada selected Engine.",
         secondAda,
-        O.some({ object: "Engine", predicate: "praised", subject: "Ada" })
+        O.some({ object: "Engine", predicate: "selected", subject: "Ada" })
       ),
     ];
 
@@ -256,6 +277,7 @@ describe("C0 hosted extractor", () => {
           expect(outcome.outcome).toBe("Extracted");
           if (outcome.outcome === "Extracted") {
             expect(A.filter(outcome.batch.claims, (claim) => claim.body.kind === "Relation")).toHaveLength(1);
+            expect(A.filter(outcome.batch.claims, (claim) => claim.body.kind === "Entity")).toHaveLength(2);
             expect(
               A.findFirst(outcome.batch.claims, (claim) => claim.body.kind === "Entity").pipe(
                 O.map((claim) => claim.body.startChar)
@@ -287,6 +309,56 @@ describe("C0 hosted extractor", () => {
           if (outcome.outcome === "Extracted") {
             expect(outcome.batch.degraded).toMatchObject([{ kind: "relation-unresolved" }]);
             expect(A.some(outcome.batch.claims, (claim) => claim.body.kind === "Relation")).toBe(false);
+          }
+        })
+      )
+    );
+  });
+
+  it("fails a malformed relation contract as typed model-output degradation", () => {
+    const text = "Ada selected Engine.";
+    const extractions = [grounded("relation", text, 0, O.some({ object: "Engine", subject: "Ada" }))];
+
+    return Effect.runPromise(
+      provideScopedLayer(Layer.merge(baseLayer, hostedLayer(extractions)))(
+        Effect.gen(function* () {
+          const { canonical, chunks } = yield* makeCanonical(text);
+          const extractor = yield* HostedExtractor;
+          const outcome = yield* extractor.extract(canonical, chunks);
+
+          expect(outcome.outcome).toBe("Extracted");
+          if (outcome.outcome === "Extracted") {
+            expect(outcome.batch.degraded).toMatchObject([{ kind: "model-output-invalid" }]);
+            expect(outcome.batch.claims).toEqual([]);
+          }
+        })
+      )
+    );
+  });
+
+  it("disqualifies fuzzy alignment for relation evidence", () => {
+    const text = "Ada selected Engine.";
+    const extraction = GroundedExtraction.cases.match_fuzzy.make({
+      alignmentStatus: "match_fuzzy",
+      attributes: O.some({ object: "Engine", predicate: "selected", subject: "Ada" }),
+      confidence: O.none(),
+      label: "relation",
+      matchedText: text,
+      span: Contract.Span.make({ end: NonNegativeInt.make(text.length), start: NonNegativeInt.make(0) }),
+      text,
+    });
+
+    return Effect.runPromise(
+      provideScopedLayer(Layer.merge(baseLayer, hostedLayer([extraction])))(
+        Effect.gen(function* () {
+          const { canonical, chunks } = yield* makeCanonical(text);
+          const extractor = yield* HostedExtractor;
+          const outcome = yield* extractor.extract(canonical, chunks);
+
+          expect(outcome.outcome).toBe("Extracted");
+          if (outcome.outcome === "Extracted") {
+            expect(outcome.batch.degraded).toMatchObject([{ kind: "fabricated-span" }]);
+            expect(outcome.batch.claims).toEqual([]);
           }
         })
       )

--- a/apps/labs/semantica/test/Fixtures.test.ts
+++ b/apps/labs/semantica/test/Fixtures.test.ts
@@ -11,6 +11,7 @@ import { FastCheck as fc } from "effect/testing";
 import { Command } from "effect/unstable/cli";
 import { describe, expect, it } from "vitest";
 import { CanaryCommand } from "@/canary/Command";
+import { RelationPreviewManifest } from "@/canary/RelationPreview";
 import { canonicalJson } from "@/corpus/Canonical";
 import { CorpusManifest, CorpusPaperId, ManifestDrift } from "@/corpus/Manifest";
 import { CorpusManifestBuilder } from "@/corpus/ManifestBuilder";
@@ -32,6 +33,7 @@ import { generateF1Pdfs } from "../scripts/generate-f1-pdfs";
 const ManifestFromJsonString = S.fromJsonString(CorpusManifest);
 const ManifestToJsonString = S.fromJsonString(CorpusManifest, { space: 2 });
 const F1IndexFromJsonString = S.fromJsonString(F1Index);
+const RelationPreviewManifestJson = S.fromJsonString(RelationPreviewManifest);
 
 const runtimeFromEnv = (env: Record<string, string>) =>
   RuntimeLayer.pipe(Layer.provide(ConfigProvider.layer(ConfigProvider.fromEnv({ env }))));
@@ -48,6 +50,23 @@ const rejectsManifest = (input: unknown) =>
   S.decodeUnknownEffect(CorpusManifest)(input).pipe(Effect.exit, Effect.map(Exit.isFailure));
 
 describe("W1 corpus manifest", () => {
+  it("decodes the committed E5 cache-preview manifest", () =>
+    Effect.runPromise(
+      provideScopedLayer(BunServices.layer)(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const manifest = yield* fs
+            .readFileString("fixtures/relation-preview.json")
+            .pipe(Effect.flatMap(S.decodeEffect(RelationPreviewManifestJson)));
+
+          expect(manifest.schemaVersion).toBe("semantica-relation-preview/v1");
+          expect(manifest.cases).toHaveLength(3);
+          expect(HashSet.size(HashSet.fromIterable(A.map(manifest.cases, (item) => item.cacheDigest)))).toBe(3);
+          expect(HashSet.size(HashSet.fromIterable(A.map(manifest.cases, (item) => item.paperId)))).toBe(2);
+        })
+      )
+    ));
+
   it("canonicalizes recursively without depending on object key insertion order", () => {
     const left = canonicalJson({ z: [{ b: 2, a: 1 }], a: { d: 4, c: 3 } });
     const right = canonicalJson({ a: { c: 3, d: 4 }, z: [{ a: 1, b: 2 }] });

--- a/apps/labs/semantica/test/Gold.test.ts
+++ b/apps/labs/semantica/test/Gold.test.ts
@@ -3,7 +3,7 @@
 import { SourceTextExtractor } from "@beep/provenance";
 import { NonNegativeInt } from "@beep/schema";
 import * as BunServices from "@effect/platform-bun/BunServices";
-import { Duration, Effect, FileSystem, Layer, Path, Stream } from "effect";
+import { Duration, Effect, FileSystem, Layer, Match, Number as N, Path, Stream } from "effect";
 import * as A from "effect/Array";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
@@ -14,7 +14,7 @@ import * as Response from "effect/unstable/ai/Response";
 import { Command } from "effect/unstable/cli";
 import { describe, expect, it } from "vitest";
 import { CanaryCommand } from "@/canary/Command";
-import { proposeGold, resolveGoldQuoteAnchor } from "@/canary/Gold";
+import { GOLD_SUBSETS, GoldArtifactSemantics, proposeGold, resolveGoldQuoteAnchor } from "@/canary/Gold";
 import { CorpusManifest, CorpusPaperId } from "@/corpus/Manifest";
 import { CorpusManifestBuilder } from "@/corpus/ManifestBuilder";
 import { F1Catalog, F1Index } from "@/fixtures/F1";
@@ -22,14 +22,15 @@ import { GOLD_PROMPT_ARTIFACT_HASH } from "@/gold/Prompts";
 import { CanonicalizerLive } from "@/layers/CanonicalizerLive";
 import { ActiveModelIdentityLive, promptText } from "@/layers/LanguageModelLive";
 import { LabConfig } from "@/runtime/Config";
-import { sha256TextSync } from "@/schema/Digest";
+import { contentDigest, sha256TextSync } from "@/schema/Digest";
 import { Origin, SourceDocument } from "@/schema/Document";
 import { GoldUnavailable } from "@/schema/Errors";
-import { CurrentGoldDocumentText, GoldFile, GoldRef } from "@/schema/Gold";
+import { CurrentGoldDocumentText, GoldFile, GoldFileEncoded, GoldRef } from "@/schema/Gold";
 import { DocumentId, ProvenanceEventId } from "@/schema/Ids";
 import { ModelIdentity } from "@/schema/Model";
 import { ParseOutcome } from "@/schema/Text";
 import { CanaryC0 } from "@/services/CanaryC0";
+import { Chunker } from "@/services/Chunker";
 import { DocumentSource } from "@/services/DocumentSource";
 import { Parser } from "@/services/Parser";
 import { ProviderCache } from "@/services/ProviderCache";
@@ -37,7 +38,24 @@ import { ProviderCache } from "@/services/ProviderCache";
 const CorpusManifestJson = S.fromJsonString(CorpusManifest);
 const F1IndexJson = S.fromJsonString(F1Index);
 const GoldFileJson = S.fromJsonString(GoldFile);
+const GoldFileEncodedJson = S.fromJsonString(GoldFileEncoded);
 const GoldRefJson = S.fromJsonString(GoldRef);
+
+const goldLabelCount = (file: GoldFileEncoded): number =>
+  Match.value(file).pipe(
+    Match.when({ subset: "structure" }, (value) => A.length(value.labels)),
+    Match.when({ subset: "entity" }, (value) => A.length(value.labels)),
+    Match.when({ subset: "relation" }, (value) => A.length(value.labels)),
+    Match.exhaustive
+  );
+
+const verifiedGoldLabelCount = (file: GoldFileEncoded): number =>
+  Match.value(file).pipe(
+    Match.when({ subset: "structure" }, (value) => A.length(A.filter(value.labels, (label) => label.verified))),
+    Match.when({ subset: "entity" }, (value) => A.length(A.filter(value.labels, (label) => label.verified))),
+    Match.when({ subset: "relation" }, (value) => A.length(A.filter(value.labels, (label) => label.verified))),
+    Match.exhaustive
+  );
 
 const provideScopedLayer =
   <ROut, E2, RIn>(layer: Layer.Layer<ROut, E2, RIn>) =>
@@ -46,6 +64,10 @@ const provideScopedLayer =
 
 const unusedCanaryC0 = CanaryC0.of({
   run: Effect.fn("CanaryC0.unused")(() => Effect.die(new Error("C0 is not used by gold command tests."))),
+});
+
+const unusedChunker = Chunker.of({
+  chunk: Effect.fn("Chunker.unused")(() => Effect.die(new Error("Chunker is not used by gold command tests."))),
 });
 
 const sourceText = "Café relates to Beta.";
@@ -181,6 +203,54 @@ describe("C0 gold proposer", () => {
       { numRuns: 20 }
     );
   });
+
+  it("keeps the committed E6 annotation and refreeze receipt coherent", () =>
+    Effect.runPromise(
+      provideScopedLayer(BunServices.layer)(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const reference = yield* fs
+            .readFileString("fixtures/gold/v1/gold.json")
+            .pipe(Effect.flatMap(S.decodeEffect(GoldRefJson)));
+          const files = A.sort(
+            yield* Effect.forEach(
+              GOLD_SUBSETS,
+              (subset) =>
+                Effect.forEach(reference.subsets[subset], (paperId) =>
+                  fs
+                    .readFileString(`fixtures/gold/v1/${paperId}.${subset}.json`)
+                    .pipe(Effect.flatMap(S.decodeEffect(GoldFileEncodedJson)))
+                ),
+              { concurrency: 1 }
+            ).pipe(Effect.map(A.flatten)),
+            GoldArtifactSemantics.fileOrder
+          );
+          const verified = A.reduce(files, 0, (total, file) => N.sum(total, verifiedGoldLabelCount(file)));
+          const total = A.reduce(files, 0, (count, file) => N.sum(count, goldLabelCount(file)));
+          const digest = yield* contentDigest(S.Array(GoldFileEncoded))(files);
+          const relationLabels = A.flatMap(files, (file) => (file.subset === "relation" ? file.labels : []));
+          const abstractLabels = A.flatMap(files, (file) =>
+            file.subset === "structure" ? A.filter(file.labels, (label) => label.role === "abstract") : []
+          );
+
+          expect(files).toHaveLength(18);
+          expect([verified, total]).toEqual([21, 377]);
+          expect(reference.digest).toBe(digest);
+          expect(reference.spotCheckedFraction).toBe(N.divideUnsafe(verified, total));
+          expect(A.every(relationLabels, (label) => label.verified)).toBe(true);
+          expect(A.some(relationLabels, (label) => Str.Equivalence(label.predicate, "affiliated_with"))).toBe(false);
+          expect(
+            A.some(relationLabels, (label) => Str.Equivalence(label.predicate, "published in proceedings of"))
+          ).toBe(false);
+          expect(
+            A.every(
+              abstractLabels,
+              (label) => label.verified && N.Equivalence(N.subtract(label.endChar, label.startChar), 8)
+            )
+          ).toBe(true);
+        })
+      )
+    ));
 
   it("keeps an exact claimed anchor ahead of an earlier whitespace-folded occurrence", () => {
     expect(resolveGoldQuoteAnchor("Alpha   Beta Alpha Beta", "Alpha Beta", 13)).toEqual(O.some([13, 23, "Alpha Beta"]));
@@ -463,6 +533,7 @@ describe("C0 gold proposer", () => {
           const error = yield* provideScopedLayer(makeGoldTestLayer(manifest, fixtures))(
             runCanary(["gold", "propose", "--offline", "--paper", paperId, "--subset", "entity"]).pipe(
               Effect.provideService(CanaryC0, unusedCanaryC0),
+              Effect.provideService(Chunker, unusedChunker),
               Effect.flip
             )
           );

--- a/explorations/semantica-lab/DECISIONS.md
+++ b/explorations/semantica-lab/DECISIONS.md
@@ -9,7 +9,7 @@ holds now; when a log entry disagrees with it, the table wins.
 
 | Topic | Holds now | Supersedes |
 | --- | --- | --- |
-| Next work | Stage `decompose`: the evidence-quote relation candidate is defined (E1-E8, 2026-08-27). Delivery order: capability PR for the fold alignment tier, then a lab PR for the relation contract, endpoint rule, frozen-vocabulary target, and preview harness. The zero-spend preview (E5) and the operator gold spot-check-and-repair pass (E6) both gate the live probe; the paused `semantica-canary` packet resumes only after both clear. Do not scaffold a queued MAP row from the failed gate; MAP v1.0's extractor prose is superseded by this table (dated note in MAP.md). | "define a new exact-evidence relation candidate" as open work; stage `graduate` and its PR A/B/C sequence |
+| Next work | Stage `P2 C0`: the evidence-quote relation candidate cleared E5 and E6 on 2026-08-30 and the `semantica-canary` packet is active. Publish the lab candidate through its mergeable PR, then spend its single live probe on F1 plus one relation paper. Do not scaffold a queued MAP row from the failed gate; MAP v1.0's extractor prose is superseded by this table (dated note in MAP.md). | E1-E8 candidate definition at stage `decompose`; "define a new exact-evidence relation candidate" as open work; stage `graduate` and its PR A/B/C sequence |
 | Stop rule | Probe-denominated circuit breaker (S1): first-probe candidate, one retry, then the family parks and the packet drops to decompose; wall-clock is `EvalRunTelemetry` sidecar telemetry (R1), never a gate. Re-entry is bounded (E8): one decompose re-entry candidate per family per stage; a second park is terminal absent an explicit operator ratification recorded in this file | BRIEF v0.1 "two weeks, C0 in four days"; contract v1.2 two-week falsifier; unbounded slate re-entry |
 | Gold labels | Gold-proposer provider family ≠ extraction provider family, enforced as a schema refinement on EvalRun; spot-checked fraction committed as a number in gold/v1 (S2) | contract v1.2 "LLM-proposed and spot-checked" |
 | Lab shape | `--app-kind tauri`, one local `cargo check`, `src-tauri` frozen through C0-C2, hand-written `server/main.ts` + `src/runtime/Layer.ts` as the headless proof surface (S4) | D12/G2 wording without a runtime entry |
@@ -18,7 +18,7 @@ holds now; when a log entry disagrees with it, the table wins.
 | Input | park-pending-canary; per-stage slate is probe order; PDF first probe = `@beep/doc-text` (the exact string the product pipeline digests); breaker retry = direct `unpdf` text items with `disableNormalization: true` inside the lab (same MIT dep) if G-structure needs page/font structure; MuPDF parked (AGPL subprocess, new binary) (M1) | the sheet's per-stage winners; "PDF.js/MuPDF is a tie" |
 | Spans | compose, not build: the lab's `CanonicalText` = `ResolvedSourceText` (`@beep/file-processing` `SourceText`) = `@beep/provenance` `SourceTextIdentity` + text, spans = `@beep/provenance` `TextAnchor`, C0 tripwire = `verifyTextAnchor`; raw extracted text IS canonical, normalization is locator-only, no raw→canonical loss map; lab-local NET-NEW shrinks to `EvidenceBatch`, `ModelIdentity`, `ConflictWitness` (M1) | shared-schema v1.1 `CanonicalText` loss map; BRIEF rabbit hole 1 |
 | Reasoning | park-pending-canary; EYE is the C2/CI correctness oracle, not the product runtime; C2 runtime = ρdf closure (rdfs2,3,5,7,9,11 as rule values + one SKOS broader-transitivity rule), naive fixpoint, emitting InferenceEvents (S5); C2 gate = closure equality on conclusions + per-InferenceEvent rule validation, never premise-set identity (S8); G-entailment splits into `rdfs` (gates C2) and `rules` (gates the spike); NET-NEW is a dated spike with kill criteria where the v3 Rete salvage and the kernel ablate against EYE | the sheet's EYE pick-one; "RDFS-lite ~13 rules" |
-| Extraction | **park** (S1, 2026-08-26): the hosted candidate and its one exact-evidence prompt retry did not produce a review-safe relation-paper slice; unique alignment exposed ambiguous endpoint anchors in two earlier apparent passes, and pattern-only declares relations unsupported. The evidence-quote candidate (E1-E8, 2026-08-27) is the queued slate row: fold alignment tier, lab-local subject/object/evidence-quote contract, endpoints anchored inside the evidence span, target enumerating the frozen gold predicate vocabulary; it carries one probe-plus-retry budget once the preview and spot-check-and-repair gates clear, and a second park is terminal (E8) | `park-pending-canary`; the sheet's dual verdict; BRIEF v1.0's C1 G-relation deferral |
+| Extraction | **active re-entry** (E9, 2026-08-30): the evidence-quote candidate passed its zero-spend preview with 10 grounded cached relations on two papers, and gold-v1 was reviewed, repaired, and refrozen. Its endpoint policy scopes unique subject/object alignment to the evidence span; fuzzy relation evidence is disqualified. One live probe plus one retry remain, and a second park is terminal (E8). | `park` (S1, 2026-08-26); `park-pending-canary`; the sheet's dual verdict; BRIEF v1.0's C1 G-relation deferral |
 | Canary | staged C0 then C1 then C2 (G1), each stage bounded by the probe breaker (S1), no calendar; code lives in the lab after graduation; every stage pass includes the full W1 + F1 run, live and replay, with equal digests and zero unexpected typed-degraded document failures (F1 malformed specimens decode to their declared degraded states; any W1 paper degrading fails the gate) (R2); C1 checks `G-projection` before rebuild identity (R3) | B2's monolithic offline run; G1 "C0 (days)" |
 | Budgets | Tier-L hard bar: cold start <5s, p95 <100ms; 16GB bundle-RSS alarm, not a park; laptop-class numbers are Tier-D telemetry in the per-run `EvalRunTelemetry` sidecar, never in the report digest (R1) | B5/A8 2GB/250MB/600MB as gates |
 | Offline | replay-offline, hosted-live: cache every provider result content-addressed; re-run must reproduce the `EvalReport` digest with network off; Tier-L/Tier-D numbers live in a per-run `EvalRunTelemetry` sidecar outside the digest (R1) | A8's fully-offline M1; "byte-identical EvalReports" |
@@ -642,3 +642,18 @@ Decisions, grilled and locked 2026-08-27:
   here, not another silent slate row. This closes the loop the breaker left
   open, where a packet could park, rename a row, and pay for probes
   indefinitely.
+
+## 2026-08-30 (evidence-quote gates) — E9
+
+- **E9 (E5 and E6 cleared; P2 resumes).** The committed zero-spend preview
+  replayed all three breaker responses through the production grounding
+  boundary and grounded 10 relations on two papers. The annotation pass
+  reviewed all 13 proposed relation labels and all nine proposed abstract
+  labels. It dropped the date-as-venue triple, normalized
+  `affiliated_with` to `affiliated with`, and standardized abstract gold on
+  the exact heading span. The gold codec recomputed edited slice digests;
+  the 18-file reference is refrozen at 21/377 reviewed labels with digest
+  `9321c57c92402fba398ff226a178d9bc2922bb48f116f892fd8584a44ad72f29`.
+  The E5/E6 gates therefore clear and `semantica-canary` returns to active
+  P2. No live probe was spent by the preview or annotation pass; E8's one
+  probe plus one retry remain.

--- a/goals/semantica-canary/PLAN.md
+++ b/goals/semantica-canary/PLAN.md
@@ -2,13 +2,11 @@
 
 ## Status
 
-Status: `paused`
+Status: `active`
 
-P1 is complete. P2 is paused after the C0 Extraction probe and its single
-retry failed the frozen relation-paper slate. Review also invalidated two
-apparent passes that had relied on ambiguous first-occurrence entity anchors.
-Extraction is `park`, the exploration has returned to `decompose`, and P3-P5
-do not proceed from this packet state.
+P1 is complete. P2 resumed after the evidence-quote candidate passed its E5
+zero-spend preview and E6 gold annotation-and-repair gate. Its single live
+probe and retry budget remain unspent. P3-P5 do not proceed until C0 passes.
 
 ## Phases
 
@@ -19,7 +17,7 @@ completion gate binds per phase, not only at close. Phase ids match
 | Phase | Status | Goal | Exit criteria |
 | --- | --- | --- | --- |
 | P1 Scaffold | complete | Mint the lab on its own PR, then commit F1 fixtures and the W1 manifest. | Lab passes its Labs lane; one local `cargo check` recorded; headless entry and runtime layer exist; F1 + W1 manifest committed. |
-| P2 C0 | paused | The spine, first vertical slice first, then all three G-relation papers. | Breaker fired: the candidate and retry failed the relation slate; no review-safe vertical slice passed. |
+| P2 C0 | in progress | The spine, first vertical slice first, then all three G-relation papers. | Evidence-quote re-entry gates passed; live probe, relation-paper extension, and full-W1 R2 gate remain. |
 | P3 C1 | pending | Derived projections: dimension-keyed vector table and RDF rebuild-from-ledger. | C1 pass criteria; Storage and Embeddings verdicts written. Needs the sibling `openai-driver` packet merged first. |
 | P4 C2 | pending | Reasoning, crash injection, and the Tier-L bars at bundle level. | C2 pass criteria; Reasoning verdict written; all Tier-L bars green. |
 | P5 Close | pending | Verdicts to DECISIONS then atlas; reflection; packet state flip in the same PR. | Closeout reflection validates; final park/drop values synced to the atlas; packet `completed-retained`. |

--- a/goals/semantica-canary/README.md
+++ b/goals/semantica-canary/README.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Lifecycle: `paused`
+Lifecycle: `active`
 
 Source: [`ops/manifest.json`](./ops/manifest.json)
 
@@ -50,18 +50,17 @@ Use this command for execution-capable sessions:
 
 ## Current phase
 
-Paused in P2 after the C0 Extraction probe and its single retry failed the
-relation-paper slate. Review invalidated two earlier apparent passes because
-their endpoint entities used ambiguous first-occurrence anchors. The family is
-`park`, and the source exploration has returned to `decompose`. C1, C2, and
-the full-W1 R2 gate did not run.
+Active in P2 on the single evidence-quote re-entry candidate. Its zero-spend
+preview grounded 10 cached relations on two papers, and the gold-v1 annotation
+pass repaired the known relation and abstract-label defects. The candidate's
+live probe and retry budgets remain unspent. C1, C2, and the full-W1 R2 gate
+have not run.
 
 ## Latest evidence
 
-[`history/p2-c0-probe-breaker.md`](./history/p2-c0-probe-breaker.md) records
-the superseded diagnostic digests, the candidate and retry failures, the
-review-closeout live/replay failure on the unique-alignment code, their
-provider-cache evidence, and the exact re-entry questions.
+[`history/p2-c0-evidence-quote-reentry.md`](./history/p2-c0-evidence-quote-reentry.md)
+records the candidate contract, zero-spend preview, gold annotation repairs,
+refrozen digests, and local proof that reopened P2.
 
 ## Notes
 

--- a/goals/semantica-canary/history/p2-c0-evidence-quote-reentry.md
+++ b/goals/semantica-canary/history/p2-c0-evidence-quote-reentry.md
@@ -1,0 +1,75 @@
+# P2 C0 evidence-quote re-entry
+
+Date: 2026-08-30
+
+Status: preview and annotation gates passed; live probe budget unspent.
+
+## Candidate
+
+The E1 capability prerequisite landed in PR #903. The lab candidate now binds
+its model identity to a versioned descriptor containing the rendered prompt,
+relation-contract identifier, accepted alignment tiers, and endpoint policy.
+The relation contract decodes a non-empty subject, object, predicate, and
+evidence quote before relation grounding. Relation evidence admits exact,
+lesser, and minimal-fold alignment only. Each endpoint must align uniquely
+inside the evidence quote; matching same-batch entity claims are reused and
+otherwise created at the scoped endpoint offsets.
+
+The hosted target lists the six predicate strings left in the repaired
+gold-v1 relation set. Legacy responses may still carry other non-empty
+predicates so the preview measures grounding rather than prompt compliance.
+
+## E5 zero-spend preview
+
+Command:
+
+```sh
+SEMANTICA_OFFLINE=true bun server/main.ts relation preview \
+  --cases fixtures/relation-preview.json \
+  --manifest fixtures/w1.manifest.json
+```
+
+The committed preview manifest selects the three breaker response cache keys.
+The command validates each immutable cache entry, parses its response, loads
+the verified W1 paper, and calls the production hosted-grounding boundary.
+It performs no hosted-model request.
+
+| Paper | Cached candidate | Relation candidates | Grounded | Degraded |
+| --- | --- | ---: | ---: | ---: |
+| `06c93f91ef3d` | first response | 16 | 0 | 16 |
+| `06c93f91ef3d` | retry | 7 | 2 | 5 |
+| `057e356e94f8` | review-closeout retry | 9 | 8 | 1 |
+
+Result: 10 grounded relations on two papers. E5 passed. The first response's
+invented relation sentences correctly remained ungrounded.
+
+## E6 annotation and repair
+
+All 13 proposed relation labels and all nine proposed abstract labels were
+hydrated from canonical W1 text and reviewed.
+
+- Dropped the `057e356e94f8` `published in proceedings of` triple whose object
+  was the date `November 19, 2020` rather than a venue.
+- Normalized `affiliated_with` to `affiliated with`.
+- Marked the 12 surviving relation labels verified.
+- Standardized abstract gold on the exact `Abstract` or `ABSTRACT` heading
+  span. Six labels already followed that convention; three were corrected.
+- Marked all nine abstract-heading labels verified.
+
+All edited files were decoded against canonical text and re-encoded through
+the gold codec, which recomputed their slice digests. The complete 18-file set
+was rehashed and `gold.json` was refrozen with:
+
+- verified labels: 21 / 377
+- `spotCheckedFraction`: `0.05570291777188329`
+- gold digest: `9321c57c92402fba398ff226a178d9bc2922bb48f116f892fd8584a44ad72f29`
+
+## Proof
+
+- Semantica typecheck: passed.
+- Semantica tests: 12 files, 123 tests passed.
+- Final E5 replay after gold and vocabulary repair: 10 relations on two
+  papers, unchanged from the initial preview.
+
+The paused packet may resume P2. The evidence-quote candidate still owns one
+live probe and one retry under E8; neither was spent by this work.

--- a/goals/semantica-canary/ops/manifest.json
+++ b/goals/semantica-canary/ops/manifest.json
@@ -3,14 +3,14 @@
   "initiative": {
     "id": "semantica-canary",
     "title": "Semantica Canary",
-    "status": "paused",
+    "status": "active",
     "created": "2026-08-24",
-    "updated": "2026-08-26",
+    "updated": "2026-08-30",
     "packetAnchorDocument": "SPEC.md"
   },
   "packetPath": "goals/semantica-canary",
-  "lifecycle": "paused",
-  "statusNote": "Paused at P2 C0 after the Extraction candidate and single retry failed the frozen relation-paper slate. Review invalidated two apparent passes that relied on ambiguous first-occurrence entity anchors; no review-safe vertical slice passed. Extraction is parked and the source exploration has returned to decompose; see history/p2-c0-probe-breaker.md.",
+  "lifecycle": "active",
+  "statusNote": "P2 C0 resumed after the evidence-quote candidate passed its E5 zero-spend preview and E6 gold annotation-and-repair gate. Its single live probe and retry budget remain unspent; see history/p2-c0-evidence-quote-reentry.md.",
   "mission": "Scaffold the headless-first Tauri lab at apps/labs/semantica and run the staged canary C0 -> C1 -> C2 over F1 + W1 under the probe breaker (S1), emitting replay-identical EvalReports; each passing stage flips its families from park-pending-canary to a verdict (B1).",
   "executionCapable": true,
   "reflectionRequired": true,


### PR DESCRIPTION
## Summary

- bind hosted relation extraction to evidence quotes with uniquely scoped endpoint alignment
- add a zero-spend preview over the three historical breaker responses
- repair and refreeze the reviewed relation and abstract gold labels
- reactivate P2 C0 while preserving the one-probe-plus-one-retry breaker

## Local evidence

- `bun run check` in `apps/labs/semantica`
- `bun run test` in `apps/labs/semantica` (123 tests)
- `bun run lint` in `apps/labs/semantica`
- `bun run beep quality package-verify @beep/semantica`
- `bun run beep quality knip`
- `bun run beep quality fallow audit --check --quiet`
- packet goal/index/doctor/reflection validations

Full Yeet proof and hosted closeout are in progress.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/923"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790737909&installation_model_id=424656&pr_number=923&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F923&signature=82fefda36034a860acf26ead57823913bfcabf40c647e475bda74a6644e7caf1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->