### PR TITLE
docs(goal): record publication proof friction

### DIFF
--- a/.changeset/review-inline-schema-static-args.md
+++ b/.changeset/review-inline-schema-static-args.md
@@ -1,0 +1,6 @@
+---
+"@beep/lint-rules": patch
+---
+
+Classify nested schema-constructor arguments recursively so runtime-dependent
+object and array literals are not reported as hoistable compiler calls.

--- a/.changeset/review-inline-schema-static-args.md
+++ b/.changeset/review-inline-schema-static-args.md
@@ -3,4 +3,5 @@
 ---
 
 Classify nested schema-constructor arguments recursively so runtime-dependent
-object and array literals are not reported as hoistable compiler calls.
+object and array literals are not reported as hoistable compiler calls, while
+static unary numeric literals remain enforceable.

--- a/goals/inline-schema-compile-hard-error/research/OPPORTUNITIES.md
+++ b/goals/inline-schema-compile-hard-error/research/OPPORTUNITIES.md
@@ -360,3 +360,25 @@
   immediately before expensive full proof, and surface newly published,
   no-fixed-release advisories early enough to perform the repository's
   time-bounded exception review before the collect-all run.
+
+## 2026-09-08 — Long-running commands lacked progress diagnostics and proof reuse
+
+- **Work:** Run the canonical repair and publication proof for the
+  repository-wide compiler-hoist campaign.
+- **Evidence:** `quality test-tsgo` announced 1,019 files across 139 packages
+  and then emitted no progress diagnostic for 493 seconds. Confirming that it
+  was still running required an external process check. JSDoc inventory was
+  similarly silent for 264 seconds, while deprecated-API lint buffered its 28
+  shard identities until its 182-second completion. A later
+  `quality package-verify @beep/repo-cli` emitted no phase or progress output
+  during its 366-second audit, then printed only its final audit and Docgen
+  summary. The immutable merge preview also reran repo-cli's same 162-file,
+  3,153-test surface in the unit and property lanes for 352 and 402 seconds,
+  respectively, despite equivalent proof earlier in that same preview.
+  Coverage then ran its distinct instrumented proof for 416 seconds.
+- **Prevention:** Give repo-cli and other shared scripts and commands a bounded
+  progress contract: structured phase, current-unit, completed, remaining,
+  elapsed, and last-completed events plus concise interactive heartbeats. Key
+  successful proofs by command, environment, dependency graph, and workspace
+  digests; reuse exact matches across nested aggregates, and report the key
+  dimension that requires a rerun when reuse is unsafe.

--- a/goals/inline-schema-compile-hard-error/research/OPPORTUNITIES.md
+++ b/goals/inline-schema-compile-hard-error/research/OPPORTUNITIES.md
@@ -368,8 +368,12 @@
 - **Evidence:** `quality test-tsgo` announced 1,019 files across 139 packages
   and then emitted no progress diagnostic for 493 seconds. Confirming that it
   was still running required an external process check. JSDoc inventory was
-  similarly silent for 264 seconds, while deprecated-API lint buffered its 28
-  shard identities until its 182-second completion. A later
+  similarly silent for 264 seconds in the earlier run and 362 seconds in a
+  later publication proof, while deprecated-API lint buffered its 28 shard
+  identities until its 182-second completion. That publication preview first
+  passed the same 1,019-file `quality test-tsgo` command in its cheap gates in
+  435 seconds, then reran it under a different pre-push lane id for 642 seconds
+  despite the unchanged preview. A later
   `quality package-verify @beep/repo-cli` emitted no phase or progress output
   during its 366-second audit, then printed only its final audit and Docgen
   summary. The immutable merge preview also reran repo-cli's same 162-file,

--- a/packages/tooling/policy-pack/lint-rules/src/rules/no-inline-schema-compile.ts
+++ b/packages/tooling/policy-pack/lint-rules/src/rules/no-inline-schema-compile.ts
@@ -168,6 +168,8 @@ export default defineRule({
               return property.kind === "init" && !property.method && isStaticSchemaExpression(property.value);
             }),
           TemplateLiteral: ({ expressions }) => A.isReadonlyArrayEmpty(expressions),
+          UnaryExpression: ({ argument, operator }) =>
+            (Str.Equivalence(operator, "-") || Str.Equivalence(operator, "+")) && isStaticSchemaExpression(argument),
           CallExpression: (call) =>
             O.match(asSchemaMethodCall(call), {
               onNone: thunkFalse,

--- a/packages/tooling/policy-pack/lint-rules/src/rules/no-inline-schema-compile.ts
+++ b/packages/tooling/policy-pack/lint-rules/src/rules/no-inline-schema-compile.ts
@@ -8,7 +8,7 @@
 
 import { thunkFalse } from "@beep/utils/thunk";
 import { defineRule } from "@oxlint/plugins";
-import { HashSet, MutableHashSet } from "effect";
+import { HashSet, Match, MutableHashSet } from "effect";
 import * as A from "effect/Array";
 import * as O from "effect/Option";
 import * as P from "effect/Predicate";
@@ -149,35 +149,33 @@ export default defineRule({
       const expression = unwrapExpression(node);
       if (O.isNone(expression)) return false;
 
-      switch (expression.value.type) {
-        case "Identifier":
-        case "MemberExpression":
-          return isStaticSchemaReference(expression.value);
-        case "Literal":
-          return true;
-        case "ArrayExpression":
-          return A.every(
-            expression.value.elements,
-            (element) =>
-              element === null ||
-              isStaticSchemaExpression(element.type === "SpreadElement" ? element.argument : element)
-          );
-        case "ObjectExpression":
-          return A.every(expression.value.properties, (property) => {
-            if (property.type === "SpreadElement") return isStaticSchemaExpression(property.argument);
-            if (property.computed && !isStaticSchemaExpression(property.key)) return false;
-            return property.kind === "init" && !property.method && isStaticSchemaExpression(property.value);
-          });
-        case "TemplateLiteral":
-          return A.isReadonlyArrayEmpty(expression.value.expressions);
-        case "CallExpression":
-          return O.match(asSchemaMethodCall(expression.value), {
-            onNone: thunkFalse,
-            onSome: ({ args }) => A.every(args, isStaticSchemaExpression),
-          });
-        default:
-          return false;
-      }
+      return Match.value(expression.value).pipe(
+        Match.discriminators("type")({
+          Identifier: isStaticSchemaReference,
+          MemberExpression: isStaticSchemaReference,
+          Literal: () => true,
+          ArrayExpression: ({ elements }) =>
+            A.every(
+              elements,
+              (element) =>
+                element === null ||
+                isStaticSchemaExpression(element.type === "SpreadElement" ? element.argument : element)
+            ),
+          ObjectExpression: ({ properties }) =>
+            A.every(properties, (property) => {
+              if (property.type === "SpreadElement") return isStaticSchemaExpression(property.argument);
+              if (property.computed && !isStaticSchemaExpression(property.key)) return false;
+              return property.kind === "init" && !property.method && isStaticSchemaExpression(property.value);
+            }),
+          TemplateLiteral: ({ expressions }) => A.isReadonlyArrayEmpty(expressions),
+          CallExpression: (call) =>
+            O.match(asSchemaMethodCall(call), {
+              onNone: thunkFalse,
+              onSome: ({ args }) => A.every(args, isStaticSchemaExpression),
+            }),
+        }),
+        Match.orElse(thunkFalse)
+      );
     };
 
     const isNestedStaticSchemaCall = (node: MaybeNode): boolean =>

--- a/packages/tooling/policy-pack/lint-rules/src/rules/no-inline-schema-compile.ts
+++ b/packages/tooling/policy-pack/lint-rules/src/rules/no-inline-schema-compile.ts
@@ -9,6 +9,7 @@
 import { thunkFalse } from "@beep/utils/thunk";
 import { defineRule } from "@oxlint/plugins";
 import { HashSet, MutableHashSet } from "effect";
+import * as A from "effect/Array";
 import * as O from "effect/Option";
 import * as P from "effect/Predicate";
 import * as Str from "effect/String";
@@ -144,23 +145,45 @@ export default defineRule({
         )
       );
 
+    const isStaticSchemaExpression = (node: MaybeNode): boolean => {
+      const expression = unwrapExpression(node);
+      if (O.isNone(expression)) return false;
+
+      switch (expression.value.type) {
+        case "Identifier":
+        case "MemberExpression":
+          return isStaticSchemaReference(expression.value);
+        case "Literal":
+          return true;
+        case "ArrayExpression":
+          return A.every(
+            expression.value.elements,
+            (element) =>
+              element === null ||
+              isStaticSchemaExpression(element.type === "SpreadElement" ? element.argument : element)
+          );
+        case "ObjectExpression":
+          return A.every(expression.value.properties, (property) => {
+            if (property.type === "SpreadElement") return isStaticSchemaExpression(property.argument);
+            if (property.computed && !isStaticSchemaExpression(property.key)) return false;
+            return property.kind === "init" && !property.method && isStaticSchemaExpression(property.value);
+          });
+        case "TemplateLiteral":
+          return A.isReadonlyArrayEmpty(expression.value.expressions);
+        case "CallExpression":
+          return O.match(asSchemaMethodCall(expression.value), {
+            onNone: thunkFalse,
+            onSome: ({ args }) => A.every(args, isStaticSchemaExpression),
+          });
+        default:
+          return false;
+      }
+    };
+
     const isNestedStaticSchemaCall = (node: MaybeNode): boolean =>
       O.match(asSchemaMethodCall(node), {
         onNone: thunkFalse,
-        onSome: ({ args }) => {
-          const [firstArg] = args;
-          if (firstArg === undefined) return true;
-          const firstExpression = unwrapExpression(firstArg);
-          if (
-            O.exists(
-              firstExpression,
-              (expression) => expression.type !== "Identifier" && expression.type !== "MemberExpression"
-            )
-          ) {
-            return O.isNone(asSchemaMethodCall(firstArg)) || isNestedStaticSchemaCall(firstArg);
-          }
-          return isStaticSchemaReference(firstArg);
-        },
+        onSome: ({ args }) => A.every(args, isStaticSchemaExpression),
       });
 
     // High when the first argument is itself a nested static schema call (literal + compiler both

--- a/packages/tooling/policy-pack/lint-rules/test/oxlint-sources.ts
+++ b/packages/tooling/policy-pack/lint-rules/test/oxlint-sources.ts
@@ -242,6 +242,15 @@ export const OXLINT_SOURCES: { readonly [K in OxlintRule]: OxlintRuleSources } =
           `export const h4 = (input: unknown): void => S.asserts(Model, input);`
         ),
       },
+      // Static schema fields nested in an object literal remain hoistable.
+      {
+        count: 1,
+        source: lines(
+          `import * as S from "effect/Schema";`,
+          `const Model = S.Struct({});`,
+          `export const h5 = () => S.decodeSync(S.Struct({ value: Model }))({});`
+        ),
+      },
     ],
     valid: [
       // Module-scope compiler call is allowed (the whole point of the rule).
@@ -283,6 +292,15 @@ export const OXLINT_SOURCES: { readonly [K in OxlintRule]: OxlintRuleSources } =
         source: lines(
           `import * as S from "effect/Schema";`,
           `export const decodeSection = (input: { schema: S.Top }) => S.decodeSync(input.schema);`
+        ),
+      },
+      // Runtime schema parameters nested in object literals cannot be hoisted.
+      {
+        count: 0,
+        source: lines(
+          `import * as S from "effect/Schema";`,
+          `export const decodeField = (fieldSchema: S.Top) =>`,
+          `  S.decodeSync(S.Struct({ value: fieldSchema }));`
         ),
       },
     ],

--- a/packages/tooling/policy-pack/lint-rules/test/oxlint-sources.ts
+++ b/packages/tooling/policy-pack/lint-rules/test/oxlint-sources.ts
@@ -260,6 +260,14 @@ export const OXLINT_SOURCES: { readonly [K in OxlintRule]: OxlintRuleSources } =
           `export const h6 = () => S.decodeSync(S.Tuple([Model]))([]);`
         ),
       },
+      // Unary numeric literals are static schema arguments.
+      {
+        count: 1,
+        source: lines(
+          `import * as S from "effect/Schema";`,
+          `export const h7 = () => S.decodeSync(S.Literal(-1))(-1);`
+        ),
+      },
     ],
     valid: [
       // Module-scope compiler call is allowed (the whole point of the rule).
@@ -319,6 +327,15 @@ export const OXLINT_SOURCES: { readonly [K in OxlintRule]: OxlintRuleSources } =
           `import * as S from "effect/Schema";`,
           `export const decodeTuple = (fieldSchema: S.Top) =>`,
           `  S.decodeSync(S.Tuple([fieldSchema]));`
+        ),
+      },
+      // Unary runtime values remain parameter-dependent.
+      {
+        count: 0,
+        source: lines(
+          `import * as S from "effect/Schema";`,
+          `export const decodeNegated = (value: -1 | 1) =>`,
+          `  S.decodeSync(S.Literal(-value));`
         ),
       },
     ],

--- a/packages/tooling/policy-pack/lint-rules/test/oxlint-sources.ts
+++ b/packages/tooling/policy-pack/lint-rules/test/oxlint-sources.ts
@@ -251,6 +251,15 @@ export const OXLINT_SOURCES: { readonly [K in OxlintRule]: OxlintRuleSources } =
           `export const h5 = () => S.decodeSync(S.Struct({ value: Model }))({});`
         ),
       },
+      // Static schema entries nested in an array literal remain hoistable.
+      {
+        count: 1,
+        source: lines(
+          `import * as S from "effect/Schema";`,
+          `const Model = S.Struct({});`,
+          `export const h6 = () => S.decodeSync(S.Tuple([Model]))([]);`
+        ),
+      },
     ],
     valid: [
       // Module-scope compiler call is allowed (the whole point of the rule).
@@ -301,6 +310,15 @@ export const OXLINT_SOURCES: { readonly [K in OxlintRule]: OxlintRuleSources } =
           `import * as S from "effect/Schema";`,
           `export const decodeField = (fieldSchema: S.Top) =>`,
           `  S.decodeSync(S.Struct({ value: fieldSchema }));`
+        ),
+      },
+      // Runtime schema parameters nested in array literals cannot be hoisted.
+      {
+        count: 0,
+        source: lines(
+          `import * as S from "effect/Schema";`,
+          `export const decodeTuple = (fieldSchema: S.Top) =>`,
+          `  S.decodeSync(S.Tuple([fieldSchema]));`
         ),
       },
     ],

--- a/packages/tooling/tool/cli/src/commands/Quality/internal/LaneProofReuse.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/internal/LaneProofReuse.ts
@@ -122,7 +122,8 @@ const laneCommandHash = (lane: GithubCheckLaneSpec): string =>
   );
 
 const environmentProfileHash = (lane: GithubCheckLaneSpec): string => {
-  const inheritedEnvironment = turboEnvExtendsAmbient(lane.step.command, lane.step.args) ? Bun.env : {};
+  const inheritedEnvironment =
+    lane.step.useLocalEnv === true || turboEnvExtendsAmbient(lane.step.command, lane.step.args) ? Bun.env : {};
   return hashText(
     stableRecordText({
       platform: process.platform,

--- a/packages/tooling/tool/cli/src/commands/Quality/internal/LaneProofReuse.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/internal/LaneProofReuse.ts
@@ -122,22 +122,17 @@ const laneCommandHash = (lane: GithubCheckLaneSpec): string =>
   );
 
 const environmentProfileHash = (lane: GithubCheckLaneSpec): string => {
-  const inheritedEnvironment =
-    lane.step.useLocalEnv === true || turboEnvExtendsAmbient(lane.step.command, lane.step.args) ? Bun.env : {};
+  const inheritedEnvironmentHash =
+    lane.step.useLocalEnv === true || turboEnvExtendsAmbient(lane.step.command, lane.step.args)
+      ? hashText(stableRecordText(Bun.env))
+      : undefined;
   return hashText(
     stableRecordText({
       platform: process.platform,
       architecture: process.arch,
       bunVersion: Bun.version,
       nodeVersion: process.version,
-      CI: inheritedEnvironment.CI,
-      GITHUB_ACTIONS: inheritedEnvironment.GITHUB_ACTIONS,
-      TURBO_CACHE: inheritedEnvironment.TURBO_CACHE,
-      TURBO_FORCE: inheritedEnvironment.TURBO_FORCE,
-      BEEP_DOCGEN_CONCURRENCY: inheritedEnvironment.BEEP_DOCGEN_CONCURRENCY,
-      BEEP_FC_NUM_RUNS: inheritedEnvironment.BEEP_FC_NUM_RUNS,
-      BEEP_FC_SEED: inheritedEnvironment.BEEP_FC_SEED,
-      NODE_OPTIONS: inheritedEnvironment.NODE_OPTIONS,
+      inheritedEnvironmentHash,
       laneEnv: stableRecordText(lane.step.env ?? {}),
     })
   );

--- a/packages/tooling/tool/cli/src/commands/Quality/internal/LaneProofReuse.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/internal/LaneProofReuse.ts
@@ -13,6 +13,7 @@ import { dual } from "effect/Function";
 import * as O from "effect/Option";
 import * as R from "effect/Record";
 import * as S from "effect/Schema";
+import { turboEnvExtendsAmbient } from "../../../internal/cli/EnvConfig.ts";
 import { JsonStringCodec } from "../../../internal/schema/JsonCodec.ts";
 import type { GithubCheckLaneSpec } from "../Quality.schemas.ts";
 
@@ -121,21 +122,21 @@ const laneCommandHash = (lane: GithubCheckLaneSpec): string =>
   );
 
 const environmentProfileHash = (lane: GithubCheckLaneSpec): string => {
-  const localEnvironment = lane.step.useLocalEnv === true ? Bun.env : {};
+  const inheritedEnvironment = turboEnvExtendsAmbient(lane.step.command, lane.step.args) ? Bun.env : {};
   return hashText(
     stableRecordText({
       platform: process.platform,
       architecture: process.arch,
       bunVersion: Bun.version,
       nodeVersion: process.version,
-      CI: localEnvironment.CI,
-      GITHUB_ACTIONS: localEnvironment.GITHUB_ACTIONS,
-      TURBO_CACHE: localEnvironment.TURBO_CACHE,
-      TURBO_FORCE: localEnvironment.TURBO_FORCE,
-      BEEP_DOCGEN_CONCURRENCY: localEnvironment.BEEP_DOCGEN_CONCURRENCY,
-      BEEP_FC_NUM_RUNS: localEnvironment.BEEP_FC_NUM_RUNS,
-      BEEP_FC_SEED: localEnvironment.BEEP_FC_SEED,
-      NODE_OPTIONS: localEnvironment.NODE_OPTIONS,
+      CI: inheritedEnvironment.CI,
+      GITHUB_ACTIONS: inheritedEnvironment.GITHUB_ACTIONS,
+      TURBO_CACHE: inheritedEnvironment.TURBO_CACHE,
+      TURBO_FORCE: inheritedEnvironment.TURBO_FORCE,
+      BEEP_DOCGEN_CONCURRENCY: inheritedEnvironment.BEEP_DOCGEN_CONCURRENCY,
+      BEEP_FC_NUM_RUNS: inheritedEnvironment.BEEP_FC_NUM_RUNS,
+      BEEP_FC_SEED: inheritedEnvironment.BEEP_FC_SEED,
+      NODE_OPTIONS: inheritedEnvironment.NODE_OPTIONS,
       laneEnv: stableRecordText(lane.step.env ?? {}),
     })
   );

--- a/packages/tooling/tool/cli/test/quality-tasks.test.ts
+++ b/packages/tooling/tool/cli/test/quality-tasks.test.ts
@@ -1665,6 +1665,36 @@ describe("quality task adapter", () => {
   );
 
   it.effect(
+    "invalidates a lane proof when an inherited ambient input changes",
+    Effect.fnUntraced(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempRoot = yield* fs.makeTempDirectoryScoped({ prefix: "lane-proof-ambient-env-" });
+      const markerPath = path.join(tempRoot, ".beep", "ambient-marker.txt");
+      yield* initializeLaneProofRepository(tempRoot);
+
+      const lane = laneProofTestLane(
+        tempRoot,
+        "proof:ambient-env",
+        "preflight",
+        "echo run >> .beep/ambient-marker.txt"
+      );
+      const run = collectGithubCheckLaneWavesForTesting(
+        "proof-ambient-env",
+        [GithubCheckLaneWaveSpec.make({ wave: "preflight", lanes: [lane] })],
+        "fail-fast",
+        "active"
+      );
+      const atSeed = (seed: string) => withEnvVarEffect("BEEP_FC_SEED", seed, run);
+
+      expect(A.map((yield* atSeed("101")).report.lanes, (result) => result.status)).toEqual(["passed"]);
+      expect(A.map((yield* atSeed("101")).report.lanes, (result) => result.status)).toEqual(["reused"]);
+      expect(A.map((yield* atSeed("202")).report.lanes, (result) => result.status)).toEqual(["passed"]);
+      expect(yield* fs.readFileString(markerPath)).toBe("run\nrun\n");
+    }, provideScopedLayer(PlatformLayer))
+  );
+
+  it.effect(
     "runs the lane when the configured proof base cannot be resolved",
     Effect.fnUntraced(function* () {
       const fs = yield* FileSystem.FileSystem;

--- a/packages/tooling/tool/cli/test/quality-tasks.test.ts
+++ b/packages/tooling/tool/cli/test/quality-tasks.test.ts
@@ -1604,6 +1604,10 @@ describe("quality task adapter", () => {
       });
       yield* persistLaneProofs(emptySession, []);
       yield* withEnvVarEffect("BEEP_YEET_LANE_PROOF_MODE", undefined, persistLaneProofs(emptySession, [[lane, 1]]));
+      yield* persistLaneProofs(emptySession, [
+        [lane, 1],
+        [laneProofTestLane(path.join(tempRoot, "other"), "proof:other", "preflight", "process.exit(0)"), 1],
+      ]);
     }, provideScopedLayer(PlatformLayer))
   );
 
@@ -1728,6 +1732,42 @@ describe("quality task adapter", () => {
 
       expect(yield* hashAtConcurrency("2")).toBe(yield* hashAtConcurrency("2"));
       expect(yield* hashAtConcurrency("2")).not.toBe(yield* hashAtConcurrency("3"));
+    }, provideScopedLayer(PlatformLayer))
+  );
+
+  it.effect(
+    "omits ambient inputs from proof identity when the lane spawn is isolated",
+    Effect.fnUntraced(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const tempRoot = yield* fs.makeTempDirectoryScoped({ prefix: "lane-proof-isolated-env-" });
+      yield* initializeLaneProofRepository(tempRoot);
+
+      const lane = GithubCheckLaneSpec.make({
+        id: "proof:isolated-env",
+        stage: "repo-quality",
+        wave: "preflight",
+        blockedBy: [],
+        step: QualityTaskStep.make({
+          label: "proof:isolated-env",
+          command: "op",
+          args: ["run", "--", "bunx", "turbo", "run", "check"],
+          cwd: tempRoot,
+          env: { PATH: "/usr/bin" },
+        }),
+      });
+      const hashAtGoldenMode = (mode: string) =>
+        withEnvVarEffect("REGEN_GOLDENS", mode, prepareLaneProofSession([lane], "active")).pipe(
+          Effect.map((session) =>
+            pipe(
+              session,
+              O.flatMap((session) => A.head(session.identities)),
+              O.map((identity) => identity.envProfileHash),
+              O.getOrThrow
+            )
+          )
+        );
+
+      expect(yield* hashAtGoldenMode("0")).toBe(yield* hashAtGoldenMode("1"));
     }, provideScopedLayer(PlatformLayer))
   );
 

--- a/packages/tooling/tool/cli/test/quality-tasks.test.ts
+++ b/packages/tooling/tool/cli/test/quality-tasks.test.ts
@@ -1695,6 +1695,43 @@ describe("quality task adapter", () => {
   );
 
   it.effect(
+    "includes ambient inputs for local-env lanes with an isolated spawn",
+    Effect.fnUntraced(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const tempRoot = yield* fs.makeTempDirectoryScoped({ prefix: "lane-proof-local-env-" });
+      yield* initializeLaneProofRepository(tempRoot);
+
+      const lane = GithubCheckLaneSpec.make({
+        id: "proof:local-env",
+        stage: "repo-quality",
+        wave: "preflight",
+        blockedBy: [],
+        step: QualityTaskStep.make({
+          label: "proof:local-env",
+          command: "op",
+          args: ["run", "--", "bunx", "turbo", "run", "check"],
+          cwd: tempRoot,
+          useLocalEnv: true,
+        }),
+      });
+      const hashAtSeed = (seed: string) =>
+        withEnvVarEffect("BEEP_FC_SEED", seed, prepareLaneProofSession([lane], "active")).pipe(
+          Effect.map((session) =>
+            pipe(
+              session,
+              O.flatMap((session) => A.head(session.identities)),
+              O.map((identity) => identity.envProfileHash),
+              O.getOrThrow
+            )
+          )
+        );
+
+      expect(yield* hashAtSeed("101")).toBe(yield* hashAtSeed("101"));
+      expect(yield* hashAtSeed("101")).not.toBe(yield* hashAtSeed("202"));
+    }, provideScopedLayer(PlatformLayer))
+  );
+
+  it.effect(
     "runs the lane when the configured proof base cannot be resolved",
     Effect.fnUntraced(function* () {
       const fs = yield* FileSystem.FileSystem;

--- a/packages/tooling/tool/cli/test/quality-tasks.test.ts
+++ b/packages/tooling/tool/cli/test/quality-tasks.test.ts
@@ -1685,17 +1685,17 @@ describe("quality task adapter", () => {
         "fail-fast",
         "active"
       );
-      const atSeed = (seed: string) => withEnvVarEffect("BEEP_FC_SEED", seed, run);
+      const withGoldenMode = (mode: string) => withEnvVarEffect("REGEN_GOLDENS", mode, run);
 
-      expect(A.map((yield* atSeed("101")).report.lanes, (result) => result.status)).toEqual(["passed"]);
-      expect(A.map((yield* atSeed("101")).report.lanes, (result) => result.status)).toEqual(["reused"]);
-      expect(A.map((yield* atSeed("202")).report.lanes, (result) => result.status)).toEqual(["passed"]);
+      expect(A.map((yield* withGoldenMode("0")).report.lanes, (result) => result.status)).toEqual(["passed"]);
+      expect(A.map((yield* withGoldenMode("0")).report.lanes, (result) => result.status)).toEqual(["reused"]);
+      expect(A.map((yield* withGoldenMode("1")).report.lanes, (result) => result.status)).toEqual(["passed"]);
       expect(yield* fs.readFileString(markerPath)).toBe("run\nrun\n");
     }, provideScopedLayer(PlatformLayer))
   );
 
   it.effect(
-    "includes ambient inputs for local-env lanes with an isolated spawn",
+    "includes the complete ambient environment for local-env lanes with an isolated spawn",
     Effect.fnUntraced(function* () {
       const fs = yield* FileSystem.FileSystem;
       const tempRoot = yield* fs.makeTempDirectoryScoped({ prefix: "lane-proof-local-env-" });
@@ -1714,8 +1714,8 @@ describe("quality task adapter", () => {
           useLocalEnv: true,
         }),
       });
-      const hashAtSeed = (seed: string) =>
-        withEnvVarEffect("BEEP_FC_SEED", seed, prepareLaneProofSession([lane], "active")).pipe(
+      const hashAtConcurrency = (concurrency: string) =>
+        withEnvVarEffect("BEEP_QUALITY_CHECK_CONCURRENCY", concurrency, prepareLaneProofSession([lane], "active")).pipe(
           Effect.map((session) =>
             pipe(
               session,
@@ -1726,8 +1726,8 @@ describe("quality task adapter", () => {
           )
         );
 
-      expect(yield* hashAtSeed("101")).toBe(yield* hashAtSeed("101"));
-      expect(yield* hashAtSeed("101")).not.toBe(yield* hashAtSeed("202"));
+      expect(yield* hashAtConcurrency("2")).toBe(yield* hashAtConcurrency("2"));
+      expect(yield* hashAtConcurrency("2")).not.toBe(yield* hashAtConcurrency("3"));
     }, provideScopedLayer(PlatformLayer))
   );
 


### PR DESCRIPTION
## fix(quality): address compiler and proof reuse review


## chore(changesets): document lint review fix


## fix(lint-rules): use Effect match for schema inputs


## docs(goal): record publication proof friction

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/codex_inline-schema-review-followups-bf0f1e73b0f4/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1022"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791510577&installation_model_id=424656&pr_number=1022&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1022&signature=721f668d671d6c2437c0bd42980fa12013f10993e2ca0bd26e1aeecc781a56a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

---

<!-- yeet-provenance:start -->
## Provenance

- Workspace: <code>beep-effect13</code>
- Branch: <code>codex/inline-schema-review-followups</code>
- Agents (newest first):
  - `codex` (tui) · `unknown` · monitored

Resume the publishing agent from any beep-effect checkout on the publishing workstation:

```sh
bun run beep yeet resume 1022
```

<!-- yeet-provenance
{
  "schemaVersion": 2,
  "pr": 1022,
  "branch": "codex/inline-schema-review-followups",
  "workspace": "beep-effect13",
  "agents": [
    {
      "harness": "codex",
      "entrypoint": "codex-tui",
      "hostHarness": null,
      "model": "unknown",
      "label": null,
      "workspace": null,
      "role": "monitored"
    }
  ]
}
-->
<!-- yeet-provenance:end -->
