### PR TITLE
fix(repo-cli): make effect-imports-markdown policy lane advisory

### DIFF
--- a/.changeset/effect-imports-markdown-advisory.md
+++ b/.changeset/effect-imports-markdown-advisory.md
@@ -1,0 +1,10 @@
+---
+"@beep/repo-cli": patch
+---
+
+Make the `lint:effect-imports-markdown` policy lane advisory (report-only)
+instead of blocking. #971 added the standalone-markdown per-module import pass
+with `--check` even though its own comment keeps it advisory until the final
+per-module import flip, so `lint policy --full` hard-failed on pre-existing repo
+docs and left `main` (and every inheriting PR) red. Dropping `--check` restores
+the intended report-only behavior; the check is re-added at the final flip.

--- a/packages/tooling/tool/cli/src/commands/Quality/Tasks.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/Tasks.ts
@@ -2297,14 +2297,10 @@ const rootRepoLintPolicySteps = (repoRoot: string, files?: ReadonlyArray<string>
       ),
       ...scopedLawStep(repoRoot, "lint:effect-imports", "effect-imports", ["--check"], files),
       // Standalone Markdown is invisible to Biome and the JSDoc inventory. Keep this
-      // full authored-corpus pass advisory until the final per-module import flip.
-      repoCliStep(repoRoot, "lint:effect-imports-markdown", [
-        "laws",
-        "effect-imports",
-        "--mode",
-        "markdown",
-        "--check",
-      ]),
+      // full authored-corpus pass advisory until the final per-module import flip:
+      // run it report-only (no `--check`) so it surfaces markdown import drift in the
+      // logs without failing the policy. `--check` is re-added at the final flip.
+      repoCliStep(repoRoot, "lint:effect-imports-markdown", ["laws", "effect-imports", "--mode", "markdown"]),
       repoCliStep(repoRoot, "lint:package-test-typecheck", ["lint", "package-test-typecheck"]),
       repoCliStep(repoRoot, "lint:tsgo-rules", ["quality", "tsgo-rules"]),
       // Gate on mandatory (error) oxlint rules; --quiet suppresses the large advisory (warn)

--- a/packages/tooling/tool/cli/test/quality-tasks.test.ts
+++ b/packages/tooling/tool/cli/test/quality-tasks.test.ts
@@ -2093,7 +2093,7 @@ describe("quality task adapter", () => {
       repoCliEntryArgs("laws", "native-runtime", "--check")
     );
     expect(steps.find((step) => step.label === "lint:effect-imports-markdown")?.args).toEqual(
-      repoCliEntryArgs("laws", "effect-imports", "--mode", "markdown", "--check")
+      repoCliEntryArgs("laws", "effect-imports", "--mode", "markdown")
     );
     expect(steps.every((step) => step.captureTimeoutMillis === 15 * 60 * 1_000)).toBe(true);
   });


### PR DESCRIPTION
## Problem

`main` (and every inheriting PR) is red on **Heavy / Lint Policy**. The failing lane is `lint:effect-imports-markdown`, which #971 ("per-module import migration vehicle") added to `bun run beep lint policy --full` with `--check` — even though its own code comment says to keep the standalone-Markdown pass *"advisory until the final per-module import flip."*

`laws effect-imports` has no `--advisory` flag (unlike the sibling `terse-effect` lane, which uses `["--check", "--advisory"]`), so the `--check` step hard-fails the policy on 14 pre-existing repo docs (`.claude/skills/**`, `.patterns/**`, `standards/**`, other goals' `SPEC.md`) that carry not-yet-migrated root `effect` imports in fenced examples. None of those docs changed recently — the lane's blocking wiring did.

## Fix

Drop `--check` from the `lint:effect-imports-markdown` step so it runs **report-only**: it still surfaces markdown import drift in the policy logs, but no longer fails the gate. `--check` is re-added at the final per-module import flip. The lane test is updated to match.

## Verification

- `bun run beep laws effect-imports --mode markdown` exits 0 (report-only).
- `packages/tooling/tool/cli` `quality-tasks.test.ts` passes with the updated arg expectation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/995"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791055511&installation_model_id=424656&pr_number=995&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F995&signature=6a848a419a69d70a7110bc90178d6f22d46b3a88027bddd55da4cf7b3efecb06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->