### PR TITLE
docs(grok-bot-automation): name the real evidence-ladder export and add friction receipts

### DIFF
--- a/explorations/grok-bot-automation/DECISIONS.md
+++ b/explorations/grok-bot-automation/DECISIONS.md
@@ -121,7 +121,7 @@ the observed system and current delivery state.
 **Question:** Should bot automation define a new receipt model family?
 
 **Answer:** No. Bot receipts and evidence bind `EvidenceReceipt`,
-`EvidenceDigest`, `EvidenceLadder`, and `RecoveryAttemptReceipt` from
+`EvidenceDigest`, `EvidenceLadderState`, and `RecoveryAttemptReceipt` from
 `@beep/skill-contract`. Every run persists a receipt for success, no-op,
 partial, and failure outside the Bot UI's 20-run window.
 

--- a/explorations/grok-bot-automation/README.md
+++ b/explorations/grok-bot-automation/README.md
@@ -18,7 +18,11 @@ authority, or merge authority.
 ## Next Open Question
 
 Measure the Heavy usage and billing state, then inspect the X and GitHub plugin
-surfaces before any routine is scheduled.
+surfaces before any routine is scheduled. At the shape stage, decide which of
+the four recorded frictions in `research/OPPORTUNITIES.md` (lane death without
+a written report, sandbox git limits for delegated lanes, staged-only commits
+landing before admission, the babysit watch exiting on tolerated reds) become
+tooling fixes inside the first bot PR rather than notes.
 
 ## Read This First
 
@@ -27,7 +31,13 @@ surfaces before any routine is scheduled.
 3. [`RESEARCH.md`](./RESEARCH.md) - product facts, prior art, and repo inventory.
 4. [`DECISIONS.md`](./DECISIONS.md) - locked and deferred outcomes from the grill.
 5. [`research/SOURCES.md`](./research/SOURCES.md) - lane and source provenance.
+6. [`research/OPPORTUNITIES.md`](./research/OPPORTUNITIES.md) - friction receipts
+   from the research fan-out and the publish session.
 
 ## Trail
 
 - 2026-09-03: packet opened after a five-lane research fan-out and a two-round grill; 8 decisions locked, 3 deferred.
+- 2026-09-03 (b): PR #969 merged the packet, the architecture decision, and the
+  nightly-research SPEC amendment. Follow-up PR #974 corrects the receipt model
+  name to `EvidenceLadderState` and adds `research/OPPORTUNITIES.md` with four
+  friction receipts from the research and publish session.

--- a/explorations/grok-bot-automation/RESEARCH.md
+++ b/explorations/grok-bot-automation/RESEARCH.md
@@ -143,7 +143,7 @@ surface, although its promised nightly commands are planned and not shipped.
 The architecture routes repo automation to `packages/tooling/tool/cli`.
 
 The existing `@beep/skill-contract` package exports `EvidenceReceipt`,
-`EvidenceDigest`, `EvidenceLadder`, and `RecoveryAttemptReceipt`.
+`EvidenceDigest`, `EvidenceLadderState`, and `RecoveryAttemptReceipt`.
 
 Bot receipts must bind those models instead of creating a parallel family.
 

--- a/explorations/grok-bot-automation/research/OPPORTUNITIES.md
+++ b/explorations/grok-bot-automation/research/OPPORTUNITIES.md
@@ -1,0 +1,58 @@
+# Research friction receipts
+
+## 2026-09-03: headless research lane died after 126 turns with an empty report
+
+- **Work:** the G2 lane (grok-4.6, xhigh, headless claude on the local proxy) researching Grok Bot
+  use cases and practitioner practices for this packet.
+- **Evidence:** the stream ended with `API Error: The response stopped arriving. The response
+  above may be incomplete.` after 126 API turns; the report file held only the 3.7 KB section
+  skeleton although the stream contained 29 x.com post URLs and about 90 fetched pages.
+- **Cost:** one full lane budget lost; a salvage pass had to extract every URL, search query, and
+  the last 60 text blocks from the raw stream into a hints file, and a second lane (G2b, 83 turns)
+  re-ran the task before synthesis could start.
+- **Prevention:** the "create the file early, append as you go" contract is not enough for long
+  lanes. Pin "append after every three tool calls; an empty file is a failed run; stop researching
+  at turn 45 of 55" in every research-lane prompt, and keep raw streams as the recovery layer.
+
+## 2026-09-03: Codex workspace-write sandbox cannot create a worktree or stage files
+
+- **Work:** delegating the packet scaffold, decision entry, and SPEC amendment to a Codex lane that
+  was asked to work in a fresh worktree and stage its files.
+- **Evidence:** inside `codex exec -s workspace-write`, `bun run beep worktree new …` failed with a
+  branch-ref lock error under the read-only common `.git` directory, `git fetch` could not write
+  `.git/FETCH_HEAD`, and the lane exited without authoring anything.
+- **Cost:** one wasted lane; the worktree had to be created by the orchestrating session, the
+  brief rewritten to forbid git writes, and the lane relaunched. Staging moved to the operator.
+- **Prevention:** document in the delegation recipe that the Codex sandbox keeps `.git` read-only
+  even for the working directory: create worktrees before launch, forbid git writes in the brief,
+  and stage by explicit path afterwards. A `beep worktree new` preflight that names this sandbox
+  limitation would save the first failed attempt.
+
+## 2026-09-03: `yeet publish --staged-only` commits before admission, so stopping a queued run does not undo it
+
+- **Work:** recovering from a stale-base refusal (`git diff --name-only … output exceeded the
+  repo-run capture limit` because `origin/main` had moved 9 commits and 5,246 files since the
+  worktree was cut) by fast-forwarding and republishing.
+- **Evidence:** the relaunched publish had already created its commit when it was stopped while
+  waiting in the admission queue; a conflict fix intended for the same commit became a second
+  commit with an identical message.
+- **Cost:** a two-commit history for a one-change PR and a second full proof.
+- **Prevention:** print the commit step explicitly before admission wait so operators know the
+  commit exists; consider committing only after admission is granted, or offer
+  `--amend --no-edit --reuse-verified` guidance in the admission-wait banner. Also have the
+  stale-base refusal print the commit count and overlapping files instead of a capture-limit
+  error, since the 5,246-file diff exceeded the runner's output buffer.
+
+## 2026-09-03: `yeet monitor --watch --until-event` exits instantly on tolerated Vercel rate-limit reds
+
+- **Work:** babysitting PR #969 for the Greptile burst and required-check results.
+- **Evidence:** every watch run ended within a second with `watch-ended … reason: "event",
+  failing: 3`; the three failures were `Vercel – oip-web`, `Vercel – oip-web-staging`, and
+  `Vercel – todox`, each reporting "Deployment rate limited — retry in 24 hours", the one failure
+  class the mergeability rule tolerates. Acknowledging their inbox capsules as won't-fix did not
+  change the watch's exit behavior.
+- **Cost:** the documented babysit loop was unusable; the PR had to be polled with `gh pr checks
+  --required` and comment counts instead.
+- **Prevention:** let the watch treat optional, won't-fix-acknowledged, or rate-limited Vercel
+  contexts as non-actionable so `--until-event` waits for the next real event, and expose the
+  "optional check" distinction that `yeet status --remote` already prints.

--- a/goals/nightly-research-routine/SPEC.md
+++ b/goals/nightly-research-routine/SPEC.md
@@ -124,7 +124,7 @@ tombstoned idea returns only with evidence that post-dates its death.
 `RUN.json` is truth for the run and records typed per-source capability
 results. Every success, no-op, partial, and failure persists evidence and
 recovery receipts outside the hosted UI's 20-run window by reusing
-`EvidenceReceipt`, `EvidenceDigest`, `EvidenceLadder`, and
+`EvidenceReceipt`, `EvidenceDigest`, `EvidenceLadderState`, and
 `RecoveryAttemptReceipt` from `@beep/skill-contract`. The publisher exports
 `beep.research.nightly.*` metrics (sources seen, claims emitted, collision
 rate, per-pool usage, wall time, status) to the dankserver OTLP endpoint.

--- a/standards/architecture/DECISIONS.md
+++ b/standards/architecture/DECISIONS.md
@@ -1754,7 +1754,7 @@ digests, completion, and redaction before model or publisher use; partial
 recovery is rejected. Private records use a content-addressed local store.
 Inline base64 or gzip prompt payloads are forbidden.
 
-Bot evidence reuses `EvidenceReceipt`, `EvidenceDigest`, `EvidenceLadder`, and
+Bot evidence reuses `EvidenceReceipt`, `EvidenceDigest`, `EvidenceLadderState`, and
 `RecoveryAttemptReceipt` from `@beep/skill-contract`. Every success, no-op,
 partial, and failure persists a receipt outside the hosted UI's 20-run window.
 The shared Bot VM receives provider OAuth only: no 1Password or publisher


### PR DESCRIPTION
## docs(grok-bot-automation): name the real evidence-ladder export and add friction receipts

## Local proof

- fallow-advisory-feedback: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/docs_grok-bot-automation-followup-837c7759e35c/verdict.json

---

## Provenance

- Branch: <code>docs/grok-bot-automation-followup</code>
- Harness: `codex`

<!-- yeet-provenance
{
  "schemaVersion": 1,
  "branch": "docs/grok-bot-automation-followup",
  "harness": "codex"
}
-->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/974"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791032455&installation_model_id=424656&pr_number=974&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F974&signature=3499a7d441a38bec9f85a6555f574c4f8494a81c268a397cabdb0df321529377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->