### PR TITLE
fix(repo-cli): stop gating index parity test on the untracked local projection

### DIFF
--- a/packages/tooling/tool/cli/test/goals-bootstrap-plan.test.ts
+++ b/packages/tooling/tool/cli/test/goals-bootstrap-plan.test.ts
@@ -411,8 +411,8 @@ describe("goals adopt --plan index parity", () => {
           expect(O.isSome(first)).toBe(true);
           if (O.isNone(first)) return;
           expect(A.every(generated, (content) => content === first.value)).toBe(true);
-          const local = yield* fs.readFileString(`${repoRoot}/${PORTFOLIO_INDEX_PATH}`).pipe(Effect.option);
-          if (O.isSome(local)) expect(local.value).toBe(first.value);
+          // The local goals/INDEX.md projection is git-ignored workstation state; drift against it is
+          // the `goals index --check` command's job (covered below on a temp dir), not this test's.
         })
       ),
     60_000


### PR DESCRIPTION
## fix(repo-cli): stop gating index parity test on the untracked local projection

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/fix_goals-index-parity-untracked-projection-32e22df61af2/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1036"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791525754&installation_model_id=424656&pr_number=1036&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1036&signature=19f14288ae7078d52296a7fea5de968aed2b68237754eb7dc5ac9ccff9ba6655"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

---

<!-- yeet-provenance:start -->
## Provenance

- Workspace: <code>beep-effect3</code>
- Branch: <code>fix/goals-index-parity-untracked-projection</code>
- Agents (newest first):
  - `claude-code` (desktop) · `claude-fable-5-1` · <code>beep-effect3-d0</code> · monitored

Resume the publishing agent from any beep-effect checkout on the publishing workstation:

```sh
bun run beep yeet resume 1036
```

<!-- yeet-provenance
{
  "schemaVersion": 2,
  "pr": 1036,
  "branch": "fix/goals-index-parity-untracked-projection",
  "workspace": "beep-effect3",
  "agents": [
    {
      "harness": "claude-code",
      "entrypoint": "claude-desktop",
      "hostHarness": null,
      "model": "claude-fable-5-1",
      "label": "beep-effect3-d0",
      "workspace": null,
      "role": "monitored"
    }
  ]
}
-->
<!-- yeet-provenance:end -->
