### PR TITLE
docs(time-to-certainty): track the YeetLaneProofState migration as C4a

### DIFF
--- a/goals/time-to-certainty/PLAN.md
+++ b/goals/time-to-certainty/PLAN.md
@@ -56,10 +56,16 @@ orchestrator owns schemas, contracts, and judgment.
       and identical failure rendering must survive), lint-policy (heterogeneous sublanes with
       root-wide inputs; one union glob would recreate a whole-tree hash), labs (three task-hash
       sets rather than one declared action; must keep the PR path gate and zero-labs-is-green).
-- [ ] C4a migrate the existing `YeetLaneProofState` records (command hash plus whole-tree diff
-      fingerprint, in `ProofState.ts` and `.beep/yeet/lane-proofs.json`) into ProofFact rows or
-      retire them with a receipt, so one ledger remains; deferred from C1 (PR #954) and owed
-      before shadow wiring reads either store.
+- [ ] C4a retire both legacy proof stores with receipts, never migrate them: (1) `YeetLaneProofState`
+      rows nested in `YeetRunState` and written to each run's `state.json` by `writeVerifiedState`
+      in `ProofState.ts`; (2) `LaneProofRecord` rows (`yeet-lane-proofs/v2`) in
+      `.beep/yeet/lane-proofs.json`, owned by `Quality/internal/LaneProofReuse.ts`. Neither carries a
+      per-lane input digest, env profile, epoch, duration, or run/attempt/origin provenance, so a
+      ProofFact built from them would attribute an old result to inputs it may never have run
+      against and could later become a reuse hit. Retirement means: the ProofLedger is the only
+      store shadow wiring reads; legacy readers keep working until C4 lands, then are removed with
+      a retirement receipt in `research/OPPORTUNITIES.md`; ProofFacts come only from lane runs
+      recorded after A5 journal facts exist. Deferred from C1 (PR #954); owed before C4.
 - [ ] C4 shadow mode with a disagreement report; enforcement between pre-push and merged preview
       only after zero disagreements over a ratified sample; hosted reuse recorded as a separate
       decision.

--- a/goals/time-to-certainty/PLAN.md
+++ b/goals/time-to-certainty/PLAN.md
@@ -41,8 +41,8 @@ orchestrator owns schemas, contracts, and judgment.
 
 - [x] C1 ProofFact schema — done 2026-09-03 (PR #954 merged as 3e46822475): ProofEnvProfile, ProofStage,
       ProofOutcome, ProofInputSource, ProofEpoch, ProofInputDigest, ProofProvenance, ProofFact,
-      ProofMissReason, hit/miss decisions, fact/shadow ledger rows; migration from `YeetLaneProofState`
-      rides the C4 wiring PR.
+      ProofMissReason, hit/miss decisions, fact/shadow ledger rows. The `YeetLaneProofState`
+      migration is tracked as C4a below.
 - [x] C2 ProofLedger Context.Service — done 2026-09-03 (PR #954): record / recordShadow / lookup /
       expire / disagreements over an append-only per-checkout NDJSON ledger with a tolerant reader,
       key derivation and epoch collection, identity-field verification on lookup, undeclared-input
@@ -56,6 +56,10 @@ orchestrator owns schemas, contracts, and judgment.
       and identical failure rendering must survive), lint-policy (heterogeneous sublanes with
       root-wide inputs; one union glob would recreate a whole-tree hash), labs (three task-hash
       sets rather than one declared action; must keep the PR path gate and zero-labs-is-green).
+- [ ] C4a migrate the existing `YeetLaneProofState` records (command hash plus whole-tree diff
+      fingerprint, in `ProofState.ts` and `.beep/yeet/lane-proofs.json`) into ProofFact rows or
+      retire them with a receipt, so one ledger remains; deferred from C1 (PR #954) and owed
+      before shadow wiring reads either store.
 - [ ] C4 shadow mode with a disagreement report; enforcement between pre-push and merged preview
       only after zero disagreements over a ratified sample; hosted reuse recorded as a separate
       decision.


### PR DESCRIPTION
Docs-only follow-up to #961 (merged before this commit was pushed): the YeetLaneProofState migration deferred from C1 is tracked as its own unchecked PLAN item C4a, owed before the C4 shadow wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791021320&installation_model_id=424656&pr_number=962&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F962&signature=70da6759920e1cd4e3cb5a2a115e1bc4a7cf496c785034995ead384606f9a837"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->