### PR TITLE
fix(coverage): floor AdmissionJournal.ts branches at 98.9

### DIFF
--- a/standards/coverage.regression-baseline.jsonc
+++ b/standards/coverage.regression-baseline.jsonc
@@ -27018,12 +27018,12 @@
         "packages/tooling/tool/cli/src/internal/repo-run/AdmissionJournal.ts": {
           "lines": 100,
           "statements": 100,
-          "branches": 100,
+          "branches": 98.9,
           "functions": 100,
           "uncovered": {
             "lines": 0,
             "statements": 0,
-            "branches": 0,
+            "branches": 1,
             "functions": 0
           }
         },


### PR DESCRIPTION
## Why

`Heavy / Coverage Regression` failed on #986 twice (original run and a manual rerun) with:

```
@beep/repo-cli (packages/tooling/tool/cli/src/internal/repo-run/AdmissionJournal.ts) branches: 98.94 < 100
```

#986 does not touch that file or its test, and the file is byte-identical to main. main's own Check run and #994 measured it at 100 within the same hour. Locally, running only `test/quality-scheduler.test.ts` with coverage restricted to `AdmissionJournal.ts` gave **94/95 branches on one run and 95/95 on the next** with no change in between. The pair at `if (!completed)` in `finishJournalLockReap` depends on how many adopter reads the claim-loss injection counts under a real clock.

## What

One row: `branches` 100 → 98.9 (uncovered 0 → 1) for `AdmissionJournal.ts`. This is the ratchet's own remediation path ("once a reviewer accepts the new floors, regenerate only the regressed rows"), hand-applied to the single regressed row so no other floor moves.

The durable follow-up is to make the claim-loss injection deterministic (fault-inject the ownership loss at the discard/restore read instead of counting reads on a real clock); this PR only stops the floor from failing unrelated PRs meanwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1010"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791084716&installation_model_id=424656&pr_number=1010&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1010&signature=9a755412f17d764dff3b989c7a37fe820be0926ae3a68549e49e90ceb95f4df3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->