### PR TITLE
chore(security): allow Semantica model digest

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -15,13 +15,6 @@ regexes = [
 ]
 
 [[allowlists]]
-description = "Semantica C1 model identity is a public deterministic SHA-256 digest, not a provider credential"
-targetRules = ["generic-api-key"]
-regexes = [
-  '''^7bdf768ab154ab6decb1509845e8380771295dd6e865d677ec298b69b02bb3cf$''',
-]
-
-[[allowlists]]
 description = "CauseRedaction is a secret-redaction helper; its JSDoc @example blocks and tests intentionally contain placeholder secret-shaped strings (sk-/token=/API_KEY=) to demonstrate redaction. These are not real secrets. Anchored at the repo root (with an optional /repo/ CI-mount prefix) so a nested attacker-controlled path like evil/packages/.../CauseRedaction.ts cannot inherit the allowlist."
 paths = [
   '''^(?:/repo/)?packages/foundation/capability/observability/src/CauseRedaction\.ts$''',

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -15,6 +15,13 @@ regexes = [
 ]
 
 [[allowlists]]
+description = "Semantica C1 model identity is a public deterministic SHA-256 digest, not a provider credential"
+targetRules = ["generic-api-key"]
+regexes = [
+  '''^7bdf768ab154ab6decb1509845e8380771295dd6e865d677ec298b69b02bb3cf$''',
+]
+
+[[allowlists]]
 description = "CauseRedaction is a secret-redaction helper; its JSDoc @example blocks and tests intentionally contain placeholder secret-shaped strings (sk-/token=/API_KEY=) to demonstrate redaction. These are not real secrets. Anchored at the repo root (with an optional /repo/ CI-mount prefix) so a nested attacker-controlled path like evil/packages/.../CauseRedaction.ts cannot inherit the allowlist."
 paths = [
   '''^(?:/repo/)?packages/foundation/capability/observability/src/CauseRedaction\.ts$''',

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -11,6 +11,19 @@
 # Documentation examples
 # docs/**
 
+# Deterministic C1 embedding model-key digests in archived Semantica reports.
+# These are public SHA-256 projection identities, not provider credentials.
+goals/semantica-canary/history/c1/g.exact-head-replay.eval-report.json:generic-api-key:518
+goals/semantica-canary/history/c1/g.exact-head-replay.eval-report.json:generic-api-key:2352
+goals/semantica-canary/history/c1/g.live.eval-report.json:generic-api-key:518
+goals/semantica-canary/history/c1/g.live.eval-report.json:generic-api-key:2352
+goals/semantica-canary/history/c1/g.replay.eval-report.json:generic-api-key:518
+goals/semantica-canary/history/c1/g.replay.eval-report.json:generic-api-key:2352
+goals/semantica-canary/history/c1/full-w1.live.eval-report.json:generic-api-key:1340
+goals/semantica-canary/history/c1/full-w1.live.eval-report.json:generic-api-key:3174
+goals/semantica-canary/history/c1/full-w1.replay.eval-report.json:generic-api-key:1340
+goals/semantica-canary/history/c1/full-w1.replay.eval-report.json:generic-api-key:3174
+
 # False positives from imported upstream test fixtures in local subtree commits.
 4f6b06621704b4f5b7f578f57914e6d9e7f4d376:packages/client/test/client/crossAppAccess.test.ts:generic-api-key:13
 4f6b06621704b4f5b7f578f57914e6d9e7f4d376:packages/client/test/client/crossAppAccess.test.ts:generic-api-key:24


### PR DESCRIPTION
## Summary

- classify one exact deterministic SHA-256 model identity as public evidence
- scope the allowlist to the `generic-api-key` rule and the exact digest
- unblock base-controlled secret scanning for Semantica C1 evidence reports

## Why this is separate

Pull-request secret scanning intentionally uses the reviewed configuration from
`origin/main`, so PR #934 cannot authorize its own exception. This narrow
prerequisite must land first; #934 will then merge current `main` without a
rebase or history rewrite.

## Verification

- pre-commit gitleaks passed
- commitlint passed
- the value is the deterministic C1 model/dimension identity, not a credential
- no path-wide or rule-wide secret-scanning exclusion is added

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790754377&installation_model_id=424656&pr_number=935&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F935&signature=7118fd33096eb4f0152ff6d701879a7056d22b1de2873a80f716a41c162311ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->