### PR TITLE
test(repo-cli): make archive mutation race deterministic

### DIFF
--- a/packages/tooling/tool/cli/test/corpus-command.test.ts
+++ b/packages/tooling/tool/cli/test/corpus-command.test.ts
@@ -48,7 +48,7 @@ import { NodeServices } from "@effect/platform-node";
 import { describe, expect, it } from "@effect/vitest";
 import { sha256 } from "@noble/hashes/sha2.js";
 import { bytesToHex, utf8ToBytes } from "@noble/hashes/utils.js";
-import { Effect, FileSystem, Layer, Match, Path, Result, Stream } from "effect";
+import { Context, Effect, FileSystem, Layer, Match, Path, Result, Stream } from "effect";
 import * as A from "effect/Array";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
@@ -56,6 +56,7 @@ import * as Str from "effect/String";
 import { FastCheck as fc } from "effect/testing";
 import * as TestClock from "effect/testing/TestClock";
 import { ChildProcess } from "effect/unstable/process";
+import type { PlatformError } from "effect";
 
 const testLayer = Layer.mergeAll(
   CorpusCommandServiceLive.pipe(Layer.provideMerge(NodeServices.layer)),
@@ -1341,15 +1342,32 @@ const measurePreservationDenominators = Effect.fn("CorpusTest.measurePreservatio
 
 const collectorManifestJson = S.fromJsonString(CollectorManifestRecord);
 
-const waitForPathToExist = Effect.fn("CorpusTest.waitForPathToExist")(function* (
-  filePath: string
-): Effect.fn.Return<boolean, never, FileSystem.FileSystem> {
-  const fs = yield* FileSystem.FileSystem;
-  for (let attempt = 0; attempt < 5_000; attempt += 1) {
-    if (yield* fs.exists(filePath).pipe(Effect.orDie)) return true;
-    yield* Effect.yieldNow;
-  }
-  return false;
+const preserveWithArchiveCopyMutation = Effect.fn("CorpusTest.preserveWithArchiveCopyMutation")(function* (
+  options: RestorationPreserveOptions,
+  partialPath: string,
+  mutation: (fs: FileSystem.FileSystem) => Effect.Effect<void, PlatformError.PlatformError>
+) {
+  const baseContext = yield* Layer.build(NodeServices.layer);
+  const fs = Context.get(baseContext, FileSystem.FileSystem);
+  let mutated = false;
+  const racingFileSystem = FileSystem.FileSystem.of({
+    ...fs,
+    open: Effect.fn("CorpusTest.mutateWhenArchiveCopyOpens")(function* (target, openOptions) {
+      const file = yield* fs.open(target, openOptions);
+      if (!mutated && Str.Equivalence(target, partialPath)) {
+        mutated = true;
+        yield* mutation(fs);
+      }
+      return file;
+    }),
+  });
+  const serviceContext = yield* Layer.build(
+    CorpusCommandServiceLive.pipe(
+      Layer.fresh,
+      Layer.provide(baseContext.pipe(Context.add(FileSystem.FileSystem, racingFileSystem), Layer.succeedContext))
+    )
+  );
+  return yield* preserveRestorationArchive(options).pipe(Effect.provide(serviceContext));
 });
 
 const writePresentCollectorManifest = Effect.fn("CorpusTest.writePresentCollectorManifest")(function* (
@@ -1559,14 +1577,9 @@ describe("corpus restoration preservation", () => {
           expectedMissingRecyclePayloadCount: NonNegativeInt.make(0),
           expectedMutatedDestinationCount: NonNegativeInt.make(0),
         });
-        yield* Effect.forkChild(
-          Effect.gen(function* () {
-            const partialExists = yield* waitForPathToExist(partialPath);
-            if (!partialExists) return yield* Effect.die("Partial archive was not observable for mutation.");
-            yield* fs.rename(replacementPath, sourcePath);
-          })
+        const summary = yield* preserveWithArchiveCopyMutation(options, partialPath, (racingFs) =>
+          racingFs.rename(replacementPath, sourcePath)
         );
-        const summary = yield* preserveRestorationArchive(options);
         const verified = yield* verifyRestorationArchive(
           RestorationVerifyOptions.make({
             corpusRoot: fixture.corpusRoot,
@@ -1638,15 +1651,14 @@ describe("corpus restoration preservation", () => {
           expectedMissingRecyclePayloadCount: NonNegativeInt.make(0),
           expectedMutatedDestinationCount: NonNegativeInt.make(0),
         });
-        yield* Effect.forkChild(
-          Effect.gen(function* () {
-            const partialExists = yield* waitForPathToExist(partialPath);
-            if (!partialExists) return yield* Effect.die("Partial archive was not observable for mutation.");
-            yield* fs.rename(replacementPath, sourcePath);
-            yield* fs.writeFileString(path.join(fixture.sourceRoot, "unrelated-added.bin"), "unexpected drift");
+        const error = yield* preserveWithArchiveCopyMutation(
+          options,
+          partialPath,
+          Effect.fn("CorpusTest.mutateArchiveSourceAndAddDrift")(function* (racingFs) {
+            yield* racingFs.rename(replacementPath, sourcePath);
+            yield* racingFs.writeFileString(path.join(fixture.sourceRoot, "unrelated-added.bin"), "unexpected drift");
           })
-        );
-        const error = yield* preserveRestorationArchive(options).pipe(Effect.flip);
+        ).pipe(Effect.flip);
         const manifestPath = path.join(fixture.corpusRoot, "raw", "synthetic-restoration", "archive-ledger.jsonl");
         const lines = A.filter(Str.split(/\r?\n/u)(yield* fs.readFileString(manifestPath)), Str.isNonEmpty);
         const records = yield* Effect.forEach(lines, decodeArchiveLedgerRecordJson);


### PR DESCRIPTION
## Summary

- replace partial-file polling with an injected FileSystem open hook
- mutate the source only after both source and destination handles are open
- keep the archive-copy mutation test deterministic across fast and slow runners

Follow-up to #922 and its Greptile review. Refs #898.

## Verification

- focused mutation tests, 10 consecutive iterations
- full corpus-command test file: 54 tests
- package verification: @beep/repo-cli
- Yeet repair, including 142 repo-cli files and 2,720 tests
- exact-head Yeet verify reached the repo-wide proof lanes; publishing was then
  switched to a direct push at operator request because the origin proof queue was busy

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/925"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790738497&installation_model_id=424656&pr_number=925&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F925&signature=c643c52cec6b08c94fb8fdcead1a034456aabea9e13cd83535038eae2520c6cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->