### PR TITLE
fix(skills): validator v14 — runs-shelter poison guard + Python 3.13 loop fix

### DIFF
--- a/.claude/skills/ontology-foundational-auditor/REVIEW-HISTORY.md
+++ b/.claude/skills/ontology-foundational-auditor/REVIEW-HISTORY.md
@@ -61,3 +61,32 @@ archive; each round's `roundN-triage.md` register names every finding and
 its disposition. Future hardening resumes by running the same loop
 protocol against v12 — two independent seats, the round-4 severity
 boundary, exhaustive registers, one-pass fixes, full replay.
+
+## Field amendments (post-loop)
+
+Amendments after the loop closed come from field use, not review seats;
+each names its provenance and ships with self-test families.
+
+- **v13** (2026-08-30, vendoring): PR-review (codex connector) families
+  added during project-scope vendoring — 156 families. Predates this
+  section; recorded for continuity.
+- **v14** (2026-09-03, auditor run 2 field defects — the
+  beep-ci-operational-ontology run-2 impl-report queued both): two
+  amendments. (1) *Runs-shelter poison guard*: v13's scanner absorbed
+  record-prefixed files under `runs/` into the live scan, so a rotated
+  predecessor's observations validated against the successor's manifest
+  (1,896 dangling references in run 2 before an ad-hoc relocation). v14
+  makes `runs/` a rotation ledger — record-prefixed or review-suffixed
+  files there are a LOUD violation, quarantined from every join — and the
+  rotation recipe now archives per-run records at the sibling shelter
+  `../archives/<root-name>/`, outside the scan root, so no in-root
+  exemption exists to hide live records in. Shadow manifests/indexes under
+  `runs/` still fall through to the authoritative-location checks.
+  (2) *Strict-first loop resolution*: Python 3.13 changed non-strict
+  `Path.resolve()` to swallow symlink loops, breaking `safe_join`'s
+  fail-closed confinement (the symlink-loop self-test family caught it —
+  the 3.12 runtime pin during run 2 was the workaround). `safe_join` now
+  resolves strict-first, with a lenient fallback reachable only for
+  merely-missing tails. 157 families; self-test green on CPython
+  3.12/3.13/3.14; v13→v14 output byte-identical over run 2's live
+  post-rotation tree.

--- a/.claude/skills/ontology-foundational-auditor/SKILL.md
+++ b/.claude/skills/ontology-foundational-auditor/SKILL.md
@@ -395,19 +395,28 @@ fi
 # OBSERVATIONS ARE RUN-SCOPED: their canonical ids embed the pinned commit
 # and adapter version, so a new run's manifest can never re-validate the old
 # records — left in place they poison the next scan as stale, undispositioned
-# observations. Archive them beside the manifest/index (refuse-if-exists;
-# they are deterministically regenerable from the archived manifest's pin):
-AO=$ONT/runs/$RID.observations
+# observations. Archive them at the SIBLING shelter, OUTSIDE the scan root
+# (refuse-if-exists; deterministically regenerable from the archived
+# manifest's pin). runs/ itself is the ROTATION LEDGER — manifest/index
+# pairs and engine history only; the validator (v14) REFUSES record-prefixed
+# files under runs/, so per-run record trees can never ride there as live
+# evidence, and no in-root exemption exists to hide live records in:
+ARCH=$(dirname "$ONT")/archives/$(basename "$ONT")
+AO=$ARCH/$RID.observations
 if [ -z "$RID" ]; then :; elif [ -e "$AO" ]; then echo "refusing: observation archive for $RID exists"; else
   mkdir -p "$AO" && mv "$WORK/observations" "$WORK/prose-observations" "$AO"/ && \
   mkdir -p "$WORK/observations" "$WORK/prose-observations" && \
-  echo "observations archived to runs/$RID.observations/"
+  echo "observations archived to $AO/"
 fi
 # CARRY-FORWARD POLICY (by design): reviews/analyses are CONTENT-ADDRESSED —
 # a new run reuses them only while their closures still verify; an engine,
 # prompt, contract, or corpus change stales the manifest or the chains and
 # forces re-lock/re-review. Carrying verified artifacts across runs is
 # therefore reuse of still-valid authority, not revival of stale authority.
+# When a later run DOES stale carried seat trees or ratifications, relocate
+# them byte-identically to the same sibling shelter with a dated README note
+# — and sweep every historical gate or script that joins on the old paths
+# before publishing the relocation.
 
 # Idempotence check: same pinned source + same adapter version => same RECORD
 # IDS (filenames prove nothing — two runs can name files alike with different

--- a/.claude/skills/ontology-foundational-auditor/scripts/validate_artifacts.py
+++ b/.claude/skills/ontology-foundational-auditor/scripts/validate_artifacts.py
@@ -1,4 +1,4 @@
-"""Machine enforcement for the auditor's artifact contracts (v13).
+"""Machine enforcement for the auditor's artifact contracts (v14).
 
 v3 bound records to id strings and file bytes; round-4 seats proved id-joins
 and lone-file digests are not coherence. v4 binds CONTENT, HISTORY, and
@@ -1651,9 +1651,17 @@ def safe_join(repo_root, rel, p, what="repository.path"):
         err(p, f"{what} {rel!r} is absolute — pinned paths are relative to the root")
         return None
     try:
-        # resolve() raises on symlink loops (RuntimeError/OSError) — a
-        # confinement check that crashes is not fail-closed
-        target = (repo_root / rel).resolve()
+        # strict-first resolution: Python 3.13 changed NON-strict resolve()
+        # to swallow symlink loops instead of raising, which would let a
+        # looped component slide through confinement. resolve(strict=True)
+        # raises OSError(ELOOP) on every supported runtime; only a
+        # merely-missing tail (FileNotFoundError) falls back to lenient
+        # resolution — a loop can never reach the fallback because strict
+        # resolution dies at the looping component before any missing tail.
+        try:
+            target = (repo_root / rel).resolve(strict=True)
+        except FileNotFoundError:
+            target = (repo_root / rel).resolve()
         root_res = repo_root.resolve()
     except (OSError, RuntimeError) as ex:
         err(p, f"{what} {rel!r} cannot be resolved ({ex}) — fails CLOSED as a "
@@ -2059,6 +2067,10 @@ def repo_fidelity(sos, pos, manifest, otps, reviews, dhs, repo_root):
 CHECKS = {"so": check_so, "po": check_po, "dh": check_dh, "ic": check_ic,
           "fa": check_fa, "otp": check_otp, "rat": check_rat, "rej": check_rej}
 
+RECORD_DISPATCH = (("so-", "so"), ("po-", "po"), ("dh-", "dh"), ("ic-", "ic"),
+                   ("fa-", "fa"), ("otp-", "otp"), ("rat-", "rat"),
+                   ("rej-", "rej"))
+
 
 def validate_dir(root, gate=False, repo=None):
     root = Path(root)
@@ -2072,6 +2084,27 @@ def validate_dir(root, gate=False, repo=None):
     for f in sorted(root.rglob("*.yaml")):
         name = f.name
         rel_parts = f.relative_to(root).parts
+        if rel_parts[:1] == ("runs",) and name not in (
+                "run-manifest.yaml", "dispositions.index.yaml"):
+            # runs/ is the ROTATION LEDGER (archived orun-<rid>.manifest/
+            # .index pairs + engine history), never live evidence. v13
+            # silently absorbed record-prefixed files here into the live
+            # scan, so a rotated predecessor's observations validated
+            # against the successor's manifest. v14 makes that poison LOUD
+            # and quarantines the file from every join; full per-run record
+            # trees rotate to the SIBLING shelter ../archives/<root-name>/,
+            # OUTSIDE the scan root — no in-root exemption exists to hide
+            # live records in. Ledger bytes are not parsed here: the one
+            # prior index this run stands on is byte- and row-validated at
+            # its manifest join, and a shadow manifest/index under runs/
+            # still falls through to the authoritative-location checks.
+            if name.endswith(".review.yaml") or \
+                    any(name.startswith(pfx) for pfx, _ in RECORD_DISPATCH):
+                err(f, "record-prefixed file under runs/ — archived per-run "
+                       "records are NOT live evidence; rotate them to the "
+                       "sibling archive shelter (../archives/<root-name>/), "
+                       "never leave them in the scan root")
+            continue
         try:
             d = yload(f.read_text()) or {}
         except Exception as ex:  # noqa: BLE001
@@ -2114,9 +2147,7 @@ def validate_dir(root, gate=False, repo=None):
                                "filed under another proposal's name hides its history")
                 kinds["review"].append((f, d))
         else:
-            for prefix, key in (("so-", "so"), ("po-", "po"), ("dh-", "dh"),
-                                ("ic-", "ic"), ("fa-", "fa"), ("otp-", "otp"),
-                                ("rat-", "rat"), ("rej-", "rej")):
+            for prefix, key in RECORD_DISPATCH:
                 if name.startswith(prefix):
                     CHECKS[key](d, f)
                     if not isinstance(d, dict):
@@ -3339,6 +3370,13 @@ def self_test():
         assert res is None and len(errors) > n, \
             "symlink loop must be a violation, never a crash"
         del errors[n:]
+        # strict-first resolution must not tighten the missing-tail case:
+        # a merely-missing in-root path still resolves through the lenient
+        # fallback with no violation (loops can never reach the fallback)
+        n = len(errors)
+        res = safe_join(td, "nope/missing.yaml", "self:missing")
+        assert res is not None and len(errors) == n, \
+            "a merely-missing path must still resolve via the lenient fallback"
 
 
     # --- round-12 families ---------------------------------------------------
@@ -3454,7 +3492,29 @@ def self_test():
     assert not any("does not address" in m for m in out), \
         "split revision_log entries for one digest must UNION, not last-win"
 
-    print("SELF-TEST PASS (156 rule families fire: canonical ids, nested closure, "
+    # --- v14 field-amendment families ----------------------------------------
+    # (auditor run 2 field defect: the scanner absorbed a rotated
+    # predecessor's record files under runs/ as live evidence)
+    with tempfile.TemporaryDirectory() as td:
+        td = Path(td)
+        (td / "runs/orun-r.observations").mkdir(parents=True)
+        (td / "runs/orun-r.observations/so-poison.yaml").write_text("id: x\n")
+        (td / "runs/orun-r.index.yaml").write_text("[]\n")
+        (td / "runs/history").mkdir()
+        (td / "runs/history/ratification.schema.yaml").write_text("a: 1\n")
+        n = len(errors)
+        validate_dir(td)
+        msgs = errors[n:]
+        assert any("NOT live evidence" in m and "so-poison" in m
+                   for m in msgs), \
+            "record-prefixed file under runs/ must be a LOUD violation"
+        assert not any("orun-r.index.yaml" in m for m in msgs), \
+            "rotation-ledger files under runs/ are not live records"
+        assert not any("ratification.schema.yaml" in m for m in msgs), \
+            "engine-history files under runs/ are not record-prefixed"
+        del errors[n:]
+
+    print("SELF-TEST PASS (157 rule families fire: canonical ids, nested closure, "
           "object grammar, mixed-unrep, discriminator, searched-true, warrant-XOR, "
           "parents grammar, id grammars incl. rat digits, crash-hardening, rat "
           "content binding + staleness + freshness, review edge-target/chain/"
@@ -3463,7 +3523,7 @@ def self_test():
           "live-carried bypass, row-evidence join, since-exact, digest-fresh IRI, "
           "identifier pad + negation context + provider agreement incl. "
           "boolean-vs-unresolved, boolean pin_waived, ufo_category required, "
-          "addressed-list shape, #-boundary, config pairing, vacuity-boolean, text exact-type sweep, container shapes, prior-FAIL coverage population, tri-state crash hardening, duplicate-key loader, syntax-aware pairing stripper, glued openers, mid-line bare keys, blank-line continuation, identity precedence, lexical component symlinks, run-id parser, closed shared run-id grammar + rotation parity, exact-hex digest locks, cross-line separator refusal, ini/properties quoted-payload, toml/BOM/form-feed comment boundaries, join quarantine, orphan review/rejection authority, predecessor-local row validation, symlink-loop fail-closed, bounded run-id fractions, CR line-break normalization, half-quote arm refusal, table-filter quarantine, predecessor date/grammar/reason/carried meters, control-escaped authority rendering, unexaminable-path fail-closed, referent-mapping guard, review revision-requests channel, ledger-rationale binding, revision-log digest union, closure-read fail-closed)")
+          "addressed-list shape, #-boundary, config pairing, vacuity-boolean, text exact-type sweep, container shapes, prior-FAIL coverage population, tri-state crash hardening, duplicate-key loader, syntax-aware pairing stripper, glued openers, mid-line bare keys, blank-line continuation, identity precedence, lexical component symlinks, run-id parser, closed shared run-id grammar + rotation parity, exact-hex digest locks, cross-line separator refusal, ini/properties quoted-payload, toml/BOM/form-feed comment boundaries, join quarantine, orphan review/rejection authority, predecessor-local row validation, symlink-loop fail-closed, bounded run-id fractions, CR line-break normalization, half-quote arm refusal, table-filter quarantine, predecessor date/grammar/reason/carried meters, control-escaped authority rendering, unexaminable-path fail-closed, referent-mapping guard, review revision-requests channel, ledger-rationale binding, revision-log digest union, closure-read fail-closed, runs-shelter poison guard)")
 
 
 def print_run_id(ont_root):

--- a/explorations/beep-ci-operational-ontology/README.md
+++ b/explorations/beep-ci-operational-ontology/README.md
@@ -132,6 +132,18 @@ graduation. Full plan with locked decisions: [`DECISIONS.md`](./DECISIONS.md).
 
 ## Trail
 
+- 2026-09-03 (twentieth stint): UPSTREAM SKILL FOLLOW-UPS APPLIED — validator
+  v14. Both engine defects run 2 queued in `work-run2/impl-report.md` are
+  discharged in the vendored skill: the scanner now treats `runs/` as a
+  rotation ledger (record-prefixed files there are a LOUD violation instead
+  of silently-absorbed live evidence — the defect that forced run 2's ad-hoc
+  archive relocation), the rotation recipe archives per-run records at the
+  sibling shelter `../archives/<root-name>/` this packet already uses, and
+  `safe_join` resolves strict-first so symlink-loop confinement stays
+  fail-closed on Python 3.13+ (the 3.12 runtime pin is LIFTED — self-test
+  green on 3.12/3.13/3.14, 157 families). v13→v14 output proven
+  byte-identical over this packet's live post-rotation tree; run 3 pins the
+  v14 digest at its own pin commit. Frozen run-2 bytes untouched.
 - 2026-09-03 (nineteenth stint): CQ-020 AMENDMENT APPLIED (PR #963). The
   steward-sanctioned post-run-2 amendment landed once the pinned run merged:
   SeatRequest ordering (`schedulesSeatRequest`), the required governing

--- a/explorations/beep-ci-operational-ontology/ops/manifest.json
+++ b/explorations/beep-ci-operational-ontology/ops/manifest.json
@@ -6,7 +6,7 @@
     "status": "active",
     "stage": "research",
     "openQuestions": [
-      "Auditor run 3 prerequisites (run 2 COMPLETE 2026-09-03, orun-2026-09-03T02:46:18Z, 21 ratifications rat-032..rat-052, gate PASSED — do not rerun): the full ordering cluster (ScheduleStep + its four relations ratify together), the deferred identity-provenance corpora, and the grant-contention + checkout-identity captures. Prior chain: runs/orun-2026-09-03T02:46:18Z.index.yaml sha12 a207a106de68. The CQ-020 amendment is APPLIED (2026-09-03, this branch: SeatRequest ordering, step-borne hasScopeTag literal, required AdmissionProjectionSpecification, S6 registry regenerated). Upstream skill follow-ups (scanner archive shelter; Python 3.13 validator fix) queued in work-run2/impl-report.md.",
+      "Auditor run 3 prerequisites (run 2 COMPLETE 2026-09-03, orun-2026-09-03T02:46:18Z, 21 ratifications rat-032..rat-052, gate PASSED — do not rerun): the full ordering cluster (ScheduleStep + its four relations ratify together), the deferred identity-provenance corpora, and the grant-contention + checkout-identity captures. Prior chain: runs/orun-2026-09-03T02:46:18Z.index.yaml sha12 a207a106de68. The CQ-020 amendment is APPLIED (2026-09-03, this branch: SeatRequest ordering, step-borne hasScopeTag literal, required AdmissionProjectionSpecification, S6 registry regenerated). Upstream skill follow-ups APPLIED (2026-09-03, validator v14: runs/ poison guard + sibling archive shelter in the rotation recipe; strict-first safe_join lifts the Python 3.12 pin — self-test green 3.12/3.13/3.14, 157 families); run 3 pins the v14 digest at its pin commit.",
       "S8 IRI scheme: deferred per the standing pipeline; the ciops-prov: namespace re-proposal now rides run 3 with the ordering cluster."
     ],
     "sources": ["research/SOURCES.md"],
@@ -16,6 +16,6 @@
       "supersededBy": null
     },
     "created": "2026-08-27",
-    "updated": "2026-09-02"
+    "updated": "2026-09-03"
   }
 }


### PR DESCRIPTION
## fix(skills): validator v14 — runs-shelter poison guard + Python 3.13 loop fix

Discharge both upstream follow-ups auditor run 2 queued in the
beep-ci-operational-ontology impl-report:

1. Runs-shelter poison guard. v13's scanner absorbed record-prefixed
   files under runs/ into the live scan, so a rotated predecessor's
   observations validated against the successor's manifest (1,896
   dangling references in run 2 before the ad-hoc relocation). v14
   treats runs/ as the rotation ledger: record-prefixed or
   review-suffixed files there are a loud violation quarantined from
   every join, shadow manifests/indexes still hit the
   authoritative-location checks, and the rotation recipe now archives
   per-run records at the sibling shelter ../archives/<root-name>/
   outside the scan root — no in-root exemption exists to hide live
   records in.

2. Strict-first loop resolution. Python 3.13 changed non-strict
   Path.resolve() to swallow symlink loops, breaking safe_join's
   fail-closed confinement (the self-test's symlink-loop family caught
   it; run 2 pinned the runtime to 3.12 as a workaround). safe_join now
   resolves strict-first with a lenient fallback reachable only for
   merely-missing tails. The 3.12 pin is lifted: self-test green on
   CPython 3.12/3.13/3.14.

Proofs: 157 self-test families (new runs-shelter family + a
missing-tail fallback lock); v13 -> v14 output byte-identical over the
packet's live post-rotation tree; all four packet gates green (--s5,
base, --s6 at 0 blockers; CQ suite 0 failures across 25 tests + 20
fixtures). Packet state flipped in the same PR (Trail twentieth stint,
manifest openQuestions: follow-ups APPLIED). Frozen run-1/run-2 bytes
untouched; run 3 pins the v14 digest (45e4f856a371) at its own pin
commit.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

## Local proof

- fallow-advisory-feedback: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/skill-v14-archive-shelter-e7ab9d960412/verdict.json

---

## Provenance

- Branch: <code>skill-v14-archive-shelter</code>
- Harness: `codex`

<!-- yeet-provenance
{
  "schemaVersion": 1,
  "branch": "skill-v14-archive-shelter",
  "harness": "codex"
}
-->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791033379&installation_model_id=424656&pr_number=977&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F977&signature=9a2565cef02a6dda1d5a84055541716b5edaa5fca8f232343a4c6422bb6a65c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->