### PR TITLE
fix(repo-cli): isolate turbo cache reference resolution

### DIFF
--- a/packages/tooling/tool/cli/src/commands/Quality/Tasks.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/Tasks.ts
@@ -33,8 +33,10 @@ import {
   configStringOption,
   isUnresolvedSecretReference,
   readTurboCacheEnvironmentSync,
+  renderTurboEnvironmentHealthWarning,
   turboCacheSecretSessionEnvironment,
   turboEnvExtendsAmbient,
+  turboEnvironmentHealthWarnings,
   turboEnvOverrides,
 } from "../../internal/cli/EnvConfig.ts";
 import { isLabsWorkspacePath, LABS_TURBO_EXCLUDE_FILTER } from "../../internal/cli/Labs/index.ts";
@@ -1080,9 +1082,14 @@ const withTurboSecretSession = Effect.fn("QualityTasks.withTurboSecretSession")(
     return withoutUnusableRemoteCache(step, needsTurboSecretSession());
   }
 
+  const environmentWarnings = yield* turboEnvironmentHealthWarnings(step.cwd, Bun.env);
+  yield* Effect.forEach(environmentWarnings, flow(renderTurboEnvironmentHealthWarning, Console.warn), {
+    discard: true,
+  });
+
   // A missing, expired, or denied 1Password session degrades the lane to
   // local-only instead of failing it.
-  const canUseSecretSession = yield* canUseTurboCacheSecretSession(step.cwd);
+  const canUseSecretSession = yield* canUseTurboCacheSecretSession(step.cwd, Bun.env);
   if (!canUseSecretSession) {
     return withoutUnusableRemoteCache(step, needsTurboSecretSession());
   }

--- a/packages/tooling/tool/cli/src/internal/cli/EnvConfig.ts
+++ b/packages/tooling/tool/cli/src/internal/cli/EnvConfig.ts
@@ -238,7 +238,8 @@ export const booleanEnvValue: {
 });
 
 /**
- * Whether a value is an unresolved 1Password secret reference (`op://...`).
+ * Whether a value contains an unresolved 1Password secret reference
+ * (`op://...`).
  *
  * **Example** (Detect unresolved op references)
  *
@@ -246,16 +247,17 @@ export const booleanEnvValue: {
  * import { isUnresolvedSecretReference } from "@beep/repo-cli/internal/cli/EnvConfig"
  *
  * console.log(isUnresolvedSecretReference("op://vault/item/field"))
+ * console.log(isUnresolvedSecretReference("postgres://user:op://vault/item/password@host/db"))
  * console.log(isUnresolvedSecretReference("postgres://localhost"))
  * ```
  *
  * @param value - The candidate value.
- * @returns Whether the value is a still-unresolved `op://` reference.
+ * @returns Whether the value contains a still-unresolved `op://` reference.
  * @category configuration
  * @since 0.0.0
  */
 export const isUnresolvedSecretReference = (value: string | undefined): boolean =>
-  value !== undefined && Str.startsWith("op://")(value);
+  value !== undefined && Str.includes("op://")(value);
 
 const OP_RUN_ARGUMENT_SEPARATOR = "--";
 
@@ -289,22 +291,33 @@ const environmentWithoutSecretReferences = (
 ): Record<string, string> =>
   R.filter(environment, (value): value is string => value !== undefined && !isUnresolvedSecretReference(value));
 
-const ENV_FILE_SECRET_REFERENCE_ASSIGNMENT =
-  /^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*["']?(op:\/\/[^"'\s#]+)["']?\s*(?:#.*)?$/u;
+const ENV_FILE_ASSIGNMENT_NAME = /^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=/u;
 
-const envFileSecretReferenceEntry = (line: string): O.Option<readonly [string, string]> =>
+const envFileAssignmentName = (line: string): O.Option<string> =>
   pipe(
-    Str.match(ENV_FILE_SECRET_REFERENCE_ASSIGNMENT)(line),
-    O.flatMap((match) =>
-      pipe(
-        O.all({ variableName: O.fromUndefinedOr(match[1]), reference: O.fromUndefinedOr(match[2]) }),
-        O.map(({ reference, variableName }) => Tuple.make(variableName, reference))
+    Str.match(ENV_FILE_ASSIGNMENT_NAME)(line),
+    O.flatMap((match) => O.fromUndefinedOr(match[1]))
+  );
+
+const envFileSecretReferenceEntries = Effect.fn("EnvConfig.envFileSecretReferenceEntries")(function* (
+  contents: string
+) {
+  const provider = ConfigProvider.fromDotEnvContents(contents, { preserveEmptyStrings: true });
+  const variableNames = pipe(Str.split(contents, "\n"), A.map(envFileAssignmentName), A.getSomes, A.dedupe);
+  const entries = yield* Effect.forEach(variableNames, (variableName) =>
+    provider.load([variableName]).pipe(
+      Effect.orDie,
+      Effect.map((node) =>
+        O.fromUndefinedOr(node).pipe(
+          O.flatMap((loaded) => O.fromUndefinedOr(loaded.value)),
+          O.filter(isUnresolvedSecretReference),
+          O.map((value) => Tuple.make(variableName, value))
+        )
       )
     )
   );
-
-const envFileSecretReferenceEntries = (contents: string): ReadonlyArray<readonly [string, string]> =>
-  pipe(Str.split(contents, "\n"), A.map(envFileSecretReferenceEntry), A.getSomes);
+  return A.getSomes(entries);
+});
 
 /**
  * Remove unrelated `op://` references from a Turbo secret-session environment.
@@ -345,7 +358,7 @@ export const turboCacheSecretSessionEnvironment = (
 const secretReferenceProbe = Effect.fn("EnvConfig.secretReferenceProbe")(function* (
   repoRoot: string,
   environment: Record<string, string>,
-  args: ReadonlyArray<string> = ["run", "--", "/usr/bin/true"]
+  args: ReadonlyArray<string> = ["run", "--", "true"]
 ): Effect.fn.Return<boolean, never, ChildProcessSpawner.ChildProcessSpawner> {
   const exitCode = yield* runToExit({
     command: "op",
@@ -416,7 +429,7 @@ export const turboEnvironmentHealthWarnings = Effect.fn("EnvConfig.turboEnvironm
   }
 
   const contents = yield* fs.readFileString(envFilePath).pipe(Effect.orElseSucceed(() => ""));
-  const references = envFileSecretReferenceEntries(contents);
+  const references = yield* envFileSecretReferenceEntries(contents);
   if (A.isReadonlyArrayEmpty(references)) {
     const warnings = A.empty<TurboEnvironmentHealthWarning>();
     MutableHashMap.set(turboEnvironmentHealthVerdicts, repoRoot, warnings);
@@ -428,7 +441,7 @@ export const turboEnvironmentHealthWarnings = Effect.fn("EnvConfig.turboEnvironm
     "run",
     `--env-file=${envFilePath}`,
     "--",
-    "/usr/bin/true",
+    "true",
   ]);
   if (healthy) {
     const warnings = A.empty<TurboEnvironmentHealthWarning>();

--- a/packages/tooling/tool/cli/src/internal/cli/EnvConfig.ts
+++ b/packages/tooling/tool/cli/src/internal/cli/EnvConfig.ts
@@ -19,7 +19,7 @@
  */
 
 import * as O from "@beep/utils/Option";
-import { Config, ConfigProvider, Effect, flow, MutableHashMap, pipe } from "effect";
+import { Config, ConfigProvider, Effect, FileSystem, flow, MutableHashMap, Path, pipe, Tuple } from "effect";
 import * as A from "effect/Array";
 import { dual } from "effect/Function";
 import * as R from "effect/Record";
@@ -31,6 +31,7 @@ import {
   TurboCacheEnvName,
   TurboCacheMode,
   TurboCacheSecretEnvName,
+  TurboEnvironmentHealthWarning,
   turboCacheValueSourceFor,
 } from "./TurboCache.ts";
 import type { ChildProcessSpawner } from "effect/unstable/process";
@@ -283,6 +284,28 @@ const isOpRunTurbo = (command: string, args: ReadonlyArray<string>): boolean =>
 
 const isTurboCacheSecretEnvName = S.is(TurboCacheSecretEnvName);
 
+const environmentWithoutSecretReferences = (
+  environment: Readonly<Record<string, string | undefined>>
+): Record<string, string> =>
+  R.filter(environment, (value): value is string => value !== undefined && !isUnresolvedSecretReference(value));
+
+const ENV_FILE_SECRET_REFERENCE_ASSIGNMENT =
+  /^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*["']?(op:\/\/[^"'\s#]+)["']?\s*(?:#.*)?$/u;
+
+const envFileSecretReferenceEntry = (line: string): O.Option<readonly [string, string]> =>
+  pipe(
+    Str.match(ENV_FILE_SECRET_REFERENCE_ASSIGNMENT)(line),
+    O.flatMap((match) =>
+      pipe(
+        O.all({ variableName: O.fromUndefinedOr(match[1]), reference: O.fromUndefinedOr(match[2]) }),
+        O.map(({ reference, variableName }) => Tuple.make(variableName, reference))
+      )
+    )
+  );
+
+const envFileSecretReferenceEntries = (contents: string): ReadonlyArray<readonly [string, string]> =>
+  pipe(Str.split(contents, "\n"), A.map(envFileSecretReferenceEntry), A.getSomes);
+
 /**
  * Remove unrelated `op://` references from a Turbo secret-session environment.
  *
@@ -318,6 +341,143 @@ export const turboCacheSecretSessionEnvironment = (
     (value, name): value is string =>
       value !== undefined && (!isUnresolvedSecretReference(value) || isTurboCacheSecretEnvName(name))
   );
+
+const secretReferenceProbe = Effect.fn("EnvConfig.secretReferenceProbe")(function* (
+  repoRoot: string,
+  environment: Record<string, string>,
+  args: ReadonlyArray<string> = ["run", "--", "/usr/bin/true"]
+): Effect.fn.Return<boolean, never, ChildProcessSpawner.ChildProcessSpawner> {
+  const exitCode = yield* runToExit({
+    command: "op",
+    args,
+    cwd: repoRoot,
+    env: environment,
+    extendEnv: false,
+    stdio: "ignore",
+  }).pipe(Effect.orElseSucceed(() => 1));
+  return exitCode === 0;
+});
+
+const turboEnvironmentHealthVerdicts = MutableHashMap.empty<string, ReadonlyArray<TurboEnvironmentHealthWarning>>();
+
+/**
+ * Check every 1Password reference in the checkout `.env` without exposing its
+ * reference or resolved value.
+ *
+ * **Details**
+ *
+ * The first output-suppressed probe runs the exact whole-file `op run` health
+ * check. On a failure, each reference assignment parsed from that file is
+ * retried in isolation so the returned warning can name the failing variable
+ * without carrying its value. Results are cached by repository root for the
+ * life of the CLI process. A checkout without `.env` has no warnings.
+ *
+ * This diagnostic is independent of cache readiness. A warning for an
+ * unrelated variable never changes the Turbo cache plan.
+ *
+ * **Example** (Build an environment-health check)
+ *
+ * ```ts
+ * import { turboEnvironmentHealthWarnings } from "@beep/repo-cli/test/SharedInternals"
+ * import { Effect } from "effect"
+ *
+ * const check = turboEnvironmentHealthWarnings("/repo", {
+ *   TURBO_TOKEN: "op://fixture-vault/turbo/token",
+ *   STALE_SERVICE_TOKEN: "op://fixture-vault/service/missing"
+ * })
+ * console.log(Effect.isEffect(check))
+ * ```
+ *
+ * @param repoRoot - Working directory used for the 1Password probes.
+ * @param environment - Ambient environment used only for non-reference process configuration.
+ * @returns Named warnings for references that cannot be resolved.
+ * @category diagnostics
+ * @since 0.0.0
+ */
+export const turboEnvironmentHealthWarnings = Effect.fn("EnvConfig.turboEnvironmentHealthWarnings")(function* (
+  repoRoot: string,
+  environment: Readonly<Record<string, string | undefined>>
+): Effect.fn.Return<
+  ReadonlyArray<TurboEnvironmentHealthWarning>,
+  never,
+  FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+> {
+  const cached = MutableHashMap.get(turboEnvironmentHealthVerdicts, repoRoot);
+  if (O.isSome(cached)) return cached.value;
+
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const envFilePath = path.join(repoRoot, ".env");
+  const envFileExists = yield* fs.exists(envFilePath).pipe(Effect.orElseSucceed(() => false));
+  if (!envFileExists) {
+    const warnings = A.empty<TurboEnvironmentHealthWarning>();
+    MutableHashMap.set(turboEnvironmentHealthVerdicts, repoRoot, warnings);
+    return warnings;
+  }
+
+  const contents = yield* fs.readFileString(envFilePath).pipe(Effect.orElseSucceed(() => ""));
+  const references = envFileSecretReferenceEntries(contents);
+  if (A.isReadonlyArrayEmpty(references)) {
+    const warnings = A.empty<TurboEnvironmentHealthWarning>();
+    MutableHashMap.set(turboEnvironmentHealthVerdicts, repoRoot, warnings);
+    return warnings;
+  }
+
+  const secretFreeEnvironment = environmentWithoutSecretReferences(environment);
+  const healthy = yield* secretReferenceProbe(repoRoot, secretFreeEnvironment, [
+    "run",
+    `--env-file=${envFilePath}`,
+    "--",
+    "/usr/bin/true",
+  ]);
+  if (healthy) {
+    const warnings = A.empty<TurboEnvironmentHealthWarning>();
+    MutableHashMap.set(turboEnvironmentHealthVerdicts, repoRoot, warnings);
+    return warnings;
+  }
+
+  const isolated = yield* Effect.forEach(
+    references,
+    ([variableName, reference]) =>
+      secretReferenceProbe(repoRoot, { ...secretFreeEnvironment, [variableName]: reference }).pipe(
+        Effect.map((usable) => (usable ? O.none() : O.some(TurboEnvironmentHealthWarning.make({ variableName }))))
+      ),
+    { concurrency: 4 }
+  );
+  const warnings = A.getSomes(isolated);
+  MutableHashMap.set(turboEnvironmentHealthVerdicts, repoRoot, warnings);
+  return warnings;
+});
+
+/**
+ * Render one value-suppressed environment-health warning for plan output.
+ *
+ * **Details**
+ *
+ * Only the failing variable name is interpolated. The cache quad is called out
+ * explicitly so operators know an unrelated warning did not disable remote
+ * reads.
+ *
+ * **Example** (Render a named warning)
+ *
+ * ```ts
+ * import {
+ *   renderTurboEnvironmentHealthWarning,
+ *   TurboEnvironmentHealthWarning
+ * } from "@beep/repo-cli/test/SharedInternals"
+ *
+ * const warning = TurboEnvironmentHealthWarning.make({ variableName: "STALE_SERVICE_TOKEN" })
+ * console.log(renderTurboEnvironmentHealthWarning(warning))
+ * ```
+ *
+ * @param warning - Named reference-resolution warning.
+ * @returns A warning line that contains no reference or resolved value.
+ * @category formatting
+ * @since 0.0.0
+ */
+export const renderTurboEnvironmentHealthWarning = (warning: TurboEnvironmentHealthWarning): string =>
+  `[beep-cli] turbo cache plan warning: ${warning.variableName} has an unavailable 1Password reference; ` +
+  "cache readiness uses only TURBO_API, TURBO_TOKEN, TURBO_TEAM, and TURBO_CACHE";
 
 /**
  * Decide whether a Turbo spawn may inherit the ambient process environment.
@@ -511,6 +671,7 @@ const turboSecretSessionVerdicts = MutableHashMap.empty<string, boolean>();
 /** Clear process-local Turbo secret-session probes for isolated tests. */
 export const clearTurboCacheSecretSessionVerdictsForTesting = (): void => {
   MutableHashMap.clear(turboSecretSessionVerdicts);
+  MutableHashMap.clear(turboEnvironmentHealthVerdicts);
 };
 
 /**
@@ -518,9 +679,11 @@ export const clearTurboCacheSecretSessionVerdictsForTesting = (): void => {
  *
  * **Details**
  *
- * Returns `false` under CI or when `op whoami` does not succeed. The caller has
- * already established that the ambient Turbo configuration contains an
- * unresolved reference.
+ * Returns `false` under CI or when the cache quad cannot resolve in an
+ * output-suppressed `op run`. The probe receives an explicit environment where
+ * unresolved references survive only for the Turbo cache credentials, so an
+ * unrelated stale reference cannot disable remote reads. The caller has already
+ * established that the Turbo configuration contains an unresolved reference.
  *
  * **Example** (Check local env Effect)
  *
@@ -531,13 +694,15 @@ export const clearTurboCacheSecretSessionVerdictsForTesting = (): void => {
  * console.log(Effect.isEffect(canUseTurboCacheSecretSession("/repo")))
  * ```
  *
- * @param repoRoot - Working directory used for the 1Password identity check.
+ * @param repoRoot - Working directory used for the 1Password reference check.
+ * @param environment - Loaded checkout environment; defaults to the current process environment.
  * @returns Whether local 1Password reference resolution is available.
  * @category execution
  * @since 0.0.0
  */
 export const canUseTurboCacheSecretSession = Effect.fn("EnvConfig.canUseTurboCacheSecretSession")(function* (
-  repoRoot: string
+  repoRoot: string,
+  environment: Readonly<Record<string, string | undefined>> = Bun.env
 ): Effect.fn.Return<boolean, never, ChildProcessSpawner.ChildProcessSpawner> {
   const ci = yield* configStringOption("CI");
   if (
@@ -553,25 +718,7 @@ export const canUseTurboCacheSecretSession = Effect.fn("EnvConfig.canUseTurboCac
   const cached = MutableHashMap.get(turboSecretSessionVerdicts, cacheKey);
   if (O.isSome(cached)) return cached.value;
 
-  const whoamiExitCode = yield* runToExit({ command: "op", args: ["whoami"], cwd: repoRoot, stdio: "ignore" }).pipe(
-    Effect.orElseSucceed(() => 1)
-  );
-  if (whoamiExitCode !== 0) {
-    MutableHashMap.set(turboSecretSessionVerdicts, cacheKey, false);
-    return false;
-  }
-
-  // `op whoami` proves only that the desktop/CLI session is alive. Resolve
-  // every `op://` value in the environment through a no-output child so a
-  // stale item or field reference degrades the lane before the real Turbo
-  // command is wrapped. No resolved value is printed or returned.
-  const referenceProbeExitCode = yield* runToExit({
-    command: "op",
-    args: ["run", "--", "/usr/bin/true"],
-    cwd: repoRoot,
-    stdio: "ignore",
-  }).pipe(Effect.orElseSucceed(() => 1));
-  const usable = referenceProbeExitCode === 0;
+  const usable = yield* secretReferenceProbe(repoRoot, turboCacheSecretSessionEnvironment(environment));
   MutableHashMap.set(turboSecretSessionVerdicts, cacheKey, usable);
   return usable;
 });

--- a/packages/tooling/tool/cli/src/internal/cli/TurboCache.ts
+++ b/packages/tooling/tool/cli/src/internal/cli/TurboCache.ts
@@ -99,6 +99,52 @@ export const TurboCacheEnvName = LiteralKit(["TURBO_API", "TURBO_TOKEN", "TURBO_
  */
 export type TurboCacheEnvName = typeof TurboCacheEnvName.Type;
 
+const TurboEnvironmentVariableName = S.String.check(
+  S.isPattern(/^[A-Za-z_][A-Za-z0-9_]*$/u, {
+    identifier: $I`TurboEnvironmentVariableNamePatternCheck`,
+    title: "Environment Variable Name Pattern",
+    description: "Environment variable names use a portable shell identifier form.",
+    message: "Expected an environment variable name matching ^[A-Za-z_][A-Za-z0-9_]*$",
+  })
+).pipe(
+  $I.annoteSchema("TurboEnvironmentVariableName", {
+    description: "A portable shell environment variable name.",
+  })
+);
+
+/**
+ * A checkout `.env` variable whose 1Password reference failed the separate
+ * environment-health check.
+ *
+ * **Details**
+ *
+ * The warning deliberately carries only the variable name. The unresolved
+ * reference and any resolved value stay inside the value-suppressed probe and
+ * can never reach plan output through this model.
+ *
+ * **Example** (Name an unhealthy environment variable)
+ *
+ * ```ts
+ * import { TurboEnvironmentHealthWarning } from "@beep/repo-cli/test/SharedInternals"
+ *
+ * const warning = TurboEnvironmentHealthWarning.make({ variableName: "STALE_SERVICE_TOKEN" })
+ * console.log(warning.variableName)
+ * ```
+ *
+ * @category diagnostics
+ * @since 0.0.0
+ */
+export class TurboEnvironmentHealthWarning extends S.Class<TurboEnvironmentHealthWarning>(
+  $I`TurboEnvironmentHealthWarning`
+)(
+  {
+    variableName: TurboEnvironmentVariableName,
+  },
+  $I.annote("TurboEnvironmentHealthWarning", {
+    description: "A checkout .env variable whose 1Password reference failed a value-suppressed health check.",
+  })
+) {}
+
 /**
  * Environment overrides that reduce any checkout to the hosted pull-request
  * cache posture: every credential scrubbed, cache pinned local-only.
@@ -566,6 +612,10 @@ const requestedTurboCacheMode = (environment: TurboCacheEnvironment): O.Option<T
  * anything else — a missing quad member, a blank value, or any other posture
  * including a remote *write* posture, which no workstation is credentialed for
  * — resolves to local-only.
+ *
+ * Only the four {@link TurboCacheEnvName} entries participate in this decision.
+ * Unrelated reference failures belong to the separate environment-health check:
+ * they are rendered as named warnings and never downgrade a healthy cache quad.
  *
  * **Gotchas**
  *

--- a/packages/tooling/tool/cli/test/shared-internals.test.ts
+++ b/packages/tooling/tool/cli/test/shared-internals.test.ts
@@ -643,6 +643,59 @@ describe("canUseTurboCacheSecretSession", () => {
   );
 
   it.effect(
+    "keeps environment-health file fallbacks and healthy references non-blocking",
+    Effect.fnUntraced(function* () {
+      const fileSystemError = (method: string, pathOrDescriptor: string) =>
+        PlatformError.systemError({
+          _tag: "PermissionDenied",
+          module: "FileSystem",
+          method,
+          pathOrDescriptor,
+          description: "fixture denied",
+        });
+      const spawner = ChildProcessSpawner.make(() => Effect.succeed(stubHandle(0)));
+      const warningsWith = (repoRoot: string, fileSystemLayer: Layer.Layer<FileSystem.FileSystem>) =>
+        provideScopedLayer(Layer.merge(fileSystemLayer, Path.layer))(turboEnvironmentHealthWarnings(repoRoot, {})).pipe(
+          Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner)
+        );
+
+      clearTurboCacheSecretSessionVerdictsForTesting();
+      const existsFailure = yield* warningsWith(
+        "/repo/exists-failure",
+        FileSystem.layerNoop({
+          exists: (target) => Effect.fail(fileSystemError("exists", target)),
+        })
+      );
+      const readFailure = yield* warningsWith(
+        "/repo/read-failure",
+        FileSystem.layerNoop({
+          exists: () => Effect.succeed(true),
+          readFileString: (target) => Effect.fail(fileSystemError("readFileString", target)),
+        })
+      );
+      const referenceFree = yield* warningsWith(
+        "/repo/reference-free",
+        FileSystem.layerNoop({
+          exists: () => Effect.succeed(true),
+          readFileString: () => Effect.succeed("PLAIN_VALUE=fixture\n# no secret references"),
+        })
+      );
+      const healthy = yield* warningsWith(
+        "/repo/healthy-reference",
+        FileSystem.layerNoop({
+          exists: () => Effect.succeed(true),
+          readFileString: () => Effect.succeed("SERVICE_TOKEN=op://fixture-vault/service/token"),
+        })
+      );
+
+      expect(existsFailure).toEqual([]);
+      expect(readFailure).toEqual([]);
+      expect(referenceFree).toEqual([]);
+      expect(healthy).toEqual([]);
+    })
+  );
+
+  it.effect(
     "fails closed when a cache-quad reference is broken",
     Effect.fnUntraced(function* () {
       const brokenReference = "op://fixture-vault/turbo/missing-token";

--- a/packages/tooling/tool/cli/test/shared-internals.test.ts
+++ b/packages/tooling/tool/cli/test/shared-internals.test.ts
@@ -280,6 +280,7 @@ describe("EnvConfig readers", () => {
 
   it("classifies unresolved op:// secret references", () => {
     expect(isUnresolvedSecretReference("op://vault/item/field")).toBe(true);
+    expect(isUnresolvedSecretReference("postgres://user:op://vault/item/password@host/db")).toBe(true);
     expect(isUnresolvedSecretReference("postgres://localhost")).toBe(false);
     expect(isUnresolvedSecretReference(undefined)).toBe(false);
   });
@@ -413,6 +414,7 @@ describe("turboEnvOverrides", () => {
       TURBO_TEAM: "op://fixture-vault/turbo/team",
       TURBO_CACHE: REMOTE_READ,
       UNRELATED_SECRET: "op://fixture-vault/unrelated/secret",
+      UNRELATED_DATABASE_URL: "postgres://user:op://fixture-vault/database/password@db.test/database",
     };
     const sanitized = {
       PATH: "/fixture/bin",
@@ -577,13 +579,13 @@ describe("canUseTurboCacheSecretSession", () => {
   it.effect(
     "keeps a correct cache quad remote when an unrelated reference is stale",
     Effect.fnUntraced(function* () {
-      const staleReference = "op://fixture-vault/unrelated/missing";
+      const staleReference = "postgres://user:op://fixture-vault/unrelated/missing@db.test/database";
       const environment = {
         TURBO_API: "https://cache.example.test",
         TURBO_TOKEN: "op://fixture-vault/turbo/token",
         TURBO_TEAM: "fixture-team",
         TURBO_CACHE: TurboCacheMode.Enum.LocalWriteRemoteRead,
-        STALE_SERVICE_TOKEN: staleReference,
+        STALE_DATABASE_URL: staleReference,
       };
       const envFileFixture = A.join(
         [
@@ -591,7 +593,7 @@ describe("canUseTurboCacheSecretSession", () => {
           `TURBO_TOKEN=${environment.TURBO_TOKEN}`,
           `TURBO_TEAM=${environment.TURBO_TEAM}`,
           `TURBO_CACHE=${environment.TURBO_CACHE}`,
-          `STALE_SERVICE_TOKEN=${staleReference}`,
+          `STALE_DATABASE_URL=${staleReference}`,
         ],
         "\n"
       );
@@ -599,16 +601,22 @@ describe("canUseTurboCacheSecretSession", () => {
         exists: () => Effect.succeed(true),
         readFileString: () => Effect.succeed(envFileFixture),
       });
-      const spawnedEnvironments = yield* Ref.make<ReadonlyArray<Record<string, string | undefined>>>([]);
+      const spawnedCommands = yield* Ref.make<
+        ReadonlyArray<{
+          readonly args: ReadonlyArray<string>;
+          readonly environment: Record<string, string | undefined>;
+        }>
+      >([]);
       const spawner = ChildProcessSpawner.make((command) => {
         if (!ChildProcess.isStandardCommand(command)) {
           return Effect.die("the cache reference fixture never spawns a piped command");
         }
         const childEnvironment = command.options.env ?? {};
         const fails =
-          A.some(command.args, Str.startsWith("--env-file=")) ||
-          childEnvironment.STALE_SERVICE_TOKEN === staleReference;
-        return Ref.update(spawnedEnvironments, A.append(childEnvironment)).pipe(Effect.as(stubHandle(fails ? 1 : 0)));
+          A.some(command.args, Str.startsWith("--env-file=")) || childEnvironment.STALE_DATABASE_URL === staleReference;
+        return Ref.update(spawnedCommands, A.append({ args: command.args, environment: childEnvironment })).pipe(
+          Effect.as(stubHandle(fails ? 1 : 0))
+        );
       });
 
       clearTurboCacheSecretSessionVerdictsForTesting();
@@ -631,14 +639,19 @@ describe("canUseTurboCacheSecretSession", () => {
       );
       expect(result.usable).toBe(true);
       expect(turboCachePlanArgs(result.plan)).toEqual(["--cache=local:rw,remote:r"]);
-      expect(A.map(result.warnings, (warning) => warning.variableName)).toEqual(["STALE_SERVICE_TOKEN"]);
+      expect(A.map(result.warnings, (warning) => warning.variableName)).toEqual(["STALE_DATABASE_URL"]);
       const warningText = renderTurboEnvironmentHealthWarning(A.head(result.warnings).pipe(O.getOrThrow));
-      expect(warningText).toContain("STALE_SERVICE_TOKEN");
+      expect(warningText).toContain("STALE_DATABASE_URL");
       expect(warningText).not.toContain(staleReference);
 
-      const spawned = yield* Ref.get(spawnedEnvironments);
-      expect(spawned[0]?.STALE_SERVICE_TOKEN).toBeUndefined();
-      expect(spawned[0]?.TURBO_TOKEN).toBe(environment.TURBO_TOKEN);
+      const spawned = yield* Ref.get(spawnedCommands);
+      expect(spawned[0]?.args).toEqual(["run", "--", "true"]);
+      expect(spawned[0]?.environment.STALE_DATABASE_URL).toBeUndefined();
+      expect(spawned[0]?.environment.TURBO_TOKEN).toBe(environment.TURBO_TOKEN);
+      const wholeFileProbe = A.findFirst(spawned, ({ args }) => A.some(args, Str.startsWith("--env-file="))).pipe(
+        O.getOrThrow
+      );
+      expect(wholeFileProbe.args).toEqual(["run", "--env-file=/repo/correct-quad/.env", "--", "true"]);
     })
   );
 

--- a/packages/tooling/tool/cli/test/shared-internals.test.ts
+++ b/packages/tooling/tool/cli/test/shared-internals.test.ts
@@ -34,25 +34,34 @@ import {
   isUnresolvedSecretReference,
   JsonStringCodec,
   jsonText,
+  localOnlyTurboCacheArgs,
   nextCursor,
+  RemoteReadTurboCache,
   readOptionalConfigString,
   readOptionalRedactedConfigString,
   readTurboCacheEnvironment,
   renderSchemaFirstPolicyFindingLine,
+  renderTurboEnvironmentHealthWarning,
+  resolveTurboCachePlan,
   SchemaFirstPolicyFinding,
   SchemaFirstPolicyIssuePrefix,
   SchemaFirstPolicySeverity,
   TurboCacheEnvironment,
+  TurboCacheMode,
+  turboCachePlanArgs,
   turboCacheSecretSessionEnvironment,
   turboEnvExtendsAmbient,
+  turboEnvironmentHealthWarnings,
   turboEnvOverrides,
 } from "@beep/repo-cli/test/SharedInternals";
 import { describe, expect, it } from "@effect/vitest";
-import { ConfigProvider, Data, Effect, Layer, Redacted, Ref, Sink, Stream } from "effect";
+import { ConfigProvider, Data, Effect, FileSystem, Layer, Path, Redacted, Ref, Sink, Stream } from "effect";
+import * as A from "effect/Array";
 import * as O from "effect/Option";
 import * as PlatformError from "effect/PlatformError";
 import * as S from "effect/Schema";
-import { ChildProcessSpawner } from "effect/unstable/process";
+import * as Str from "effect/String";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 const provideScopedLayer =
   <ROut, E2, RIn>(layer: Layer.Layer<ROut, E2, RIn>) =>
@@ -524,7 +533,7 @@ describe("canUseTurboCacheSecretSession", () => {
       ).pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
       expect(yield* probe).toBe(true);
       expect(yield* probe).toBe(true);
-      expect(yield* Ref.get(spawned)).toBe(2);
+      expect(yield* Ref.get(spawned)).toBe(1);
     })
   );
 
@@ -539,15 +548,15 @@ describe("canUseTurboCacheSecretSession", () => {
   );
 
   it.effect(
-    "requires both a live session and resolvable secret references",
+    "requires the cache references to resolve",
     Effect.fnUntraced(function* () {
-      expect(yield* sessionWith({}, [Effect.succeed(stubHandle(0)), Effect.succeed(stubHandle(0))])).toEqual({
+      expect(yield* sessionWith({}, [Effect.succeed(stubHandle(0))])).toEqual({
         usable: true,
-        spawned: 2,
+        spawned: 1,
       });
-      expect(yield* sessionWith({}, [Effect.succeed(stubHandle(0)), Effect.succeed(stubHandle(1))])).toEqual({
+      expect(yield* sessionWith({}, [Effect.succeed(stubHandle(1))])).toEqual({
         usable: false,
-        spawned: 2,
+        spawned: 1,
       });
       expect(yield* sessionWith({ CI: "false" }, [Effect.succeed(stubHandle(1))])).toEqual({
         usable: false,
@@ -558,10 +567,112 @@ describe("canUseTurboCacheSecretSession", () => {
         method: "spawn",
         description: "reference probe failed",
       });
-      expect(yield* sessionWith({}, [Effect.succeed(stubHandle(0)), Effect.fail(probeFailure)])).toEqual({
+      expect(yield* sessionWith({}, [Effect.fail(probeFailure)])).toEqual({
         usable: false,
-        spawned: 2,
+        spawned: 1,
       });
+    })
+  );
+
+  it.effect(
+    "keeps a correct cache quad remote when an unrelated reference is stale",
+    Effect.fnUntraced(function* () {
+      const staleReference = "op://fixture-vault/unrelated/missing";
+      const environment = {
+        TURBO_API: "https://cache.example.test",
+        TURBO_TOKEN: "op://fixture-vault/turbo/token",
+        TURBO_TEAM: "fixture-team",
+        TURBO_CACHE: TurboCacheMode.Enum.LocalWriteRemoteRead,
+        STALE_SERVICE_TOKEN: staleReference,
+      };
+      const envFileFixture = A.join(
+        [
+          `TURBO_API=${environment.TURBO_API}`,
+          `TURBO_TOKEN=${environment.TURBO_TOKEN}`,
+          `TURBO_TEAM=${environment.TURBO_TEAM}`,
+          `TURBO_CACHE=${environment.TURBO_CACHE}`,
+          `STALE_SERVICE_TOKEN=${staleReference}`,
+        ],
+        "\n"
+      );
+      const fileSystemLayer = FileSystem.layerNoop({
+        exists: () => Effect.succeed(true),
+        readFileString: () => Effect.succeed(envFileFixture),
+      });
+      const spawnedEnvironments = yield* Ref.make<ReadonlyArray<Record<string, string | undefined>>>([]);
+      const spawner = ChildProcessSpawner.make((command) => {
+        if (!ChildProcess.isStandardCommand(command)) {
+          return Effect.die("the cache reference fixture never spawns a piped command");
+        }
+        const childEnvironment = command.options.env ?? {};
+        const fails =
+          A.some(command.args, Str.startsWith("--env-file=")) ||
+          childEnvironment.STALE_SERVICE_TOKEN === staleReference;
+        return Ref.update(spawnedEnvironments, A.append(childEnvironment)).pipe(Effect.as(stubHandle(fails ? 1 : 0)));
+      });
+
+      clearTurboCacheSecretSessionVerdictsForTesting();
+      const result = yield* provideScopedLayer(
+        Layer.mergeAll(ConfigProvider.layer(ConfigProvider.fromUnknown(environment)), fileSystemLayer, Path.layer)
+      )(
+        Effect.gen(function* () {
+          const plan = resolveTurboCachePlan(readTurboCacheEnvironment(environment), { args: [], ci: false });
+          const usable = yield* canUseTurboCacheSecretSession("/repo/correct-quad", environment);
+          const warnings = yield* turboEnvironmentHealthWarnings("/repo/correct-quad", environment);
+          return { plan, usable, warnings };
+        })
+      ).pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+
+      expect(result.plan).toEqual(
+        RemoteReadTurboCache.make({
+          mode: TurboCacheMode.Enum.LocalWriteRemoteRead,
+          requiresSecretSession: true,
+        })
+      );
+      expect(result.usable).toBe(true);
+      expect(turboCachePlanArgs(result.plan)).toEqual(["--cache=local:rw,remote:r"]);
+      expect(A.map(result.warnings, (warning) => warning.variableName)).toEqual(["STALE_SERVICE_TOKEN"]);
+      const warningText = renderTurboEnvironmentHealthWarning(O.getOrThrow(A.head(result.warnings)));
+      expect(warningText).toContain("STALE_SERVICE_TOKEN");
+      expect(warningText).not.toContain(staleReference);
+
+      const spawned = yield* Ref.get(spawnedEnvironments);
+      expect(spawned[0]?.STALE_SERVICE_TOKEN).toBeUndefined();
+      expect(spawned[0]?.TURBO_TOKEN).toBe(environment.TURBO_TOKEN);
+    })
+  );
+
+  it.effect(
+    "fails closed when a cache-quad reference is broken",
+    Effect.fnUntraced(function* () {
+      const brokenReference = "op://fixture-vault/turbo/missing-token";
+      const environment = {
+        TURBO_API: "https://cache.example.test",
+        TURBO_TOKEN: brokenReference,
+        TURBO_TEAM: "fixture-team",
+        TURBO_CACHE: TurboCacheMode.Enum.LocalWriteRemoteRead,
+      };
+      const spawner = ChildProcessSpawner.make((command) => {
+        if (!ChildProcess.isStandardCommand(command)) {
+          return Effect.die("the cache reference fixture never spawns a piped command");
+        }
+        return Effect.succeed(stubHandle(command.options.env?.TURBO_TOKEN === brokenReference ? 1 : 0));
+      });
+
+      clearTurboCacheSecretSessionVerdictsForTesting();
+      const result = yield* provideScopedLayer(ConfigProvider.layer(ConfigProvider.fromUnknown(environment)))(
+        Effect.gen(function* () {
+          const plan = resolveTurboCachePlan(readTurboCacheEnvironment(environment), { args: [], ci: false });
+          const usable = yield* canUseTurboCacheSecretSession("/repo/broken-quad", environment);
+          return { plan, usable };
+        })
+      ).pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+
+      expect(result.plan._tag).toBe("remote-read");
+      expect(result.usable).toBe(false);
+      expect(
+        result.usable ? turboCachePlanArgs(result.plan) : localOnlyTurboCacheArgs(turboCachePlanArgs(result.plan))
+      ).toEqual(["--cache=local:rw"]);
     })
   );
 

--- a/packages/tooling/tool/cli/test/shared-internals.test.ts
+++ b/packages/tooling/tool/cli/test/shared-internals.test.ts
@@ -632,7 +632,7 @@ describe("canUseTurboCacheSecretSession", () => {
       expect(result.usable).toBe(true);
       expect(turboCachePlanArgs(result.plan)).toEqual(["--cache=local:rw,remote:r"]);
       expect(A.map(result.warnings, (warning) => warning.variableName)).toEqual(["STALE_SERVICE_TOKEN"]);
-      const warningText = renderTurboEnvironmentHealthWarning(O.getOrThrow(A.head(result.warnings)));
+      const warningText = renderTurboEnvironmentHealthWarning(A.head(result.warnings).pipe(O.getOrThrow));
       expect(warningText).toContain("STALE_SERVICE_TOKEN");
       expect(warningText).not.toContain(staleReference);
 

--- a/standards/turbo-remote-cache.md
+++ b/standards/turbo-remote-cache.md
@@ -22,9 +22,9 @@ TURBO_CACHE=local:rw,remote:r
 ```
 
 `TURBO_TOKEN` is a **1Password secret reference to the read-only token**, not a
-value. It stays a reference on disk; `op run --env-file=.env` resolves it when
-the lane spawns. The read-only token itself lives in the SSM parameter the
-`CiTurboCache` stack is configured with
+value. It stays a reference on disk; the CLI passes only the cache quad to
+`op run` when the lane spawns. The read-only token itself lives in the SSM
+parameter the `CiTurboCache` stack is configured with
 (`readOnlyTokenSsmParameterArn` in `infra/ci-runners/Pulumi.production.yaml`);
 mirror it into 1Password once and reference it from every checkout. `TURBO_API`
 and `TURBO_TEAM` are the same values CI uses (`gh variable list`).
@@ -89,13 +89,25 @@ covered by `packages/tooling/tool/cli/test/turbo-cache.test.ts`:
 | Any quad member missing or blank | `--cache=local:rw` |
 | Quad complete, any other posture (including `remote:rw`) | `--cache=local:rw` |
 
-A remote-read plan whose values are still `op://` references probes each
-reference once per CLI process and runs the lane under `op run` only when every
-reference resolves. A missing, expired, or denied 1Password session degrades to
-`--cache=local:rw` and keeps going — a cache credential never blocks quality
-work. The same fail-closed rule applies in the environment: on a *direct* turbo
-spawn, scrubbing an unresolved credential also pins `TURBO_CACHE` to local-only,
-so turbo is never asked to read a remote cache it cannot authenticate to.
+A remote-read plan whose values are still `op://` references probes the cache
+credential references once per CLI process and runs the lane under `op run`
+only when the quad resolves. The resolver receives an explicit environment
+where unresolved references survive only for `TURBO_API`, `TURBO_TOKEN`, and
+`TURBO_TEAM`; an unrelated stale reference cannot disable remote reads. A
+missing, expired, or denied cache reference degrades to `--cache=local:rw` and
+keeps going — a cache credential never blocks quality work. The same
+fail-closed rule applies in the environment: on a *direct* turbo spawn,
+scrubbing an unresolved credential also pins `TURBO_CACHE` to local-only, so
+turbo is never asked to read a remote cache it cannot authenticate to.
+
+### Separate environment health
+
+The CLI also probes all `op://` references in the checkout `.env` with output
+suppressed. When that independent health check fails, it retries references one
+at a time and prints only each failing variable name as a plan warning. It never
+prints a reference or resolved value, and its result never changes the cache
+plan; repair the named variable separately while a healthy Turbo quad continues
+to read the remote cache.
 
 That scrub deliberately does **not** apply to an `op run`-wrapped spawn.
 `op run` resolves `op://` references out of the environment it is handed, not


### PR DESCRIPTION
## Summary

- resolve reference-backed Turbo cache credentials from only the cache quad
- report unrelated checkout reference failures as value-suppressed warnings
- retain local-only fail-closed behavior when any cache credential is unavailable

## Tests before early publish

- `bun run --cwd packages/tooling/tool/cli check`
- focused Vitest: 3 files and 249 tests passed

Packet: time-to-certainty B4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791012059&installation_model_id=424656&pr_number=953&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F953&signature=683266a0de4f9ccec7c1d48c69c1ed45515cbc8d004b2216438b9d5a6809e1b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->