### PR TITLE
chore(agents): wire Graft into Claude Code, Codex, and Grok

### DIFF
--- a/.changeset/wire-graft-agents.md
+++ b/.changeset/wire-graft-agents.md
@@ -1,0 +1,5 @@
+---
+"@beep/ai-sync": patch
+---
+
+Approve `Bash(graft:*)` in the checked-in Claude repo safety policy so the Graft code-graph CLI wired by `graft init` can run without a permission prompt.

--- a/.claude/helpers/graft-hooks.cjs
+++ b/.claude/helpers/graft-hooks.cjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+const path = require('path');
+const fs = require('fs');
+const { pathToFileURL } = require('url');
+const { execFileSync } = require('child_process');
+const dir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+const BAKED = "/home/elpresidank/.nvm/versions/node/v24.20.0/lib/node_modules/@nanonets/graft/dist/claude";
+
+// The dist/claude dir of @nanonets/graft resolved from a base whose node_modules is searched.
+function fromPkg(base) {
+  try {
+    const pkg = require.resolve('@nanonets/graft/package.json', { paths: [base] });
+    return path.join(path.dirname(pkg), 'dist', 'claude');
+  } catch { return null; }
+}
+
+// The global node_modules dir per npm (handles Homebrew/Windows/volta). Queried on demand.
+function globalRoot() {
+  try {
+    const root = execFileSync('npm', ['root', '-g'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], shell: process.platform === 'win32' }).trim();
+    return root || null;
+  } catch { return null; /* npm unavailable */ }
+}
+
+// The version of the package a dist/claude dir belongs to, or null if unreadable.
+function versionOf(distClaude) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(distClaude, '..', '..', 'package.json'), 'utf8')).version || null;
+  } catch { return null; }
+}
+
+// Numeric-dotted compare of the release part; an unreadable version loses to any known one.
+function newer(a, b) {
+  if (!a) return false;
+  if (!b) return true;
+  const p = (v) => String(v).split('-')[0].split('.').map((n) => Number(n) || 0);
+  const pa = p(a), pb = p(b);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const d = (pa[i] || 0) - (pb[i] || 0);
+    if (d !== 0) return d > 0;
+  }
+  return false;
+}
+
+// The highest-versioned dir in `dirs` that actually contains `name`, or null.
+function best(dirs, name) {
+  let bestDir = null, bestVer = null;
+  for (const d of dirs) {
+    if (!d || !fs.existsSync(path.join(d, name))) continue;
+    const v = versionOf(d);
+    if (bestDir === null || newer(v, bestVer)) { bestDir = d; bestVer = v; }
+  }
+  return bestDir;
+}
+
+function entry(name) {
+  // Cheap candidates first, and only shell out to npm when every one of them misses.
+  const cheap = [BAKED, fromPkg(dir), fromPkg(path.join(path.dirname(process.execPath), '..', 'lib'))];
+  const hit = best(cheap, name);
+  if (hit) return path.join(hit, name);
+  const gr = globalRoot();
+  const global = gr && path.join(gr, '@nanonets', 'graft', 'dist', 'claude');
+  if (global && fs.existsSync(path.join(global, name))) return path.join(global, name);
+  return path.join(dir, 'dist', 'claude', name); // last-ditch; import will no-op if absent
+}
+
+import(pathToFileURL(entry("hooks.js")).href).then((m) => m.main(process.argv[2])).catch(() => { /* graft unavailable — no-op */ });

--- a/.claude/helpers/graft-statusline.cjs
+++ b/.claude/helpers/graft-statusline.cjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+const path = require('path');
+const fs = require('fs');
+const { pathToFileURL } = require('url');
+const { execFileSync } = require('child_process');
+const dir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+const BAKED = "/home/elpresidank/.nvm/versions/node/v24.20.0/lib/node_modules/@nanonets/graft/dist/claude";
+
+// The dist/claude dir of @nanonets/graft resolved from a base whose node_modules is searched.
+function fromPkg(base) {
+  try {
+    const pkg = require.resolve('@nanonets/graft/package.json', { paths: [base] });
+    return path.join(path.dirname(pkg), 'dist', 'claude');
+  } catch { return null; }
+}
+
+// The global node_modules dir per npm (handles Homebrew/Windows/volta). Queried on demand.
+function globalRoot() {
+  try {
+    const root = execFileSync('npm', ['root', '-g'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], shell: process.platform === 'win32' }).trim();
+    return root || null;
+  } catch { return null; /* npm unavailable */ }
+}
+
+// The version of the package a dist/claude dir belongs to, or null if unreadable.
+function versionOf(distClaude) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(distClaude, '..', '..', 'package.json'), 'utf8')).version || null;
+  } catch { return null; }
+}
+
+// Numeric-dotted compare of the release part; an unreadable version loses to any known one.
+function newer(a, b) {
+  if (!a) return false;
+  if (!b) return true;
+  const p = (v) => String(v).split('-')[0].split('.').map((n) => Number(n) || 0);
+  const pa = p(a), pb = p(b);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const d = (pa[i] || 0) - (pb[i] || 0);
+    if (d !== 0) return d > 0;
+  }
+  return false;
+}
+
+// The highest-versioned dir in `dirs` that actually contains `name`, or null.
+function best(dirs, name) {
+  let bestDir = null, bestVer = null;
+  for (const d of dirs) {
+    if (!d || !fs.existsSync(path.join(d, name))) continue;
+    const v = versionOf(d);
+    if (bestDir === null || newer(v, bestVer)) { bestDir = d; bestVer = v; }
+  }
+  return bestDir;
+}
+
+function entry(name) {
+  // Cheap candidates first, and only shell out to npm when every one of them misses.
+  const cheap = [BAKED, fromPkg(dir), fromPkg(path.join(path.dirname(process.execPath), '..', 'lib'))];
+  const hit = best(cheap, name);
+  if (hit) return path.join(hit, name);
+  const gr = globalRoot();
+  const global = gr && path.join(gr, '@nanonets', 'graft', 'dist', 'claude');
+  if (global && fs.existsSync(path.join(global, name))) return path.join(global, name);
+  return path.join(dir, 'dist', 'claude', name); // last-ditch; import will no-op if absent
+}
+
+import(pathToFileURL(entry("statusline.js")).href).then((m) => m.main()).catch(() => { /* graft unavailable — no-op */ });

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -50,7 +50,8 @@
       "Bash(bun run beep laws:*)",
       "Bash(rm -rf .beep/fallow)",
       "Bash(bunx commitlint:*)",
-      "Bash(bun install:*)"
+      "Bash(bun install:*)",
+      "Bash(graft:*)"
     ],
     "deny": [
       "Bash(git push --force:*)",
@@ -134,6 +135,26 @@
             "command": "BEEP_HOOK_PULSE_NOTIFIER_REV=desktop-ntfy-1 $CLAUDE_PROJECT_DIR/.claude/hooks/hook-pulse.sh"
           }
         ]
+      },
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-hooks.cjs\" post-edit",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Bash|mcp__graft__|Read|Grep|Glob",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-hooks.cjs\" tool-savings",
+            "timeout": 8
+          }
+        ]
       }
     ],
     "PostToolUseFailure": [
@@ -170,6 +191,15 @@
             "statusMessage": "Reading Yeet inbox"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-hooks.cjs\" prompt",
+            "timeout": 15
+          }
+        ]
       }
     ],
     "SessionStart": [
@@ -188,6 +218,15 @@
             "statusMessage": "Reading Yeet inbox"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-hooks.cjs\" session-start",
+            "timeout": 8
+          }
+        ]
       }
     ],
     "Stop": [
@@ -202,6 +241,15 @@
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/yeet-inbox.sh claude",
             "timeout": 2,
             "statusMessage": "Checking Yeet inbox"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-hooks.cjs\" stop",
+            "timeout": 8
           }
         ]
       }
@@ -230,5 +278,13 @@
       }
     }
   },
-  "autoMemoryDirectory": "~/.claude/memory/beep-effect"
+  "autoMemoryDirectory": "~/.claude/memory/beep-effect",
+  "statusLine": {
+    "type": "command",
+    "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-statusline.cjs\""
+  },
+  "subagentStatusLine": {
+    "type": "command",
+    "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-statusline.cjs\""
+  }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -51,7 +51,14 @@
       "Bash(rm -rf .beep/fallow)",
       "Bash(bunx commitlint:*)",
       "Bash(bun install:*)",
-      "Bash(graft:*)"
+      "Bash(graft ask:*)",
+      "Bash(graft grep:*)",
+      "Bash(graft skeleton:*)",
+      "Bash(graft callers:*)",
+      "Bash(graft map:*)",
+      "Bash(graft blast:*)",
+      "Bash(graft check:*)",
+      "Bash(graft build:*)"
     ],
     "deny": [
       "Bash(git push --force:*)",

--- a/.claude/skills/graft/SKILL.md
+++ b/.claude/skills/graft/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: graft
+description: This repo is indexed by graft/. For ANY task here, whether
+  understanding how something works, finding where code lives, tracing what
+  calls a symbol or what a change breaks, or scoping an edit, get your context
+  from graft before grepping or reading source files.
+---
+
+# graft
+
+`graft/` holds a graph of this repo: small markdown nodes that each explain one
+part in prose and name the exact `file:line` spans they cover, plus a wiring
+graph of who-calls-what. Querying a node costs a few hundred tokens; rebuilding
+that understanding by reading source costs thousands, and misses the edges.
+
+Every command below is `$0`, needs no API key, and returns in under a second.
+There are six of them. **Pick the one that fits the task, run it, act on the
+answer; don't chain tools hoping for more. Most tasks need one call.**
+
+## The tools
+
+### 1 · `graft ask "<question>" --source`: locate + understand (the default)
+Ranked retrieval over the graph, routed automatically between prose nodes and
+the wiring graph, returning the top hits with exact `file:line`.
+- `--source` inlines the code at each hit, the ≤8-line **crux** of each
+  definition, so the result IS the code you need, no follow-up file read. Add
+  `--full` only when the crux is too small to act on.
+- `--in <path>` narrows to a subtree before ranking; `-n N` caps results (default 8).
+- **Use it when** the question is conceptual or locational: "how does auth
+  work", "where is rate-limiting handled", "what assembles the request pipeline".
+- One ask usually answers. A genuinely multi-part question needs one ask per
+  distinct sub-aspect, never the same question reworded. Few or weak hits mean
+  switch tool (grep / skeleton / callers), don't re-ask.
+
+### 2 · `graft grep "<pattern>"`: exhaustive find
+Regex (or `--fixed` for a literal) over every indexed file, hits **grouped by
+enclosing symbol** and ranked by coupling; it also reports files it couldn't read.
+- **Use it when** you need every occurrence: all call sites, all uses of a
+  constant, all providers. `ask` is ranked top-N and *will* miss instances;
+  grep won't. One grep replaces a spray of asks.
+- Search a **short symbol name or literal**, not a full guessed signature: an
+  over-specific regex (`func (s *Server) GenerateHandler`) returns nothing even
+  when the code is indexed. If a grep misses, **loosen it** (drop the receiver
+  and signature, keep the bare name) and retry `graft grep` — do NOT switch to
+  raw `grep -rn`, which is slower and unranked.
+- `-i` case-insensitive; `--in <path>` scopes to a subtree. Raw `grep -rn` is
+  only for files graft genuinely doesn't index (docs, configs, brand-new files).
+
+### 3 · `graft skeleton <file>`: a file's API at a glance
+Signatures-only view of one file (every function / method / type with its span)
+in ~200 tokens, ~10x cheaper than reading the file.
+- **Use it when** you need "what's in this file / what can I call here" before
+  editing or wiring into it. One skeleton is the whole answer for a file; don't
+  re-skeleton the same file, and don't skeleton every file `map` already named.
+
+### 4 · `graft callers <symbol>`: the exact edges
+Precomputed call/reference edges, not a text search. Symbol can be bare
+(`Foo`), qualified (`Class.method`), or package-qualified (`pkg.Fn`).
+- default `--direction in`: **who calls/references** this; run before you
+  rename, delete, or change its signature.
+- `--direction out`: **what this symbol itself calls/depends on** (the old `callees`).
+- `--depth N`: walk transitively N hops for the **full blast radius** (the old
+  `impact`); `--depth 2` is the usual "what breaks if I touch this".
+- `--depth all`: the **entire connected closure** — every source reachable
+  through the edges. Reach for this before a **refactor, rename, or any
+  multi-file change**: it surfaces the sibling and downstream files (platform
+  variants, a module you must split out) that a single-file edit would miss.
+
+### 5 · `graft map`: orientation for an unfamiliar repo or area
+A token-budgeted tour: directory clusters, per-directory hubs, and global
+hotspots, straight from the wiring graph.
+- **Use it when** you land in a repo cold or are asked for "the architecture".
+  `map` alone is the answer: read the hub cards it names; do NOT then skeleton
+  or ask your way through every subsystem it lists. `--max-dirs N` widens it.
+
+### 6 · Lifecycle: `graft build` / `graft check`
+Every tool above refreshes the graph itself before answering, so what those tools
+return always describes the code as it is right now — including edits you just made
+and have not committed. You do **not** need to run `build` after editing.
+
+One caveat, if you `grep` the markdown under `graft/` directly: those cards are a
+projection, rebuilt at the end of the turn rather than on each query, so after an edit
+they can lag. The tools above never do — prefer them, and treat a card's spans as
+stale if you have edited that file this turn.
+
+`build` is for the LLM layer (`--deep` adds a concept map; skip unless asked);
+`check` fails when `graft/` is stale, for CI.
+
+## Scenarios: the shortest path through a coding task
+
+| When you're… | Reach for | Calls |
+|---|---|---|
+| Onboarding / "explain this codebase" | `graft map`, then read the named hub cards | 1 |
+| Understanding a flow ("how does X work") | `graft ask "<flow>" --source` | 1 |
+| Finding where a change belongs | `graft ask "where is <behavior>" --source` | 1 |
+| Editing a symbol you can already name | `graft grep "<symbol>"`, edit at the `file:line` (skip `ask` — you know where it is) | 1 |
+| Renaming / deleting / changing a signature | `graft callers <sym> --depth 2` first | 1 |
+| Refactor / multi-file change (before editing) | `graft callers <sym> --depth all` — map every connected file, don't stop at the first | 1 |
+| "What does this depend on?" | `graft callers <sym> --direction out` | 1 |
+| Finding every occurrence of a pattern | `graft grep "<literal>"` | 1 |
+| "What's the API of this file?" | `graft skeleton <file>` | 1 |
+| Debugging a failure in area X | `graft ask "<symptom>" --source`, then `callers` on the suspect | 1–2 |
+| Judging a diff's risk before merge | `graft callers <changed sym> --depth 2` | 1 / symbol |
+| Working inside one repo of a monorepo | add `--in <scope>/` to ask / grep / callers | n/a |
+
+In a multi-repo workspace, graft ranks fairly so the biggest repo can't drown
+the rest, and every hit carries a `[scope/]` label naming its sub-project; when
+you already know where you're working, narrow with `graft ask "<task>" --in <scope>/`.
+
+## Spend the fewest calls
+- A node's `covers:` list already gives exact `file:line` for every symbol, so
+  cite straight from it. The spans are generated from source and authoritative;
+  don't re-open or re-grep files to "double-check".
+- When the task already names the file or symbol to change, go straight there:
+  `graft grep "<symbol>"` for the exact `file:line`, then edit. Reserve
+  `graft ask` for when you don't yet know where the code lives — an `ask`
+  round-trip is wasted on a target you can already name.
+- Trust the answer and act. Reach for a second tool only when the first genuinely
+  fell short: weak hits, a truncated span, or a need to be exhaustive.
+- If graft names a path that isn't on disk, its index is ahead of your checkout
+  (a branch switch or unpulled move). Don't read the missing file — `graft grep`
+  the symbol to find where it lives now, or run `graft build` to refresh.
+
+## Report what graft saved, every turn
+Each retrieval tool **opens** its output with a `[graft] tokens saved ≈ N` line:
+the estimated tokens that call saved versus reading the files it covers whole.
+Whenever you used any graft tool in a turn, close your reply with a one-line
+tally summing those numbers across every graft call you made, e.g.
+`🌱 graft saved ~12,400 tokens this turn (3 calls)`. A call with no such line
+(tiny files, where the pointers cost as much as the source) saved nothing, so
+skip it. This is the per-turn figure; the statusline carries the running
+session total.
+
+**Never pipe a graft command through `head`, `tail`, or `sed -n`.** Every tool
+is already capped and states what it dropped; clipping it costs you hits you
+asked for, and it silently drops the savings line the statusline's running
+total is parsed from.
+
+## When graft isn't enough
+- Span truncated ("+N more lines"): open the file at that exact range.
+- A node lacks a detail: ask a more specific question; only then read source at
+  the exact `file:line`, never a whole file to rebuild understanding graft gives.
+- You may also grep / ls / cat inside `graft/` directly (plain markdown;
+  `graft/INDEX.md` indexes the nodes), but the tools above are faster and
+  exhaustive where it matters, so reach for them first.
+
+When the graft MCP server is connected, these are exposed as tools too:
+`graft_find_code`, `graft_find_all`, `graft_file_api`, `graft_trace_calls` (with
+`direction` / `depth`), `graft_repo_map`, `graft_check_freshness`. Use whichever surface is
+available; the guidance is identical.

--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -106,6 +106,9 @@
   "ignorePatterns": [
     // The GitHub Copilot Impeccable tree mirrors the analyzed Claude Code source.
     ".github/skills/impeccable/**",
+    // Graft-owned hook/statusline shims written by `graft init` (rewritten on
+    // upgrade); Claude Code runs them by path from .claude/settings.json.
+    ".claude/helpers/**",
     // Browser QA operators copy this documented harness template beside the app
     // under test; it is a distributed resource, not workspace-owned source.
     ".claude/skills/browser-qa-loop/resources/qa-capture-template.mjs",
@@ -321,7 +324,8 @@
   "duplicates": {
     // Vendored Impeccable scripts keep their upstream shape; dependency graph
     // analysis above must not opt that vendor tree into authored-code cloning.
-    "ignore": [".claude/skills/impeccable/**"]
+    // The two graft shims are generated from one template and differ by a line.
+    "ignore": [".claude/skills/impeccable/**", ".claude/helpers/**"]
   },
   "health": {
     // Complexity ceilings — ratified 2026-07-30 (law in standards/effect-laws-v1.md;
@@ -336,7 +340,8 @@
     "maxUnitSize": 60,
     // Preserve the vendor tree's prior exclusion from authored-code complexity
     // while its module graph remains visible to dead-code dependency analysis.
-    "ignore": [".claude/skills/impeccable/**"],
+    // Graft's generated shims are not authored code either.
+    "ignore": [".claude/skills/impeccable/**", ".claude/helpers/**"],
     "thresholdOverrides": [
       {
         "files": [

--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,6 @@ explorations/beep-ci-operational-ontology/research/evidence/journal-snapshot-*/g
 # Python bytecode (packet research scripts)
 **/__pycache__/
 *.pyc
+
+# graft's local graph cache — regenerable, not committed (run `graft build`).
+/graft/

--- a/.grok/config.toml
+++ b/.grok/config.toml
@@ -1,0 +1,3 @@
+[mcp_servers.graft]
+command = "graft"
+args = ["mcp"]

--- a/.grok/skills/graft/SKILL.md
+++ b/.grok/skills/graft/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: graft
+description: This repo is indexed by graft/. For ANY task here, whether
+  understanding how something works, finding where code lives, tracing what
+  calls a symbol or what a change breaks, or scoping an edit, get your context
+  from graft before grepping or reading source files.
+---
+
+# graft
+
+`graft/` holds a graph of this repo: small markdown nodes that each explain one
+part in prose and name the exact `file:line` spans they cover, plus a wiring
+graph of who-calls-what. Querying a node costs a few hundred tokens; rebuilding
+that understanding by reading source costs thousands, and misses the edges.
+
+Every command below is `$0`, needs no API key, and returns in under a second.
+There are six of them. **Pick the one that fits the task, run it, act on the
+answer; don't chain tools hoping for more. Most tasks need one call.**
+
+## The tools
+
+### 1 · `graft ask "<question>" --source`: locate + understand (the default)
+Ranked retrieval over the graph, routed automatically between prose nodes and
+the wiring graph, returning the top hits with exact `file:line`.
+- `--source` inlines the code at each hit, the ≤8-line **crux** of each
+  definition, so the result IS the code you need, no follow-up file read. Add
+  `--full` only when the crux is too small to act on.
+- `--in <path>` narrows to a subtree before ranking; `-n N` caps results (default 8).
+- **Use it when** the question is conceptual or locational: "how does auth
+  work", "where is rate-limiting handled", "what assembles the request pipeline".
+- One ask usually answers. A genuinely multi-part question needs one ask per
+  distinct sub-aspect, never the same question reworded. Few or weak hits mean
+  switch tool (grep / skeleton / callers), don't re-ask.
+
+### 2 · `graft grep "<pattern>"`: exhaustive find
+Regex (or `--fixed` for a literal) over every indexed file, hits **grouped by
+enclosing symbol** and ranked by coupling; it also reports files it couldn't read.
+- **Use it when** you need every occurrence: all call sites, all uses of a
+  constant, all providers. `ask` is ranked top-N and *will* miss instances;
+  grep won't. One grep replaces a spray of asks.
+- Search a **short symbol name or literal**, not a full guessed signature: an
+  over-specific regex (`func (s *Server) GenerateHandler`) returns nothing even
+  when the code is indexed. If a grep misses, **loosen it** (drop the receiver
+  and signature, keep the bare name) and retry `graft grep` — do NOT switch to
+  raw `grep -rn`, which is slower and unranked.
+- `-i` case-insensitive; `--in <path>` scopes to a subtree. Raw `grep -rn` is
+  only for files graft genuinely doesn't index (docs, configs, brand-new files).
+
+### 3 · `graft skeleton <file>`: a file's API at a glance
+Signatures-only view of one file (every function / method / type with its span)
+in ~200 tokens, ~10x cheaper than reading the file.
+- **Use it when** you need "what's in this file / what can I call here" before
+  editing or wiring into it. One skeleton is the whole answer for a file; don't
+  re-skeleton the same file, and don't skeleton every file `map` already named.
+
+### 4 · `graft callers <symbol>`: the exact edges
+Precomputed call/reference edges, not a text search. Symbol can be bare
+(`Foo`), qualified (`Class.method`), or package-qualified (`pkg.Fn`).
+- default `--direction in`: **who calls/references** this; run before you
+  rename, delete, or change its signature.
+- `--direction out`: **what this symbol itself calls/depends on** (the old `callees`).
+- `--depth N`: walk transitively N hops for the **full blast radius** (the old
+  `impact`); `--depth 2` is the usual "what breaks if I touch this".
+- `--depth all`: the **entire connected closure** — every source reachable
+  through the edges. Reach for this before a **refactor, rename, or any
+  multi-file change**: it surfaces the sibling and downstream files (platform
+  variants, a module you must split out) that a single-file edit would miss.
+
+### 5 · `graft map`: orientation for an unfamiliar repo or area
+A token-budgeted tour: directory clusters, per-directory hubs, and global
+hotspots, straight from the wiring graph.
+- **Use it when** you land in a repo cold or are asked for "the architecture".
+  `map` alone is the answer: read the hub cards it names; do NOT then skeleton
+  or ask your way through every subsystem it lists. `--max-dirs N` widens it.
+
+### 6 · Lifecycle: `graft build` / `graft check`
+Every tool above refreshes the graph itself before answering, so what those tools
+return always describes the code as it is right now — including edits you just made
+and have not committed. You do **not** need to run `build` after editing.
+
+One caveat, if you `grep` the markdown under `graft/` directly: those cards are a
+projection, rebuilt at the end of the turn rather than on each query, so after an edit
+they can lag. The tools above never do — prefer them, and treat a card's spans as
+stale if you have edited that file this turn.
+
+`build` is for the LLM layer (`--deep` adds a concept map; skip unless asked);
+`check` fails when `graft/` is stale, for CI.
+
+## Scenarios: the shortest path through a coding task
+
+| When you're… | Reach for | Calls |
+|---|---|---|
+| Onboarding / "explain this codebase" | `graft map`, then read the named hub cards | 1 |
+| Understanding a flow ("how does X work") | `graft ask "<flow>" --source` | 1 |
+| Finding where a change belongs | `graft ask "where is <behavior>" --source` | 1 |
+| Editing a symbol you can already name | `graft grep "<symbol>"`, edit at the `file:line` (skip `ask` — you know where it is) | 1 |
+| Renaming / deleting / changing a signature | `graft callers <sym> --depth 2` first | 1 |
+| Refactor / multi-file change (before editing) | `graft callers <sym> --depth all` — map every connected file, don't stop at the first | 1 |
+| "What does this depend on?" | `graft callers <sym> --direction out` | 1 |
+| Finding every occurrence of a pattern | `graft grep "<literal>"` | 1 |
+| "What's the API of this file?" | `graft skeleton <file>` | 1 |
+| Debugging a failure in area X | `graft ask "<symptom>" --source`, then `callers` on the suspect | 1–2 |
+| Judging a diff's risk before merge | `graft callers <changed sym> --depth 2` | 1 / symbol |
+| Working inside one repo of a monorepo | add `--in <scope>/` to ask / grep / callers | n/a |
+
+In a multi-repo workspace, graft ranks fairly so the biggest repo can't drown
+the rest, and every hit carries a `[scope/]` label naming its sub-project; when
+you already know where you're working, narrow with `graft ask "<task>" --in <scope>/`.
+
+## Spend the fewest calls
+- A node's `covers:` list already gives exact `file:line` for every symbol, so
+  cite straight from it. The spans are generated from source and authoritative;
+  don't re-open or re-grep files to "double-check".
+- When the task already names the file or symbol to change, go straight there:
+  `graft grep "<symbol>"` for the exact `file:line`, then edit. Reserve
+  `graft ask` for when you don't yet know where the code lives — an `ask`
+  round-trip is wasted on a target you can already name.
+- Trust the answer and act. Reach for a second tool only when the first genuinely
+  fell short: weak hits, a truncated span, or a need to be exhaustive.
+- If graft names a path that isn't on disk, its index is ahead of your checkout
+  (a branch switch or unpulled move). Don't read the missing file — `graft grep`
+  the symbol to find where it lives now, or run `graft build` to refresh.
+
+## Report what graft saved, every turn
+Each retrieval tool **opens** its output with a `[graft] tokens saved ≈ N` line:
+the estimated tokens that call saved versus reading the files it covers whole.
+Whenever you used any graft tool in a turn, close your reply with a one-line
+tally summing those numbers across every graft call you made, e.g.
+`🌱 graft saved ~12,400 tokens this turn (3 calls)`. A call with no such line
+(tiny files, where the pointers cost as much as the source) saved nothing, so
+skip it. This is the per-turn figure; the statusline carries the running
+session total.
+
+**Never pipe a graft command through `head`, `tail`, or `sed -n`.** Every tool
+is already capped and states what it dropped; clipping it costs you hits you
+asked for, and it silently drops the savings line the statusline's running
+total is parsed from.
+
+## When graft isn't enough
+- Span truncated ("+N more lines"): open the file at that exact range.
+- A node lacks a detail: ask a more specific question; only then read source at
+  the exact `file:line`, never a whole file to rebuild understanding graft gives.
+- You may also grep / ls / cat inside `graft/` directly (plain markdown;
+  `graft/INDEX.md` indexes the nodes), but the tools above are faster and
+  exhaustive where it matters, so reach for them first.
+
+When the graft MCP server is connected, these are exposed as tools too:
+`graft_find_code`, `graft_find_all`, `graft_file_api`, `graft_trace_calls` (with
+`direction` / `depth`), `graft_repo_map`, `graft_check_freshness`. Use whichever surface is
+available; the guidance is identical.

--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,5 @@
+# graft's cards are gitignored but should stay greppable: ripgrep reads
+# .ignore before .gitignore, so this re-admits the tree to search only.
+!graft/
+graft/.cache/
+graft/.graph/

--- a/.mcp.json
+++ b/.mcp.json
@@ -50,6 +50,10 @@
     "phoenix": {
       "type": "http",
       "url": "https://dankserver.tailc7c348.ts.net:8447/mcp"
+    },
+    "graft": {
+      "command": "graft",
+      "args": ["mcp"]
     }
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,9 +151,12 @@ If you touch this, load or run this first. Do not hand-author around it.
 
 - File memory is the memory layer: each agent's own durable files
   (`CLAUDE.md` / `MEMORY.md` auto-memory) plus repo docs. There is no shared
-  external memory service and no code-KG index; basic-memory and codegraph
-  were removed on 2026-08-29 (`standards/memory-architecture/04-decision-log.md`).
-  Do not reintroduce either or wire a successor without a new decision there.
+  external memory service; basic-memory and codegraph were removed on
+  2026-08-29 (`standards/memory-architecture/04-decision-log.md`). Graft is
+  the sanctioned code-structure query path (2026-09-08 entry there): a
+  git-ignored, regenerable tree-sitter code graph, not a memory layer. Do not
+  reintroduce a memory service or wire another code index without a new
+  decision there.
 - If context is missing, fall back to repo-local docs, code search, and this
   file.
 
@@ -182,3 +185,45 @@ If you touch this, load or run this first. Do not hand-author around it.
   of spawning fresh ones.
 - Durable on-disk handoffs: agent/session transitions exchange deliverables as
   files on disk (packet `research/`, scratchpad), never chat-only summaries.
+
+<!-- graft:start -->
+## Graft — repo context graph
+
+This repo is indexed in `graft/`: small linked markdown nodes that explain each
+system and carry exact file:line spans, kept in sync with the code through git.
+
+For ANY task here — understanding how something works, finding where code lives,
+or scoping a change — get context from the graph before grepping or opening
+source files. Re-ask freely (it's cheap) and reuse literal identifiers you
+already have (symbol, error string, file name) as the query. New to this repo?
+Run `graft map` first — a token-budgeted orientation (dir clusters, hubs,
+hotspots), no LLM, no key.
+
+- Run `graft ask "<your question>" --source` → ranked nodes with the relevant
+  code spans inlined (each hit's ≤8-line crux by default; `--full` for whole
+  definitions when the crux isn't enough). Match the tool to the task shape:
+  for understanding or editing, the top node IS the answer — cite its
+  `covers:` file:line spans and edit straight from `--source`. For
+  exhaustive tasks ("every occurrence / every caller of this pattern"), ranked
+  results are top-N, not complete — run `graft grep "<literal>"` instead
+  (exhaustive over indexed files, grouped by enclosing symbol), falling back
+  to raw `grep -rn` only for unindexed files.
+- `graft skeleton <file>` → every definition's signature + span, ~10× cheaper
+  than reading the file; use it to skim an API surface.
+- `graft callers <symbol>` gives precomputed, exact edges — who calls this.
+  Add `--direction out` for what it calls, or `--depth N` to walk
+  transitively for the full blast radius. For structural questions, skip
+  ranking and use this directly.
+- Or browse: `graft/INDEX.md` lists every node; follow the links.
+- Monorepos and folders of multiple repos rank fairly across sub-projects —
+  hits carry `[scope/]` labels naming which one they're from. Narrow with
+  `graft ask "<task>" --in <scope>/` once you know where you're working.
+
+If a returned span is truncated ("+N more lines"), open the file at that exact
+range before finalizing. Only open source files when a node genuinely lacks a
+needed detail, and then at the exact file:line the node points to — never
+re-read whole files.
+
+After big code changes, refresh the graph with `graft build` (deterministic,
+no API key, $0).
+<!-- graft:end -->

--- a/_typos.toml
+++ b/_typos.toml
@@ -84,6 +84,9 @@ metalness = "metalness"
 
 [files]
 extend-exclude = [
+  # graft per-file wiring cards mirror every source file (including excluded
+  # trees such as scratchpad/); graft .ignore re-admits them to ignore-aware tools.
+  "graft/**",
   # Vendored upstream API documents drivers generate from (OpenAPI / JSON Schema);
   # kept byte-faithful to upstream, so their spelling is not ours to fix.
   "packages/drivers/*/openapi.json",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -27,6 +27,12 @@
       // GitHub Copilot; keep upstream bundles outside authored repo formatting.
       "!.claude/skills/impeccable",
       "!.github/skills/impeccable",
+      // Graft-owned generated wiring (shims, skill, Grok/OpenCode config) is
+      // rewritten by `graft init` on upgrade; keep it outside repo formatting.
+      "!.claude/helpers",
+      "!.claude/skills/graft",
+      "!.grok",
+      "!opencode.json",
       "!specs",
       "!**/.tsup",
       "!**/.turbo",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -30,6 +30,11 @@ export default [
     "**/src-tauri/target/**",
     ".claude/worktrees/**",
     ".claude/skills/impeccable/**",
+    // Graft-owned generated wiring (rewritten by `graft init` on upgrade).
+    ".claude/helpers/**",
+    ".claude/skills/graft/**",
+    ".grok/**",
+    "opencode.json",
     ".github/skills/impeccable/**",
     "infra/lambda/**/build/**",
   ]),

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -121,6 +121,9 @@
     // The GitHub Copilot Impeccable tree mirrors the Claude Code source, whose
     // detector CLI is a root package script and therefore an analyzed entry.
     ".github/skills/impeccable/**",
+    // Graft-owned hook/statusline shims written by `graft init` and rewritten on
+    // upgrade; Claude Code runs them by path from .claude/settings.json.
+    ".claude/helpers/**",
     "goals/**",
     // explorations/ is the fuzzy front end of the goals/ pipeline (capture -> graduate, see
     // explorations/CLAUDE.md); prototype code there (e.g. identity-as-iri/assets/ontology-prototype)

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,12 @@
+{
+  "mcp": {
+    "graft": {
+      "type": "local",
+      "command": [
+        "graft",
+        "mcp"
+      ],
+      "enabled": true
+    }
+  }
+}

--- a/packages/tooling/library/ai-sync/src/validation.ts
+++ b/packages/tooling/library/ai-sync/src/validation.ts
@@ -133,10 +133,11 @@ const ApprovedClaudeRepoBashPermission = LiteralKit([
   "Bash(rm -rf .beep/fallow)",
   "Bash(bunx commitlint:*)",
   "Bash(bun install:*)",
+  "Bash(graft:*)",
 ]).pipe(
   $I.annoteSchema("ApprovedClaudeRepoBashPermission", {
     description:
-      "Exact 50-value Bash grant domain approved for this repository, including named read-only GitHub queries, intentional Yeet publication commands, and stale-lane cleanup (stash drop, archive refs under refs/archive/, and Yeet sweep; worktree removal only through the Beep CLI).",
+      "Exact 51-value Bash grant domain approved for this repository, including named read-only GitHub queries, intentional Yeet publication commands, and stale-lane cleanup (stash drop, archive refs under refs/archive/, and Yeet sweep; worktree removal only through the Beep CLI), plus the read-only Graft code-graph CLI.",
   })
 );
 

--- a/packages/tooling/library/ai-sync/src/validation.ts
+++ b/packages/tooling/library/ai-sync/src/validation.ts
@@ -133,11 +133,18 @@ const ApprovedClaudeRepoBashPermission = LiteralKit([
   "Bash(rm -rf .beep/fallow)",
   "Bash(bunx commitlint:*)",
   "Bash(bun install:*)",
-  "Bash(graft:*)",
+  "Bash(graft ask:*)",
+  "Bash(graft grep:*)",
+  "Bash(graft skeleton:*)",
+  "Bash(graft callers:*)",
+  "Bash(graft map:*)",
+  "Bash(graft blast:*)",
+  "Bash(graft check:*)",
+  "Bash(graft build:*)",
 ]).pipe(
   $I.annoteSchema("ApprovedClaudeRepoBashPermission", {
     description:
-      "Exact 51-value Bash grant domain approved for this repository, including named read-only GitHub queries, intentional Yeet publication commands, and stale-lane cleanup (stash drop, archive refs under refs/archive/, and Yeet sweep; worktree removal only through the Beep CLI), plus the read-only Graft code-graph CLI.",
+      "Exact 58-value Bash grant domain approved for this repository, including named read-only GitHub queries, intentional Yeet publication commands, and stale-lane cleanup (stash drop, archive refs under refs/archive/, and Yeet sweep; worktree removal only through the Beep CLI), plus the read-only Graft code-graph query subcommands (never `graft init`, `uninstall`, or `upgrade`, which rewrite tracked agent configuration).",
   })
 );
 

--- a/packages/tooling/library/ai-sync/test/ai-sync.test.ts
+++ b/packages/tooling/library/ai-sync/test/ai-sync.test.ts
@@ -582,6 +582,15 @@ layer(NodeServices.layer as Layer.Layer<TUnsafe.Any>)("@beep/ai-sync", (it) => {
       const settings = yield* decodeStructInlineSchemaJson(settingsText);
 
       assert.lengthOf(settings.permissions.allow, 58);
+      assert.include(settings.permissions.allow, "Bash(graft ask:*)");
+      assert.include(settings.permissions.allow, "Bash(graft grep:*)");
+      assert.include(settings.permissions.allow, "Bash(graft skeleton:*)");
+      assert.include(settings.permissions.allow, "Bash(graft callers:*)");
+      assert.include(settings.permissions.allow, "Bash(graft map:*)");
+      assert.include(settings.permissions.allow, "Bash(graft blast:*)");
+      assert.include(settings.permissions.allow, "Bash(graft check:*)");
+      assert.include(settings.permissions.allow, "Bash(graft build:*)");
+      assert.notInclude(settings.permissions.allow, "Bash(graft:*)");
       assert.include(settings.permissions.allow, "Bash(git worktree prune:*)");
       assert.include(settings.permissions.allow, "Bash(bun run beep yeet sweep:*)");
       assert.notInclude(settings.permissions.allow, "Bash(git worktree remove:*)");

--- a/packages/tooling/library/ai-sync/test/ai-sync.test.ts
+++ b/packages/tooling/library/ai-sync/test/ai-sync.test.ts
@@ -573,7 +573,7 @@ layer(NodeServices.layer as Layer.Layer<TUnsafe.Any>)("@beep/ai-sync", (it) => {
   );
 
   it.effect(
-    "keeps checked-in Claude grants inside the exact 50-value allow domain",
+    "keeps checked-in Claude grants inside the exact 51-value allow domain",
     Effect.fn(function* () {
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
@@ -581,7 +581,7 @@ layer(NodeServices.layer as Layer.Layer<TUnsafe.Any>)("@beep/ai-sync", (it) => {
       const settingsText = yield* fs.readFileString(path.join(repoRoot, ".claude/settings.json"));
       const settings = yield* decodeStructInlineSchemaJson(settingsText);
 
-      assert.lengthOf(settings.permissions.allow, 50);
+      assert.lengthOf(settings.permissions.allow, 51);
       assert.include(settings.permissions.allow, "Bash(git worktree prune:*)");
       assert.include(settings.permissions.allow, "Bash(bun run beep yeet sweep:*)");
       assert.notInclude(settings.permissions.allow, "Bash(git worktree remove:*)");

--- a/packages/tooling/library/ai-sync/test/ai-sync.test.ts
+++ b/packages/tooling/library/ai-sync/test/ai-sync.test.ts
@@ -573,7 +573,7 @@ layer(NodeServices.layer as Layer.Layer<TUnsafe.Any>)("@beep/ai-sync", (it) => {
   );
 
   it.effect(
-    "keeps checked-in Claude grants inside the exact 51-value allow domain",
+    "keeps checked-in Claude grants inside the exact 58-value allow domain",
     Effect.fn(function* () {
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
@@ -581,7 +581,7 @@ layer(NodeServices.layer as Layer.Layer<TUnsafe.Any>)("@beep/ai-sync", (it) => {
       const settingsText = yield* fs.readFileString(path.join(repoRoot, ".claude/settings.json"));
       const settings = yield* decodeStructInlineSchemaJson(settingsText);
 
-      assert.lengthOf(settings.permissions.allow, 51);
+      assert.lengthOf(settings.permissions.allow, 58);
       assert.include(settings.permissions.allow, "Bash(git worktree prune:*)");
       assert.include(settings.permissions.allow, "Bash(bun run beep yeet sweep:*)");
       assert.notInclude(settings.permissions.allow, "Bash(git worktree remove:*)");

--- a/standards/memory-architecture/04-decision-log.md
+++ b/standards/memory-architecture/04-decision-log.md
@@ -422,8 +422,13 @@ Claude Code hook `timeout` is in seconds (graft writes milliseconds, so its
 values were divided by 1000), and its `npx graft` / `graft-dev` /
 `node dist/cli.js` allowlist entries were dropped (`npx graft` would resolve
 the unrelated unscoped npm package; the other two are for developing graft
-itself). Only `Bash(graft:*)` is allowed. A re-run of `graft init` restores
-the upstream values, so re-apply both corrections after any upgrade.
+itself). Only the read-only query subcommands are allowed (`graft ask`,
+`grep`, `skeleton`, `callers`, `map`, `blast`, `check`, and `build`);
+`graft init`, `uninstall`, and `upgrade` rewrite tracked agent configuration
+and keep their permission prompt. A re-run of `graft init` restores the
+upstream values, so re-apply both corrections after any upgrade; the
+`@beep/ai-sync` repo safety policy pins the exact allow domain and fails the
+check lane if the broad `Bash(graft:*)` grant comes back.
 
 **Prerequisite on every machine:** the `graft` executable must be on the PATH
 of the agent process, because the MCP registrations launch the bare command.

--- a/standards/memory-architecture/04-decision-log.md
+++ b/standards/memory-architecture/04-decision-log.md
@@ -382,3 +382,75 @@ The `.codegraph/` gitignore entry is retained defensively while stale
 machine-local indexes exist. This supersedes the 2026-08-06 role assignment
 above and the operational detail in `07-shared-memory-adoption.md`, which is
 retained as history, not instruction.
+
+---
+
+## 2026-09-08: Graft Wired as the Deterministic Code-Graph Cache (Claude Code, Codex, Grok)
+
+**Context:** The 2026-08-29 entry removed basic-memory and codegraph and ruled
+that any successor "starts as a fresh exploration with its own decision here
+first." On 2026-09-08 the operator asked for Graft (`@nanonets/graft`, MIT,
+0.16.0) to be installed and wired into Claude Code, Codex, and Grok. Graft is
+a structural code graph, not a memory system: `graft build` runs tree-sitter
+over the tracked tree with no model and no key, writes one markdown wiring
+card per source file plus a per-symbol call graph into a git-ignored cache
+directory, and every query re-syncs that graph against the working tree
+before answering. The 2026-04-15 "Deterministic-First" entry already names
+this class of AST-derived facts (certainty 1.0) as the layer that escapes the
+No-Escape Theorem.
+
+**Decision (operator, 2026-09-08):** Graft is the sanctioned code-structure
+query path for coding agents in this repository. It is a local, regenerable
+cache like `node_modules` — each checkout runs `graft build`, or the agent
+hooks do — and it is **not** a memory layer. File memory remains the memory
+layer exactly as the 2026-08-29 entry states. The LLM "deep" tier
+(`graft build --deep`: concept nodes and per-symbol summaries) is not
+enabled; nothing wired here calls a model or needs a key.
+
+**Mechanics:** `graft init --agents claude agents grok` wrote the tracked
+wiring: the Claude Code skill, hook and statusline shims, hook and allowlist
+blocks in `.claude/settings.json`, the `graft` server in `.mcp.json`, the
+fenced Graft section in `AGENTS.md`, the Grok skill and MCP config under
+`.grok/`, `opencode.json`, and `.ignore` (which re-admits the git-ignored
+cards to ripgrep). It also wrote machine-local Codex wiring outside the repo
+(a `[mcp_servers.graft]` entry and a hooks file under the Codex home). The
+generated shims, skill files, and Grok/OpenCode config are graft-owned and
+rewritten on upgrade, so they are excluded from Biome, ESLint, Knip, and
+Fallow rather than hand-formatted or refactored; the git-ignored card tree
+is excluded from typos because `.ignore` re-admits it to ignore-aware tools. Two of graft's settings values were corrected after review:
+Claude Code hook `timeout` is in seconds (graft writes milliseconds, so its
+values were divided by 1000), and its `npx graft` / `graft-dev` /
+`node dist/cli.js` allowlist entries were dropped (`npx graft` would resolve
+the unrelated unscoped npm package; the other two are for developing graft
+itself). Only `Bash(graft:*)` is allowed. A re-run of `graft init` restores
+the upstream values, so re-apply both corrections after any upgrade.
+
+**Prerequisite on every machine:** the `graft` executable must be on the PATH
+of the agent process, because the MCP registrations launch the bare command.
+Install it with `npm install -g @nanonets/graft` (0.16.0 is the version this
+wiring was generated and tested with). On this workstation the global install
+lives under the interactive shell's nvm prefix, so a user-local `bin` symlink
+exposes it to desktop-launched sessions. The committed shims also carry the
+initializing machine's absolute install path as their first lookup candidate;
+on any other machine that candidate misses and the shim falls through to the
+repo `node_modules`, the running node's global prefix, and `npm root -g`,
+taking the highest installed version it finds.
+
+**Boundaries and watch items:**
+
+- The 2026-08-29 failure shape was per-conversation stdio MCP frontends with
+  no reaping path. Graft's MCP server has the same launch shape: one
+  `graft mcp` process per session that requests it. In Claude Code the server
+  is gated by the project MCP approval list; in Codex it is registered
+  machine-wide. If frontends accumulate, remove the `graft` server entries by
+  hand from `.mcp.json`, `.grok/config.toml`, `opencode.json`, and the Codex
+  config (`graft init --no-mcp` only skips registration for non-Claude hosts
+  and never removes an entry; `graft uninstall` is the full inverse of
+  `graft init`) and keep the CLI-and-skill path, which is the primary
+  integration.
+- Anonymous usage telemetry is on by default (buckets and fixed labels only,
+  per its published contract); `graft telemetry disable` or `DO_NOT_TRACK=1`
+  turns it off.
+- Review after four weeks of use: does the graph replace grep-storms in
+  practice, and do the hooks' per-prompt injections earn their tokens? If
+  not, `graft uninstall` is the inverse of `graft init`.


### PR DESCRIPTION
## chore(agents): wire Graft into Claude Code, Codex, and Grok

Install `@nanonets/graft` 0.16.0 and run `graft init --agents claude agents
grok`. The generated wiring is tracked; the graph itself (`graft/`, 38,507
nodes / 96,568 edges / 5,191 markdown cards for this checkout) is a
git-ignored, regenerable tree-sitter cache with no model and no key.

- Claude Code: graft skill, hook + statusline shims under `.claude/helpers`,
  hook/allowlist/statusLine blocks merged into `.claude/settings.json`, and
  the `graft` MCP server in `.mcp.json`.
- Codex and other AGENTS.md hosts: fenced Graft section in `AGENTS.md`,
  `opencode.json` MCP entry; the machine-wide Codex MCP + hooks live outside
  the repo.
- Grok: `.grok/skills/graft/SKILL.md` and `.grok/config.toml`.
- `.ignore` re-admits the git-ignored cards to ripgrep; `/graft/` is ignored.
- Biome, ESLint, Knip, and Fallow exclude the graft-owned generated files
  (rewritten on upgrade) instead of hand-formatting them; typos excludes the
  git-ignored card tree that `.ignore` re-admits.
- Hook timeouts are corrected to seconds and the allowlist keeps only
  `Bash(graft:*)`; see the decision-log entry for why.
- `@beep/ai-sync` approves `Bash(graft:*)` in the checked-in Claude repo
  safety policy (51-value allow domain) with a patch changeset.
- Record the adoption in `standards/memory-architecture/04-decision-log.md`
  (2026-09-08) and amend the AGENTS.md Agent Memory law: Graft is the
  sanctioned code-structure query path, not a memory layer.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/chore_wire-graft-agents-90ec5b79502c/verdict.json

---

## Review notes

- **What is committed vs local.** The graph (`graft/`, 294 MB here) is git-ignored; every checkout runs `graft build` (the hooks do it on the first session). Only the wiring is tracked.
- **Prerequisite on every machine:** `npm install -g @nanonets/graft` (0.16.0 tested) with `graft` on the PATH of the agent process, because `.mcp.json`, `.grok/config.toml`, and `opencode.json` launch the bare command. On the publishing workstation the nvm global install is exposed to desktop-launched sessions through a user-local bin symlink.
- **Outside the repo:** `graft init` also registered the Graft MCP server and hooks in the machine-local Codex config (backed up before the run). Not part of this diff.
- **Corrections to graft's generated settings** (re-apply after any `graft init` re-run): hook `timeout` values converted from milliseconds to seconds (Claude Code reads seconds); `Bash(npx graft:*)`, `Bash(graft-dev:*)`, `Bash(node dist/cli.js:*)` dropped from the allowlist (`npx graft` resolves the unrelated unscoped npm package); project-scoped `footerLinksRegexes` dropped (user/managed scope only). After Greptile's P1 the grant is narrowed further to the read-only query subcommands (`graft ask|grep|skeleton|callers|map|blast|check|build`); `graft init`, `uninstall`, and `upgrade` keep their prompt, and the `@beep/ai-sync` policy fails the check lane if the broad grant comes back.
- **Gate wiring:** the two generated shims are excluded from Biome, ESLint, Knip, and Fallow; `graft/**` is excluded from typos because graft's `.ignore` re-admits the card tree to ignore-aware tools (this also means an unscoped `rg` now returns card hits alongside source; scope with `--glob '!graft/**'`).
- **Watch item recorded in the decision log:** the MCP server has the same per-session stdio launch shape as the 2026-08-29 process-amplification failure. Removal path is documented there (`graft uninstall`, or delete the `graft` server entries by hand — `--no-mcp` does not remove them).
- **Telemetry:** anonymous, on by default; `graft telemetry disable` or `DO_NOT_TRACK=1` turns it off.
- Reviewed adversarially by a Codex lane before publish; its six findings are all folded in or explained above.

---

<!-- yeet-provenance:start -->
## Provenance

- Workspace: <code>beep-effect6</code>
- Branch: <code>chore/wire-graft-agents</code>
- Agents (newest first):
  - `claude-code` (desktop) · `claude-fable-5-1` · <code>beep-effect6-96</code> · monitored

Resume the publishing agent from any beep-effect checkout on the publishing workstation:

```sh
bun run beep yeet resume 1023
```

<!-- yeet-provenance
{
  "schemaVersion": 2,
  "pr": 1023,
  "branch": "chore/wire-graft-agents",
  "workspace": "beep-effect6",
  "agents": [
    {
      "harness": "claude-code",
      "entrypoint": "claude-desktop",
      "hostHarness": null,
      "model": "claude-fable-5-1",
      "label": "beep-effect6-96",
      "workspace": null,
      "role": "monitored"
    }
  ]
}
-->
<!-- yeet-provenance:end -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791510666&installation_model_id=424656&pr_number=1023&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1023&signature=9c820a573713a9391b6259e23b900abf51c6adc05bd3e410988ae43c56262f3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
