### PR TITLE
fix(yeet): baseline the PR body snapshot on updatedAt

### DIFF
--- a/.changeset/yeet-pr-body-snapshot-updated-at.md
+++ b/.changeset/yeet-pr-body-snapshot-updated-at.md
@@ -1,0 +1,5 @@
+---
+"@beep/repo-cli": patch
+---
+
+Read the pull-request body snapshot's `updatedAt` instead of `lastEditedAt`, which `gh pr view --json` does not expose, so the provenance footer stamp no longer skips on every create, push, and monitor.

--- a/goals/yeet-pr-resume-footer/research/OPPORTUNITIES.md
+++ b/goals/yeet-pr-resume-footer/research/OPPORTUNITIES.md
@@ -38,3 +38,11 @@
    22:15Z to 00:10Z hit the 45 s probe budget on four different instances; the probe now has a
    120 s budget and logs its failure cause (`SqlTest.pglite.test.ts`), so the next skip note
    names the reason instead of "unavailable or redundant".
+8. **A `gh --json` field that does not exist shipped through green CI.** Doing: the first
+   `yeet monitor` after #975 merged. Evidence: `[yeet] provenance footer stamp skipped:
+   YeetCommandError: Unknown JSON field: "lastEditedAt"`; `gh pr view --json` (gh 2.99) lists
+   `createdAt` and `updatedAt` only, and every stamp since the reconcile round had been
+   skipping non-fatally. The fake gh runner in the tests encoded whatever fields the code asked
+   for. Prevention: validate every `gh <command> --json` field list against `gh <command>
+   --json` (no argument prints the supported fields) in a test or a doctest, and make one live
+   stamp part of closeout; fixed by PR #1004 (`updatedAt` as the inclusive baseline).

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/ProvenanceFooter.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/ProvenanceFooter.ts
@@ -46,14 +46,17 @@ class GhPrBody extends S.Class<GhPrBody>($I`GhPrBody`)(
   $I.annote("GhPrBody", { description: "Narrow gh pr view response carrying the body." })
 ) {}
 
+// `gh pr view --json` exposes `updatedAt` but not `lastEditedAt` (gh 2.99).
+// Any body edit bumps `updatedAt`, so it is a sound inclusive baseline: an
+// edit that lands after this snapshot is timestamped at or after it, and the
+// snapshot's own body is already a known body for the reconcile.
 class GhPrBodySnapshot extends S.Class<GhPrBodySnapshot>($I`GhPrBodySnapshot`)(
   {
     body: S.NullOr(S.String),
-    createdAt: S.DateTimeUtcFromString,
-    lastEditedAt: S.OptionFromNullOr(S.DateTimeUtcFromString),
+    updatedAt: S.DateTimeUtcFromString,
   },
   $I.annote("GhPrBodySnapshot", {
-    description: "Fresh pull-request body plus the GitHub edit timestamp used as a race-detection baseline.",
+    description: "Fresh pull-request body plus the GitHub update timestamp used as a race-detection baseline.",
   })
 ) {}
 
@@ -125,11 +128,7 @@ const readPrBodySnapshot = Effect.fn("ProvenanceFooter.readPrBodySnapshot")(func
   context: RepoRunContext,
   prNumber: PrNumber
 ) {
-  const viewed = yield* capture(
-    "gh",
-    ["pr", "view", `${prNumber}`, "--json", "body,createdAt,lastEditedAt"],
-    context.repoRoot
-  );
+  const viewed = yield* capture("gh", ["pr", "view", `${prNumber}`, "--json", "body,updatedAt"], context.repoRoot);
   if (viewed.exitCode !== 0) {
     return yield* YeetCommandError.make({ message: viewed.output, exitCode: viewed.exitCode });
   }
@@ -627,7 +626,7 @@ export const ensureProvenanceFooter = Effect.fn("ProvenanceFooter.ensure")(funct
     const next = splicePrProvenanceFooter(freshBody, rendered);
     if (Str.Equivalence(next, freshBody)) return O.none<string>();
     const bodyPath = yield* runArtifactPathForContext(context, "pr-provenance-body.md");
-    const baseline = O.getOrElse(fresh.lastEditedAt, () => fresh.createdAt);
+    const baseline = fresh.updatedAt;
     return yield* reconcilePrBodyAfterWrite(
       capture,
       context,

--- a/packages/tooling/tool/cli/test/yeet-provenance-footer.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-provenance-footer.test.ts
@@ -30,7 +30,7 @@ import { makeRecord, PlatformLayer, repository } from "./yeet-pr-fixtures.ts";
 import type { YeetExecutedStep } from "@beep/repo-cli/test/Yeet";
 
 const footer = renderPrProvenance(toPublicPrProvenance([makeRecord()], O.some(42), true));
-const GhBody = S.Struct({ body: S.String, createdAt: S.String, lastEditedAt: S.NullOr(S.String) });
+const GhBody = S.Struct({ body: S.String, updatedAt: S.String });
 const GhBodyEdit = S.Struct({ editedAt: S.String, editor: S.NullOr(S.Struct({ login: S.String })), diff: S.String });
 const GhBodyEditsDocument = S.Struct({
   data: S.Struct({
@@ -38,10 +38,9 @@ const GhBodyEditsDocument = S.Struct({
   }),
 });
 type GhBodyEdit = typeof GhBodyEdit.Type;
-const createdAt = "2026-09-03T12:00:00Z";
 const editedAt = "2026-09-03T12:01:00Z";
-const encodeGhBody = (body: string, lastEditedAt: string | null = editedAt): string =>
-  Result.getOrThrow(S.encodeUnknownResult(S.fromJsonString(GhBody))({ body, createdAt, lastEditedAt }));
+const encodeGhBody = (body: string, updatedAt: string = editedAt): string =>
+  Result.getOrThrow(S.encodeUnknownResult(S.fromJsonString(GhBody))({ body, updatedAt }));
 const encodeGhBodyEdits = (nodes: ReadonlyArray<GhBodyEdit>): string =>
   Result.getOrThrow(
     S.encodeUnknownResult(S.fromJsonString(GhBodyEditsDocument))({
@@ -101,7 +100,7 @@ const makeGhRunner = Effect.fn("test.makeGhRunner")(function* (
       editor: { login: "yeet" },
     },
   ],
-  freshLastEditedAt: string | null = editedAt
+  freshUpdatedAt: string = editedAt
 ) {
   const views = yield* Ref.make(0);
   const writes = yield* Ref.make(0);
@@ -117,7 +116,7 @@ const makeGhRunner = Effect.fn("test.makeGhRunner")(function* (
     if (args[1] === "view") {
       const view = yield* Ref.getAndUpdate(views, (count) => count + 1);
       const current = view === 0 ? initialBody : view === 1 ? freshBody : afterWrite(yield* Ref.get(written));
-      return { exitCode: 0, output: encodeGhBody(current, freshLastEditedAt), truncated: false };
+      return { exitCode: 0, output: encodeGhBody(current, freshUpdatedAt), truncated: false };
     }
     if (args[1] === "graphql") {
       const read = yield* Ref.getAndUpdate(historyReads, (count) => count + 1);
@@ -142,7 +141,7 @@ const runStamp = Effect.fn("test.runStamp")(function* (
   freshBody: string,
   afterWrite?: (body: string) => string,
   editHistory?: (writtenBodies: ReadonlyArray<string>, read: number) => ReadonlyArray<GhBodyEdit>,
-  freshLastEditedAt?: string | null
+  freshUpdatedAt?: string
 ) {
   const fs = yield* FileSystem.FileSystem;
   const root = yield* fs.makeTempDirectory();
@@ -152,7 +151,7 @@ const runStamp = Effect.fn("test.runStamp")(function* (
     Effect.provideService(ConfigProvider.ConfigProvider, provider)
   );
   yield* registry.append(makeRecord());
-  const runner = yield* makeGhRunner(fs, initialBody, freshBody, afterWrite, editHistory, freshLastEditedAt);
+  const runner = yield* makeGhRunner(fs, initialBody, freshBody, afterWrite, editHistory, freshUpdatedAt);
   yield* ensureProvenanceFooter(context(root), repository, 42, runner.capture).pipe(
     Effect.provideService(ConfigProvider.ConfigProvider, provider)
   );
@@ -502,7 +501,7 @@ describe("Yeet provenance footer splice", () => {
     }).pipe(provideScopedLayer(PlatformLayer))
   );
 
-  it.effect("uses createdAt as the baseline when lastEditedAt is null", () =>
+  it.effect("ignores an edit older than the snapshot's updatedAt whose body the snapshot already carries", () =>
     Effect.gen(function* () {
       let warnings = A.empty<unknown>();
       const currentConsole = yield* Console.Console;
@@ -512,12 +511,50 @@ describe("Yeet provenance footer splice", () => {
           warnings = A.appendAll(warnings, args);
         },
       };
-      const result = yield* runStamp("Original body", "Original body", undefined, undefined, null).pipe(
-        Effect.provideService(Console.Console, warningConsole)
-      );
+      const result = yield* runStamp(
+        "Original body",
+        "Original body",
+        undefined,
+        (bodies) => [
+          { diff: "Original body", editedAt: "2026-09-03T12:00:30Z", editor: { login: "alice" } },
+          { diff: O.getOrElse(A.head(bodies), () => ""), editedAt: "2026-09-03T12:03:00Z", editor: { login: "yeet" } },
+        ],
+        "2026-09-03T12:01:00Z"
+      ).pipe(Effect.provideService(Console.Console, warningConsole));
       expect(result.writes).toBe(1);
       expect(result.historyReads).toBe(1);
       expect(warnings).toHaveLength(0);
+    }).pipe(provideScopedLayer(PlatformLayer))
+  );
+
+  it.effect("re-splices an edit stamped in the same second as the snapshot's updatedAt", () =>
+    Effect.gen(function* () {
+      const result = yield* runStamp(
+        "Original body",
+        "Original body",
+        undefined,
+        (bodies, read) => {
+          const firstWrite = O.getOrElse(A.head(bodies), () => "");
+          const history: ReadonlyArray<GhBodyEdit> = [
+            { diff: "Edited in the snapshot's second", editedAt: "2026-09-03T12:01:00Z", editor: { login: "bob" } },
+            { diff: firstWrite, editedAt: "2026-09-03T12:03:00Z", editor: { login: "yeet" } },
+          ];
+          return read === 0
+            ? history
+            : [
+                ...history,
+                {
+                  diff: O.getOrElse(A.get(bodies, 1), () => ""),
+                  editedAt: "2026-09-03T12:04:00Z",
+                  editor: { login: "yeet" },
+                },
+              ];
+        },
+        "2026-09-03T12:01:00Z"
+      );
+      expect(result.writes).toBe(2);
+      expect(result.body).toContain("Edited in the snapshot's second");
+      expect(result.body).toContain("<!-- yeet-provenance:start -->");
     }).pipe(provideScopedLayer(PlatformLayer))
   );
 

--- a/packages/tooling/tool/cli/test/yeet-provenance-footer.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-provenance-footer.test.ts
@@ -51,11 +51,26 @@ const unsupportedGhPrViewField = (args: ReadonlyArray<string>): O.Option<string>
     O.flatMap((index) => A.get(args, index + 1)),
     O.flatMap((fields) => A.findFirst(Str.split(fields, ","), (field) => !HashSet.has(GhPrViewJsonFields, field)))
   );
-const ghUnknownJsonField = (field: string) => ({
+interface GhCaptureResult {
+  readonly exitCode: number;
+  readonly output: string;
+  readonly truncated: boolean;
+}
+const ghUnknownJsonField = (field: string): GhCaptureResult => ({
   exitCode: 1,
   output: `Unknown JSON field: "${field}"\nAvailable fields:\n  body\n  createdAt\n  updatedAt`,
   truncated: false,
 });
+// Answers a `gh pr view --json …` call the way gh does: refuse an unsupported
+// field before serving the snapshot the fake would otherwise return.
+const ghPrView = <E, R>(
+  args: ReadonlyArray<string>,
+  snapshot: Effect.Effect<GhCaptureResult, E, R>
+): Effect.Effect<GhCaptureResult, E, R> =>
+  O.match(unsupportedGhPrViewField(args), {
+    onNone: () => snapshot,
+    onSome: (field) => Effect.succeed(ghUnknownJsonField(field)),
+  });
 const encodeGhBody = (body: string, updatedAt: string = editedAt): string =>
   Result.getOrThrow(S.encodeUnknownResult(S.fromJsonString(GhBody))({ body, updatedAt }));
 const encodeGhBodyEdits = (nodes: ReadonlyArray<GhBodyEdit>): string =>
@@ -131,11 +146,14 @@ const makeGhRunner = Effect.fn("test.makeGhRunner")(function* (
     _env: Record<string, string | undefined> | undefined = undefined
   ) {
     if (args[1] === "view") {
-      const unsupported = unsupportedGhPrViewField(args);
-      if (O.isSome(unsupported)) return ghUnknownJsonField(unsupported.value);
-      const view = yield* Ref.getAndUpdate(views, (count) => count + 1);
-      const current = view === 0 ? initialBody : view === 1 ? freshBody : afterWrite(yield* Ref.get(written));
-      return { exitCode: 0, output: encodeGhBody(current, freshUpdatedAt), truncated: false };
+      return yield* ghPrView(
+        args,
+        Effect.gen(function* () {
+          const view = yield* Ref.getAndUpdate(views, (count) => count + 1);
+          const current = view === 0 ? initialBody : view === 1 ? freshBody : afterWrite(yield* Ref.get(written));
+          return { exitCode: 0, output: encodeGhBody(current, freshUpdatedAt), truncated: false };
+        })
+      );
     }
     if (args[1] === "graphql") {
       const read = yield* Ref.getAndUpdate(historyReads, (count) => count + 1);
@@ -198,9 +216,10 @@ const makePublishGhRunner = Effect.fn("test.makePublishGhRunner")(function* (fs:
       return { exitCode: 0, output: "https://github.com/beep-effect/beep-effect/pull/42", truncated: false };
     }
     if (args[1] === "view") {
-      const unsupported = unsupportedGhPrViewField(args);
-      if (O.isSome(unsupported)) return ghUnknownJsonField(unsupported.value);
-      return { exitCode: 0, output: encodeGhBody(yield* Ref.get(body)), truncated: false };
+      return yield* ghPrView(
+        args,
+        Effect.map(Ref.get(body), (current) => ({ exitCode: 0, output: encodeGhBody(current), truncated: false }))
+      );
     }
     if (args[1] === "graphql") {
       return {

--- a/packages/tooling/tool/cli/test/yeet-provenance-footer.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-provenance-footer.test.ts
@@ -22,10 +22,12 @@ import {
 } from "@beep/repo-cli/test/Yeet";
 import { provideScopedLayer } from "@beep/test-utils";
 import { assert, describe, expect, it } from "@effect/vitest";
-import { ConfigProvider, Console, Effect, FileSystem, Layer, Ref, Result } from "effect";
+import { ConfigProvider, Console, Effect, FileSystem, Layer, pipe, Ref, Result } from "effect";
 import * as A from "effect/Array";
+import * as HashSet from "effect/HashSet";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
+import * as Str from "effect/String";
 import { makeRecord, PlatformLayer, repository } from "./yeet-pr-fixtures.ts";
 import type { YeetExecutedStep } from "@beep/repo-cli/test/Yeet";
 
@@ -39,6 +41,21 @@ const GhBodyEditsDocument = S.Struct({
 });
 type GhBodyEdit = typeof GhBodyEdit.Type;
 const editedAt = "2026-09-03T12:01:00Z";
+// The `gh pr view --json` fields gh 2.99 exposes that the stamp may ask for.
+// A field outside this set is exactly what shipped the `lastEditedAt` skip, so
+// the fake refuses it the way gh does instead of returning a snapshot anyway.
+const GhPrViewJsonFields = HashSet.make("body", "createdAt", "updatedAt", "number", "title", "url", "state");
+const unsupportedGhPrViewField = (args: ReadonlyArray<string>): O.Option<string> =>
+  pipe(
+    A.findFirstIndex(args, (arg) => arg === "--json"),
+    O.flatMap((index) => A.get(args, index + 1)),
+    O.flatMap((fields) => A.findFirst(Str.split(fields, ","), (field) => !HashSet.has(GhPrViewJsonFields, field)))
+  );
+const ghUnknownJsonField = (field: string) => ({
+  exitCode: 1,
+  output: `Unknown JSON field: "${field}"\nAvailable fields:\n  body\n  createdAt\n  updatedAt`,
+  truncated: false,
+});
 const encodeGhBody = (body: string, updatedAt: string = editedAt): string =>
   Result.getOrThrow(S.encodeUnknownResult(S.fromJsonString(GhBody))({ body, updatedAt }));
 const encodeGhBodyEdits = (nodes: ReadonlyArray<GhBodyEdit>): string =>
@@ -114,6 +131,8 @@ const makeGhRunner = Effect.fn("test.makeGhRunner")(function* (
     _env: Record<string, string | undefined> | undefined = undefined
   ) {
     if (args[1] === "view") {
+      const unsupported = unsupportedGhPrViewField(args);
+      if (O.isSome(unsupported)) return ghUnknownJsonField(unsupported.value);
       const view = yield* Ref.getAndUpdate(views, (count) => count + 1);
       const current = view === 0 ? initialBody : view === 1 ? freshBody : afterWrite(yield* Ref.get(written));
       return { exitCode: 0, output: encodeGhBody(current, freshUpdatedAt), truncated: false };
@@ -178,7 +197,11 @@ const makePublishGhRunner = Effect.fn("test.makePublishGhRunner")(function* (fs:
       yield* Ref.set(createBody, yield* fs.readFileString(bodyPath).pipe(Effect.orDie));
       return { exitCode: 0, output: "https://github.com/beep-effect/beep-effect/pull/42", truncated: false };
     }
-    if (args[1] === "view") return { exitCode: 0, output: encodeGhBody(yield* Ref.get(body)), truncated: false };
+    if (args[1] === "view") {
+      const unsupported = unsupportedGhPrViewField(args);
+      if (O.isSome(unsupported)) return ghUnknownJsonField(unsupported.value);
+      return { exitCode: 0, output: encodeGhBody(yield* Ref.get(body)), truncated: false };
+    }
     if (args[1] === "graphql") {
       return {
         exitCode: 0,
@@ -200,6 +223,14 @@ const makePublishGhRunner = Effect.fn("test.makePublishGhRunner")(function* (fs:
 });
 
 describe("Yeet provenance footer splice", () => {
+  it("refuses gh pr view fields the CLI does not expose, as gh does", () => {
+    expect(unsupportedGhPrViewField(["pr", "view", "42", "--json", "body,createdAt,lastEditedAt"])).toStrictEqual(
+      O.some("lastEditedAt")
+    );
+    expect(unsupportedGhPrViewField(["pr", "view", "42", "--json", "body,updatedAt"])).toStrictEqual(O.none());
+    expect(unsupportedGhPrViewField(["pr", "view", "42", "--json", "body"])).toStrictEqual(O.none());
+  });
+
   it("is idempotent for current markers", () => {
     const once = splicePrProvenanceFooter("Body", footer);
     expect(splicePrProvenanceFooter(once, footer)).toBe(once);


### PR DESCRIPTION
First post-merge dogfood of #975 (`yeet monitor` on #1003) skipped the provenance footer stamp:

```
[yeet] provenance footer stamp skipped: YeetCommandError: Unknown JSON field: "lastEditedAt"
```

`gh pr view --json` (gh 2.99) exposes `createdAt` and `updatedAt` but not `lastEditedAt`, which the reconcile round of #975 introduced as the race-detection baseline. Every stamp on create, push, and monitor has been skipping since.

Fix: read `body,updatedAt` and use `updatedAt` as the inclusive baseline. Any body edit bumps `updatedAt`, so an edit that lands after the snapshot is timestamped at or after it, and the snapshot's own body is already in the reconcile's known-body set. Tests cover an older edit the snapshot already carries and an edit stamped in the snapshot's own second; the `createdAt` fallback test is retired with the field.

Live proof: this PR's own body is stamped by `yeet monitor` running from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1004"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791078866&installation_model_id=424656&pr_number=1004&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1004&signature=c6aa1776714a9260baba753df59a7a575ea9ca84b74959c27a1e2df0016949ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

---

<!-- yeet-provenance:start -->
## Provenance

- Workspace: <code>beep-effect10</code>
- Branch: <code>fix/yeet-pr-body-snapshot-updated-at</code>
- Agents (newest first):
  - `claude-code` (desktop) · `claude-fable-5-1` · <code>beep-effect10-e1</code> · monitored

Resume the publishing agent from any beep-effect checkout on the publishing workstation:

```sh
bun run beep yeet resume 1004
```

<!-- yeet-provenance
{
  "schemaVersion": 2,
  "pr": 1004,
  "branch": "fix/yeet-pr-body-snapshot-updated-at",
  "workspace": "beep-effect10",
  "agents": [
    {
      "harness": "claude-code",
      "entrypoint": "claude-desktop",
      "hostHarness": null,
      "model": "claude-fable-5-1",
      "label": "beep-effect10-e1",
      "workspace": null,
      "role": "monitored"
    }
  ]
}
-->
<!-- yeet-provenance:end -->
