### PR TITLE
feat(ciops): emit the S7 ordering-cluster evidence (emission v2)

### DIFF
--- a/apps/labs/ciops/scripts/check-emission-cq.py
+++ b/apps/labs/ciops/scripts/check-emission-cq.py
@@ -1,0 +1,96 @@
+"""Query the runtime-verified emission v2 golden with amended CQ-020.
+
+Run after the package tests (which compare this fixture with current emission):
+  uv run --with pyoxigraph python apps/labs/ciops/scripts/check-emission-cq.py
+
+Only provisional term spellings and the episode binding are adapted in memory.
+The packet CQ, seed, registry, and frozen extraction artifacts stay read-only.
+"""
+
+import re
+from pathlib import Path
+from textwrap import dedent
+
+from pyoxigraph import Literal, NamedNode, RdfFormat, Store
+
+APP = Path(__file__).resolve().parents[1]
+REPO = APP.parents[2]
+CIOPS = "https://oip.law/ontology/ci-ops#"
+PROV = "https://oip.law/ontology/ci-ops-prov#"
+RDF_TYPE = NamedNode("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
+XSD_STRING = NamedNode("http://www.w3.org/2001/XMLSchema#string")
+
+cq_source = (
+    REPO / "explorations/beep-ci-operational-ontology/ontology/docs/competency-questions.yaml"
+).read_text()
+cq_section = cq_source.split("- id: CQ-020\n", 1)[1].split("\n- id:", 1)[0]
+sparql_block = re.search(r"^  sparql: \|\n((?:    .*\n)+)", cq_section, re.MULTILINE)
+assert sparql_block is not None, "CQ-020 must retain its explicit SPARQL block"
+query = dedent(sparql_block.group(1))
+for term in (
+    "hasCurrentProposal",
+    "hasProjectionSpecification",
+    "AdmissionProjectionSpecification",
+    "hasStep",
+    "stepIndex",
+    "schedulesSeatRequest",
+    "hasScopeTag",
+):
+    query = re.sub(rf"\bciops:{term}\b", f"ciops-prov:{term}", query)
+query = f"PREFIX ciops-prov: <{PROV}>\n{query}"
+
+store = Store()
+store.load((APP / "test/fixtures/emission-v2.ttl").read_bytes(), RdfFormat.TURTLE)
+
+
+def objects(subject, namespace, predicate):
+    return [
+        quad.object
+        for quad in store.quads_for_pattern(subject, NamedNode(namespace + predicate), None, None)
+    ]
+
+
+episodes = list(store.quads_for_pattern(None, RDF_TYPE, NamedNode(PROV + "VerificationEpisode"), None))
+assert len(episodes) == 1, "Exactly one typed episode must anchor the projection"
+episode = episodes[0].subject
+query, bindings = re.subn(r"VALUES \?ep \{[^}]*\}", f"VALUES ?ep {{ {episode} }}", query)
+assert bindings == 1, "Bind exactly the CQ's episode parameter"
+rows = list(store.query(query))
+assert len(rows) == 2, "CQ-020 must return the two admitted requests, excluding the tail"
+assert [int(row["idx"].value) for row in rows] == [0, 1]
+assert all(row[name] is not None for row in rows for name in ("proposal", "spec", "step", "idx", "req", "scope"))
+assert all(row["scope"] == Literal("admission", datatype=XSD_STRING) for row in rows)
+assert [objects(row["req"], PROV, "scheduledUnitRef") for row in rows] == [
+    [Literal("admitted-a", datatype=XSD_STRING)],
+    [Literal("admitted-b", datatype=XSD_STRING)],
+]
+
+proposal = rows[0]["proposal"]
+specification = rows[0]["spec"]
+assert objects(episode, PROV, "hasCurrentProposal") == [proposal]
+assert objects(proposal, PROV, "hasProjectionSpecification") == [specification]
+assert len(list(store.quads_for_pattern(None, RDF_TYPE, NamedNode(PROV + "AdmissionProjectionSpecification"), None))) == 1
+assert objects(specification, PROV, "policyDigest") == [Literal("policy-digest", datatype=XSD_STRING)]
+assert objects(specification, PROV, "journalPrefixDigest") == [Literal("journal-prefix-digest", datatype=XSD_STRING)]
+tail = objects(proposal, PROV, "defersSeatRequest")
+assert len(tail) == 1
+assert objects(tail[0], PROV, "scheduledUnitRef") == [Literal("deferred-c", datatype=XSD_STRING)]
+assert objects(tail[0], "http://www.w3.org/1999/02/22-rdf-syntax-ns#", "type") == [NamedNode(CIOPS + "SeatRequest")]
+assert not list(store.quads_for_pattern(None, NamedNode(PROV + "schedulesSeatRequest"), tail[0], None))
+assert len(list(store.quads_for_pattern(None, NamedNode(PROV + "scheduledUnitRef"), None, None))) == 3
+assert not list(store.quads_for_pattern(None, NamedNode(PROV + "hasScope"), None, None))
+
+# A missing specification edge or type must prevent a superficially ordered
+# graph from passing the amended query. Check both joins independently.
+for subject, predicate, obj in (
+    (proposal, NamedNode(PROV + "hasProjectionSpecification"), specification),
+    (specification, RDF_TYPE, NamedNode(PROV + "AdmissionProjectionSpecification")),
+):
+    quad = next(store.quads_for_pattern(subject, predicate, obj, None))
+    store.remove(quad)
+    assert list(store.query(query)) == [], "Missing specification evidence must break the CQ join"
+    store.add(quad)
+
+print("PASS: amended CQ-020 on emission v2: 2 ordered admitted rows (0, 1), 1 step-less deferred request")
+print("PASS: typed episode/specification, both digests, all 3 nonce literals, and 2 negative specification joins")
+print("Namespace adaptation is provisional instrumentation, not vocabulary ratification.")

--- a/apps/labs/ciops/scripts/generate-replay-evidence.ts
+++ b/apps/labs/ciops/scripts/generate-replay-evidence.ts
@@ -1,7 +1,8 @@
 import { createHash } from "node:crypto";
 import { BunRuntime } from "@effect/platform-bun";
 import * as BunFileSystem from "@effect/platform-bun/BunFileSystem";
-import { Effect, FileSystem, Layer } from "effect";
+import { Console, Effect, FileSystem, Layer } from "effect";
+import * as A from "effect/Array";
 import { decodeAdmissionPolicyParams } from "@/projection/AboxPolicy";
 import {
   decodeAdmissionJournal,
@@ -45,7 +46,11 @@ const generate = Effect.gen(function* () {
   const policyDigest = sha256(artifacts.abox);
   const journalDigest = sha256(artifacts.journal);
   const report = yield* replayAdmissionJournal(policy, events, policyDigest, journalDigest);
-  yield* writeEvidence(renderReplayEvidence(report, journalDigest));
+  if (A.contains(process.argv, "--check")) {
+    yield* Console.log(renderReplayEvidence(report, journalDigest));
+  } else {
+    yield* writeEvidence(renderReplayEvidence(report, journalDigest));
+  }
   yield* requireReplayMatch(report);
 }).pipe(Effect.withSpan("S7Evidence.generate"));
 

--- a/apps/labs/ciops/src/projection/CiOpsProjection.ts
+++ b/apps/labs/ciops/src/projection/CiOpsProjection.ts
@@ -29,6 +29,8 @@ const $I = $CiopsId.create("projection/CiOpsProjection");
  * **Details**
  *
  * `project` and `emitAbox` are deterministic pure-core operations.
+ * `project` preserves the caller's bounded `episodeId` on its proposal;
+ * `emitAbox` uses that identity for the typed current-proposal subject.
  * `projectCurrent` is the explicit stateful boundary that records the latest
  * proposal and publishes it to the transactional change queue.
  *

--- a/apps/labs/ciops/src/projection/Engine.ts
+++ b/apps/labs/ciops/src/projection/Engine.ts
@@ -198,6 +198,7 @@ const admitInto =
  *   priorityOrder: ["publish", "verify"]
  * })
  * const proposal = Effect.runSync(projectSchedule(ProjectionInput.make({
+ *   episodeId: "verification-1",
  *   policy,
  *   pending: [],
  *   ledger: emptyTokenLedger,
@@ -230,6 +231,7 @@ export const projectSchedule = Effect.fn("CiOpsProjection.project")(function* (
   );
 
   return ScheduleProposal.make({
+    episodeId: input.episodeId,
     proposalId: `schedule-${input.policyDigest}-${input.journalPrefixDigest}-${input.projectionInstantMillis}`,
     projectionInstantMillis: input.projectionInstantMillis,
     steps: folded.steps,

--- a/apps/labs/ciops/src/projection/Replay.ts
+++ b/apps/labs/ciops/src/projection/Replay.ts
@@ -310,6 +310,9 @@ const releaseFromLedger = Effect.fnUntraced(function* (
  * is included until its grant transition commits; every other candidate uses
  * the binding strict `t < admittedAtMillis` boundary. Releases remove the
  * exact active charge paired by nonce.
+ * Each grant verification is a bounded episode identified by
+ * `replay-${journalDigest}-${eventIndex}` (zero-based source event index).
+ * Replaying the same pinned journal preserves that occurrence identity.
  *
  * **Example** (Replay an empty event stream)
  *
@@ -418,6 +421,7 @@ export const replayAdmissionJournal = Effect.fn("Replay.replayAdmissionJournal")
     const pending = pendingAtAdmission(admittedEvents, admitted);
     const proposal = yield* projectSchedule(
       ProjectionInput.make({
+        episodeId: `replay-${journalDigest}-${eventIndex}`,
         policy,
         pending,
         ledger,

--- a/apps/labs/ciops/src/projection/Schemas.ts
+++ b/apps/labs/ciops/src/projection/Schemas.ts
@@ -324,6 +324,7 @@ export class ScheduleStep extends S.Class<ScheduleStep>($I`ScheduleStep`)(
  * import { NonNegativeInt } from "@beep/schema"
  *
  * const proposal = ScheduleProposal.make({
+ *   episodeId: "verification-1",
  *   proposalId: "schedule-policy-prefix-1000",
  *   projectionInstantMillis: NonNegativeInt.make(1000),
  *   steps: [],
@@ -339,6 +340,7 @@ export class ScheduleStep extends S.Class<ScheduleStep>($I`ScheduleStep`)(
  */
 export class ScheduleProposal extends S.Class<ScheduleProposal>($I`ScheduleProposal`)(
   {
+    episodeId: S.NonEmptyString,
     proposalId: S.NonEmptyString,
     projectionInstantMillis: NonNegativeInt,
     steps: S.Array(ScheduleStep),
@@ -354,6 +356,13 @@ export class ScheduleProposal extends S.Class<ScheduleProposal>($I`SchedulePropo
 /**
  * Complete explicit input to the clock-free projection core.
  *
+ * **Details**
+ *
+ * `episodeId` identifies a bounded verification occurrence supplied by the
+ * caller. Keep it across revisions of that occurrence's proposal; allocate a
+ * different id for a different occurrence. Replay uses its pinned journal
+ * digest and the zero-based grant event index, never a scheduler singleton.
+ *
  * **Example** (Construct projection input)
  *
  * ```ts
@@ -363,6 +372,7 @@ export class ScheduleProposal extends S.Class<ScheduleProposal>($I`SchedulePropo
  * import * as HashSet from "effect/HashSet"
  *
  * const input = ProjectionInput.make({
+ *   episodeId: "verification-1",
  *   policy: AdmissionPolicyParams.make({
  *     capacityMaxTokens: PosInt.make(10),
  *     slotSizeGib: PosInt.make(5),
@@ -397,6 +407,7 @@ export class ScheduleProposal extends S.Class<ScheduleProposal>($I`SchedulePropo
  */
 export class ProjectionInput extends S.Class<ProjectionInput>($I`ProjectionInput`)(
   {
+    episodeId: S.NonEmptyString,
     policy: AdmissionPolicyParams,
     pending: S.Array(PendingRequest),
     ledger: TokenLedgerState,
@@ -405,7 +416,7 @@ export class ProjectionInput extends S.Class<ProjectionInput>($I`ProjectionInput
     journalPrefixDigest: S.NonEmptyString,
   },
   $I.annote("ProjectionInput", {
-    description: "Policy, pending requests, token state, instant, and provenance digests supplied to projection.",
+    description: "Verification occurrence, policy, pending requests, token state, instant, and provenance digests.",
   })
 ) {}
 

--- a/apps/labs/ciops/src/projection/Turtle.ts
+++ b/apps/labs/ciops/src/projection/Turtle.ts
@@ -8,7 +8,7 @@
 import { Effect, Order, pipe } from "effect";
 import * as A from "effect/Array";
 import * as Str from "effect/String";
-import { TurtleDocument } from "./Schemas.ts";
+import { ScheduleScope, TurtleDocument } from "./Schemas.ts";
 import type { PendingRequest, ScheduleProposal } from "./Schemas.ts";
 
 const prefixes = [
@@ -17,6 +17,9 @@ const prefixes = [
   "@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .",
   "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .",
 ];
+
+// Instrumentation contract identity; vocabulary ratification remains run-3 work.
+const emissionContractVersion = "s7-emission/v2";
 
 const turtleLiteral = (value: string): string =>
   `"${pipe(
@@ -54,6 +57,16 @@ const requestTriples =
 
 const serializeProposal = (proposal: ScheduleProposal): TurtleDocument => {
   const proposalNode = `ciops-prov:${pnLocalSlug(proposal.proposalId)}`;
+  const episodeNode = `ciops-prov:episode-${pnLocalSlug(proposal.episodeId)}`;
+  // Each component encodes '-' itself, so the tuple separators are injective.
+  // Scope comes from the admission engine's LiteralKit even for an empty queue.
+  const specificationNode = `ciops-prov:specification-${A.join(
+    A.map(
+      [emissionContractVersion, proposal.policyDigest, proposal.journalPrefixDigest, ScheduleScope.Enum.admission],
+      pnLocalSlug
+    ),
+    "-"
+  )}`;
   const admittedRequests = A.map(proposal.steps, (step) => step.request);
   const requests = A.appendAll(admittedRequests, proposal.deferredTail);
   const ratifiedTriples = pipe(
@@ -61,19 +74,34 @@ const serializeProposal = (proposal: ScheduleProposal): TurtleDocument => {
     A.sort(Order.String)
   );
   const provisionalTriples = pipe(
-    A.append(
-      A.flatMap(proposal.steps, (step, index) => {
+    [
+      ...A.flatMap(proposal.steps, (step, index) => {
         const stepSubject = `${proposalNode}-step-${step.stepIndex}`;
         return [
           `${proposalNode} ciops-prov:hasStep ${stepSubject} .`,
-          `${stepSubject} ciops-prov:hasScope ${turtleLiteral(step.scope)} .`,
+          `${stepSubject} ciops-prov:hasScopeTag ${turtleLiteral(step.scope)}^^xsd:string .`,
           `${stepSubject} ciops-prov:schedulesSeatRequest ${proposalNode}-request-${index} .`,
           `${stepSubject} ciops-prov:stepIndex "${step.stepIndex}"^^xsd:integer .`,
           `${stepSubject} rdf:type ciops-prov:ScheduleStep .`,
         ];
       }),
-      `ciops-prov:scheduler ciops-prov:hasCurrentProposal ${proposalNode} .`
-    ),
+      ...A.map(
+        requests,
+        (request, index) =>
+          `${proposalNode}-request-${index} ciops-prov:scheduledUnitRef ${turtleLiteral(request.nonce)}^^xsd:string .`
+      ),
+      ...A.map(
+        proposal.deferredTail,
+        (_request, index) =>
+          `${proposalNode} ciops-prov:defersSeatRequest ${proposalNode}-request-${A.length(admittedRequests) + index} .`
+      ),
+      `${episodeNode} rdf:type ciops-prov:VerificationEpisode .`,
+      `${episodeNode} ciops-prov:hasCurrentProposal ${proposalNode} .`,
+      `${proposalNode} ciops-prov:hasProjectionSpecification ${specificationNode} .`,
+      `${specificationNode} rdf:type ciops-prov:AdmissionProjectionSpecification .`,
+      `${specificationNode} ciops-prov:policyDigest ${turtleLiteral(proposal.policyDigest)}^^xsd:string .`,
+      `${specificationNode} ciops-prov:journalPrefixDigest ${turtleLiteral(proposal.journalPrefixDigest)}^^xsd:string .`,
+    ],
     A.sort(Order.String)
   );
   const content = A.join(
@@ -99,11 +127,14 @@ const serializeProposal = (proposal: ScheduleProposal): TurtleDocument => {
  * **Details**
  *
  * The output is valid Turtle. Ratified node classes and properties use
- * `ciops:`; the provisional `ScheduleStep` class and ordering edges follow
+ * `ciops:`; provisional episode, specification, step, and ordering facts follow
  * under the S6-census provisional comment header, prefix-separated as
  * `ciops-prov:`. Every proposal mints a distinct node id from its
- * `proposalId`, so `hasCurrentProposal` genuinely re-points across loads,
- * and each section is lexically sorted for byte determinism.
+ * `proposalId`. The caller's `episodeId` anchors `hasCurrentProposal`;
+ * consumers replace the current document when that episode's proposal changes.
+ * The specification identity encodes version, policy digest, journal-prefix
+ * digest, and admission scope as an injective tuple. Each section is sorted
+ * lexically for byte determinism, including empty and fully deferred proposals.
  *
  * **Example** (Emit an empty proposal)
  *
@@ -114,6 +145,7 @@ const serializeProposal = (proposal: ScheduleProposal): TurtleDocument => {
  * import { Effect } from "effect"
  *
  * const proposal = ScheduleProposal.make({
+ *   episodeId: "verification-1",
  *   proposalId: "schedule-policy-prefix-1000",
  *   projectionInstantMillis: NonNegativeInt.make(1000),
  *   steps: [],

--- a/apps/labs/ciops/test/fixtures/emission-v2.ttl
+++ b/apps/labs/ciops/test/fixtures/emission-v2.ttl
@@ -1,0 +1,37 @@
+@prefix ciops: <https://oip.law/ontology/ci-ops#> .
+@prefix ciops-prov: <https://oip.law/ontology/ci-ops-prov#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ciops-prov:schedule%2Dpolicy%2Ddigest%2Djournal%2Dprefix%2Ddigest%2D1000 rdf:type ciops:ScheduleProposal .
+ciops-prov:schedule%2Dpolicy%2Ddigest%2Djournal%2Dprefix%2Ddigest%2D1000-request-0 ciops:admissionChargeTokens "5"^^xsd:integer .
+ciops-prov:schedule%2Dpolicy%2Ddigest%2Djournal%2Dprefix%2Ddigest%2D1000-request-0 ciops:hasOriginKey "origin-test" .
+ciops-prov:schedule%2Dpolicy%2Ddigest%2Djournal%2Dprefix%2Ddigest%2D1000-request-0 rdf:type ciops:SeatRequest .
+ciops-prov:schedule%2Dpolicy%2Ddigest%2Djournal%2Dprefix%2Ddigest%2D1000-request-1 ciops:admissionChargeTokens "5"^^xsd:integer .
+ciops-prov:schedule%2Dpolicy%2Ddigest%2Djournal%2Dprefix%2Ddigest%2D1000-request-1 ciops:hasOriginKey "origin-test" .
+ciops-prov:schedule%2Dpolicy%2Ddigest%2Djournal%2Dprefix%2Ddigest%2D1000-request-1 rdf:type ciops:SeatRequest .
+ciops-prov:schedule%2Dpolicy%2Ddigest%2Djournal%2Dprefix%2Ddigest%2D1000-request-2 ciops:admissionChargeTokens "5"^^xsd:integer .
+ciops-prov:schedule%2Dpolicy%2Ddigest%2Djournal%2Dprefix%2Ddigest%2D1000-request-2 ciops:hasOriginKey "origin-test" .
+ciops-prov:schedule%2Dpolicy%2Ddigest%2Djournal%2Dprefix%2Ddigest%2D1000-request-2 rdf:type ciops:SeatRequest .
+
+# PROVISIONAL GRAPH — closure OPEN; excluded from negation and ratified typing.
+ciops-prov:episode-verification%2D1 ciops-prov:hasCurrentProposal ciops-prov:schedule%2Dpolicy%2Ddigest%2Djournal%2Dprefix%2Ddigest%2D1000 .
+ciops-prov:episode-verification%2D1 rdf:type ciops-prov:VerificationEpisode .
+ciops-prov:schedule%2Dpolicy%2Ddigest%2Djournal%2Dprefix%2Ddigest%2D1000 ciops-prov:defersSeatRequest ciops-prov:schedule%2Dpolicy%2Ddigest%2Djournal%2Dprefix%2Ddigest%2D1000-request-2 .
+ciops-prov:schedule%2Dpolicy%2Ddigest%2Djournal%2Dprefix%2Ddigest%2D1000 ciops-prov:hasProjectionSpecification ciops-prov:specification-s7%2Demission%2Fv2-policy%2Ddigest-journal%2Dprefix%2Ddigest-admission .
+ciops-prov:schedule%2Dpolicy%2Ddigest%2Djournal%2Dprefix%2Ddigest%2D1000 ciops-prov:hasStep ciops-prov:schedule%2Dpolicy%2Ddigest%2Djournal%2Dprefix%2Ddigest%2D1000-step-0 .
+ciops-prov:schedule%2Dpolicy%2Ddigest%2Djournal%2Dprefix%2Ddigest%2D1000 ciops-prov:hasStep ciops-prov:schedule%2Dpolicy%2Ddigest%2Djournal%2Dprefix%2Ddigest%2D1000-step-1 .
+ciops-prov:schedule%2Dpolicy%2Ddigest%2Djournal%2Dprefix%2Ddigest%2D1000-request-0 ciops-prov:scheduledUnitRef "admitted-a"^^xsd:string .
+ciops-prov:schedule%2Dpolicy%2Ddigest%2Djournal%2Dprefix%2Ddigest%2D1000-request-1 ciops-prov:scheduledUnitRef "admitted-b"^^xsd:string .
+ciops-prov:schedule%2Dpolicy%2Ddigest%2Djournal%2Dprefix%2Ddigest%2D1000-request-2 ciops-prov:scheduledUnitRef "deferred-c"^^xsd:string .
+ciops-prov:schedule%2Dpolicy%2Ddigest%2Djournal%2Dprefix%2Ddigest%2D1000-step-0 ciops-prov:hasScopeTag "admission"^^xsd:string .
+ciops-prov:schedule%2Dpolicy%2Ddigest%2Djournal%2Dprefix%2Ddigest%2D1000-step-0 ciops-prov:schedulesSeatRequest ciops-prov:schedule%2Dpolicy%2Ddigest%2Djournal%2Dprefix%2Ddigest%2D1000-request-0 .
+ciops-prov:schedule%2Dpolicy%2Ddigest%2Djournal%2Dprefix%2Ddigest%2D1000-step-0 ciops-prov:stepIndex "0"^^xsd:integer .
+ciops-prov:schedule%2Dpolicy%2Ddigest%2Djournal%2Dprefix%2Ddigest%2D1000-step-0 rdf:type ciops-prov:ScheduleStep .
+ciops-prov:schedule%2Dpolicy%2Ddigest%2Djournal%2Dprefix%2Ddigest%2D1000-step-1 ciops-prov:hasScopeTag "admission"^^xsd:string .
+ciops-prov:schedule%2Dpolicy%2Ddigest%2Djournal%2Dprefix%2Ddigest%2D1000-step-1 ciops-prov:schedulesSeatRequest ciops-prov:schedule%2Dpolicy%2Ddigest%2Djournal%2Dprefix%2Ddigest%2D1000-request-1 .
+ciops-prov:schedule%2Dpolicy%2Ddigest%2Djournal%2Dprefix%2Ddigest%2D1000-step-1 ciops-prov:stepIndex "1"^^xsd:integer .
+ciops-prov:schedule%2Dpolicy%2Ddigest%2Djournal%2Dprefix%2Ddigest%2D1000-step-1 rdf:type ciops-prov:ScheduleStep .
+ciops-prov:specification-s7%2Demission%2Fv2-policy%2Ddigest-journal%2Dprefix%2Ddigest-admission ciops-prov:journalPrefixDigest "journal-prefix-digest"^^xsd:string .
+ciops-prov:specification-s7%2Demission%2Fv2-policy%2Ddigest-journal%2Dprefix%2Ddigest-admission ciops-prov:policyDigest "policy-digest"^^xsd:string .
+ciops-prov:specification-s7%2Demission%2Fv2-policy%2Ddigest-journal%2Dprefix%2Ddigest-admission rdf:type ciops-prov:AdmissionProjectionSpecification .

--- a/apps/labs/ciops/test/projection.test.ts
+++ b/apps/labs/ciops/test/projection.test.ts
@@ -10,6 +10,7 @@ import * as HashSet from "effect/HashSet";
 import * as N from "effect/Number";
 import * as O from "effect/Option";
 import * as S from "effect/Schema";
+import * as Str from "effect/String";
 import { FastCheck as fc } from "effect/testing";
 import { decodeAdmissionPolicyParams } from "@/projection/AboxPolicy";
 import { CiOpsProjection, CiOpsProjectionLive } from "@/projection/CiOpsProjection";
@@ -99,6 +100,7 @@ const inputFor = (
   projectionInstantMillis: number = projectionInstantFor(pending)
 ): ProjectionInput =>
   ProjectionInput.make({
+    episodeId: "verification-1",
     policy,
     pending,
     ledger,
@@ -359,6 +361,7 @@ describe("@beep/ciops S7 projection", () => {
       const policy = yield* readPolicy();
       const emptyFor = (proposalId: string) =>
         ScheduleProposal.make({
+          episodeId: "verification-1",
           proposalId,
           projectionInstantMillis: NonNegativeInt.make(1_000),
           steps: [],
@@ -372,8 +375,12 @@ describe("@beep/ciops S7 projection", () => {
 
       expect(slash.content).toBe(again.content);
       expect(slash.content).not.toBe(question.content);
-      expect(slash.content).toContain("ciops-prov:scheduler ciops-prov:hasCurrentProposal ciops-prov:a%2Fb .");
-      expect(question.content).toContain("ciops-prov:scheduler ciops-prov:hasCurrentProposal ciops-prov:a%3Fb .");
+      expect(slash.content).toContain(
+        "ciops-prov:episode-verification%2D1 ciops-prov:hasCurrentProposal ciops-prov:a%2Fb ."
+      );
+      expect(question.content).toContain(
+        "ciops-prov:episode-verification%2D1 ciops-prov:hasCurrentProposal ciops-prov:a%3Fb ."
+      );
       expect(slash.content).toContain(
         "# PROVISIONAL GRAPH — closure OPEN; excluded from negation and ratified typing."
       );
@@ -395,6 +402,107 @@ describe("@beep/ciops S7 projection", () => {
       expect(stepped.content).toContain("rdf:type ciops:SeatRequest .");
       expect(stepped.content).not.toContain("WorkUnitSpecification");
       expect(stepped.content).not.toContain("schedulesWorkUnit ");
+    }).pipe(provideScopedLayer(BunFileSystem.layer))
+  );
+
+  it.effect("emits the v2 golden ordering cluster with nonce evidence and a step-less deferred tail", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const policy = yield* readPolicy();
+      const pending = A.map(["admitted-a", "admitted-b", "deferred-c"], (nonce, index) =>
+        PendingRequest.make({
+          nonce,
+          kind: "merged-preview",
+          priority: "verify",
+          weightTokens: policy.weights.mergedPreview,
+          originKey: "origin-test",
+          enqueuedAtMillis: NonNegativeInt.make(index),
+        })
+      );
+      const proposal = yield* projectSchedule(inputFor(policy, pending, emptyTokenLedger, 1_000));
+      const document = yield* emitScheduleAbox(proposal);
+      const golden = yield* fs.readFileString("test/fixtures/emission-v2.ttl");
+
+      expect(document.content).toBe(golden);
+      expect(proposal.episodeId).toBe("verification-1");
+      expect(A.map(proposal.steps, (step) => step.stepIndex)).toEqual([0, 1]);
+      expect(A.map(proposal.deferredTail, (request) => request.nonce)).toEqual(["deferred-c"]);
+      expect(document.content).toContain('ciops-prov:scheduledUnitRef "deferred-c"^^xsd:string');
+      expect(document.content).toContain('ciops-prov:hasScopeTag "admission"^^xsd:string');
+      expect(document.content).not.toContain("ciops-prov:hasScope ");
+      expect(document.content).not.toContain("ciops-prov:scheduler ");
+      expect(document.content).not.toContain("-step-2 ");
+      expect(document.content).not.toContain("ciops-prov:Scope");
+    }).pipe(provideScopedLayer(BunFileSystem.layer))
+  );
+
+  it.effect("keeps empty and fully deferred proposals grounded without inventing steps", () =>
+    Effect.gen(function* () {
+      const policy = yield* readPolicy();
+      const request = PendingRequest.make({
+        nonce: "deferred-only",
+        kind: "full-proof",
+        priority: "verify",
+        weightTokens: policy.weights.fullProof,
+        originKey: "origin-test",
+        enqueuedAtMillis: NonNegativeInt.make(0),
+      });
+      const ledger = TokenLedgerState.make({
+        activeGrants: HashMap.make(["active", policy.capacityMaxTokens]),
+        activeReviewFixNonces: HashSet.empty(),
+        activeTokenTotal: NonNegativeInt.make(policy.capacityMaxTokens),
+      });
+      const empty = yield* projectSchedule(inputFor(policy, []));
+      const deferred = yield* projectSchedule(inputFor(policy, [request], ledger));
+      for (const proposal of [empty, deferred]) {
+        const document = yield* emitScheduleAbox(proposal);
+        expect(document.content).toContain("rdf:type ciops-prov:VerificationEpisode .");
+        expect(document.content).toContain("rdf:type ciops-prov:AdmissionProjectionSpecification .");
+        expect(document.content).toContain("ciops-prov:hasProjectionSpecification ");
+        expect(document.content).not.toContain("ciops-prov:hasStep ");
+        expect(document.content).not.toContain("ciops-prov:stepIndex ");
+      }
+      const document = yield* emitScheduleAbox(deferred);
+      expect(document.content).toContain("ciops-prov:defersSeatRequest ");
+      expect(document.content).toContain('ciops-prov:scheduledUnitRef "deferred-only"^^xsd:string');
+    }).pipe(provideScopedLayer(BunFileSystem.layer))
+  );
+
+  it.effect("separates episode identity from specification content and escapes tuple boundaries", () =>
+    Effect.gen(function* () {
+      const policy = yield* readPolicy();
+      const first = yield* projectSchedule(inputFor(policy, []));
+      const emitVariant = (patch: Partial<ScheduleProposal>) =>
+        emitScheduleAbox(ScheduleProposal.make({ ...first, ...patch }));
+      const firstDocument = yield* emitVariant({ policyDigest: "a-b", journalPrefixDigest: "c" });
+      const otherDigest = yield* emitVariant({ policyDigest: "a", journalPrefixDigest: "b-c" });
+      const otherEpisode = yield* emitVariant({ episodeId: "other/episode" });
+      const sameSpec = yield* emitVariant({ episodeId: "other?episode", proposalId: "revision-2" });
+      const specLine = (content: string) =>
+        A.filter(Str.split(content, "\n"), Str.includes("rdf:type ciops-prov:AdmissionProjectionSpecification"));
+
+      expect(specLine(firstDocument.content)).not.toEqual(specLine(otherDigest.content));
+      expect(specLine(otherEpisode.content)).toEqual(specLine(sameSpec.content));
+      expect(otherEpisode.content).toContain(
+        "ciops-prov:episode-other%2Fepisode rdf:type ciops-prov:VerificationEpisode"
+      );
+      expect(sameSpec.content).toContain("ciops-prov:episode-other%3Fepisode rdf:type ciops-prov:VerificationEpisode");
+
+      const special = yield* emitVariant({ policyDigest: 'policy"\\\n', journalPrefixDigest: 'prefix"\\\n' });
+      expect(special.content).toContain('ciops-prov:policyDigest "policy\\"\\\\\\n"^^xsd:string');
+      expect(special.content).toContain('ciops-prov:journalPrefixDigest "prefix\\"\\\\\\n"^^xsd:string');
+    }).pipe(provideScopedLayer(BunFileSystem.layer))
+  );
+
+  it.effect("requires a non-empty episode identity at the input boundary", () =>
+    Effect.gen(function* () {
+      const policy = yield* readPolicy();
+      const input = inputFor(policy, []);
+      const empty = yield* S.decodeEffect(ProjectionInput)({ ...input, episodeId: "" }).pipe(Effect.result);
+      expect(empty._tag).toBe("Failure");
+      const { episodeId: _episodeId, ...missingEpisode } = input;
+      const missing = yield* S.decodeUnknownEffect(ProjectionInput)(missingEpisode).pipe(Effect.result);
+      expect(missing._tag).toBe("Failure");
     }).pipe(provideScopedLayer(BunFileSystem.layer))
   );
 

--- a/apps/labs/ciops/test/projection.test.ts
+++ b/apps/labs/ciops/test/projection.test.ts
@@ -109,6 +109,10 @@ const inputFor = (
     journalPrefixDigest: "journal-prefix-digest",
   });
 
+// Hoisted: the compiled decoders are built once per module, not per test call.
+const decodeProjectionInput = S.decodeEffect(ProjectionInput);
+const decodeUnknownProjectionInput = S.decodeUnknownEffect(ProjectionInput);
+
 describe("@beep/ciops S7 projection", () => {
   it.effect("strictly decodes every ratified S6 policy parameter from Turtle bytes", () =>
     Effect.gen(function* () {
@@ -498,10 +502,10 @@ describe("@beep/ciops S7 projection", () => {
     Effect.gen(function* () {
       const policy = yield* readPolicy();
       const input = inputFor(policy, []);
-      const empty = yield* S.decodeEffect(ProjectionInput)({ ...input, episodeId: "" }).pipe(Effect.result);
+      const empty = yield* decodeProjectionInput({ ...input, episodeId: "" }).pipe(Effect.result);
       expect(empty._tag).toBe("Failure");
       const { episodeId: _episodeId, ...missingEpisode } = input;
-      const missing = yield* S.decodeUnknownEffect(ProjectionInput)(missingEpisode).pipe(Effect.result);
+      const missing = yield* decodeUnknownProjectionInput(missingEpisode).pipe(Effect.result);
       expect(missing._tag).toBe("Failure");
     }).pipe(provideScopedLayer(BunFileSystem.layer))
   );

--- a/explorations/beep-ci-operational-ontology/ontology/docs/s7-projection-contract.md
+++ b/explorations/beep-ci-operational-ontology/ontology/docs/s7-projection-contract.md
@@ -3,14 +3,15 @@
 Stage S7 of the pipeline: the **projection function** — the loop-closer.
 `(T-Box, A-Box, live instance data) → WorkUnit schedule`, deterministic and
 property-tested (uncontested amendment 1, DECISIONS.md 2026-08-27). This
-contract binds the v1 implementation. Rulings: DECISIONS.md
-§"2026-08-30 — S7 sitting 1".
+contract binds the v1 admission engine with S7 emission v2. Rulings:
+DECISIONS.md §"2026-08-30 — S7 sitting 1" and
+§"2026-09-03 — run-3 corpora design grill", rulings 4, 13–16.
 
-Sequencing note: the steward re-ordered the queue on merging #919 — S7 runs
-now; auditor run 2 follows. The six S6-surfaced gaps are explicitly
-unavailable inputs recorded below, never silent assumptions.
+**This is instrumentation FOR run-3 ratification evidence, not ratification.**
+The ordering cluster and its `ciops-prov:` namespace re-proposal remain
+run-3 decisions. Emission v2 does not implement the future lane-DAG planner.
 
-## 1. Inputs (all frozen at the branch cut, `ontology-s7-projection`)
+## 1. Inputs (historical S7 baseline, frozen at `ontology-s7-projection`)
 
 | Input | Artifact | Role |
 | --- | --- | --- |
@@ -31,7 +32,7 @@ Journal reality (raw NDJSON, decoded via `AdmissionJournalEvent`): admitted
 events carry `kind`, `weightTokens`, `priority`, `originKey`,
 `enqueuedAtMillis`, `admittedAtMillis`; released events pair by `nonce`. The
 S6 vocabulary gaps were about missing RDF predicates, not missing bytes — the
-raw replay corpus is complete for the admission slice. Known censorship:
+raw replay corpus carries the recorded admission slice. Known censorship:
 requests that never reached admission are absent entirely (no queue-entry
 event exists); recorded, not modeled.
 
@@ -42,10 +43,12 @@ event exists); recorded, not modeled.
    territory) that v1 declares but does not implement.
 2. **Provisional ordering vocabulary**: emitted nodes typed with ratified
    `ciops:` classes; ordering predicates (`hasCurrentProposal`, `hasStep`,
-   `stepIndex`, `schedulesWorkUnit`, `hasScope`) and class `ScheduleStep`
-   emitted in the provisional `ciops-prov:` named graph (S6 census precedent:
-   open closure, excluded from negation/typing). These terms join the run-2
-   re-proposal queue.
+   `stepIndex`, `schedulesSeatRequest`, `hasScopeTag`) and class `ScheduleStep`
+   emitted in `ciops-prov:`. Emission v2 adds the episode, specification,
+   digests, nonce carrier, and deferred-tail edge described in §3.5. These
+   are prefix-separated triples under a provisional comment in valid Turtle,
+   not a TriG named-graph block. Closure is open; provisional facts are
+   excluded from negation and ratified typing. The cluster goes to run 3.
 3. **Landing zone**: new labs app `apps/labs/ciops` via
    `bun run beep create-package` — schemas, `Context.Service` contract,
    engine, and property tests all incubate there, off the required turbo
@@ -74,7 +77,11 @@ event exists); recorded, not modeled.
 - `ScheduleStep` — stepIndex, scheduled unit ref, scope tag (v1: the
   admission act itself; the planner seam widens this in v2).
 - `ScheduleProposal` — proposal id, projection instant, ordered steps,
-  input digests (policy digest + journal-prefix digest) for provenance.
+  deferred tail, required episode id, and input digests (policy digest +
+  journal-prefix digest) for provenance.
+- `ProjectionInput` — the explicit policy, pending requests, token ledger,
+  projection instant, provenance digests, and required non-empty `episodeId`.
+  The caller supplies the occurrence identity; there is no singleton default.
 - `ProjectionMismatch` / typed errors — `S.TaggedError` family
   (`CyclicPlanError` reserved for the planner seam, `PolicyDecodeError`,
   `ReplayMismatchError`).
@@ -88,6 +95,8 @@ event exists); recorded, not modeled.
 - `emitAbox(proposal): Effect<TurtleDocument>` — schedule-as-A-Box emission
   per ruling 2 (ratified classes in `ciops:`, ordering edges in
   `ciops-prov:`), deterministic serialization (canonical triple order).
+  The proposal retains `episodeId` from `project` through `projectCurrent`
+  and the transactional current-proposal/change-queue shell to `emitAbox`.
 - `planEpisode` — the lane-DAG planner SEAM: typed signature reserved
   (`Effect<never, PlannerNotImplementedError>` or equivalent honest
   stub), documented as v2; `Graph.topo` + `isAcyclic` pre-check territory.
@@ -105,6 +114,8 @@ event exists); recorded, not modeled.
   `Graph.topo` (Kahn's over CSR) is deterministic only for a fixed insertion
   order; cyclic input fails typed after an `isAcyclic` pre-check.
 - Emission is byte-deterministic: same input → byte-equal Turtle.
+- `stepIndex` stays **0-based**. Only admitted actions get steps; the
+  deferred tail never extends or renumbers that sequence (run-3 ruling 14).
 
 ### 3.4 Admission semantics v1 (mirrors the deployed scheduler; never invents)
 
@@ -117,6 +128,92 @@ bound without a modeled `StarvationException` is a projection error, not a
 warning). Where the deployed scheduler's observed behavior and this contract
 disagree, the REPLAY decides: reproduce deployed semantics and record the
 contract delta as run-2 evidence.
+
+### 3.5 Emission v2 individuals, relations, and identity criteria
+
+Ratified `ciops:ScheduleProposal` and `ciops:SeatRequest` typing, admission
+charges (`xsd:integer`), and origin-key literals are preserved. Every
+projection, including empty and fully deferred proposals, emits one typed
+episode subject and one typed specification individual. The following
+terms remain provisional under `https://oip.law/ontology/ci-ops-prov#`:
+
+| Term | Subject → object / value |
+| --- | --- |
+| `VerificationEpisode` | Class of the bounded verification occurrence |
+| `hasCurrentProposal` | Episode → `ciops:ScheduleProposal` |
+| `hasProjectionSpecification` | Proposal → specification, matching amended CQ-020's join |
+| `AdmissionProjectionSpecification` | Class of the governing projection specification |
+| `policyDigest` | Specification → supplied policy digest (`xsd:string`) |
+| `journalPrefixDigest` | Specification → supplied journal-prefix digest / locator (`xsd:string`) |
+| `hasStep` | Proposal → `ScheduleStep` |
+| `ScheduleStep` | Class of an admitted ordering step |
+| `stepIndex` | Step → 0-based ordinal (`xsd:integer`) |
+| `schedulesSeatRequest` | Step → positional `ciops:SeatRequest` node |
+| `hasScopeTag` | Step → `ScheduleScope` literal (`xsd:string`), exactly `{"admission"}` in v1 |
+| `scheduledUnitRef` | Every request → its scheduled unit's nonce (`xsd:string`) |
+| `defersSeatRequest` | Proposal → each deferred request, with no associated step |
+
+**Episode identity.** `ProjectionInput.episodeId` is a required non-empty
+caller-owned occurrence key and is copied unchanged into `ScheduleProposal`.
+The node is `ciops-prov:episode-${pnLocalSlug(episodeId)}`. For differential
+replay the key is exactly `replay-${journalDigest}-${eventIndex}`, where
+`journalDigest` is the pinned full-journal SHA-256 supplied by the evidence
+generator and `eventIndex` is the zero-based decoded source-event index
+(including release and eviction rows). Its occurrence is one verification
+of a recorded grant: reconstruct the pending/ledger snapshot immediately
+before that transition, project, compare against the recorded nonce, and
+finish with a verdict and ledger fold. This is bounded by an identified
+transition, not the scheduler's lifetime. Changing the source path or
+replaying the same pinned bytes preserves identity; a changed corpus digest
+or another event index denotes another corpus-scoped verification episode.
+It does not claim cross-capture identity when a journal grows.
+
+A live caller must supply a key for its bounded verification occurrence
+and retain it across proposal revisions for that occurrence. The emitter
+returns a current snapshot: consumers must **replace** the prior document
+for that episode, not append snapshots and expect RDF to retract the old
+`hasCurrentProposal` edge. The in-process shell holds one latest proposal;
+it is not a persistent per-episode graph store.
+
+**Specification identity (authority / version / applicability).** Authority
+is this S7 contract and the `@beep/ciops` admission projection of the
+S6 policy A-Box. The immutable emission contract version is `s7-emission/v2`.
+The specification IRI is `ciops-prov:specification-` followed by the ordered
+tuple `(contract version, policyDigest, journalPrefixDigest, admission)`.
+Each component is independently encoded with the existing `pnLocalSlug`;
+literal `-` separates components. The encoder preserves only ASCII
+alphanumerics and escapes every other UTF-8 byte as `%HH`, including `-`,
+so tuple boundaries cannot be forged. This is content-derived and
+collision-free for distinct well-formed UTF-8 tuples without truncated
+hashes; the tradeoff is a longer IRI. It reuses the existing IRI encoding,
+with no change to proposal/step/request syntax and no new S8 scheme.
+
+Applicability is the supplied policy artifact, journal boundary, and
+admission scope, even when no step is emitted. Episode id, proposal id, and
+projection instant do not change specification identity. Any tuple member
+change does. `policyDigest` and `journalPrefixDigest` are serialized exactly
+as supplied; emission does not recompute or certify them. In existing replay,
+the latter is `${journalDigest}-${eventIndex}`, a digest-bound boundary
+locator, not a separate SHA-256 of prefix bytes. Both remain non-empty
+strings at the existing schema boundary.
+
+**Tail and nonce evidence.** No existing emitted relation linked the
+deferred tail to its proposal. V2 therefore adds the single provisional
+`defersSeatRequest` edge per tail request. Amended CQ-020 deliberately sees
+only admitted steps; consumers can inspect deferred membership separately,
+without treating a deferral as a scheduled action or assigning it an ordinal.
+Request IRIs remain `${proposalNode}-request-${index}` over admitted requests
+followed by the deferred tail. `scheduledUnitRef` carries `request.nonce`
+on every request, including deferred ones; for admitted requests the engine
+also copies that nonce to `ScheduleStep.scheduledUnitRef`. This supplies
+nonce-grain evidence without claiming nonce-based RDF identity.
+
+The literal emission `hasScope` is retired in favor of `hasScopeTag`.
+No object-property `hasScope` or `Scope` individual is introduced. The
+historical `schedulesWorkUnit` carrier in CQ-019 arm 3 and its fixture remain
+unchanged under ruling 16. No registry, T-Box, seed, or CQ amendment occurs
+here. Emission-to-CQ checks adapt only the provisional namespace spellings
+and episode binding in memory; they do not certify vocabulary ratification.
 
 ## 4. Property suite (all gate; @effect/vitest + schema-derived Arbitraries)
 
@@ -142,18 +239,23 @@ contract delta as run-2 evidence.
 
 - Replay outcome (pass, or the mismatch census) lands in packet
   `research/s7-replay-evidence.md` — generated content marked as such.
+  For read-only verification, run `bun run evidence:s7 --check` from
+  `apps/labs/ciops`; it prints the replay report without overwriting frozen
+  packet evidence. The v2 emission golden is compared byte-for-byte with
+  current emitter output by the package tests, then queried with amended
+  CQ-020 by `scripts/check-emission-cq.py` in that app.
 - `bun run beep quality package-verify @beep/ciops` green before handoff;
   packet gates (`validate_packet.py` base/`--s5`/`--s6`, CQ suite) stay
   green and untouched.
 - The pinned S6 evidence bytes are read-only inputs — never edited, never
   regenerated by S7 (the digest-locked-evidence law).
 
-## 6. Non-goals (v1)
+## 6. Non-goals (admission v1 / emission v2)
 
 - No lane-DAG planner implementation (seam only).
 - No scheduler replacement or repo-cli integration — the deployed
   `QualityScheduler` stays the only writer of real admissions.
-- No T-Box changes, no vocabulary ratification (run 2's job), no IRI-scheme
+- No T-Box changes, no vocabulary ratification (run 3's job), no IRI-scheme
   changes (S8).
 - No live-journal tailing daemon — v1 projects from explicit inputs; the Tx
   wrapper holds state in-process only.

--- a/explorations/beep-ci-operational-ontology/ontology/docs/s7-projection-contract.md
+++ b/explorations/beep-ci-operational-ontology/ontology/docs/s7-projection-contract.md
@@ -243,7 +243,7 @@ and episode binding in memory; they do not certify vocabulary ratification.
   `apps/labs/ciops`; it prints the replay report without overwriting frozen
   packet evidence. The v2 emission golden is compared byte-for-byte with
   current emitter output by the package tests, then queried with amended
-  CQ-020 by `scripts/check-emission-cq.py` in that app.
+  CQ-020 by `apps/labs/ciops/scripts/check-emission-cq.py`.
 - `bun run beep quality package-verify @beep/ciops` green before handoff;
   packet gates (`validate_packet.py` base/`--s5`/`--s6`, CQ suite) stay
   green and untouched.


### PR DESCRIPTION
## Summary

Bundled S7 emission v2 for `@beep/ciops` — the instrumentation that lets auditor run 3 evidence the amended CQ-020 ordering cluster. Implements DECISIONS.md run-3 rulings **4, 13, 14, 15, 16** (`explorations/beep-ci-operational-ontology/DECISIONS.md`, "run-3 corpora design grill"). This is **instrumentation FOR run-3 ratification evidence, not ratification**: no T-Box, seed, CQ, registry, or frozen extraction artifact changes.

The five bundled emission changes (Ruling 13):

1. **Scope literal rename** — literal-valued `ciops-prov:hasScope` → `ciops-prov:hasScopeTag` (`xsd:string`, domain = `ScheduleScope` literals). No object-property `hasScope` / `Scope` is introduced (Ruling 16).
2. **Typed `AdmissionProjectionSpecification` individual** + `hasProjectionSpecification` edge from the proposal (the subject amended CQ-020 joins on). Content-derived IRI over `(contract version, policyDigest, journalPrefixDigest, scope)` via the existing injective slug encoder.
3. **Digest serialization** — `policyDigest` and `journalPrefixDigest` become datatype properties on that specification.
4. **Typed episode subject** (Ruling 4) — `hasCurrentProposal` now hangs off a typed `VerificationEpisode` instead of the untyped `ciops-prov:scheduler` singleton. `ProjectionInput` / `ScheduleProposal` gain a required caller-owned `episodeId`; differential replay derives `replay-<journalDigest>-<eventIndex>`, so identical pinned input still yields byte-identical Turtle.
5. **Deferred-tail decision** — tail SeatRequests stay step-less (CQ-020 keeps seeing admitted steps only, `stepIndex` stays 0-based per Ruling 14) and attach to their proposal via one provisional `defersSeatRequest` edge so they are no longer dangling.

Rider (Ruling 15): every SeatRequest node carries its nonce as `scheduledUnitRef` beside the positional node id — nonce-grain identity evidence without touching IRI syntax (S8 stays deferred).

Contract refresh: `ontology/docs/s7-projection-contract.md` loses its two stale spellings (`schedulesWorkUnit`, `hasScope`), documents the v2 terms and the episode/specification identity criteria, and states the ratification boundary explicitly.

## Verification

| Check | Result |
| --- | --- |
| `CI=true bun run beep quality package-verify @beep/ciops` | pass (17/17 tests, lint, audit) |
| `bun run docgen:local` | pass (noop — app has no docgen surface) |
| Packet CQ suite (`run_cq_suite.py`) | 0 failures across 25 seed tests + 20 fixtures |
| `bun run evidence:s7 --check` (new read-only mode) | 41/41 admissions matched, zero mismatches, frozen evidence untouched |
| `scripts/check-emission-cq.py` (new) | amended CQ-020 over the runtime-verified golden returns exactly the two admitted steps (idx 0, 1), tail excluded; both negative specification-join checks pass |

Packet trail: lane brief and report live under `research/run3-lanes/` in the Stage A PR that follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791511477&installation_model_id=424656&pr_number=1024&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1024&signature=3f98038aed797946cfcabe081546a2b3ada7f1b82b241241ed36d9da8147da89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

---

<!-- yeet-provenance:start -->
## Provenance

- Workspace: <code>beep-effect8</code>
- Branch: <code>feat/ontology-s7-emission-v2</code>
- Agents (newest first):
  - `claude-code` (desktop) · `claude-fable-5-1` · <code>beep-effect5-02</code> · workspace <code>beep-effect5</code> · monitored

Resume the publishing agent from any beep-effect checkout on the publishing workstation:

```sh
bun run beep yeet resume 1024
```

<!-- yeet-provenance
{
  "schemaVersion": 2,
  "pr": 1024,
  "branch": "feat/ontology-s7-emission-v2",
  "workspace": "beep-effect8",
  "agents": [
    {
      "harness": "claude-code",
      "entrypoint": "claude-desktop",
      "hostHarness": null,
      "model": "claude-fable-5-1",
      "label": "beep-effect5-02",
      "workspace": "beep-effect5",
      "role": "monitored"
    }
  ]
}
-->
<!-- yeet-provenance:end -->
