### PR TITLE
docs(goals): close per-module imports at pilot stop

### DIFF
--- a/goals/per-module-imports/GOAL.md
+++ b/goals/per-module-imports/GOAL.md
@@ -10,6 +10,10 @@ foundation barrels uses per-module form (`import * as Effect from
 `noRestrictedImports` with a warn→error family ratchet — gated on a measured
 pilot. Barrels stay as the public/docgen surface.
 
+Terminal disposition: P2 selected the normative stop route in `SPEC.md` D14.
+P3 was not authorized, so this run closes after P4 with the bounded P1/P2
+vehicle and pilot evidence retained; it does not claim the global outcome.
+
 This is a compact `/goal` launcher. The packet files are the contract:
 
 - `goals/per-module-imports/README.md`
@@ -57,9 +61,10 @@ Workflow:
 
 Acceptance:
 
-- [ ] `SPEC.md` acceptance boxes all check.
-- [ ] Pilot verdict + raw stats recorded; operator sign-off at the gate.
-- [ ] Zero forbidden root specifiers in migrated scope; root rule at `error`.
+- [x] `SPEC.md` terminal-route acceptance boxes all check.
+- [x] Pilot verdict + raw stats recorded; the gate's stop disposition applied.
+- [x] Strict-pass-only P3 outcomes are explicitly not executed under D14 and
+  are not represented as completed migration work.
 
 Stop and report instead of improvising when: the gate says no-win or material
 regression; leaf bypass exposes a design-level cycle; a foundation batch's CI

--- a/goals/per-module-imports/PLAN.md
+++ b/goals/per-module-imports/PLAN.md
@@ -2,9 +2,10 @@
 
 ## Status
 
-Status: `paused` — P1 and P2 complete. The Professional Desktop pilot remained
-inconclusive after its one permitted symmetric extension, so the recorded stop
-condition prevents P3.
+Status: `completed-retained` — terminal at the P2 measured stop. P1 and P2
+shipped, P3 was not authorized, and P4 closeout is complete. The Professional
+Desktop pilot remained inconclusive after its one permitted symmetric
+extension, so the recorded stop condition prevents the mass migration.
 
 ## Phases
 
@@ -13,8 +14,8 @@ condition prevents P3.
 | P0 Research | complete | Ground the migration: enforcement census, import census + mapping table, tooling evaluation, pilot/measurement design, community evidence. | Six cited reports under `research/` (2026-08-23 fan-out: 4 codex `gpt-5.6-sol` xhigh lanes + 2 grok CLI lanes). |
 | P1 Vehicle & unblocks | complete (2026-09-03) | Invert `laws effect-imports` into the per-module law + ts-morph migration command (mapping table as data; code/JSDoc/Markdown modes; manual-review queue); land pilot-blocking foundation leaf exports; fix generator templates; extend the JSDoc example-import detector. | New law green on its own fixtures; dry-run over the pilot reports zero unmapped/ambiguous; new leaves resolve under NodeNext build, Bundler check, and docgen. Shipped via `/yeet`. |
 | P2 Pilot gate | complete — inconclusive stop (2026-09-03) | Run the approved `apps/professional-desktop` before/after measurement protocol; apply win/no-win/stop rules. | The tracked verdict and raw samples record no stable qualifying win after the permitted extension; the stop rule applies. |
-| P3 Batches & ratchet | pending — not authorized | Introduce and freeze the Biome `noRestrictedImports` warn rule; migrate the foundation kernel as one batch, then vertical families, then tools/tests/apps (composition roots last); migrate the JSDoc/Markdown corpus; flip written laws/skills with enforcement; final single root-error flip. | Zero forbidden specifiers in scope; law-flip checklist (`research/enforcement-census.md` §B) complete; every batch PR mergeable via `/yeet`. |
-| P4 Close | pending | Closeout reflection, packet state flip, and off-repo follow-ups (operator's global rules file update happens in-session when the convention lands, per the grilled decision). | Reflection passes `bun run beep lint reflection-artifacts`; manifest/README/INDEX updated in the final PR. |
+| P3 Batches & ratchet | complete — stopped by P2 gate; not executed | Would introduce and freeze the Biome `noRestrictedImports` warn rule; migrate the foundation kernel, vertical families, tools/tests/apps, and JSDoc/Markdown corpus; flip written laws/skills with enforcement; and finish with the single root-error flip. | Terminal disposition recorded under D14. None of the strict-pass-only work was authorized or claimed complete. |
+| P4 Close | complete (2026-09-03) | Closeout reflection and packet state flip. The operator's global rules file remains unchanged because the convention did not land. | Reflection passes `bun run beep lint reflection-artifacts`; manifest/README/INDEX describe the terminal stop. |
 
 ## Working notes per phase
 
@@ -114,10 +115,10 @@ condition prevents P3.
 
 ## P4 Closeout Checklist
 
-1. Write a closeout reflection via `/reflect` to
+1. [x] Write a closeout reflection via `/reflect` to
    `history/reflections/<YYYY-MM-DD>-<agent>.md` (frontmatter must validate).
-2. Run `bun run beep lint reflection-artifacts`.
-3. Update `README.md`, `ops/manifest.json` phase statuses +
+2. [x] Run `bun run beep lint reflection-artifacts`.
+3. [x] Update `README.md`, `ops/manifest.json` phase statuses +
    `initiative.status`, and regenerate `goals/INDEX.md` in the same PR.
 
 ## Execution Notes

--- a/goals/per-module-imports/PLAN.md
+++ b/goals/per-module-imports/PLAN.md
@@ -15,7 +15,7 @@ extension, so the recorded stop condition prevents the mass migration.
 | P1 Vehicle & unblocks | complete (2026-09-03) | Invert `laws effect-imports` into the per-module law + ts-morph migration command (mapping table as data; code/JSDoc/Markdown modes; manual-review queue); land pilot-blocking foundation leaf exports; fix generator templates; extend the JSDoc example-import detector. | New law green on its own fixtures; dry-run over the pilot reports zero unmapped/ambiguous; new leaves resolve under NodeNext build, Bundler check, and docgen. Shipped via `/yeet`. |
 | P2 Pilot gate | complete — inconclusive stop (2026-09-03) | Run the approved `apps/professional-desktop` before/after measurement protocol; apply win/no-win/stop rules. | The tracked verdict and raw samples record no stable qualifying win after the permitted extension; the stop rule applies. |
 | P3 Batches & ratchet | complete — stopped by P2 gate; not executed | Would introduce and freeze the Biome `noRestrictedImports` warn rule; migrate the foundation kernel, vertical families, tools/tests/apps, and JSDoc/Markdown corpus; flip written laws/skills with enforcement; and finish with the single root-error flip. | Terminal disposition recorded under D14. None of the strict-pass-only work was authorized or claimed complete. |
-| P4 Close | complete (2026-09-03) | Closeout reflection and packet state flip. The operator's global rules file remains unchanged because the convention did not land. | Reflection passes `bun run beep lint reflection-artifacts`; manifest/README/INDEX describe the terminal stop. |
+| P4 Close | complete (2026-09-03) | Closeout reflection and packet state flip. The operator's global rules file remains unchanged because the convention did not land. | Reflection passes `bun run beep lint reflection-artifacts`; tracked packet files describe the terminal stop; the ignored local goals index projection regenerates and checks cleanly. |
 
 ## Working notes per phase
 
@@ -118,8 +118,9 @@ extension, so the recorded stop condition prevents the mass migration.
 1. [x] Write a closeout reflection via `/reflect` to
    `history/reflections/<YYYY-MM-DD>-<agent>.md` (frontmatter must validate).
 2. [x] Run `bun run beep lint reflection-artifacts`.
-3. [x] Update `README.md`, `ops/manifest.json` phase statuses +
-   `initiative.status`, and regenerate `goals/INDEX.md` in the same PR.
+3. [x] Update `README.md`, `ops/manifest.json` phase statuses, and
+   `initiative.status` in the same PR; then regenerate the ignored local
+   `goals/INDEX.md` projection and pass `bun run beep goals index --check`.
 
 ## Execution Notes
 

--- a/goals/per-module-imports/README.md
+++ b/goals/per-module-imports/README.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Lifecycle: `paused`
+Lifecycle: `completed-retained`
 
 Source: [`ops/manifest.json`](./ops/manifest.json)
 
@@ -36,28 +36,38 @@ tsserver, dev tooling), not production bundle bytes.
 
 ## Current Phase
 
-P2 Pilot gate complete with an **inconclusive — stop** verdict. The approved
-`apps/professional-desktop` pilot passed every correctness gate, reached zero
-root imports, and was idempotent, but its one permitted symmetric extension
-produced no stable qualifying performance improvement. The strict-pass
-authority therefore did not activate P3; the default promoted-family ratchet
-is empty again, and the packet is paused at the gate.
+**Terminal at the measured stop.** P2 completed with an
+**inconclusive — stop** verdict. The approved `apps/professional-desktop`
+pilot passed every correctness gate, reached zero root imports, and was
+idempotent, but its one permitted symmetric extension produced no stable
+qualifying performance improvement. The strict-pass authority therefore did
+not activate P3. The mass migration, Biome warn-to-error ratchet, written-law
+flip, and global enforcement flip were not executed. P4 closeout is complete,
+and this packet is retained as the vehicle, pilot, and decision record.
 
 ## Latest Evidence
 
-P2 complete 2026-09-03: 15 valid source-tsgo and Vitest samples per state, 7
-cold route samples, and 5 deterministic builds produced no decisive win and
-no stable material regression. The full threshold math and stop decision are
-recorded in [`history/p2-pilot-verdict.md`](./history/p2-pilot-verdict.md),
-with auditable raw samples under
-[`history/measurements/`](./history/measurements/). P1 evidence remains in
-[`research/p1-census-baseline.md`](./research/p1-census-baseline.md).
+P2 merged through PR #990 on 2026-09-03. Fifteen valid source-tsgo and Vitest
+samples per state, seven cold-route samples, and five deterministic builds
+produced no decisive win and no stable material regression. The full
+threshold math and stop decision are recorded in
+[`history/p2-pilot-verdict.md`](./history/p2-pilot-verdict.md), with auditable
+raw samples under [`history/measurements/`](./history/measurements/).
+
+P1's migration vehicle, foundation leaf exports, generator fixes, and focused
+law/doc gates merged through PR #971. Its evidence remains in
+[`research/p1-census-baseline.md`](./research/p1-census-baseline.md). The P4
+reflection is
+[`history/reflections/2026-09-03-codex.md`](./history/reflections/2026-09-03-codex.md).
 
 ## Notes
 
 - The pilot gate is a real gate: no-win or a material regression stops the
   mass migration (`SPEC.md` § Pilot Gate).
+- P3 is recorded as terminally stopped, not as completed implementation. It
+  may be reconsidered only through a new decision with new evidence; this
+  closed packet grants no continuation authority.
 - Foundation leaf-export work (`@beep/dock`, `@beep/observability`,
   `@beep/schema`, …) must precede the consumers that import those barrels.
-- The operator's global Effect rules file is updated in-session when the
-  in-repo convention lands (see `SPEC.md` Decision Log).
+- The operator's global Effect rules file was not changed because the global
+  convention did not land (see `SPEC.md` D14).

--- a/goals/per-module-imports/SPEC.md
+++ b/goals/per-module-imports/SPEC.md
@@ -236,12 +236,20 @@ imports can regress cold start; a material regression stops the migration.
       Yeet repair and Lint Policy run the new semantics.
 - [x] Pilot measured under the protocol; verdict + raw stats recorded in the
       packet; operator sign-off on continuation (or a recorded stop).
-- [ ] Post-gate: zero forbidden root specifiers in scope (executable and doc
-      fences); Biome rule at root `error` with family overrides removed.
 - [x] Foundation leaf exports shipped in both export maps; docgen green.
-- [ ] Law-flip checklist (`research/enforcement-census.md` §B) fully applied.
-- [ ] Every batch shipped as a PR driven to mergeable via `/yeet`.
-- [ ] Closeout reflection passes `bun run beep lint reflection-artifacts`.
+- [x] The selected terminal route is explicit: D14 stopped P3, so the
+      post-gate zero-root census, Biome root-`error` flip, and remaining
+      law-flip checklist items were not executed or claimed as complete.
+- [x] Every authorized batch shipped through `/yeet`: P1 via PR #971 and P2
+      via PR #990. No P3 batch was authorized.
+- [x] Closeout reflection passes `bun run beep lint reflection-artifacts`.
+
+The strict-pass route would additionally require zero forbidden root
+specifiers in the complete in-scope corpus, the Biome rule at root `error`
+with family overrides removed, and the full law-flip checklist in
+`research/enforcement-census.md` §B. D14 made that route inapplicable to this
+run. Reaching those outcomes requires a new decision backed by new evidence;
+closing this packet does not waive or silently satisfy them.
 
 ## Verification Matrix
 

--- a/goals/per-module-imports/history/reflections/2026-09-03-codex.md
+++ b/goals/per-module-imports/history/reflections/2026-09-03-codex.md
@@ -1,0 +1,106 @@
+---
+goal: per-module-imports
+agent: codex
+date: 2026-09-03
+trigger: closeout
+confidence: high
+findings:
+  - category: implementation-improvement
+    confidence: high
+    instruction: Preserve the family-scoped migration vehicle and leaf exports, but leave the promoted-family list empty after a stopped pilot.
+    explanation: PR #971 delivered reusable mechanics and PR #990 proved them on Professional Desktop, while the measured gate supplied no authority for a repository-wide behavior change.
+  - category: goal-critique
+    confidence: high
+    instruction: Define strict-pass and stop closeout routes in the launcher and acceptance criteria before pilot execution.
+    explanation: The packet correctly made no-win or unresolved variance terminal, but its original acceptance list only described the strict-pass outcome and therefore made an evidence-backed stop look permanently incomplete.
+  - category: tooling-friction
+    confidence: high
+    instruction: Make early PR publication and runner-backed verification a first-class Yeet path that does not depend on unrelated checkout scheduler capacity.
+    explanation: The operator had to override repeated scheduler waiting even though start-pr-early and hosted runners could provide the required feedback without killing or displacing healthy leases.
+  - category: implementation-improvement
+    confidence: medium
+    instruction: Add an explicit closeout disposition field or helper for phases stopped by a preceding empirical gate.
+    explanation: The canonical phase vocabulary requires terminally dispositioned work to use complete plus prose metadata, which is valid but easy to misread as implementation completion.
+  - category: codification-todo
+    confidence: high
+    instruction: Teach goal templates and doctor checks that every normative stop condition needs a complete retained closeout route.
+    explanation: A stop is a successful application of the experiment contract, not an invitation to leave the packet paused indefinitely or to weaken the threshold after seeing results.
+todos:
+  - Add paired strict-pass and stop-route acceptance guidance to the goal packet template.
+  - Consider a typed phase disposition for gate-stopped work while retaining canonical phase statuses.
+  - Keep future performance pilots paired, thresholded, and auditable before authorizing mass mechanical rewrites.
+---
+
+# Reflection — per-module-imports (2026-09-03, codex)
+
+## Summary
+
+The packet delivered the per-module migration vehicle, required foundation
+leaf exports, generator and documentation gates, and a complete Professional
+Desktop pilot. The pilot was correctness-clean but produced no stable
+qualifying performance win, so the right outcome was to stop P3 and retain the
+implementation and measurements rather than manufacture a migration mandate.
+
+## Tooling experience
+
+- **Worked:** The inverted `laws effect-imports` command made the pilot
+  mechanical and auditable across executable, type-only, and JSDoc imports.
+  The measurement bundle preserved raw samples and threshold math, while Yeet
+  and hosted checks proved PRs #971 and #990 before merge.
+- **Didn't:** Machine-wide scheduler availability became a long-lived proxy
+  blocker even after the operator preferred affected-package filters, early PR
+  creation, and hosted runners.
+- **Frustrating:** A terminal empirical stop and an unfinished initiative were
+  represented by the same `paused` lifecycle until closeout. The original
+  acceptance list also described only the successful-migration branch, even
+  though the protocol made a stopped pilot equally terminal.
+- **Wished existed:** A canonical `gate-stopped` phase disposition and a goal
+  template that requires both success and stop closeout routes would remove the
+  semantic ambiguity without expanding the phase-status vocabulary.
+
+## Implementation improvement opportunities
+
+- Retain the migration vehicle as an opt-in candidate tool, with an empty
+  promoted-family list by default. This preserves proven mechanics without
+  silently imposing the convention on unmeasured families.
+- If new evidence reopens the proposal, start with a new pilot decision. Do not
+  continue P3 from this packet's stale authority or reinterpret its noisy
+  source-check and Vitest deltas as a pass.
+- Keep the P1 leaf exports. They are valid public subpaths independently of the
+  stopped performance hypothesis and were proven under NodeNext, Bundler, and
+  docgen resolution.
+
+## Goal & prompt critique
+
+The launcher should have said: “On a strict pass, continue through P3 and the
+global error flip. On no-win, material regression, or unresolved variance,
+skip P3 and proceed directly to P4, marking the packet completed-retained with
+the unexecuted migration requirements explicitly dispositioned.” That edit
+would have made the correct post-pilot action obvious and prevented a terminal
+stop from being mistaken for a capacity blocker.
+
+The execution prompt should also have named early hosted validation as an
+allowed verification lane from the beginning. It eventually did so through
+operator direction, but only after repeated scheduler monitoring.
+
+## TODOs worth codifying
+
+- Extend the goal template with mutually exclusive pass and stop acceptance
+  routes whenever a phase contains a binding empirical gate.
+- Consider a typed manifest field for `stopped-by-gate` so `status: complete`
+  cannot be mistaken for “implementation executed.”
+- Preserve a rule that measurement thresholds may not be weakened after
+  observing results; unresolved variance remains a stop unless the protocol
+  pre-authorized another sample extension.
+
+## Lessons (confidence-tiered)
+
+- **HIGH — Critical:** Treat a binding no-win or unresolved-variance result as
+  terminal evidence — continuing after the gate would invalidate the decision
+  contract the pilot was designed to enforce.
+- **MEDIUM — Best practice:** Separate reusable migration machinery from
+  activation authority — a sound codemod and valid leaf exports do not prove
+  that mass adoption is worth its repository-wide cost.
+- **LOW — Consideration:** If editor or runtime behavior changes materially,
+  reopen with a fresh candidate and measurement protocol instead of reviving
+  the closed P3 plan by default.

--- a/goals/per-module-imports/ops/manifest.json
+++ b/goals/per-module-imports/ops/manifest.json
@@ -80,7 +80,7 @@
       "name": "Close",
       "status": "complete",
       "disposition": "close-bookkeeping-complete-2026-09-03",
-      "exit": "Reflection, packet lifecycle, terminal-route acceptance, and goals index updated in the closeout PR."
+      "exit": "Reflection, packet lifecycle, and terminal-route acceptance updated in the closeout PR; the ignored local goals index projection was regenerated and checked."
     }
   ],
   "verificationCommands": [

--- a/goals/per-module-imports/ops/manifest.json
+++ b/goals/per-module-imports/ops/manifest.json
@@ -3,14 +3,14 @@
   "initiative": {
     "id": "per-module-imports",
     "title": "Per-Module Imports",
-    "status": "paused",
+    "status": "completed-retained",
     "created": "2026-08-23",
     "updated": "2026-09-03",
     "packetAnchorDocument": "SPEC.md"
   },
   "packetPath": "goals/per-module-imports",
-  "lifecycle": "paused",
-  "statusNote": "P2 completed 2026-09-03 with an inconclusive stop after the one permitted symmetric extension: all correctness gates passed, but no stable qualifying performance win authorized P3. The bounded pilot and evidence proceed through Yeet start-pr-early; merging remains unauthorized.",
+  "lifecycle": "completed-retained",
+  "statusNote": "Terminal at the measured P2 stop. P1 shipped through PR #971 and the bounded Professional Desktop pilot shipped through PR #990. All correctness gates passed, but no stable qualifying performance win authorized P3; the mass migration, Biome ratchet, written-law flip, and global enforcement flip were not executed. P4 closeout is complete and the packet is retained as evidence.",
   "mission": "Migrate effect + @beep foundation barrel imports to per-module form, enforced by a Biome warn-to-error ratchet and an inverted effect-imports law, gated on a measured pilot.",
   "executionCapable": true,
   "reflectionRequired": true,
@@ -71,12 +71,16 @@
     {
       "id": "P3",
       "name": "Batches & ratchet",
-      "status": "pending"
+      "status": "complete",
+      "disposition": "stopped-by-p2-inconclusive-gate",
+      "exit": "Not executed. SPEC D14 denied continuation authority after the inconclusive pilot."
     },
     {
       "id": "P4",
       "name": "Close",
-      "status": "pending"
+      "status": "complete",
+      "disposition": "close-bookkeeping-complete-2026-09-03",
+      "exit": "Reflection, packet lifecycle, terminal-route acceptance, and goals index updated in the closeout PR."
     }
   ],
   "verificationCommands": [


### PR DESCRIPTION
## docs(goals): close per-module imports at pilot stop

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/codex_per-module-imports-p4-closeout-0f5c2c98c876/verdict.json

---

## Provenance

- Branch: <code>codex/per-module-imports-p4-closeout</code>
- Harness: `codex`

<!-- yeet-provenance
{
  "schemaVersion": 1,
  "branch": "codex/per-module-imports-p4-closeout",
  "harness": "codex"
}
-->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791059580&installation_model_id=424656&pr_number=997&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F997&signature=c743d840abb97edd19dc7bd702739c0f22d3c1a74dd8ad10f2611583fdfb7eb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->