### PR TITLE
fix(repo-cli): default scheduler reap --apply to false

### DIFF
--- a/packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts
@@ -3412,6 +3412,7 @@ const schedulerReapCommand = Command.make(
   "reap",
   {
     apply: Flag.boolean("apply").pipe(
+      Flag.withDefault(false),
       Flag.withDescription("Actually remove dead admission state (default: dry-run report)")
     ),
   },

--- a/packages/tooling/tool/cli/test/quality-scheduler.test.ts
+++ b/packages/tooling/tool/cli/test/quality-scheduler.test.ts
@@ -3278,6 +3278,38 @@ describe("quality-scheduler", () => {
       })
     ));
 
+  it("scheduler reap dispatched without --apply prints the dry-run report and mutates nothing", () =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const gibRef = yield* Ref.make(50);
+        yield* withAdmissionTempRoot(gibRef, (tempRoot) =>
+          Effect.gen(function* () {
+            const path = yield* Path.Path;
+            const deadTicket = yield* writeFakeTicket(tempRoot, {
+              pid: DEAD_PID,
+              procStart: "dead-flagless-owner",
+              nonce: "dead-flagless-ticket",
+              originKey: "dead-flagless-origin",
+            });
+            const before = yield* listDirectory(tempRoot.queue);
+            expect(before).toStrictEqual([path.basename(deadTicket)]);
+
+            // Regression: the boolean flag once had no default, so the flagless
+            // invocation failed with "Missing required flag: --apply" and the
+            // documented dry-run path was unreachable from the CLI.
+            const exit = yield* Effect.exit(runQualityCommand(["scheduler", "reap"]));
+            expect(exit._tag, String(exit)).toBe("Success");
+
+            const output = A.join(A.map(yield* TestConsole.logLines, String), "\n");
+            expect(output).toContain("dry run — would reap:");
+            expect(output).toContain(deadTicket);
+            expect(output).not.toContain("reaped dead admission state:");
+            expect(yield* listDirectory(tempRoot.queue)).toStrictEqual([path.basename(deadTicket)]);
+          })
+        );
+      }).pipe(provideScopedLayer(TestConsole.layer), provideScopedLayer(SchedulerCommandLayer))
+    ));
+
   it("atomically claims dead leases and tickets before journaling each death once", () =>
     Effect.runPromise(
       Effect.gen(function* () {


### PR DESCRIPTION
## fix(repo-cli): default scheduler reap --apply to false

The boolean flag had no default, so the flagless invocation failed with
"Missing required flag: --apply" and the documented dry-run path was
unreachable from the CLI. Sibling tmpfs-reap and residue-reap already
default to false. Adds a regression test that dispatches the command
without the flag.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/claude_serene-chebyshev-43c441-7b281c16eacf/verdict.json

---

<!-- yeet-provenance:start -->
## Provenance

- Workspace: <code>beep-effect5</code>
- Branch: <code>claude/serene-chebyshev-43c441</code>
- Agents (newest first):
  - `claude-code` (desktop) · `claude-fable-5-1` · <code>vigilant-khorana-0c8658-2b</code> · monitored

Resume the publishing agent from any beep-effect checkout on the publishing workstation:

```sh
bun run beep yeet resume 1035
```

<!-- yeet-provenance
{
  "schemaVersion": 2,
  "pr": 1035,
  "branch": "claude/serene-chebyshev-43c441",
  "workspace": "beep-effect5",
  "agents": [
    {
      "harness": "claude-code",
      "entrypoint": "claude-desktop",
      "hostHarness": null,
      "model": "claude-fable-5-1",
      "label": "vigilant-khorana-0c8658-2b",
      "workspace": null,
      "role": "monitored"
    }
  ]
}
-->
<!-- yeet-provenance:end -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791523287&installation_model_id=424656&pr_number=1035&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1035&signature=10889d74330450f1ef38bea02871ab913edcf2562fb62c0f2fb2504546e62b77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->