### PR TITLE
fix(explorations): teach the S5 gate the two-run world

### DIFF
--- a/explorations/beep-ci-operational-ontology/research/scripts/validate_packet.py
+++ b/explorations/beep-ci-operational-ontology/research/scripts/validate_packet.py
@@ -621,7 +621,16 @@ if _args.s5:
     ledger = yaml.safe_load((S4D / "LEDGER.yaml").read_text())
     cons = yaml.safe_load((S5 / "CONSTRAINTS.yaml").read_text())
     index = yaml.safe_load((BC / "runs/orun-2026-08-29T08:20:55Z.index.yaml").read_text())
+    # Ratifications resolve from the live governance dir AND the archived
+    # per-run governance dirs: auditor run 2 relocated run-1's rat-001..031
+    # to extraction/s4/archives/ (the v13 scanner has no archive exemption;
+    # see the relocation notes in the run-1 rotation README), so the S5
+    # joins bound to those records must follow the relocation.
     rats = {f.stem for f in (BC / "governance/ratifications").glob("rat-*.yaml")}
+    rats |= {
+        f.stem
+        for f in (S4D / "archives").glob("*/orun-*.governance/ratifications/rat-*.yaml")
+    }
     con_ids = {c["id"] for c in cons.get("constraints", [])}
     ledger_ids = {e["id"] for e in ledger}
     # constraints reference real ledger entries
@@ -691,9 +700,14 @@ if _args.s5:
         terms = {t.get("term"): t for t in term_list}
         accepted_terms = set(terms)
         # REQUIRED set derives from the ratified proposals + accepted dispositions,
-        # never from what the seats submitted (PR #905 review)
+        # never from what the seats submitted (PR #905 review). The proposals
+        # S5 consumed are RUN 1's survivors, which auditor run 2 relocated to
+        # extraction/s4/archives/ — the live work/proposals dir belongs to
+        # later runs and must not leak into the S5-era derivation (this gate
+        # already pins run 1's index above for the same reason).
         required = set()
-        for f in sorted((BC / "work/proposals").glob("otp-*.yaml")):
+        s5_proposals = S4D / "archives/beep-ci-ops/orun-2026-08-29T08:20:55Z.work/proposals"
+        for f in sorted(s5_proposals.glob("otp-*.yaml")):
             if "review" not in f.name:
                 required.add(yaml.safe_load(f.read_text())["term"]["local_name"])
         allowed_extra = set()


### PR DESCRIPTION
## fix(explorations): teach the S5 gate the two-run world

validate_packet.py --s5 read 43 blockers on main since the run-2 merge:
its ratification join globbed only the live governance dir, and its
required-term derivation read the live work/proposals — both single-run-era
proxies that broke when auditor run 2 relocated run-1's ratifications and
survivor proposals to extraction/s4/archives/ (the v13 scanner has no
archive exemption) and populated those live dirs with run-2 records. The
gate now also resolves archived per-run ratifications and pins the S5-era
proposal derivation to run 1's archived survivors, consistent with the
run-1 index it already hard-pins. All four packet gates prove green:
--s5, base, and --s6 at 0 blockers; CQ suite 0 failures (25 tests +
20 fixtures).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

## Local proof

- fallow-advisory-feedback: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/ontology-s5-gate-archived-rats-a3ee401aced7/verdict.json

---

## Provenance

- Branch: <code>ontology-s5-gate-archived-rats</code>
- Harness: `codex`

<!-- yeet-provenance
{
  "schemaVersion": 1,
  "branch": "ontology-s5-gate-archived-rats",
  "harness": "codex"
}
-->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791029419&installation_model_id=424656&pr_number=972&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F972&signature=102fd7d52c9034d9a3bfba1532a88b7d42d7571859d630a0640abe3b018b6183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->