### PR TITLE
test(html): cover the per-module entry points after #971

### DIFF
--- a/.changeset/html-coverage-entrypoints.md
+++ b/.changeset/html-coverage-entrypoints.md
@@ -1,0 +1,5 @@
+---
+"@beep/html": patch
+---
+
+Cover the per-module entry points after #971.

--- a/packages/foundation/modeling/html/test/Html.entrypoints.test.ts
+++ b/packages/foundation/modeling/html/test/Html.entrypoints.test.ts
@@ -1,0 +1,25 @@
+import { Html } from "@beep/html/Html";
+import { Input } from "@beep/html/Html.model";
+import { VERSION } from "@beep/html/Version";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as O from "effect/Option";
+
+describe("@beep/html per-module entry points", () => {
+  it("exports the package version from its explicit subpath", () => {
+    expect(VERSION).toBe("0.0.0");
+  });
+
+  it("validates detailed autocomplete through the staged facade", () => {
+    const root = Input.make({
+      autocomplete: O.some("section-checkout shipping email"),
+      type: O.some("email"),
+    });
+
+    expect(Html.Conformant.issues(root)).toStrictEqual([]);
+    const conformant = Effect.runSync(Html.Conformant.decode(root));
+    expect(Html.Safe.issues(conformant)[0]?.rule).toBe("deniedElement");
+    expect(Exit.isFailure(Effect.runSyncExit(Html.Safe.decode(conformant)))).toBe(true);
+  });
+});

--- a/packages/foundation/modeling/html/test/Html.entrypoints.test.ts
+++ b/packages/foundation/modeling/html/test/Html.entrypoints.test.ts
@@ -5,11 +5,59 @@ import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as O from "effect/Option";
+import * as S from "effect/Schema";
+
+const packageRoot = new URL("..", import.meta.url).pathname;
+const PackageJson = S.Struct({
+  exports: S.Record(S.String, S.NullOr(S.String)),
+  publishConfig: S.Struct({
+    exports: S.Record(S.String, S.NullOr(S.String)),
+  }),
+  version: S.String,
+});
+const decodePackageJson = S.decodeUnknownEffect(S.fromJsonString(PackageJson));
 
 describe("@beep/html per-module entry points", () => {
-  it("exports the package version from its explicit subpath", () => {
-    expect(VERSION).toBe("0.0.0");
-  });
+  it.effect("resolves the explicit subpaths through the package export map", () =>
+    Effect.gen(function* () {
+      const child = Bun.spawn(
+        [
+          process.execPath,
+          "-e",
+          'const { Html } = await import("@beep/html/Html"); const { VERSION } = await import("@beep/html/Version"); if (typeof Html.Conformant.decode !== "function" || typeof VERSION !== "string") process.exit(1)',
+        ],
+        {
+          cwd: packageRoot,
+          stderr: "pipe",
+          stdout: "ignore",
+        }
+      );
+      const [exitCode, stderr] = yield* Effect.all([
+        Effect.promise(() => child.exited),
+        Effect.promise(() => new Response(child.stderr).text()),
+      ]);
+
+      expect({ exitCode, stderr }).toStrictEqual({ exitCode: 0, stderr: "" });
+    })
+  );
+
+  it.effect("keeps the source and published exports aligned with the package version", () =>
+    Effect.gen(function* () {
+      const packageJson = yield* Effect.promise(() =>
+        Bun.file(new URL("../package.json", import.meta.url)).text()
+      ).pipe(Effect.flatMap(decodePackageJson));
+
+      expect(packageJson.exports).toMatchObject({
+        "./Html": "./src/Html.ts",
+        "./Version": "./src/Version.ts",
+      });
+      expect(packageJson.publishConfig.exports).toMatchObject({
+        "./Html": "./dist/Html.js",
+        "./Version": "./dist/Version.js",
+      });
+      expect(VERSION).toBe(packageJson.version);
+    })
+  );
 
   it("validates detailed autocomplete through the staged facade", () => {
     const root = Input.make({


### PR DESCRIPTION
## Summary

- test the `@beep/html/Html` and `@beep/html/Version` entry points added by #971
- cover detailed autocomplete conformance through the staged `Html` facade
- repair the inherited coverage-ratchet breach without changing its baseline

## Local proof

- `bunx --bun vitest run test/Html.entrypoints.test.ts`
- `bun run beep:check:tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791046387&installation_model_id=424656&pr_number=983&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F983&signature=3ae08f4d7fa04ba34b604ae8a5b293c234797ee303db77035dd68c0a4e637adc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->