### PR TITLE
docs(time-to-certainty): check off C1 and C2 after PR #954 merged

### DIFF
--- a/goals/time-to-certainty/PLAN.md
+++ b/goals/time-to-certainty/PLAN.md
@@ -39,8 +39,14 @@ orchestrator owns schemas, contracts, and judgment.
 
 ## P2 — Proof reuse
 
-- [ ] C1 ProofFact schema + migration from `YeetLaneProofState` (schema PR, no behavior change).
-- [ ] C2 ProofLedger Context.Service (record / lookup / expire) over an append-only NDJSON ledger.
+- [x] C1 ProofFact schema — done 2026-09-03 (PR #954 merged as 3e46822475): ProofEnvProfile, ProofStage,
+      ProofOutcome, ProofInputSource, ProofEpoch, ProofInputDigest, ProofProvenance, ProofFact,
+      ProofMissReason, hit/miss decisions, fact/shadow ledger rows; migration from `YeetLaneProofState`
+      rides the C4 wiring PR.
+- [x] C2 ProofLedger Context.Service — done 2026-09-03 (PR #954): record / recordShadow / lookup /
+      expire / disagreements over an append-only per-checkout NDJSON ledger with a tolerant reader,
+      key derivation and epoch collection, identity-field verification on lookup, undeclared-input
+      facts never reused; not yet wired into any lane.
 - [~] C3 declared inputs per script lane; Turbo lanes adopt the task hash; undeclared lanes report
       as non-reusable. Coverage done 2026-09-03 (PR #952 merged as 1ef10a6906: package-owned
       inputs replace the default glob, `cache: false` kept, a docs-only edit leaves the hash


### PR DESCRIPTION
Docs-only: PLAN C1/C2 checked after #954 (ProofFact schema + ProofLedger service) merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/961"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791021010&installation_model_id=424656&pr_number=961&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F961&signature=ff623ca6223919cf3335a4b62f1f6695ebba18e2edb935bd81d8cdfcd31cb6eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->