### PR TITLE
fix(box): tolerate Box Sign listing 403 during inventory

### DIFF
--- a/.changeset/box-provisioning-sign-403.md
+++ b/.changeset/box-provisioning-sign-403.md
@@ -1,0 +1,6 @@
+---
+"@beep/box-provisioning": patch
+---
+
+Treat a 403 from the Box Sign request or template listings as a permission-blocked
+discovery instead of failing the whole inventory.

--- a/packages/drivers/box-provisioning/src/BoxProvisioningInventory.ts
+++ b/packages/drivers/box-provisioning/src/BoxProvisioningInventory.ts
@@ -62,7 +62,7 @@ const observeCollaborations = (box: B.Box["Service"], folders: ReadonlyArray<Box
   ).pipe(Effect.map(A.flatten));
 
 const entitlementDiscovery = (
-  kind: "metadata" | "retention",
+  kind: BoxDiscoveryKind,
   count: Effect.Effect<number, B.BoxError>
 ): Effect.Effect<BoxDiscovery, B.BoxError> =>
   count.pipe(
@@ -156,9 +156,7 @@ const observeSimpleMarkerCount = <A>(
   kind: Extract<BoxDiscoveryKind, "signRequests" | "signTemplates">,
   load: (marker: O.Option<string>) => Effect.Effect<MarkerPage<A>, B.BoxError>
 ): Effect.Effect<BoxDiscovery, B.BoxError> =>
-  collectMarkerPages(load).pipe(
-    Effect.map((entries) => BoxDiscoveryAvailable.make({ count: A.length(entries), kind }))
-  );
+  entitlementDiscovery(kind, collectMarkerPages(load).pipe(Effect.map(A.length)));
 
 const observeSignRequests = (box: B.Box["Service"]) =>
   observeSimpleMarkerCount<B.SignRequest>("signRequests", (marker) =>

--- a/packages/drivers/box-provisioning/test/BoxProvisioningInventory.test.ts
+++ b/packages/drivers/box-provisioning/test/BoxProvisioningInventory.test.ts
@@ -10,6 +10,7 @@ type InventoryClientOptions = {
   readonly collaboration?: boolean;
   readonly folderMetadataRead?: () => void;
   readonly metadataFailure?: unknown;
+  readonly signRequestsFailure?: unknown;
   readonly paginateMetadata?: boolean;
   readonly webhookEntries?: ReadonlyArray<unknown>;
 };
@@ -77,7 +78,10 @@ const makeInventoryClient = (options: InventoryClientOptions = {}) => ({
     getRetentionPolicies: (_queryParams: unknown): Promise<unknown> => Promise.resolve({ entries: [] }),
   },
   signRequests: {
-    getSignRequests: (_queryParams: unknown): Promise<unknown> => Promise.resolve({ entries: [] }),
+    getSignRequests: (_queryParams: unknown): Promise<unknown> =>
+      options.signRequestsFailure === undefined
+        ? Promise.resolve({ entries: [] })
+        : Promise.reject(options.signRequestsFailure),
   },
   signTemplates: {
     getSignTemplates: (_queryParams: unknown): Promise<unknown> => Promise.resolve({ entries: [] }),
@@ -190,6 +194,23 @@ describe("@beep/box-provisioning inventory", () => {
       if (observed.metadata._tag === "BlockedByPermission") {
         expect(O.getOrUndefined(observed.metadata.code)).toBe("forbidden");
       }
+    })
+  );
+
+  it.effect(
+    "classifies a Box Sign listing 403 as permission-blocked instead of failing",
+    Effect.fnUntraced(function* () {
+      const observed = yield* observeWithClient(
+        makeInventoryClient({
+          signRequestsFailure: { responseInfo: { code: "forbidden", statusCode: 403 } },
+        })
+      );
+
+      expect(observed.signRequests._tag).toBe("BlockedByPermission");
+      if (observed.signRequests._tag === "BlockedByPermission") {
+        expect(O.getOrUndefined(observed.signRequests.code)).toBe("forbidden");
+      }
+      expect(observed.signTemplates._tag).toBe("Available");
     })
   );
 


### PR DESCRIPTION
## fix(box): tolerate Box Sign listing 403 during inventory

The live practice tenant returns 403 for sign request listings, which failed
the whole dry-run. Sign discovery now uses the same permission-blocked
classification as metadata and retention, with a regression test.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/fix_box-sign-inventory-403-a5fe21630f23/verdict.json

---

## Provenance

- Branch: <code>fix/box-sign-inventory-403</code>
- Harness: `codex`

<!-- yeet-provenance
{
  "schemaVersion": 1,
  "branch": "fix/box-sign-inventory-403",
  "harness": "codex"
}
-->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791019549&installation_model_id=424656&pr_number=959&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F959&signature=3aebea71ef261ba6a3fedd5e2ccb5db07a6cccd8d03e1eb5e96053ef5cba4b2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->