### PR TITLE
docs(time-to-certainty): amend ruling 17 with the pid-only age bound

### DIFF
--- a/goals/time-to-certainty/research/decisions.md
+++ b/goals/time-to-certainty/research/decisions.md
@@ -153,8 +153,11 @@ unfinished (terminal facts still vanish whenever the unfinished count nears 50);
 period for legacy starts (protects an unlikely window at the cost of a second rule).
 Amendment 2 (Greptile review of PR #978, ratified 2026-09-03): a start that recorded an owner pid
 but no process-start identity is bounded by age, because without a start-time identity age is the
-only detector of pid reuse. Pid absent: `owner-dead` now. Pid present: the attempt stays open until
-the start is older than the longest plausible attempt (24 hours from the start row's `recordedAt`);
+only detector of pid reuse. Three states are distinct: a start with no owner pid recorded at all is
+a legacy start (amendment 1, `legacy-unowned-start`); a start whose recorded pid no longer exists as
+a process is closed as `owner-dead` at the next reconciliation; a start whose recorded pid still
+exists, with no start-time identity to confirm it is the same process, stays open until the start
+is older than the longest plausible attempt (24 hours from the start row's `recordedAt`);
 the first reconciliation after that closes it with `attempt-terminated` reason
 `stale-unverifiable-owner` and one receipt per pass. Rejected: keeping such starts open
 indefinitely (pid reuse leaves permanent unfinished rows and M5 drifts upward); retrying identity

--- a/goals/time-to-certainty/research/decisions.md
+++ b/goals/time-to-certainty/research/decisions.md
@@ -157,7 +157,8 @@ only detector of pid reuse. Three states are distinct: a start with no owner pid
 a legacy start (amendment 1, `legacy-unowned-start`); a start whose recorded pid no longer exists as
 a process is closed as `owner-dead` at the next reconciliation; a start whose recorded pid still
 exists, with no start-time identity to confirm it is the same process, stays open until the start
-is older than the longest plausible attempt (24 hours from the start row's `recordedAt`);
+is older than the longest plausible attempt (24 hours from the start row's `startedAt`, the
+`attempt-started` timestamp field);
 the first reconciliation after that closes it with `attempt-terminated` reason
 `stale-unverifiable-owner` and one receipt per pass. Rejected: keeping such starts open
 indefinitely (pid reuse leaves permanent unfinished rows and M5 drifts upward); retrying identity

--- a/goals/time-to-certainty/research/decisions.md
+++ b/goals/time-to-certainty/research/decisions.md
@@ -151,6 +151,14 @@ baseline window and as terminated thereafter. Rejected: a separate ceiling on un
 starts (can drop a start whose owner is merely unverifiable); a single total cap that never evicts
 unfinished (terminal facts still vanish whenever the unfinished count nears 50); a 24-hour grace
 period for legacy starts (protects an unlikely window at the cost of a second rule).
+Amendment 2 (Greptile review of PR #978, ratified 2026-09-03): a start that recorded an owner pid
+but no process-start identity is bounded by age, because without a start-time identity age is the
+only detector of pid reuse. Pid absent: `owner-dead` now. Pid present: the attempt stays open until
+the start is older than the longest plausible attempt (24 hours from the start row's `recordedAt`);
+the first reconciliation after that closes it with `attempt-terminated` reason
+`stale-unverifiable-owner` and one receipt per pass. Rejected: keeping such starts open
+indefinitely (pid reuse leaves permanent unfinished rows and M5 drifts upward); retrying identity
+discovery before the age bound (more code for the same outcome).
 
 **Ruling 18 — economics left-censors from compaction receipts.** The journal-compacted receipt keeps
 the evicted attempt ids and a monotonic cutoff: the newest `recordedAt` among every terminal attempt


### PR DESCRIPTION
Records amendment 2 to ruling 17 in the time-to-certainty decisions log: a start that recorded an owner pid but no process-start identity is bounded by age (24 hours), then closed with attempt-terminated reason stale-unverifiable-owner. Ratified by the operator on 2026-09-03 after the Greptile review of #978; PR #978 implements it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/999"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791063174&installation_model_id=424656&pr_number=999&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F999&signature=86f6c9a2cea1951b5214dca8b505de080ddf0ce80af742fe2d10cd40f5fa3897"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->