### PR TITLE
fix(lint): shard the deprecated-apis eslint pass over packages/tooling

### DIFF
--- a/.changeset/lint-deprecated-apis-tooling-shards.md
+++ b/.changeset/lint-deprecated-apis-tooling-shards.md
@@ -1,0 +1,5 @@
+---
+"@beep/repo-cli": patch
+---
+
+Shard the deprecated-apis eslint lint of `packages/tooling` by subtree so the hosted lane no longer exhausts the 8 GiB heap on the repo-cli tree.

--- a/packages/tooling/tool/cli/src/commands/Lint/Lint.command.ts
+++ b/packages/tooling/tool/cli/src/commands/Lint/Lint.command.ts
@@ -72,7 +72,12 @@ const DEPRECATED_API_LINT_SHARDS = [
   "packages/foundation/ui-system",
   "packages/law-practice",
   "packages/shared",
-  "packages/tooling",
+  // One `packages/tooling` shard exhausted the 8 GiB eslint heap on hosted
+  // runners (repo-cli alone is ~1,250 TypeScript files); shard it by subtree.
+  "packages/tooling/library",
+  "packages/tooling/policy-pack",
+  "packages/tooling/test-kit",
+  "packages/tooling/tool",
   "packages/workspace",
 ] as const;
 const deprecatedApiLintCacheLocation = (shard: string): string =>

--- a/packages/tooling/tool/cli/test/lint-command.test.ts
+++ b/packages/tooling/tool/cli/test/lint-command.test.ts
@@ -39,7 +39,10 @@ const deprecatedApiLintShards = [
   "packages/foundation/ui-system",
   "packages/law-practice",
   "packages/shared",
-  "packages/tooling",
+  "packages/tooling/library",
+  "packages/tooling/policy-pack",
+  "packages/tooling/test-kit",
+  "packages/tooling/tool",
   "packages/workspace",
 ];
 
@@ -151,9 +154,9 @@ describe("deprecated-apis lint command", { concurrent: false }, () => {
               A.map(invocationLines, (line) => argumentAfter(line, "--cache-location"))
             );
 
-            expect(logLines).toContain("[lint:deprecated-apis] running 25 shards with concurrency 4");
-            expect(invocationLines).toHaveLength(25);
-            expect(A.dedupe(cacheLocations)).toHaveLength(25);
+            expect(logLines).toContain("[lint:deprecated-apis] running 28 shards with concurrency 4");
+            expect(invocationLines).toHaveLength(28);
+            expect(A.dedupe(cacheLocations)).toHaveLength(28);
             expect(A.every(invocationLines, (line) => Str.includes("--cache-strategy content")(line))).toBe(true);
             expect(
               A.every(cacheLocations, Str.startsWith("node_modules/.cache/eslint-deprecated-apis/.eslintcache-"))
@@ -201,7 +204,7 @@ describe("deprecated-apis lint command", { concurrent: false }, () => {
             );
 
             expect(logLines).toContain("[lint:deprecated-apis] skipping missing shard: apps/labs");
-            expect(invocationLines).toHaveLength(24);
+            expect(invocationLines).toHaveLength(27);
             expect(logLines).toContain("[lint:deprecated-apis] OK: no deprecated vendor API usage found.");
           })
         ).pipe(provideScopedLayer(testLayer))


### PR DESCRIPTION
`Heavy / Lint Policy` went red twice tonight (#1003 first run, #1004) in `lint:deprecated-apis` with:

```
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
Unknown: ChildProcess.exitCode (./node_modules/.bin/eslint ... packages/tooling)
```

The single `packages/tooling` shard lints ~1,700 TypeScript files with the deprecation rules (repo-cli alone is ~1,250) inside the 8 GiB `--max-old-space-size` the lane sets, and the EC2 heavy runner runs four shards at once. This splits it into `packages/tooling/library`, `packages/tooling/policy-pack`, `packages/tooling/test-kit`, and `packages/tooling/tool`, mirroring how `packages/epistemic` and `packages/foundation` are already sharded. The lint-command tests pin the new shard count (28).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791081200&installation_model_id=424656&pr_number=1007&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1007&signature=2baeb4d8df7ed6e8c091046cec442a8dddf8a16baa8174e9a35f1ca43c9a37c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->