### PR TITLE
feat(quality): declare coverage Turbo inputs

### DIFF
--- a/packages/tooling/tool/cli/test/coverage-turbo-inputs.test.ts
+++ b/packages/tooling/tool/cli/test/coverage-turbo-inputs.test.ts
@@ -1,5 +1,6 @@
 import { $RepoCliId } from "@beep/identity/packages";
 import { findRepoRoot } from "@beep/repo-utils/Root";
+import { encodeJsonString } from "@beep/schema/Json";
 import { provideScopedLayer } from "@beep/test-utils";
 import { A } from "@beep/utils";
 import { NodeServices } from "@effect/platform-node";
@@ -59,7 +60,6 @@ const TurboConfiguration = S.Struct({
 
 const decodeTurboConfiguration = S.decodeUnknownEffect(S.fromJsonString(TurboConfiguration));
 const decodeTurboRunSummary = S.decodeUnknownEffect(S.fromJsonString(TurboRunSummary));
-const encodeJson = S.encodeUnknownEffect(S.UnknownFromJsonString);
 
 const writeFixtureFile = Effect.fn("CoverageTurboInputsTest.writeFixtureFile")(function* (
   root: string,
@@ -79,7 +79,7 @@ const writeFixtureJson = Effect.fn("CoverageTurboInputsTest.writeFixtureJson")(f
   relativePath: string,
   document: unknown
 ) {
-  yield* writeFixtureFile(root, relativePath, `${yield* encodeJson(document)}\n`);
+  yield* writeFixtureFile(root, relativePath, `${yield* encodeJsonString(document)}\n`);
 });
 
 const coverageHashFromSummary = Effect.fn("CoverageTurboInputsTest.coverageHashFromSummary")(function* (

--- a/packages/tooling/tool/cli/test/coverage-turbo-inputs.test.ts
+++ b/packages/tooling/tool/cli/test/coverage-turbo-inputs.test.ts
@@ -1,0 +1,182 @@
+import { $RepoCliId } from "@beep/identity/packages";
+import { findRepoRoot } from "@beep/repo-utils/Root";
+import { provideScopedLayer } from "@beep/test-utils";
+import { A } from "@beep/utils";
+import { NodeServices } from "@effect/platform-node";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, FileSystem, Path, pipe } from "effect";
+import * as O from "effect/Option";
+import * as S from "effect/Schema";
+import * as Str from "effect/String";
+
+const $I = $RepoCliId.create("test/coverage-turbo-inputs");
+
+const EXPECTED_COVERAGE_INPUTS: ReadonlyArray<string> = [
+  "package.json",
+  "src/**",
+  "test/**",
+  "tsconfig*.json",
+  "vitest.config.ts",
+  "$TURBO_ROOT$/vitest.aliases.generated.json",
+  "$TURBO_ROOT$/vitest.shared.ts",
+  "$TURBO_ROOT$/vitest.setup.ts",
+];
+
+class TurboTaskSummary extends S.Class<TurboTaskSummary>($I`TurboTaskSummary`)(
+  {
+    hash: S.String,
+    taskId: S.String,
+  },
+  $I.annote("TurboTaskSummary", {
+    description: "Task identity and input hash read from a Turbo run summary fixture.",
+  })
+) {}
+
+class TurboRunSummary extends S.Class<TurboRunSummary>($I`TurboRunSummary`)(
+  {
+    tasks: S.Array(TurboTaskSummary),
+  },
+  $I.annote("TurboRunSummary", {
+    description: "Subset of a Turbo run summary needed by the coverage input tripwire.",
+  })
+) {}
+
+const TurboConfiguration = S.Struct({
+  tasks: S.Struct({
+    coverage: S.Struct({
+      cache: S.Boolean,
+      inputs: S.Array(S.String),
+    }),
+  }),
+}).annotate(
+  $I.annote("TurboConfiguration", {
+    description: "Coverage input declaration decoded from the repository Turbo configuration.",
+  })
+);
+
+const decodeTurboConfiguration = S.decodeUnknownEffect(S.fromJsonString(TurboConfiguration));
+const decodeTurboRunSummary = S.decodeUnknownEffect(S.fromJsonString(TurboRunSummary));
+const encodeJson = S.encodeUnknownEffect(S.UnknownFromJsonString);
+
+const writeFixtureFile = Effect.fn("CoverageTurboInputsTest.writeFixtureFile")(function* (
+  root: string,
+  relativePath: string,
+  content: string
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const absolutePath = path.join(root, relativePath);
+
+  yield* fs.makeDirectory(path.dirname(absolutePath), { recursive: true });
+  yield* fs.writeFileString(absolutePath, content);
+});
+
+const writeFixtureJson = Effect.fn("CoverageTurboInputsTest.writeFixtureJson")(function* (
+  root: string,
+  relativePath: string,
+  document: unknown
+) {
+  yield* writeFixtureFile(root, relativePath, `${yield* encodeJson(document)}\n`);
+});
+
+const coverageHashFromSummary = Effect.fn("CoverageTurboInputsTest.coverageHashFromSummary")(function* (
+  root: string,
+  turboBinary: string
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const runsDirectory = path.join(root, ".turbo", "runs");
+
+  yield* fs.remove(runsDirectory, { recursive: true, force: true });
+  const run = Bun.spawnSync(
+    [turboBinary, "run", "coverage", "--filter=@fixture/coverage", "--cache=local:rw", "--summarize"],
+    {
+      cwd: root,
+      env: { ...process.env, TURBO_TELEMETRY_DISABLED: "1", TURBO_UI: "stream" },
+      stderr: "pipe",
+      stdout: "pipe",
+    }
+  );
+  expect(run.exitCode, `${run.stdout.toString()}\n${run.stderr.toString()}`).toBe(0);
+
+  const summaryFiles = pipe(yield* fs.readDirectory(runsDirectory), A.filter(Str.endsWith(".json")));
+  expect(summaryFiles).toHaveLength(1);
+
+  const summary = yield* decodeTurboRunSummary(
+    yield* fs.readFileString(path.join(runsDirectory, summaryFiles[0] ?? "missing-summary.json"))
+  );
+  const coverageTask = A.findFirst(summary.tasks, (task) => task.taskId === "@fixture/coverage#coverage");
+
+  expect(O.isSome(coverageTask)).toBe(true);
+  return pipe(
+    coverageTask,
+    O.map((task) => task.hash),
+    O.getOrElse(() => "missing-coverage-hash")
+  );
+});
+
+describe("coverage Turbo inputs", () => {
+  it.effect(
+    "keeps docs outside the package hash and invalidates source or test edits",
+    Effect.fnUntraced(
+      function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const repoRoot = yield* findRepoRoot();
+        const root = yield* fs.makeTempDirectoryScoped({ prefix: "coverage-turbo-inputs-" });
+        const turboBinary = path.join(repoRoot, "node_modules", ".bin", "turbo");
+        const turboConfiguration = yield* decodeTurboConfiguration(
+          yield* fs.readFileString(path.join(repoRoot, "turbo.json"))
+        );
+        const coverageTask = turboConfiguration.tasks.coverage;
+
+        expect(coverageTask.cache).toBe(false);
+        expect(coverageTask.inputs).toEqual(EXPECTED_COVERAGE_INPUTS);
+
+        yield* writeFixtureJson(root, "package.json", {
+          name: "coverage-turbo-input-fixture",
+          packageManager: "bun@1.4.0",
+          private: true,
+          workspaces: ["packages/*"],
+        });
+        yield* writeFixtureJson(root, "packages/coverage/package.json", {
+          name: "@fixture/coverage",
+          private: true,
+          scripts: { coverage: "echo coverage" },
+        });
+        yield* writeFixtureJson(root, "turbo.json", {
+          tasks: {
+            coverage: {
+              cache: coverageTask.cache,
+              inputs: coverageTask.inputs,
+            },
+          },
+        });
+        yield* writeFixtureJson(root, "vitest.aliases.generated.json", {});
+        yield* writeFixtureFile(root, "vitest.shared.ts", "export const shared = true;\n");
+        yield* writeFixtureFile(root, "vitest.setup.ts", "export const setup = true;\n");
+        yield* writeFixtureFile(root, "packages/coverage/src/index.ts", "export const value = 1;\n");
+        yield* writeFixtureFile(root, "packages/coverage/test/index.test.ts", "export const expected = 1;\n");
+        yield* writeFixtureFile(root, "packages/coverage/tsconfig.json", "{}\n");
+        yield* writeFixtureFile(root, "packages/coverage/vitest.config.ts", "export default {};\n");
+        yield* writeFixtureFile(root, "packages/coverage/README.md", "# Initial docs\n");
+
+        const baselineHash = yield* coverageHashFromSummary(root, turboBinary);
+
+        yield* writeFixtureFile(root, "packages/coverage/README.md", "# Docs-only edit\n");
+        expect(yield* coverageHashFromSummary(root, turboBinary)).toBe(baselineHash);
+
+        yield* writeFixtureFile(root, "packages/coverage/src/index.ts", "export const value = 2;\n");
+        expect(yield* coverageHashFromSummary(root, turboBinary)).not.toBe(baselineHash);
+
+        yield* writeFixtureFile(root, "packages/coverage/src/index.ts", "export const value = 1;\n");
+        expect(yield* coverageHashFromSummary(root, turboBinary)).toBe(baselineHash);
+
+        yield* writeFixtureFile(root, "packages/coverage/test/index.test.ts", "export const expected = 2;\n");
+        expect(yield* coverageHashFromSummary(root, turboBinary)).not.toBe(baselineHash);
+      },
+      Effect.scoped,
+      provideScopedLayer(NodeServices.layer)
+    )
+  );
+});

--- a/packages/tooling/tool/cli/test/coverage-turbo-inputs.test.ts
+++ b/packages/tooling/tool/cli/test/coverage-turbo-inputs.test.ts
@@ -13,7 +13,9 @@ const $I = $RepoCliId.create("test/coverage-turbo-inputs");
 
 const EXPECTED_COVERAGE_INPUTS: ReadonlyArray<string> = [
   "package.json",
+  "server/**",
   "src/**",
+  "src-tauri/**",
   "test/**",
   "tsconfig*.json",
   "vitest.config.ts",
@@ -156,7 +158,9 @@ describe("coverage Turbo inputs", () => {
         yield* writeFixtureJson(root, "vitest.aliases.generated.json", {});
         yield* writeFixtureFile(root, "vitest.shared.ts", "export const shared = true;\n");
         yield* writeFixtureFile(root, "vitest.setup.ts", "export const setup = true;\n");
+        yield* writeFixtureFile(root, "packages/coverage/server/index.ts", "export const serverValue = 1;\n");
         yield* writeFixtureFile(root, "packages/coverage/src/index.ts", "export const value = 1;\n");
+        yield* writeFixtureFile(root, "packages/coverage/src-tauri/src/lib.rs", "pub const VALUE: u8 = 1;\n");
         yield* writeFixtureFile(root, "packages/coverage/test/index.test.ts", "export const expected = 1;\n");
         yield* writeFixtureFile(root, "packages/coverage/tsconfig.json", "{}\n");
         yield* writeFixtureFile(root, "packages/coverage/vitest.config.ts", "export default {};\n");
@@ -181,6 +185,12 @@ describe("coverage Turbo inputs", () => {
         expect(yield* coverageHashFromSummary(root, turboBinary)).toBe(baselineHash);
 
         yield* writeFixtureFile(root, "packages/coverage/vitest.coverage.config.ts", "export default { test: {} };\n");
+        expect(yield* coverageHashFromSummary(root, turboBinary)).not.toBe(baselineHash);
+
+        yield* writeFixtureFile(root, "packages/coverage/vitest.coverage.config.ts", "export default {};\n");
+        expect(yield* coverageHashFromSummary(root, turboBinary)).toBe(baselineHash);
+
+        yield* writeFixtureFile(root, "packages/coverage/server/index.ts", "export const serverValue = 2;\n");
         expect(yield* coverageHashFromSummary(root, turboBinary)).not.toBe(baselineHash);
       },
       Effect.scoped,

--- a/packages/tooling/tool/cli/test/coverage-turbo-inputs.test.ts
+++ b/packages/tooling/tool/cli/test/coverage-turbo-inputs.test.ts
@@ -17,6 +17,7 @@ const EXPECTED_COVERAGE_INPUTS: ReadonlyArray<string> = [
   "test/**",
   "tsconfig*.json",
   "vitest.config.ts",
+  "vitest.coverage.config.ts",
   "$TURBO_ROOT$/vitest.aliases.generated.json",
   "$TURBO_ROOT$/vitest.shared.ts",
   "$TURBO_ROOT$/vitest.setup.ts",
@@ -159,6 +160,7 @@ describe("coverage Turbo inputs", () => {
         yield* writeFixtureFile(root, "packages/coverage/test/index.test.ts", "export const expected = 1;\n");
         yield* writeFixtureFile(root, "packages/coverage/tsconfig.json", "{}\n");
         yield* writeFixtureFile(root, "packages/coverage/vitest.config.ts", "export default {};\n");
+        yield* writeFixtureFile(root, "packages/coverage/vitest.coverage.config.ts", "export default {};\n");
         yield* writeFixtureFile(root, "packages/coverage/README.md", "# Initial docs\n");
 
         const baselineHash = yield* coverageHashFromSummary(root, turboBinary);
@@ -173,6 +175,12 @@ describe("coverage Turbo inputs", () => {
         expect(yield* coverageHashFromSummary(root, turboBinary)).toBe(baselineHash);
 
         yield* writeFixtureFile(root, "packages/coverage/test/index.test.ts", "export const expected = 2;\n");
+        expect(yield* coverageHashFromSummary(root, turboBinary)).not.toBe(baselineHash);
+
+        yield* writeFixtureFile(root, "packages/coverage/test/index.test.ts", "export const expected = 1;\n");
+        expect(yield* coverageHashFromSummary(root, turboBinary)).toBe(baselineHash);
+
+        yield* writeFixtureFile(root, "packages/coverage/vitest.coverage.config.ts", "export default { test: {} };\n");
         expect(yield* coverageHashFromSummary(root, turboBinary)).not.toBe(baselineHash);
       },
       Effect.scoped,

--- a/standards/turbo-remote-cache.md
+++ b/standards/turbo-remote-cache.md
@@ -110,6 +110,24 @@ those values. Those lanes are `cache: false` in `turbo.json`, so they lose no
 remote hits — and because the degradation rule applies to *every* unwrapped
 spawn, they never receive a remote posture they could not use anyway.
 
+### Reading coverage task hashes
+
+Coverage remains `cache: false`: its V8 output and ratchet result must be
+recomputed for the hosted-CI identity. Turbo still computes a task hash from
+the declared package inputs, root Vitest configuration, task definition,
+dependency graph, lockfile-derived dependency state, and declared environment.
+
+Run the lane with `--summarize`. Turbo writes one JSON document per invocation
+under `.turbo/runs/<run-id>.json`; the weighted coverage executor therefore
+writes a prebuild summary and one summary for each non-empty coverage shard.
+Read every summary created by that lane, select `tasks[]` entries whose
+`taskId` is `<package-name>#coverage`, and take that entry's `hash`. The run
+filename is an execution identifier, not an input digest. A later proof ledger
+can key each package fact by this `tasks[].hash` without enabling Turbo output
+caching. Hosted Coverage Regression already supplies `--summarize` through the
+shared `beep ci lane coverage` builder, and its workflow summary step reads all
+of the shard summaries with `beep ci append-turbo-summary --all`.
+
 ## Rules
 
 - Never put the trusted write token on a workstation. A read token that leaks

--- a/turbo.json
+++ b/turbo.json
@@ -197,6 +197,7 @@
         "test/**",
         "tsconfig*.json",
         "vitest.config.ts",
+        "vitest.coverage.config.ts",
         "$TURBO_ROOT$/vitest.aliases.generated.json",
         "$TURBO_ROOT$/vitest.shared.ts",
         "$TURBO_ROOT$/vitest.setup.ts"

--- a/turbo.json
+++ b/turbo.json
@@ -192,10 +192,14 @@
         "VITEST_COVERAGE_RATCHET"
       ],
       "inputs": [
-        "$TURBO_DEFAULT$",
+        "package.json",
+        "src/**",
+        "test/**",
+        "tsconfig*.json",
+        "vitest.config.ts",
+        "$TURBO_ROOT$/vitest.aliases.generated.json",
         "$TURBO_ROOT$/vitest.shared.ts",
-        "$TURBO_ROOT$/vitest.setup.ts",
-        "!.beep/**"
+        "$TURBO_ROOT$/vitest.setup.ts"
       ],
       "outputs": ["coverage/**"]
     },

--- a/turbo.json
+++ b/turbo.json
@@ -193,7 +193,9 @@
       ],
       "inputs": [
         "package.json",
+        "server/**",
         "src/**",
+        "src-tauri/**",
         "test/**",
         "tsconfig*.json",
         "vitest.config.ts",


### PR DESCRIPTION
## Summary

- declare the uncached per-package coverage task inputs precisely
- retain Turbo summaries as the source of each package coverage task hash
- prove docs-only stability and source/test invalidation with a real Turbo run

## Early proof

- focused coverage-input and CiLane suites: 52 tests passed
- Turbo 2.10.12 dry run: cache disabled, root Vitest inputs present, package README excluded
- hosted parity remains on the shared `beep ci lane coverage --summarize` builder

## Packet

Time-to-certainty C3, implementing decisions.md rulings 5 and 10. This PR does not enable proof
reuse and does not change coverage thresholds, baselines, execution topology, or ratchet semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791011534&installation_model_id=424656&pr_number=952&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F952&signature=21af951664e51511aaa811c3eff42e7782e86005f9ac9e62ca08e0029d387680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->