### PR TITLE
docs(time-to-certainty): ratify rulings 17 and 18 from the compaction review

### DIFF
--- a/goals/time-to-certainty/GOAL.md
+++ b/goals/time-to-certainty/GOAL.md
@@ -39,8 +39,10 @@ checkmarks as items land; the status flip and closeout reflection ride the final
 
 Status (2026-09-03): P0 complete. `research/baseline.md` is ratified (ruling 8: M1 P50 43.3 min /
 P95 3.95 h; pre-push wave 65.9% of local wrapper time; hosted-wait 19.4%; M3/M4 unmeasurable until
-journals carry fingerprints and inner lanes). `research/decisions.md` holds sixteen ratified rulings: seven on the
-ProofFact schema, baseline ratification, A5 first, coverage-first migration, and six from the A5
+journals carry fingerprints and inner lanes). `research/decisions.md` holds eighteen ratified rulings: seven on the
+ProofFact schema, baseline ratification, A5 first, coverage-first migration, six from the A5
 journal-facts review (terminal tags, durable inner-lane reports, ticket death, forward-compatible
-eviction variant, atomic claims, stage and profile via the C1 vocabulary). Landed: A5 (partial, A5b owes four gaps), A4, B2, B4, C3 coverage, C1/C2; in flight: B1 and
+eviction variant, atomic claims, stage and profile via the C1 vocabulary), and two from the A5b
+compaction review (retention budget over terminal attempts only; economics left-censored from
+compaction receipts). Landed: A5 (partial, A5b owes four gaps), A4, B2, B4, C3 coverage, C1/C2; in flight: B1 and
 A5b. B3 and A3 are unblocked now that journal facts exist.

--- a/goals/time-to-certainty/ops/manifest.json
+++ b/goals/time-to-certainty/ops/manifest.json
@@ -10,7 +10,7 @@
   },
   "packetPath": "goals/time-to-certainty",
   "lifecycle": "active",
-  "statusNote": "P0 complete 2026-09-03: economics report, prior-art survey, baseline ratified (ruling 8: M1 P50 43.3 min / P95 3.95 h; M5 327 of 3,069 starts unfinished, 10.7%), sixteen ratified rulings in research/decisions.md. Landed: A5 journal facts (partial; A5b owes the four post-merge review gaps), A4, B2, B4, C3 coverage inputs, C1/C2 ledger; in flight: B1 and A5b; B3 and A3 unblocked. Review on PR #950 asked for portable reproduction inputs and full hosted-rerun matching in the economics script; that repair rides this PR.",
+  "statusNote": "P0 complete 2026-09-03: economics report, prior-art survey, baseline ratified (ruling 8: M1 P50 43.3 min / P95 3.95 h; M5 327 of 3,069 starts unfinished, 10.7%), eighteen ratified rulings in research/decisions.md (17: retention budget over terminal attempts only, legacy unowned starts terminalized at first reconciliation; 18: economics left-censors from a monotonic compaction cutoff). Landed: A5 journal facts (partial; A5b owes the four post-merge review gaps), A4, B2, B4, C3 coverage inputs, C1/C2 ledger; in flight: B1 and A5b; B3 and A3 unblocked. Review on PR #950 asked for portable reproduction inputs and full hosted-rerun matching in the economics script; that repair rides this PR.",
   "mission": "Cut the fleet-aggregated P50/P95 time-to-certainty per verification episode by removing redundant lane executions across tiers, false-positive gate round-trips, and silent process deaths, measured before and after on the same operational proxies.",
   "executionCapable": true,
   "reflectionRequired": true,

--- a/goals/time-to-certainty/research/decisions.md
+++ b/goals/time-to-certainty/research/decisions.md
@@ -139,15 +139,25 @@ independent four-lens review of head 9c37b20d67 run on GPT-5.6 Sol (xhigh) with 
 refuters per finding; six of nine candidates survived.
 
 **Ruling 17 — the retention budget is over terminal attempts only.** The journal keeps the newest
-50 unprotected terminal attempts; unfinished starts are never counted toward the budget and never
-evicted, so the journal may hold (unfinished + 50) rows and stale-start reconciliation is what bounds
-the unfinished set. Rejected: a separate ceiling on unverifiable unfinished starts (can drop a start
-whose owner is merely unverifiable); a single total cap that never evicts unfinished (terminal facts
-still vanish whenever the unfinished count nears 50).
+50 unprotected terminal *attempts* (each a start/terminal pair, so up to 100 paired event rows) plus
+every unfinished start and the compaction receipt; unfinished starts are never counted toward the
+budget and never evicted, and stale-start reconciliation is what bounds the unfinished set.
+Amendment (Codex review of this PR, ratified 2026-09-03): a start recorded before process identity
+existed (no owner pid and start time; the frozen baseline holds 327 such unmatched starts) cannot be
+classified dead by pid-plus-start-time reconciliation, so the first post-rollout reconciliation closes
+it with `attempt-terminated` reason `legacy-unowned-start` (a new LiteralKit member) and one journal
+receipt per pass; the P0 baseline stays frozen, M5 counts these rows as unfinished inside the
+baseline window and as terminated thereafter. Rejected: a separate ceiling on unverifiable unfinished
+starts (can drop a start whose owner is merely unverifiable); a single total cap that never evicts
+unfinished (terminal facts still vanish whenever the unfinished count nears 50); a 24-hour grace
+period for legacy starts (protects an unlikely window at the cost of a second rule).
 
 **Ruling 18 — economics left-censors from compaction receipts.** The journal-compacted receipt keeps
-the evicted attempt ids and the boundary timestamp; the economics loader marks the branch
-left-censored there and excludes, or reports separately with a count, any red-to-green episode whose
-start may have been evicted. No archive file and no second writer. Rejected: an append-only economics
-archive (exact M1 forever, unbounded second file); accepting the gap with a report caveat (M1
-comparability at close-out unproven).
+the evicted attempt ids and a monotonic cutoff: the newest `recordedAt` among every terminal attempt
+evicted so far on that journal (the existing accumulated `oldestEvictedRecordedAt` is not sufficient,
+because after a second compaction an episode that started between the two evictions may have lost
+its leading red attempts). The economics loader marks the branch left-censored at that cutoff and
+excludes, or reports separately with a count, any red-to-green episode that starts at or before it.
+No archive file and no second writer. Rejected: an append-only economics archive (exact M1 forever,
+unbounded second file); accepting the gap with a report caveat (M1 comparability at close-out
+unproven).

--- a/goals/time-to-certainty/research/decisions.md
+++ b/goals/time-to-certainty/research/decisions.md
@@ -131,3 +131,23 @@ parallel field.
 
 **Ratification status:** rulings 11–16 ratified by the operator on 2026-09-03 (all six, as amended
 after the PR #968 review).
+
+## 2026-09-03 — A5b compaction review, round 5 (two rulings, steward: Benjamin)
+
+Inputs: the third Greptile P1 on PR #978 (unfinished attempts erase terminal facts) and an
+independent four-lens review of head 9c37b20d67 run on GPT-5.6 Sol (xhigh) with three adversarial
+refuters per finding; six of nine candidates survived.
+
+**Ruling 17 — the retention budget is over terminal attempts only.** The journal keeps the newest
+50 unprotected terminal attempts; unfinished starts are never counted toward the budget and never
+evicted, so the journal may hold (unfinished + 50) rows and stale-start reconciliation is what bounds
+the unfinished set. Rejected: a separate ceiling on unverifiable unfinished starts (can drop a start
+whose owner is merely unverifiable); a single total cap that never evicts unfinished (terminal facts
+still vanish whenever the unfinished count nears 50).
+
+**Ruling 18 — economics left-censors from compaction receipts.** The journal-compacted receipt keeps
+the evicted attempt ids and the boundary timestamp; the economics loader marks the branch
+left-censored there and excludes, or reports separately with a count, any red-to-green episode whose
+start may have been evicted. No archive file and no second writer. Rejected: an append-only economics
+archive (exact M1 forever, unbounded second file); accepting the gap with a report caveat (M1
+comparability at close-out unproven).


### PR DESCRIPTION
Records rulings 17 (retention budget over terminal attempts only) and 18 (economics left-censors from journal-compacted receipts) in the time-to-certainty decisions log. Both were ratified by the operator on 2026-09-03 after the third Greptile P1 on #978 and an independent Sol-xhigh review of the compaction logic; PR #978 implements them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791051759&installation_model_id=424656&pr_number=991&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F991&signature=a5e4e0dbaa302ae3886eaf37b16747d831ef9d97718e6b16c461af2e09f5d175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->