### PR TITLE
fix(ci): lint only a pull request's own commits in the commitlint lane

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -926,7 +926,8 @@ jobs:
         shell: bash
         env:
           BEFORE_SHA: ${{ github.event.before }}
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
 
@@ -935,8 +936,15 @@ jobs:
           to_ref="HEAD"
 
           if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
-            from_ref="${PR_BASE_SHA:?missing pull request base sha}"
-            git rev-parse --verify "${from_ref}^{commit}" >/dev/null 2>&1 || git fetch --quiet --no-tags --depth=1 origin "$from_ref"
+            # Lint only the pull request's own commits. The checkout is the merge
+            # ref and `pull_request.base.sha` is frozen when the PR opens, so
+            # base.sha..HEAD also linted every commit the base branch gained
+            # since — including the bodies GitHub generates for squash merges.
+            to_ref="${PR_HEAD_SHA:?missing pull request head sha}"
+            base_branch="${PR_BASE_REF:-main}"
+            git fetch --quiet --no-tags origin "+refs/heads/${base_branch}:refs/remotes/origin/${base_branch}"
+            git rev-parse --verify "${to_ref}^{commit}" >/dev/null 2>&1 || git fetch --quiet --no-tags origin "$to_ref"
+            from_ref="$(git merge-base "refs/remotes/origin/${base_branch}" "$to_ref")"
           elif [[ -n "${BEFORE_SHA:-}" && ! "$BEFORE_SHA" =~ ^0+$ ]]; then
             from_ref="$BEFORE_SHA"
             to_ref="${GITHUB_SHA:-HEAD}"


### PR DESCRIPTION
`Commitlint` went red on #1004 with:

```
✖   footer's lines must not be longer than 100 characters [footer-max-line-length]
```

for a commit that is not on that branch: #1003's squash merge on `main`, whose GitHub-generated body bullets each squashed subject as `* <subject>`, turning a 99-character subject into a 101-character line. The lane linted `pull_request.base.sha..HEAD`, where HEAD is the merge ref and `base.sha` is frozen when the PR opens, so every commit `main` gained after the PR opened was linted on that PR.

This ranges from the live merge base with the base branch to `pull_request.head.sha`, so a PR lints exactly its own commits. The job already checks out with `fetch-depth: 0`, so the merge base is available; the base branch is fetched explicitly to be safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791082297&installation_model_id=424656&pr_number=1009&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1009&signature=fb5a89c1de69271badab6138e73b9218b8f93e9458b6a610b41d808dd45b2a51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->