### PR TITLE
docs(goal): close inline-schema-compile-hard-error evidence

### DIFF
--- a/goals/inline-schema-compile-hard-error/PLAN.md
+++ b/goals/inline-schema-compile-hard-error/PLAN.md
@@ -10,16 +10,18 @@ Status: `in-progress`
 | --- | --- | --- | --- |
 | P0 Research | complete | Reproduce and classify the 2,931-finding opening baseline. | Every finding has an ownership family and migration shape; drift is explained. |
 | P1 Implement | complete | Hoist compilers family by family and update generators before outputs. | All governed findings are removed without semantic changes. |
-| P2 Verify | in-progress | Promote the rule to error and run local proof. | Rule tests, affected package checks, docgen, and canonical verification are green. |
+| P2 Verify | complete | Promote the rule to error and run local proof. | Rule tests, affected package checks, docgen, and canonical verification are green. |
 | P3 Yeet: PR to mergeable | in-progress | Publish through Yeet and close checks and review threads. | `bun run beep yeet monitor` reports `merge-ready: yes`. |
 | P4 Close | in-progress | Write the reflection and flip packet state. | Packet status and evidence are synchronized; reflection validates. |
 
 The implementation and review corrections merged in PRs #1019 and #1022.
 `research/closeout-evidence.md` records the full passing local proof and hosted
-checks on the same implementation tree. Both PRs were manually merged before
-the packet closed. PR #1028 now contains the package-proof runner repair and
-reflection; the lifecycle update will land in that same PR after the fresh
-package matrix and terminal publication/monitor result are available.
+checks on the same implementation tree. PR #1028 shipped the package-proof
+runner repair and reflection, but also merged before local verification and
+packet closeout finished. The clean v2 matrix passed all 106 owners, and two
+supplemental package verifications cover the remaining audited owners. The
+full local proof passed all 34 reported lanes. The final publication path
+awaits operator direction. The package and terminal monitor gates remain unchanged.
 
 ## P0 — Research
 

--- a/goals/inline-schema-compile-hard-error/PLAN.md
+++ b/goals/inline-schema-compile-hard-error/PLAN.md
@@ -10,7 +10,7 @@ Status: `in-progress`
 | --- | --- | --- | --- |
 | P0 Research | complete | Reproduce and classify the 2,931-finding opening baseline. | Every finding has an ownership family and migration shape; drift is explained. |
 | P1 Implement | complete | Hoist compilers family by family and update generators before outputs. | All governed findings are removed without semantic changes. |
-| P2 Verify | complete | Promote the rule to error and run local proof. | Rule tests, affected package checks, docgen, and canonical verification are green. |
+| P2 Verify | in-progress | Promote the rule to error and run local proof. | Rule tests, affected package checks, docgen, and canonical verification are green. |
 | P3 Yeet: PR to mergeable | in-progress | Publish through Yeet and close checks and review threads. | `bun run beep yeet monitor` reports `merge-ready: yes`. |
 | P4 Close | in-progress | Write the reflection and flip packet state. | Packet status and evidence are synchronized; reflection validates. |
 
@@ -22,8 +22,13 @@ packet closeout finished. The clean v2 matrix passed all 106 owners, and two
 supplemental package verifications cover the remaining audited owners. The
 full local proof passed all 34 reported lanes. All nine review threads across
 the three PRs are resolved, and the receipts are pushed in `abd5416aa2`.
-The final PR path awaits operator direction. The package and terminal monitor
-gates remain unchanged.
+The operator approved final closeout PR #1038 on 2026-09-09 after #1028 merged
+before closeout. Publication of evidence commit `59bba09125` passed all 67
+reported lanes, including all 23 local CI-parity stages. The final packet
+update belongs in #1038, which must remain open through the terminal monitor
+gate on its final head. No verification requirement is waived.
+P2 remains in progress while the canonical repository and hosted acceptance
+item is open, even though the implementation's local and package proofs passed.
 
 ## P0 — Research
 
@@ -70,4 +75,5 @@ git diff --check -- goals/inline-schema-compile-hard-error
 bun run beep goals doctor
 bun run beep goals index --write
 bun run beep goals index --check
+bun test goals/inline-schema-compile-hard-error/research/scripts/package-verification.test.ts
 ```

--- a/goals/inline-schema-compile-hard-error/PLAN.md
+++ b/goals/inline-schema-compile-hard-error/PLAN.md
@@ -20,8 +20,10 @@ checks on the same implementation tree. PR #1028 shipped the package-proof
 runner repair and reflection, but also merged before local verification and
 packet closeout finished. The clean v2 matrix passed all 106 owners, and two
 supplemental package verifications cover the remaining audited owners. The
-full local proof passed all 34 reported lanes. The final publication path
-awaits operator direction. The package and terminal monitor gates remain unchanged.
+full local proof passed all 34 reported lanes. All nine review threads across
+the three PRs are resolved, and the receipts are pushed in `abd5416aa2`.
+The final PR path awaits operator direction. The package and terminal monitor
+gates remain unchanged.
 
 ## P0 — Research
 

--- a/goals/inline-schema-compile-hard-error/README.md
+++ b/goals/inline-schema-compile-hard-error/README.md
@@ -82,6 +82,9 @@ The final PR path awaits operator direction after PR #1028 merged before closeou
   [package-evidence reply](https://github.com/beep-effect/beep-effect/pull/1028#discussion_r3964829818)
   links the pushed receipts. The lifecycle remains active until publication
   and terminal monitoring satisfy the remaining gates.
+- The [September 9 reflection](./history/reflections/2026-09-09-codex.md)
+  supplements the earlier account with the completed proofs, the full owner
+  inventory, and the remaining publication gate.
 
 ## Notes
 

--- a/goals/inline-schema-compile-hard-error/README.md
+++ b/goals/inline-schema-compile-hard-error/README.md
@@ -33,10 +33,11 @@ Use this command for execution-capable sessions:
 
 ## Current Phase
 
-P2 verification, P3 review, and P4 closeout are in progress. The implementation
-fixes are merged; this follow-up repairs the package-proof receipt identity and
-retains the reflection. Closure requires fresh package receipts and a terminal
-Yeet monitor result.
+P2 verification is complete; P3 review and P4 closeout are in progress. The
+implementation and package-proof identity repair are merged. The new full
+local proof and all package verification passed. Closure still requires
+publication of the final receipts and a terminal Yeet monitor verdict. The
+final publication path awaits operator direction after PR #1028 merged before closeout.
 
 ## Latest Evidence
 
@@ -49,14 +50,15 @@ Yeet monitor result.
   2026-09-08. The refreshed
   [`residual census`](./research/residual-census.json) reports zero findings on
   the merged implementation, and `beep/no-inline-schema-compile` is an error.
-- The [`106-owner matrix`](./research/package-verification.json) records a
-  historical passing run. Its old digest omitted committed code, so that
-  artifact is not accepted as final-tree package evidence. A fresh matrix with
-  a committed-tree fingerprint is required before closure.
-  Later reconciliation passed full package verification for `@beep/semantica`,
-  `@beep/freshbooks`, and `@beep/repo-cli`, plus focused tests and quick package
-  verification for the four test-only owners. Fresh HTML regeneration has no
-  tracked diff; the final lint-rule suite passes all 66 tests.
+- The [v2 package matrix](./research/package-verification.json) passed all 106
+  owners in a clean worktree at `02d88af51c`, with committed tree
+  `786d98065f3a3628599a4691e0314b5fb004bff3`. Its owner inventory has no missing,
+  extra, or duplicate entries. The earlier local-settings failure is excluded
+  from acceptance, as is the legacy report without committed-tree identity.
+  Supplemental canonical verification for `@beep/freshbooks` and `@beep/effect-drizzle`
+  covers the two additional owners found in the shipped implementation diff.
+  Fresh HTML regeneration has no tracked diff; the lint-rule suite passes all
+  66 tests.
 - [PR #1019](https://github.com/beep-effect/beep-effect/pull/1019) shipped the
   migration. [PR #1022](https://github.com/beep-effect/beep-effect/pull/1022)
   shipped recursive schema-literal classification and complete environment
@@ -66,9 +68,18 @@ Yeet monitor result.
   share Git tree `6a9533d44b007cb26959789f22d7fa7768dc7615`. Hosted checks are
   green. [`research/closeout-evidence.md`](./research/closeout-evidence.md)
   records the commits, commands, results, and review links.
-- The [closeout reflection](./history/reflections/2026-09-08-codex.md) is retained
-  with the proof-runner repair. The lifecycle will close in this PR after its
-  publication and review checks reach the required terminal result.
+- The new PR #1028 merged-preview proof also passed: full tier, 34 reported
+  lanes, recorded execution time 37 minutes 2 seconds. The preview and reviewed
+  head share tree `786d98065f3a3628599a4691e0314b5fb004bff3`. Affected-package
+  steps select no tasks for this goal-only diff; the separate owner matrix
+  supplies the required package-level coverage.
+- [PR #1028](https://github.com/beep-effect/beep-effect/pull/1028) shipped the
+  proof-runner repair and retained the
+  [reflection](./history/reflections/2026-09-08-codex.md). Its required hosted
+  checks passed, but it merged before local verification finished. Three of
+  its four review threads are resolved; the package-evidence thread remains
+  open. The lifecycle remains active until final evidence and publication
+  satisfy the remaining gates.
 
 ## Notes
 

--- a/goals/inline-schema-compile-hard-error/README.md
+++ b/goals/inline-schema-compile-hard-error/README.md
@@ -66,6 +66,9 @@ completed local and package proofs do not close that remaining gate.
   [structured canonical receipts](./research/package-verification-supplemental.json).
   The receipt test decodes both report formats and checks all 108 owners,
   matching heads, and complete successful audit/docgen steps.
+  Its expected owners come from the independent
+  [implementation-diff inventory](./research/implementation-owner-inventory.json),
+  captured from all files in merged PRs #1019, #1022, and #1028.
   Fresh HTML regeneration has no tracked diff; the lint-rule suite passes all
   66 tests.
 - [PR #1019](https://github.com/beep-effect/beep-effect/pull/1019) shipped the

--- a/goals/inline-schema-compile-hard-error/README.md
+++ b/goals/inline-schema-compile-hard-error/README.md
@@ -33,11 +33,12 @@ Use this command for execution-capable sessions:
 
 ## Current Phase
 
-P2 verification is complete; P3 review and P4 closeout are in progress. The
+P2 verification is complete; P3 publication and P4 closeout are in progress. The
 implementation and package-proof identity repair are merged. The new full
-local proof and all package verification passed. Closure still requires
-publication of the final receipts and a terminal Yeet monitor verdict. The
-final publication path awaits operator direction after PR #1028 merged before closeout.
+local proof and all package verification passed. All nine review threads are
+resolved, and the final receipts are pushed in `abd5416aa2`. Closure still
+requires landing those receipts and recording a terminal Yeet monitor verdict.
+The final PR path awaits operator direction after PR #1028 merged before closeout.
 
 ## Latest Evidence
 
@@ -76,10 +77,11 @@ final publication path awaits operator direction after PR #1028 merged before cl
 - [PR #1028](https://github.com/beep-effect/beep-effect/pull/1028) shipped the
   proof-runner repair and retained the
   [reflection](./history/reflections/2026-09-08-codex.md). Its required hosted
-  checks passed, but it merged before local verification finished. Three of
-  its four review threads are resolved; the package-evidence thread remains
-  open. The lifecycle remains active until final evidence and publication
-  satisfy the remaining gates.
+  checks passed, but it merged before local verification finished. All four
+  review threads are resolved; the final
+  [package-evidence reply](https://github.com/beep-effect/beep-effect/pull/1028#discussion_r3964829818)
+  links the pushed receipts. The lifecycle remains active until publication
+  and terminal monitoring satisfy the remaining gates.
 
 ## Notes
 

--- a/goals/inline-schema-compile-hard-error/README.md
+++ b/goals/inline-schema-compile-hard-error/README.md
@@ -33,12 +33,16 @@ Use this command for execution-capable sessions:
 
 ## Current Phase
 
-P2 verification is complete; P3 publication and P4 closeout are in progress. The
+P2 verification, P3 publication, and P4 closeout are in progress. The
 implementation and package-proof identity repair are merged. The new full
 local proof and all package verification passed. All nine review threads are
 resolved, and the final receipts are pushed in `abd5416aa2`. Closure still
 requires landing those receipts and recording a terminal Yeet monitor verdict.
-The final PR path awaits operator direction after PR #1028 merged before closeout.
+The operator approved [final closeout PR #1038](https://github.com/beep-effect/beep-effect/pull/1038)
+on 2026-09-09 after PR #1028 merged before closeout. The final packet update
+will be included in #1038 and verified on its final head before handoff.
+P2 stays open with the canonical repository and hosted acceptance item; the
+completed local and package proofs do not close that remaining gate.
 
 ## Latest Evidence
 
@@ -58,6 +62,10 @@ The final PR path awaits operator direction after PR #1028 merged before closeou
   from acceptance, as is the legacy report without committed-tree identity.
   Supplemental canonical verification for `@beep/freshbooks` and `@beep/effect-drizzle`
   covers the two additional owners found in the shipped implementation diff.
+  The primary matrix explicitly links their
+  [structured canonical receipts](./research/package-verification-supplemental.json).
+  The receipt test decodes both report formats and checks all 108 owners,
+  matching heads, and complete successful audit/docgen steps.
   Fresh HTML regeneration has no tracked diff; the lint-rule suite passes all
   66 tests.
 - [PR #1019](https://github.com/beep-effect/beep-effect/pull/1019) shipped the
@@ -85,6 +93,11 @@ The final PR path awaits operator direction after PR #1028 merged before closeou
 - The [September 9 reflection](./history/reflections/2026-09-09-codex.md)
   supplements the earlier account with the completed proofs, the full owner
   inventory, and the remaining publication gate.
+- The full Yeet publication of `59bba09125` passed all 67 reported lanes,
+  including all 23 local CI-parity stages, and pushed that commit. The reusable
+  proof state and lane receipts pin its correct identity despite the verdict
+  header retaining the invocation's starting SHA. The closeout audit records
+  the tested merge preview and the receipt-consistency limitation.
 
 ## Notes
 

--- a/goals/inline-schema-compile-hard-error/SPEC.md
+++ b/goals/inline-schema-compile-hard-error/SPEC.md
@@ -62,7 +62,7 @@ Higher sources outrank lower sources when they conflict.
 - [x] Repository lint reports zero `beep(no-inline-schema-compile)` findings.
 - [x] The lint rule is configured as an error after zero is reached.
 - [x] Focused rule tests cover inline rejection and module-scope acceptance.
-- [ ] Every affected workspace package completes its required package verify.
+- [x] Every affected workspace package completes its required package verify.
 - [x] Generated sources are regenerated from their updated owners without
       unexplained drift.
 - [ ] Canonical repository and hosted verification are green.

--- a/goals/inline-schema-compile-hard-error/SPEC.md
+++ b/goals/inline-schema-compile-hard-error/SPEC.md
@@ -76,6 +76,7 @@ Higher sources outrank lower sources when they conflict.
 | Rule tests | Focused policy-pack lint-rule tests | Green |
 | Repository lint | Canonical lint/Yeet lane | Zero findings, error severity enabled |
 | Packages | `bun run beep quality package-verify <package>` | Green for every touched package |
+| Package evidence inventory | `bun test goals/inline-schema-compile-hard-error/research/scripts/package-verification.test.ts` | Primary and linked supplemental receipts cover all 108 affected owners on the pinned head |
 | Packet launcher | `test "$(wc -m < goals/inline-schema-compile-hard-error/GOAL.md)" -le 4000` | Passes |
 | Goal fleet | `bun run beep goals doctor` and index check | Green |
 | Hosted closure | `bun run beep yeet monitor` | `merge-ready: yes` |
@@ -94,4 +95,4 @@ Higher sources outrank lower sources when they conflict.
 
 | Exception | Scope | Owner | Rationale | Removal condition |
 | --- | --- | --- | --- | --- |
-| None | N/A | N/A | N/A | N/A |
+| Final closeout follows the implementation PR | Packet publication only; PR #1038 | Operator, approved 2026-09-09 | PR #1028 merged before final verification and lifecycle closeout. The operator authorized a final closeout PR; no implementation or verification requirement is waived. | Final packet update is included in #1038 and its final head reaches Yeet `merge-ready: yes`. |

--- a/goals/inline-schema-compile-hard-error/history/reflections/2026-09-09-codex.md
+++ b/goals/inline-schema-compile-hard-error/history/reflections/2026-09-09-codex.md
@@ -79,6 +79,14 @@ matrix links them explicitly, and a receipt test validates the complete
 keeps the original matrix identity intact while making supplemental evidence
 machine-readable.
 
+The next review correctly rejected deriving the test's expected owners from
+the opening census again. The expected inventory now comes from complete,
+paginated file lists for all three merged implementation PRs and each head's
+declared workspace manifests. Persisted file-to-owner mappings account for
+599, 6, and 11 changed files and independently establish the 108-owner union.
+The receipt test compares against that inventory instead of repeating the
+matrix's selection logic.
+
 ## Goal & prompt critique
 
 The terminal `merge-ready: yes` requirement is unambiguous, but the publication

--- a/goals/inline-schema-compile-hard-error/history/reflections/2026-09-09-codex.md
+++ b/goals/inline-schema-compile-hard-error/history/reflections/2026-09-09-codex.md
@@ -1,0 +1,94 @@
+---
+goal: inline-schema-compile-hard-error
+agent: codex
+date: 2026-09-09
+trigger: closeout
+confidence: high
+findings:
+  - category: implementation-improvement
+    confidence: high
+    instruction: Derive the final package inventory from both the opening census and every shipped implementation diff.
+    explanation: The corrected matrix passed all 106 selected owners, but the implementation changed 108. Supplemental canonical verification covered FreshBooks and effect-drizzle. A complete run of an incomplete inventory would still miss required handoffs.
+  - category: tooling-friction
+    confidence: high
+    instruction: Prove committed source in a clean worktree when unrelated local agent settings affect package audits.
+    explanation: The first v2 matrix stopped at ai-sync because pre-existing Graft permissions failed its safety policy. The same committed source passed in a clean detached worktree, and all 106 matrix owners then passed without changing the user's settings.
+  - category: goal-critique
+    confidence: high
+    instruction: Keep a packet's final publication gate visible before the operator merges its implementation PR.
+    explanation: PR 1028 merged while local verification was still running. Its required hosted checks passed, but Yeet monitor subsequently refused the merged PR, leaving the explicit merge-ready result and final lifecycle update outstanding.
+todos:
+  - Compare selected package owners with the complete implementation diff before admitting a matrix.
+  - Report local overlay inputs separately from committed proof identity.
+  - Show packet closeout readiness beside implementation and hosted-check readiness.
+---
+
+# Reflection: inline-schema-compile-hard-error follow-up
+
+## Summary
+
+This update supplements the September 8 reflection after the corrected proofs
+finished. The fresh matrix passed all 106 expected owners; two supplemental
+verifications cover all 108 affected owners. All nine review threads are
+resolved. The goal remains active because the final receipts still need to
+land and the terminal Yeet monitor result has not been recorded.
+
+## Tooling experience
+
+The v2 receipt records committed tree
+`786d98065f3a3628599a4691e0314b5fb004bff3`, verifier inputs, and owner inventory.
+Recomputing its identity matched the saved digest. Only the report changed in
+the proof worktree, so local source edits did not contaminate that result.
+
+The full Yeet preview passed all 34 reported lanes. Several affected-package
+lanes selected no tasks because the follow-up changed only goal artifacts.
+Those successful no-ops did not replace the separate package matrix. The
+preview's recorded execution time was 37 minutes 2 seconds; admission waiting
+extended the start-to-finish span to 56 minutes 26 seconds.
+
+The unchanged preview ran the 1,022-file TSGo test check three times, taking
+440.5, 456.7, and 460.5 seconds. The friction ledger retains these timings and
+the requested diagnostics and proof-reuse opportunities. These are follow-up
+tooling changes, not additional compiler-migration scope.
+
+## Implementation improvement opportunities
+
+The receipt identity regression now covers clean commits as well as dirty
+inputs. Keep that test beside the runner. Extend a future matrix's preflight
+to compare selected owners against the shipped diff and stop before expensive
+work if any owner is uncovered.
+
+## Goal & prompt critique
+
+The terminal `merge-ready: yes` requirement is unambiguous, but the publication
+sequence allowed manual merges before that result and the packet state flip.
+A future launcher should require a visible closeout checklist in the early PR
+body, including any running local proof and the lifecycle update still due.
+Passing checks and an already-merged PR do not satisfy that explicit gate.
+
+## TODOs worth codifying
+
+- Reject incomplete owner inventories before package verification starts.
+- Explain proof invalidation by input dimension and isolate unrelated overlays.
+- Show whether implementation, local proof, hosted review, and packet closeout
+  are independently ready before an operator merges.
+
+## Lessons (confidence-tiered)
+
+- HIGH, critical: verify the inventory as well as each result. A 106/106 pass
+  was insufficient until the two additional affected owners were checked.
+- HIGH, critical: distinguish the tested source tree from later commits.
+  The #1028 merge preserved package sources but added unrelated exploration
+  data and Biome exclusions, so its complete tree was not identical.
+- MEDIUM, best practice: use an isolated proof worktree to preserve unrelated
+  user settings without accepting a contaminated verification run.
+- LOW, consideration: make packet readiness a distinct PR status once its
+  lifecycle and proof transitions have a stable contract.
+
+## Evidence
+
+- [Verification and publication audit](../../research/closeout-evidence.md)
+- [Fresh v2 package matrix](../../research/package-verification.json)
+- [Friction ledger](../../research/OPPORTUNITIES.md)
+- [Previous reflection](./2026-09-08-codex.md)
+- [Final package-evidence reply](https://github.com/beep-effect/beep-effect/pull/1028#discussion_r3964829818)

--- a/goals/inline-schema-compile-hard-error/history/reflections/2026-09-09-codex.md
+++ b/goals/inline-schema-compile-hard-error/history/reflections/2026-09-09-codex.md
@@ -17,10 +17,15 @@ findings:
     confidence: high
     instruction: Keep a packet's final publication gate visible before the operator merges its implementation PR.
     explanation: PR 1028 merged while local verification was still running. Its required hosted checks passed, but Yeet monitor subsequently refused the merged PR, leaving the explicit merge-ready result and final lifecycle update outstanding.
+  - category: tooling-friction
+    confidence: high
+    instruction: Record the starting head separately from the committed proof head in publish verdicts.
+    explanation: The full publication of 59bba09125 passed, but its verdict header retained starting SHA 88c4036de4. Reusable proof state, lane receipts, and installation and preview logs identified the correct tested commit. A single consistent receipt would avoid that cross-check.
 todos:
   - Compare selected package owners with the complete implementation diff before admitting a matrix.
   - Report local overlay inputs separately from committed proof identity.
   - Show packet closeout readiness beside implementation and hosted-check readiness.
+  - Test publish receipt identities across the commit created by the command itself.
 ---
 
 # Reflection: inline-schema-compile-hard-error follow-up
@@ -30,8 +35,9 @@ todos:
 This update supplements the September 8 reflection after the corrected proofs
 finished. The fresh matrix passed all 106 expected owners; two supplemental
 verifications cover all 108 affected owners. All nine review threads are
-resolved. The goal remains active because the final receipts still need to
-land and the terminal Yeet monitor result has not been recorded.
+resolved. The operator authorized final closeout PR #1038 after #1028 merged
+early. The goal remains active until that PR contains the final packet update
+and its final head reaches the terminal Yeet monitor gate.
 
 ## Tooling experience
 
@@ -51,12 +57,27 @@ The unchanged preview ran the 1,022-file TSGo test check three times, taking
 the requested diagnostics and proof-reuse opportunities. These are follow-up
 tooling changes, not additional compiler-migration scope.
 
+The later evidence publication passed all 67 reported lanes, including all 23
+local CI-parity stages, and pushed `59bba09125`. Its verdict retained the
+starting SHA in its header while its reusable proof state and lane receipts
+correctly pinned the new commit. Checking those records against the install,
+preview, and push logs established the tested identity without relabeling
+the verdict. The friction ledger records the consistency defect for follow-up.
+
 ## Implementation improvement opportunities
 
 The receipt identity regression now covers clean commits as well as dirty
 inputs. Keep that test beside the runner. Extend a future matrix's preflight
 to compare selected owners against the shipped diff and stop before expensive
 work if any owner is uncovered.
+
+PR #1038 review exposed a second handoff gap: the two supplemental runs were
+only described in prose. Fresh reports now reuse the package verifier's
+existing `PackageVerifyReport` schema and canonical JSON codec. The primary
+matrix links them explicitly, and a receipt test validates the complete
+108-owner union, common source head, and successful audit/docgen steps. This
+keeps the original matrix identity intact while making supplemental evidence
+machine-readable.
 
 ## Goal & prompt critique
 
@@ -72,6 +93,8 @@ Passing checks and an already-merged PR do not satisfy that explicit gate.
 - Explain proof invalidation by input dimension and isolate unrelated overlays.
 - Show whether implementation, local proof, hosted review, and packet closeout
   are independently ready before an operator merges.
+- Keep starting-head and tested-head metadata explicit and consistent across
+  publish receipts when the command creates a new commit.
 
 ## Lessons (confidence-tiered)
 

--- a/goals/inline-schema-compile-hard-error/ops/manifest.json
+++ b/goals/inline-schema-compile-hard-error/ops/manifest.json
@@ -6,7 +6,7 @@
     "title": "Inline Schema Compiler Hard Error",
     "status": "active",
     "created": "2026-08-30",
-    "updated": "2026-09-08",
+    "updated": "2026-09-09",
     "packetAnchorDocument": "SPEC.md"
   },
   "packetPath": "goals/inline-schema-compile-hard-error",
@@ -63,20 +63,20 @@
     {
       "id": "P2",
       "name": "Verify",
-      "status": "in-progress",
-      "evidence": "The shipped implementation passes full local Yeet verification. PR #1028 review found that the historical package matrix omitted committed code from its digest; the repaired runner must produce a fresh 106-owner receipt before closure."
+      "status": "complete",
+      "evidence": "The clean v2 matrix passed all 106 expected owners at head 02d88af51c and committed tree 786d98065f3a3628599a4691e0314b5fb004bff3. FreshBooks and effect-drizzle passed supplemental verification, covering all 108 owners in the implementation PR diffs. Full local Yeet verification passed all 34 reported lanes on preview 64a5996a4e, which shares that committed tree."
     },
     {
       "id": "P3",
       "name": "Yeet: PR to mergeable",
       "status": "in-progress",
-      "evidence": "PRs #1019 and #1022 merged and their five review threads are resolved. PR #1028 remains under review; P3 requires its terminal merge-ready: yes result."
+      "evidence": "PRs #1019, #1022, and #1028 merged. The first two PRs' five review threads are resolved; three of #1028's four threads are resolved and its package-evidence thread remains open. The required terminal merge-ready: yes result remains unrecorded."
     },
     {
       "id": "P4",
       "name": "Close",
       "status": "in-progress",
-      "evidence": "The validated reflection is present. README.md, PLAN.md, and this manifest remain active until the corrected package evidence and terminal monitor gate are satisfied; final state updates stay in PR #1028 with the proof-runner repair."
+      "evidence": "The validated reflection is present. README.md, PLAN.md, and this manifest remain active until corrected package evidence and the terminal monitor gate are satisfied. The final publication path awaits operator direction after #1028 merged before closeout."
     }
   ],
   "verificationCommands": [

--- a/goals/inline-schema-compile-hard-error/ops/manifest.json
+++ b/goals/inline-schema-compile-hard-error/ops/manifest.json
@@ -76,7 +76,7 @@
       "id": "P4",
       "name": "Close",
       "status": "in-progress",
-      "evidence": "The validated reflection is present, and the corrected package evidence is pushed. README.md, PLAN.md, and this manifest remain active until the receipts land and the terminal monitor gate is satisfied. The final PR path awaits operator direction after #1028 merged before closeout."
+      "evidence": "The September 8 reflection and September 9 follow-up record the implementation lessons and completed proofs. The corrected package evidence is pushed. README.md, PLAN.md, and this manifest remain active until the receipts land and the terminal monitor gate is satisfied. The final PR path awaits operator direction after #1028 merged before closeout."
     }
   ],
   "verificationCommands": [

--- a/goals/inline-schema-compile-hard-error/ops/manifest.json
+++ b/goals/inline-schema-compile-hard-error/ops/manifest.json
@@ -39,7 +39,8 @@
     "research/SOURCES.md",
     "research/closeout-evidence.md",
     "research/package-verification.json",
-    "research/package-verification-supplemental.json"
+    "research/package-verification-supplemental.json",
+    "research/implementation-owner-inventory.json"
   ],
   "agentLaunchers": [
     {

--- a/goals/inline-schema-compile-hard-error/ops/manifest.json
+++ b/goals/inline-schema-compile-hard-error/ops/manifest.json
@@ -70,13 +70,13 @@
       "id": "P3",
       "name": "Yeet: PR to mergeable",
       "status": "in-progress",
-      "evidence": "PRs #1019, #1022, and #1028 merged. The first two PRs' five review threads are resolved; three of #1028's four threads are resolved and its package-evidence thread remains open. The required terminal merge-ready: yes result remains unrecorded."
+      "evidence": "PRs #1019, #1022, and #1028 merged. All nine review threads are replied to and resolved, confirmed on GitHub on 2026-09-09. The final #1028 package-evidence reply links receipts pushed in abd5416aa2. The required terminal merge-ready: yes result remains unrecorded."
     },
     {
       "id": "P4",
       "name": "Close",
       "status": "in-progress",
-      "evidence": "The validated reflection is present. README.md, PLAN.md, and this manifest remain active until corrected package evidence and the terminal monitor gate are satisfied. The final publication path awaits operator direction after #1028 merged before closeout."
+      "evidence": "The validated reflection is present, and the corrected package evidence is pushed. README.md, PLAN.md, and this manifest remain active until the receipts land and the terminal monitor gate is satisfied. The final PR path awaits operator direction after #1028 merged before closeout."
     }
   ],
   "verificationCommands": [

--- a/goals/inline-schema-compile-hard-error/ops/manifest.json
+++ b/goals/inline-schema-compile-hard-error/ops/manifest.json
@@ -35,7 +35,12 @@
     "goals/inline-schema-compile-hard-error/research/SOURCES.md",
     "goals/schema-utils-selective-codec-statics/research/closing-census.json"
   ],
-  "researchReports": ["research/SOURCES.md", "research/closeout-evidence.md"],
+  "researchReports": [
+    "research/SOURCES.md",
+    "research/closeout-evidence.md",
+    "research/package-verification.json",
+    "research/package-verification-supplemental.json"
+  ],
   "agentLaunchers": [
     {
       "kind": "codex-goal",
@@ -63,20 +68,20 @@
     {
       "id": "P2",
       "name": "Verify",
-      "status": "complete",
-      "evidence": "The clean v2 matrix passed all 106 expected owners at head 02d88af51c and committed tree 786d98065f3a3628599a4691e0314b5fb004bff3. FreshBooks and effect-drizzle passed supplemental verification, covering all 108 owners in the implementation PR diffs. Full local Yeet verification passed all 34 reported lanes on preview 64a5996a4e, which shares that committed tree."
+      "status": "in-progress",
+      "evidence": "The clean v2 matrix passed all 106 expected owners at head 02d88af51c and committed tree 786d98065f3a3628599a4691e0314b5fb004bff3. FreshBooks and effect-drizzle passed supplemental verification, covering all 108 owners in the implementation PR diffs. Full local Yeet verification passed all 34 reported lanes on preview 64a5996a4e, which shares that committed tree. P2 remains open while the canonical repository and hosted acceptance item is unchecked; PR #1038 must satisfy the remaining final-head verification and monitor gate."
     },
     {
       "id": "P3",
       "name": "Yeet: PR to mergeable",
       "status": "in-progress",
-      "evidence": "PRs #1019, #1022, and #1028 merged. All nine review threads are replied to and resolved, confirmed on GitHub on 2026-09-09. The final #1028 package-evidence reply links receipts pushed in abd5416aa2. The required terminal merge-ready: yes result remains unrecorded."
+      "evidence": "PRs #1019, #1022, and #1028 merged. All nine review threads are replied to and resolved, confirmed on GitHub on 2026-09-09. Evidence commit 59bba09125 passed full Yeet publication with 67 reported lanes and all 23 local CI-parity stages. Operator-approved final closeout PR #1038 is open; its final head must reach the required terminal merge-ready: yes result."
     },
     {
       "id": "P4",
       "name": "Close",
       "status": "in-progress",
-      "evidence": "The September 8 reflection and September 9 follow-up record the implementation lessons and completed proofs. The corrected package evidence is pushed. README.md, PLAN.md, and this manifest remain active until the receipts land and the terminal monitor gate is satisfied. The final PR path awaits operator direction after #1028 merged before closeout."
+      "evidence": "The September 8 reflection and September 9 follow-up record the implementation lessons and completed proofs. The corrected package evidence is pushed. The operator approved final closeout PR #1038 on 2026-09-09 as the publication exception after #1028 merged early. README.md, PLAN.md, and this manifest remain active until the packet update and terminal monitor gate are satisfied in #1038."
     }
   ],
   "verificationCommands": [
@@ -85,6 +90,7 @@
     "rg -n \"inline-schema-compile-hard-error|GOAL.md|agentLaunchers|packetAnchorDocument\" goals/inline-schema-compile-hard-error",
     "git diff --check -- goals/inline-schema-compile-hard-error",
     "bun run beep lint reflection-artifacts",
+    "bun test goals/inline-schema-compile-hard-error/research/scripts/package-verification.test.ts",
     "bun run beep goals doctor",
     "bun run beep goals index --check"
   ],

--- a/goals/inline-schema-compile-hard-error/research/OPPORTUNITIES.md
+++ b/goals/inline-schema-compile-hard-error/research/OPPORTUNITIES.md
@@ -380,6 +380,13 @@
   3,153-test surface in the unit and property lanes for 352 and 402 seconds,
   respectively, despite equivalent proof earlier in that same preview.
   Coverage then ran its distinct instrumented proof for 416 seconds.
+  In preview `64a5996a4e`, the 1,022-file TSGo test check passed in 440.5
+  seconds under `cheap-gates:test-tsgo`, then the unchanged preview dispatched
+  the identical command again as `quality:check:tsgo-tests` after JSDoc; that
+  second pass took 456.7 seconds. The nested check aggregate then started a
+  third invocation of the same TSGo test checker through the direct CLI
+  entry point, still checking 1,022 files across 139 packages; it passed after
+  another 460.5 seconds.
 - **Prevention:** Give repo-cli and other shared scripts and commands a bounded
   progress contract: structured phase, current-unit, completed, remaining,
   elapsed, and last-completed events plus concise interactive heartbeats. Key
@@ -431,3 +438,38 @@
   and uncommitted inputs in the receipt identity; pin the recorded head for
   the run and refuse to relabel results if it changes. Test resume behavior
   across two clean commits, then rerun the full owner matrix.
+
+## 2026-09-08 — Opening census did not cover later package changes
+
+- **Work:** Check the scope of the fresh package matrix against the shipped
+  implementation diff before accepting its receipt.
+- **Evidence:** PR #1019 changed 108 package owners, while the runner selected
+  106 from the opening census plus lint-rules. FreshBooks and effect-drizzle
+  were missing. Separate canonical package verification passed for both on
+  the current head; the original matrix alone does not cover every handoff.
+- **Prevention:** Union census owners with owners of the final implementation
+  diff, including later reconciliation and quality repairs. Record that owner
+  inventory with the proof identity and report uncovered owners before running.
+
+## 2026-09-08 — Admission wait suggested an incomplete status command
+
+- **Work:** Inspect scheduler holders after the package matrix waited ten
+  minutes for admission.
+- **Evidence:** Admission suggested `bun run beep quality scheduler status`,
+  but that exact command exited 1 with `Missing required flag: --json`.
+- **Prevention:** Keep emitted recovery commands executable as printed. Make
+  the status flag optional or include it in the wait diagnostic, and test the
+  suggested command against the CLI's parsed options.
+
+## 2026-09-08 — Unrelated agent settings stopped the package proof
+
+- **Work:** Run the fresh committed-tree package matrix for PR #1028.
+- **Evidence:** Seven packages passed before `@beep/ai-sync` rejected four
+  Graft auto-approval entries in the pre-existing dirty `.claude/settings.json`.
+  The overlay is unrelated to this goal and must not be modified to make the
+  proof pass. A separate worktree at the same commit isolates the acceptance
+  run without changing the user's settings.
+  The isolated `@beep/ai-sync` verification then passed with audit and docgen.
+- **Prevention:** Run final package matrices in a clean, pinned worktree, or
+  explicitly identify dirty configuration inputs before admission. Keep local
+  overlay diagnostics separate from committed-source acceptance evidence.

--- a/goals/inline-schema-compile-hard-error/research/OPPORTUNITIES.md
+++ b/goals/inline-schema-compile-hard-error/research/OPPORTUNITIES.md
@@ -447,6 +447,10 @@
   106 from the opening census plus lint-rules. FreshBooks and effect-drizzle
   were missing. Separate canonical package verification passed for both on
   the current head; the original matrix alone does not cover every handoff.
+  PR #1038 review also found that prose-only supplemental evidence was not
+  discoverable from the matrix JSON. Fresh structured reports now reuse the
+  canonical `PackageVerifyReport` JSON codec and are explicitly linked from
+  the primary receipt; a test checks the complete 108-owner union.
 - **Prevention:** Union census owners with owners of the final implementation
   diff, including later reconciliation and quality repairs. Record that owner
   inventory with the proof identity and report uncovered owners before running.
@@ -473,3 +477,21 @@
 - **Prevention:** Run final package matrices in a clean, pinned worktree, or
   explicitly identify dirty configuration inputs before admission. Keep local
   overlay diagnostics separate from committed-source acceptance evidence.
+
+## 2026-09-09 - Publish verdict retained the pre-commit head
+
+- **Work:** Check the final evidence commit after `bun run beep yeet publish
+  --staged-only` completed its full proof and push.
+- **Evidence:** The successful `yeet-verdict/v2` records `88c4036de4` in both
+  `head` and `resolvedHeadSha`, although the command created and pushed
+  `59bba09125`. The branch's `yeet-run-state/v1` correctly records the latter
+  as `commitSha`. The clean-HEAD installation log also names `59bba09125`,
+  and the CI-parity log identifies preview `f416b94770`, whose second parent
+  is that commit. All 67 reported lanes passed, including all 23 CI-parity
+  stages; the remote branch matches the pushed commit. These independent
+  receipts establish the execution identity, but the verdict header alone
+  does not.
+- **Prevention:** Distinguish the invocation's starting head from the committed
+  proof head and merged-preview identity. Keep the final verdict, reusable
+  proof state, and pushed-head receipt consistent, with a regression test for
+  publish commands that create a commit before proving it.

--- a/goals/inline-schema-compile-hard-error/research/OPPORTUNITIES.md
+++ b/goals/inline-schema-compile-hard-error/research/OPPORTUNITIES.md
@@ -451,6 +451,9 @@
   discoverable from the matrix JSON. Fresh structured reports now reuse the
   canonical `PackageVerifyReport` JSON codec and are explicitly linked from
   the primary receipt; a test checks the complete 108-owner union.
+  A subsequent review caught the test deriving expected owners from the same
+  census again. The independent inventory now retains every changed file and
+  its workspace owner from the three merged PRs' complete file lists.
 - **Prevention:** Union census owners with owners of the final implementation
   diff, including later reconciliation and quality repairs. Record that owner
   inventory with the proof identity and report uncovered owners before running.

--- a/goals/inline-schema-compile-hard-error/research/closeout-evidence.md
+++ b/goals/inline-schema-compile-hard-error/research/closeout-evidence.md
@@ -90,9 +90,20 @@ and the length of captured output are sanitized; result status, source head,
 step names, exit codes, and durations retain the executed values.
 
 `bun test goals/inline-schema-compile-hard-error/research/scripts/package-verification.test.ts`
-passes 241 assertions covering the primary counts and link, the canonical
-supplemental reports, matching heads, full audit/docgen execution, and the
-combined 108-owner inventory with no duplicates or missing owners.
+checks the primary counts and link, the canonical supplemental reports,
+matching heads, full audit/docgen execution, and the combined owner inventory
+with no duplicates or missing owners. Its expected owners come from
+`implementation-owner-inventory.json`, not the opening census or receipts.
+
+That independent inventory was captured from all paginated GitHub file lists
+for merged PRs #1019, #1022, and #1028: 599, 6, and 11 files respectively,
+matching each PR's reported `changed_files` count. Each file was assigned to
+the nearest workspace manifest declared by root `package.json` at that PR's
+recorded head. The artifact retains those head and merge SHAs, workspace
+roots, every owned file, and every path outside a workspace. The resulting
+union contains 108 owners. The test checks complete file accounting and
+compares the receipt union with these independently captured owners, so an
+owner missing from both the census and receipts is no longer invisible.
 
 The first v2 matrix stopped after seven passing owners when `@beep/ai-sync`
 rejected unrelated, pre-existing Graft permissions in the dirty local agent

--- a/goals/inline-schema-compile-hard-error/research/closeout-evidence.md
+++ b/goals/inline-schema-compile-hard-error/research/closeout-evidence.md
@@ -1,6 +1,7 @@
 # Closeout evidence
 
-Recorded on 2026-09-08 after the implementation and review follow-up merged.
+Initially recorded on 2026-09-08; refreshed on 2026-09-09 after the full proof
+and clean package matrix passed.
 
 ## Code identity
 
@@ -10,10 +11,18 @@ Recorded on 2026-09-08 after the implementation and review follow-up merged.
 | PR #1022 reviewed head | `9ac60da26b09a2ada78c65ac31d645c9ab324bc4` |
 | Local Yeet merged preview | `af4de931af6bf0f38b50b9f91b8a7b5c1ea7190e` |
 | PR #1022 squash merge | `ed66cbce8f17111458f8b4801ec417d9adafaabd` |
+| PR #1028 reviewed head | `02d88af51cff03dcbaeb50c3b6da663c1f99fd97` |
+| PR #1028 local Yeet preview | `64a5996a4ec603ae1851716c217b960723cf3f25` |
+| PR #1028 squash merge | `39132ff64b24e851391624b8799f023495ae9cc2` |
 
-The reviewed head, local merged preview, and PR #1022 squash merge all resolve
+The PR #1022 reviewed head, its local preview, and its squash merge all resolve
 to Git tree `6a9533d44b007cb26959789f22d7fa7768dc7615`. The local proof therefore
 covers the shipped implementation exactly.
+
+The PR #1028 reviewed head and local preview share Git tree
+`786d98065f3a3628599a4691e0314b5fb004bff3`. Its squash merge also contains an
+unrelated exploration corpus and two Biome exclusions, as detailed below;
+the package sources are unchanged, but the complete merge tree differs.
 
 ## Requirement audit
 
@@ -23,18 +32,56 @@ covers the shipped implementation exactly.
 | Remove governed compiler calls | Fresh `research/scripts/census.ts` run on the merged implementation; `residual-census.json` | Zero findings and zero unresolved generated owners |
 | Enable the hard error | `.oxlintrc.json` sets `beep/no-inline-schema-compile` to `error`; full lint-policy passes | Complete |
 | Preserve static and runtime-dependent forms | 66 policy-pack tests, including nested objects, arrays, spreads, computed keys, and unary operands | Green |
-| Verify affected package owners | The historical 106/106 report predates the shipped tree and has an invalid resume identity; a fresh run with the corrected committed-tree fingerprint is required | Pending |
+| Verify affected package owners | Fresh v2 matrix: 106/106 passed at `02d88af51c`, committed tree `786d98065f3a3628599a4691e0314b5fb004bff3`; FreshBooks and effect-drizzle supplemental receipts below cover the two other owners | All 108 audited owners passed |
 | Keep generated output reproducible | Fresh `bun run --cwd packages/foundation/modeling/html generate:check`; full codegen lane | No tracked generated diff |
-| Complete local repository proof | `bun run beep yeet verify --merged`, proof tier `full`, outcome `success`, exit 0 | All 33 reported lanes passed in 2,614,527 ms |
+| Complete local repository proof | PR #1028 preview: `bun run beep yeet verify --merged`, full tier, outcome success, process exit 0, 34 reported lanes passed in 2,222,351 ms | Green on the pinned follow-up tree; package matrix remains separately required |
 | Complete hosted implementation checks | [PR #1022 Check run](https://github.com/beep-effect/beep-effect/actions/runs/34303197901) and the PR's status rollup | Required checks green; no failing rollup entry |
 | Address review comments | Two original PR #1019 threads and all three PR #1022 threads | Replies posted; all resolved |
 | Capture friction and lessons | `OPPORTUNITIES.md` and `history/reflections/2026-09-08-codex.md` | Retained with the packet |
 
 The historical package report is stamped at `45b422a58e75324c30d7d4e60e5ef0b91be35bab`.
 Its original digest only included uncommitted differences and therefore did
-not establish committed code identity. PR #1028 repairs that defect and keeps
-P2 open until a fresh matrix finishes. The implementation's aggregate Yeet
-success below does not substitute for that required package receipt.
+not establish committed code identity. PR #1028 repaired that defect. The
+fresh v2 matrix is complete, with 106 unique expected owners, no missing or
+extra entries, and zero failures. Its recomputed identity matches the saved
+receipt and permits resume; the worktree has no tracked source changes apart
+from the report itself. The aggregate Yeet success below does not substitute
+for this separate package receipt.
+
+### Supplemental owner verification
+
+The shipped PR #1019 diff touches 108 package owners. Comparing their nearest
+workspace manifests with the opening census plus the lint-rule owner found
+two owners outside the 106-entry matrix. Both passed fresh canonical package
+verification at head `02d88af51cff03dcbaeb50c3b6da663c1f99fd97`, committed tree
+`786d98065f3a3628599a4691e0314b5fb004bff3`:
+
+| Command | Audit | Docgen | Package subtree |
+| --- | --- | --- | --- |
+| `bun run beep quality package-verify @beep/freshbooks` | Passed, 14.4 s | Passed, 3.2 s | `8bf3c408c1d9aee91d57d176440d959f9322e0d4` |
+| `bun run beep quality package-verify @beep/effect-drizzle` | Passed, 16.2 s | Passed, 2.9 s | `c2033fd99100c67c211a6a7238e49c42a4996b17` |
+
+Both commands exited 0. These receipts supplement, rather than replace, the
+passing 106-owner v2 matrix. FreshBooks contains a later compiler hoist;
+effect-drizzle contains type-alias repairs included in the implementation PR.
+
+The first v2 matrix stopped after seven passing owners when `@beep/ai-sync`
+rejected unrelated, pre-existing Graft permissions in the dirty local agent
+settings. The file was preserved unchanged. At the same commit in a clean
+detached worktree, `bun run beep quality package-verify @beep/ai-sync` passed
+with audit 13.0 s, docgen 3.0 s, and exit 0. The full matrix then passed in
+that worktree; the failed overlay run is not acceptance evidence.
+
+The follow-up runs the canonical full Yeet tier at preview `64a5996a4e`.
+Because its changed paths are goal artifacts, affected-package docgen,
+integration, unit-test, coverage, and check steps select no package tasks.
+Those successful no-op steps are not presented as full package verification.
+The separate 106-owner matrix and two supplemental owner receipts provide
+that required coverage. The full preview also runs repository-wide gates,
+including TSGo test checks and lint policy. The saved `yeet-verdict/v2` reports full tier, success, and
+34 passing lanes with no non-passing lane. Its recorded execution elapsed time
+is 2,222,351 ms; the start/end span is 56 minutes 26 seconds including admission
+waiting. This result does not replace the outstanding terminal PR monitor gate.
 
 The local full proof includes codegen, build, test-TSGo, lint, lint-policy,
 Docgen, integration tests, unit tests, coverage, security, secrets, SAST, Nix,
@@ -58,14 +105,30 @@ lowered, and the subsequent hosted Coverage Regression check passed.
 
 Both implementation PRs merged before packet closeout. The watcher recorded
 all required checks green, then ended with `reason: pr-merged` and `failing: 0`.
-PR #1028 now carries the proof-runner repair and reflection together. The
-lifecycle remains active until fresh package evidence and a terminal
-`merge-ready: yes` result exist; the final lifecycle update will stay in that
-PR with the remaining implementation work.
+PR #1028 carried the proof-runner repair and reflection together. Package
+evidence is now complete; the lifecycle remains active while publication and
+the terminal `merge-ready: yes` result are outstanding.
+
+PR #1028 was also merged externally before the local matrix completed and
+before the requested terminal monitor result was recorded. All required
+hosted checks had passed. The watcher ended with two Vercel deployment quota
+failures, which the repository permits as an environment-only exception. A
+subsequent `yeet monitor --summary` could not run against the already-merged
+PR; the goal's terminal monitor requirement therefore remains open.
+
+The #1028 squash merge is `39132ff64b24e851391624b8799f023495ae9cc2`.
+Compared with pinned proof commit `02d88af51c`, it adds the unrelated run-3
+exploration corpus and two Biome exclusions for that corpus. Packages, apps,
+tools, scripts, infrastructure, `package.json`, and `bun.lock` are unchanged;
+the package proof still covers the shipped package sources. The complete Git
+trees are different and are not claimed to be identical.
 
 The packet's reflection validator reports zero blocking and advisory findings.
-Goal doctor reports zero blocking findings. It retains a non-fatal
-`completion-gate-unsatisfied` advisory because neither implementation squash
-message names the packet slug; the documentation closeout commit names
-`inline-schema-compile-hard-error` so that citation can be recognized when it
-merges. The goal index, JSON, launcher-size, and whitespace checks pass.
+The refreshed goal doctor run reports zero blocking findings and no advisory
+for this active packet; its four fleet advisories concern other goals. The
+goal index, JSON, launcher-size, and whitespace checks pass. Fresh HTML
+generation on `02d88af51c` also exits 0 with no tracked generated diff.
+
+The final closed-state audit must still check the packet-citation gate. The
+closeout commit must name `inline-schema-compile-hard-error` so that the
+completion citation can be recognized when this PR merges.

--- a/goals/inline-schema-compile-hard-error/research/closeout-evidence.md
+++ b/goals/inline-schema-compile-hard-error/research/closeout-evidence.md
@@ -14,6 +14,8 @@ and clean package matrix passed.
 | PR #1028 reviewed head | `02d88af51cff03dcbaeb50c3b6da663c1f99fd97` |
 | PR #1028 local Yeet preview | `64a5996a4ec603ae1851716c217b960723cf3f25` |
 | PR #1028 squash merge | `39132ff64b24e851391624b8799f023495ae9cc2` |
+| PR #1038 opening evidence head | `59bba09125b8e57648052bc29227df6e93d34c87` |
+| PR #1038 opening local CI-parity preview | `f416b94770845d213f947c85cc85e5d027bccaaf` |
 
 The PR #1022 reviewed head, its local preview, and its squash merge all resolve
 to Git tree `6a9533d44b007cb26959789f22d7fa7768dc7615`. The local proof therefore
@@ -69,6 +71,29 @@ Both commands exited 0. These receipts supplement, rather than replace, the
 passing 106-owner v2 matrix. FreshBooks contains a later compiler hoist;
 effect-drizzle contains type-alias repairs included in the implementation PR.
 
+PR #1038 review requested structured evidence for those two owners. Fresh
+canonical `runPackageVerify` executions on the same pinned head captured both
+`PackageVerifyReport` values in `package-verification-supplemental.json` on
+2026-09-09. Effect-drizzle passed audit in 17,909 ms and docgen in 3,599 ms;
+FreshBooks passed audit in 13,539 ms and docgen in 3,101 ms. Both reports have
+`quick: false`, both required steps executed with exit code 0, and the capture
+process exited 0. Git HEAD and tree identity matched before and after capture,
+with no changes outside the goal's report files in the proof worktree.
+
+The primary matrix explicitly links that supplemental file through
+`supplementalReceipts`; its original 106-owner summary and tree digest are not
+relabeled. Consumers decode the supplemental array with the existing
+`PackageVerifyReport` from `@beep/repo-cli/test/Quality`, using
+`S.fromJsonString(S.toCodecJson(S.Array(PackageVerifyReport)))`. The JSON codec
+round-trips the canonical report's Option-valued exit codes. Only local paths
+and the length of captured output are sanitized; result status, source head,
+step names, exit codes, and durations retain the executed values.
+
+`bun test goals/inline-schema-compile-hard-error/research/scripts/package-verification.test.ts`
+passes 241 assertions covering the primary counts and link, the canonical
+supplemental reports, matching heads, full audit/docgen execution, and the
+combined 108-owner inventory with no duplicates or missing owners.
+
 The first v2 matrix stopped after seven passing owners when `@beep/ai-sync`
 rejected unrelated, pre-existing Graft permissions in the dirty local agent
 settings. The file was preserved unchanged. At the same commit in a clean
@@ -105,7 +130,7 @@ lowered, and the subsequent hosted Coverage Regression check passed.
 - [Unary schema literals](https://github.com/beep-effect/beep-effect/pull/1022#discussion_r3963944769): accept static signed literals for hoist detection while retaining runtime-dependent factories; resolved.
 - [Ambient values outside the allowlist](https://github.com/beep-effect/beep-effect/pull/1022#discussion_r3963964963): hash all inherited values into a digest; resolved.
 - [Tracked lint configuration path](https://github.com/beep-effect/beep-effect/pull/1028#discussion_r3964376328): corrected the audit to reference `.oxlintrc.json`; resolved.
-- [Same-PR packet closeout](https://github.com/beep-effect/beep-effect/pull/1028#discussion_r3964376332): proof-runner repair and reflection shipped together in #1028; thread resolved. The subsequent external merge prevented the final lifecycle flip in that PR, so the publication exception still awaits operator direction.
+- [Same-PR packet closeout](https://github.com/beep-effect/beep-effect/pull/1028#discussion_r3964376332): proof-runner repair and reflection shipped together in #1028; thread resolved. The subsequent external merge prevented the final lifecycle flip in that PR. On 2026-09-09 the operator authorized final closeout PR #1038 as the publication exception, without waiving verification gates.
 - [Premature P3 completion](https://github.com/beep-effect/beep-effect/pull/1028#discussion_r3964376341): restored active lifecycle and incomplete closeout gates; resolved. P3 remains open until the actual terminal monitor result exists.
 - [Fresh committed-tree package receipt](https://github.com/beep-effect/beep-effect/pull/1028#discussion_r3964829818): pushed the completed v2 matrix and supplemental owner evidence in `abd5416aa2`, posted the proof links, and resolved the thread.
 
@@ -121,8 +146,38 @@ evidence is now complete; the lifecycle remains active while publication and
 the terminal `merge-ready: yes` result are outstanding.
 
 The final receipts are committed and pushed in `abd5416aa2` on
-`codex/inline-schema-final-evidence`. No further PR has been opened while the
-operator's choice about final publication remains pending.
+`codex/inline-schema-final-evidence`, followed by review-state and reflection
+updates through `59bba09125`. On 2026-09-09 the operator approved
+[final closeout PR #1038](https://github.com/beep-effect/beep-effect/pull/1038).
+The final packet-state update belongs in that PR, which must remain open
+until Yeet reports `merge-ready: yes` on its final head. This publication
+exception does not waive any package, local, hosted, or review requirement.
+
+### Opening evidence publication for PR #1038
+
+`bun run beep yeet publish --staged-only` completed at 06:30:48 UTC on
+2026-09-09 with process exit 0, full tier, outcome success, and a successful
+push of `59bba09125b8e57648052bc29227df6e93d34c87`. All 67 reported lanes passed,
+including all 23 local CI-parity stages. The complete invocation took
+4,439,809 ms, including admission waiting.
+
+The committed evidence tree is `62619979faf58d945618c4a58d2db0e109ebde23`.
+The CI-parity preview is `f416b94770845d213f947c85cc85e5d027bccaaf`, tree
+`5fb198101b2e45cda0cdeb763606491a5cf72e05`, with parents
+`e7b66eb31fdfd750ed7a55d702d33a838d7cafab` and
+`59bba09125b8e57648052bc29227df6e93d34c87`. Its fresh build passed 140/140 tasks
+with zero cache hits, and the labs aggregate passed 91/91 tasks. Affected
+package steps that selected no tasks still do not replace the 108-owner
+implementation evidence. Local CI parity does not replace hosted-only checks.
+
+The verdict's `head` and `resolvedHeadSha` retain pre-commit SHA `88c4036de4`.
+The separate reusable run state records the correct `commitSha` `59bba09125`,
+and all 39 saved lane-proof records identify that head and its committed tree.
+The installation, preview, and push logs independently corroborate the new
+commit. This is a verdict-header consistency issue recorded in
+`OPPORTUNITIES.md`, not permission to relabel a receipt or treat the stale
+header alone as exact-head proof. The user's unrelated settings overlay was
+restored with its original checksum after publication.
 
 PR #1028 was also merged externally before the local matrix completed and
 before the requested terminal monitor result was recorded. All required

--- a/goals/inline-schema-compile-hard-error/research/closeout-evidence.md
+++ b/goals/inline-schema-compile-hard-error/research/closeout-evidence.md
@@ -24,6 +24,10 @@ The PR #1028 reviewed head and local preview share Git tree
 unrelated exploration corpus and two Biome exclusions, as detailed below;
 the package sources are unchanged, but the complete merge tree differs.
 
+The refreshed repository census at `88c4036de4817cd179d2e0d65af29e885eca9eb3`
+reports zero findings. That evidence branch changes only goal artifacts from
+the #1028 squash merge; it does not introduce another package implementation.
+
 ## Requirement audit
 
 | Requirement | Evidence | Result |
@@ -37,7 +41,7 @@ the package sources are unchanged, but the complete merge tree differs.
 | Complete local repository proof | PR #1028 preview: `bun run beep yeet verify --merged`, full tier, outcome success, process exit 0, 34 reported lanes passed in 2,222,351 ms | Green on the pinned follow-up tree; package matrix remains separately required |
 | Complete hosted implementation checks | [PR #1022 Check run](https://github.com/beep-effect/beep-effect/actions/runs/34303197901) and the PR's status rollup | Required checks green; no failing rollup entry |
 | Address review comments | Two PR #1019 threads, three PR #1022 threads, and four PR #1028 threads | Replies posted; all nine resolved, confirmed on GitHub on 2026-09-09 |
-| Capture friction and lessons | `OPPORTUNITIES.md` and `history/reflections/2026-09-08-codex.md` | Retained with the packet |
+| Capture friction and lessons | `OPPORTUNITIES.md` and the September 8 and September 9 reflections under `history/reflections/` | Retained with the packet |
 
 The historical package report is stamped at `45b422a58e75324c30d7d4e60e5ef0b91be35bab`.
 Its original digest only included uncommitted differences and therefore did

--- a/goals/inline-schema-compile-hard-error/research/closeout-evidence.md
+++ b/goals/inline-schema-compile-hard-error/research/closeout-evidence.md
@@ -36,7 +36,7 @@ the package sources are unchanged, but the complete merge tree differs.
 | Keep generated output reproducible | Fresh `bun run --cwd packages/foundation/modeling/html generate:check`; full codegen lane | No tracked generated diff |
 | Complete local repository proof | PR #1028 preview: `bun run beep yeet verify --merged`, full tier, outcome success, process exit 0, 34 reported lanes passed in 2,222,351 ms | Green on the pinned follow-up tree; package matrix remains separately required |
 | Complete hosted implementation checks | [PR #1022 Check run](https://github.com/beep-effect/beep-effect/actions/runs/34303197901) and the PR's status rollup | Required checks green; no failing rollup entry |
-| Address review comments | Two original PR #1019 threads and all three PR #1022 threads | Replies posted; all resolved |
+| Address review comments | Two PR #1019 threads, three PR #1022 threads, and four PR #1028 threads | Replies posted; all nine resolved, confirmed on GitHub on 2026-09-09 |
 | Capture friction and lessons | `OPPORTUNITIES.md` and `history/reflections/2026-09-08-codex.md` | Retained with the packet |
 
 The historical package report is stamped at `45b422a58e75324c30d7d4e60e5ef0b91be35bab`.
@@ -100,6 +100,13 @@ lowered, and the subsequent hosted Coverage Regression check passed.
 - [Explicit local environment](https://github.com/beep-effect/beep-effect/pull/1022#discussion_r3963927989): account for `useLocalEnv` as well as ambient extension; resolved.
 - [Unary schema literals](https://github.com/beep-effect/beep-effect/pull/1022#discussion_r3963944769): accept static signed literals for hoist detection while retaining runtime-dependent factories; resolved.
 - [Ambient values outside the allowlist](https://github.com/beep-effect/beep-effect/pull/1022#discussion_r3963964963): hash all inherited values into a digest; resolved.
+- [Tracked lint configuration path](https://github.com/beep-effect/beep-effect/pull/1028#discussion_r3964376328): corrected the audit to reference `.oxlintrc.json`; resolved.
+- [Same-PR packet closeout](https://github.com/beep-effect/beep-effect/pull/1028#discussion_r3964376332): proof-runner repair and reflection shipped together in #1028; thread resolved. The subsequent external merge prevented the final lifecycle flip in that PR, so the publication exception still awaits operator direction.
+- [Premature P3 completion](https://github.com/beep-effect/beep-effect/pull/1028#discussion_r3964376341): restored active lifecycle and incomplete closeout gates; resolved. P3 remains open until the actual terminal monitor result exists.
+- [Fresh committed-tree package receipt](https://github.com/beep-effect/beep-effect/pull/1028#discussion_r3964829818): pushed the completed v2 matrix and supplemental owner evidence in `abd5416aa2`, posted the proof links, and resolved the thread.
+
+A complete GitHub review-thread query on 2026-09-09 returned all nine threads
+as resolved, with no additional pages for any of the three PRs.
 
 ## Publication sequence
 
@@ -108,6 +115,10 @@ all required checks green, then ended with `reason: pr-merged` and `failing: 0`.
 PR #1028 carried the proof-runner repair and reflection together. Package
 evidence is now complete; the lifecycle remains active while publication and
 the terminal `merge-ready: yes` result are outstanding.
+
+The final receipts are committed and pushed in `abd5416aa2` on
+`codex/inline-schema-final-evidence`. No further PR has been opened while the
+operator's choice about final publication remains pending.
 
 PR #1028 was also merged externally before the local matrix completed and
 before the requested terminal monitor result was recorded. All required

--- a/goals/inline-schema-compile-hard-error/research/implementation-owner-inventory.json
+++ b/goals/inline-schema-compile-hard-error/research/implementation-owner-inventory.json
@@ -1,0 +1,1360 @@
+{
+  "schemaVersion": "inline-schema-implementation-owners/v1",
+  "generatedAt": "2026-09-09T07:00:20.839Z",
+  "method": "Paginated merged PR file lists, matched to the nearest declared workspace manifest at each PR head.",
+  "pullRequests": [
+    {
+      "number": 1019,
+      "headSha": "21d289c36b5001b1b7151d7076bc5b0a28e58f4c",
+      "mergeSha": "52fcc8d1353db9481ef9edb6cc9619500f95568d",
+      "changedFileCount": 599,
+      "owners": [
+        {
+          "packageName": "@beep/acp",
+          "workspaceRoot": "packages/drivers/acp",
+          "files": ["packages/drivers/acp/src/AcpProtocol.service.ts"]
+        },
+        {
+          "packageName": "@beep/agents-client",
+          "workspaceRoot": "packages/agents/client",
+          "files": [
+            "packages/agents/client/src/Chat.atoms.ts",
+            "packages/agents/client/src/ClientObservability.ts",
+            "packages/agents/client/test/Chat.schema-parity.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/agents-domain",
+          "workspaceRoot": "packages/agents/domain",
+          "files": [
+            "packages/agents/domain/test/AgentsDomain.test.ts",
+            "packages/agents/domain/test/ProviderInstance.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/agents-server",
+          "workspaceRoot": "packages/agents/server",
+          "files": ["packages/agents/server/test/AnthropicTurnCodec.test.ts"]
+        },
+        {
+          "packageName": "@beep/agents-tables",
+          "workspaceRoot": "packages/agents/tables",
+          "files": ["packages/agents/tables/test/ProviderInstanceTable.test.ts"]
+        },
+        {
+          "packageName": "@beep/agents-use-cases",
+          "workspaceRoot": "packages/agents/use-cases",
+          "files": ["packages/agents/use-cases/test/Chat.test.ts"]
+        },
+        {
+          "packageName": "@beep/ai-provider-cli",
+          "workspaceRoot": "packages/drivers/ai-provider-cli",
+          "files": [
+            "packages/drivers/ai-provider-cli/src/AiProviderCli.service.ts",
+            "packages/drivers/ai-provider-cli/test/AiProviderCli.service.test.ts",
+            "packages/drivers/ai-provider-cli/test/AiProviderCli.snapshot.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/ai-sync",
+          "workspaceRoot": "packages/tooling/library/ai-sync",
+          "files": ["packages/tooling/library/ai-sync/test/ai-sync.test.ts"]
+        },
+        {
+          "packageName": "@beep/anthropic",
+          "workspaceRoot": "packages/drivers/anthropic",
+          "files": ["packages/drivers/anthropic/test/Anthropic.repair.test.ts"]
+        },
+        {
+          "packageName": "@beep/api-transport",
+          "workspaceRoot": "packages/foundation/capability/api-transport",
+          "files": [
+            "packages/foundation/capability/api-transport/src/Transport.ts",
+            "packages/foundation/capability/api-transport/test/EgressDenied.test.ts",
+            "packages/foundation/capability/api-transport/test/Transport.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/architecture-lab-config",
+          "workspaceRoot": "packages/architecture-lab/config",
+          "files": [
+            "packages/architecture-lab/config/test/WorkItemConfig.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/architecture-lab-proof",
+          "workspaceRoot": "apps/architecture-lab-proof",
+          "files": [
+            "apps/architecture-lab-proof/test/ArchitectureLabProof.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/architecture-lab-ui",
+          "workspaceRoot": "packages/architecture-lab/ui",
+          "files": [
+            "packages/architecture-lab/ui/test/WorkItemViewModel.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/architecture-lab-use-cases",
+          "workspaceRoot": "packages/architecture-lab/use-cases",
+          "files": [
+            "packages/architecture-lab/use-cases/test/SchemaParity.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/box",
+          "workspaceRoot": "packages/drivers/box",
+          "files": [
+            "packages/drivers/box/src/Box.streaming.ts",
+            "packages/drivers/box/test/Box.service.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/box-provisioning",
+          "workspaceRoot": "packages/drivers/box-provisioning",
+          "files": [
+            "packages/drivers/box-provisioning/src/BoxProvisioningApplier.ts",
+            "packages/drivers/box-provisioning/src/BoxProvisioningArtifacts.ts",
+            "packages/drivers/box-provisioning/src/BoxProvisioningInventory.ts",
+            "packages/drivers/box-provisioning/src/internal/canonical.ts",
+            "packages/drivers/box-provisioning/src/internal/live.ts",
+            "packages/drivers/box-provisioning/test/BoxProvisioning.test.ts",
+            "packages/drivers/box-provisioning/test/BoxProvisioningArtifactPrivacy.test.ts",
+            "packages/drivers/box-provisioning/test/BoxProvisioningIntent.test.ts",
+            "packages/drivers/box-provisioning/test/BoxProvisioningPlanner.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/brand",
+          "workspaceRoot": "packages/foundation/ui-system/brand",
+          "files": ["packages/foundation/ui-system/brand/test/Brand.test.ts"]
+        },
+        {
+          "packageName": "@beep/chalk",
+          "workspaceRoot": "packages/foundation/capability/chalk",
+          "files": ["packages/foundation/capability/chalk/test/index.test.ts"]
+        },
+        {
+          "packageName": "@beep/ciops",
+          "workspaceRoot": "apps/labs/ciops",
+          "files": ["apps/labs/ciops/src/projection/Replay.ts"]
+        },
+        {
+          "packageName": "@beep/colors",
+          "workspaceRoot": "packages/foundation/capability/colors",
+          "files": ["packages/foundation/capability/colors/test/index.test.ts"]
+        },
+        {
+          "packageName": "@beep/db-admin",
+          "workspaceRoot": "packages/_internal/db-admin",
+          "files": [
+            "packages/_internal/db-admin/test/integration/LawPracticeCandorGateMigration.pglite.test.ts",
+            "packages/_internal/db-admin/test/integration/LawPracticeLegalPositionMigration.pglite.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/discord",
+          "workspaceRoot": "packages/drivers/discord",
+          "files": ["packages/drivers/discord/test/Discord.service.test.ts"]
+        },
+        {
+          "packageName": "@beep/doc-text",
+          "workspaceRoot": "packages/drivers/doc-text",
+          "files": ["packages/drivers/doc-text/test/DocText.service.test.ts"]
+        },
+        {
+          "packageName": "@beep/dock",
+          "workspaceRoot": "packages/foundation/ui-system/dock",
+          "files": [
+            "packages/foundation/ui-system/dock/src/DockEngine.service.ts",
+            "packages/foundation/ui-system/dock/test/DockAtoms.test.ts",
+            "packages/foundation/ui-system/dock/test/DockEngine.test.ts",
+            "packages/foundation/ui-system/dock/test/Floating.test.ts",
+            "packages/foundation/ui-system/dock/test/GestureParity.test.ts",
+            "packages/foundation/ui-system/dock/test/dockview-anchored-box.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/documents-domain",
+          "workspaceRoot": "packages/documents/domain",
+          "files": [
+            "packages/documents/domain/src/values/Taxonomy/Taxonomy.projection.ts",
+            "packages/documents/domain/test/SyncConflict.test.ts",
+            "packages/documents/domain/test/SyncCursor.test.ts",
+            "packages/documents/domain/test/SyncItem.test.ts",
+            "packages/documents/domain/test/SyncOperation.test.ts",
+            "packages/documents/domain/test/Taxonomy.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/documents-server",
+          "workspaceRoot": "packages/documents/server",
+          "files": [
+            "packages/documents/server/test/DocumentIntake.test.ts",
+            "packages/documents/server/test/FilingDecisionLlm.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/documents-tables",
+          "workspaceRoot": "packages/documents/tables",
+          "files": [
+            "packages/documents/tables/test/SyncConflictTable.test.ts",
+            "packages/documents/tables/test/SyncCursorTable.test.ts",
+            "packages/documents/tables/test/SyncItemTable.test.ts",
+            "packages/documents/tables/test/SyncOperationTable.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/documents-use-cases",
+          "workspaceRoot": "packages/documents/use-cases",
+          "files": [
+            "packages/documents/use-cases/test/FilingDecision.test.ts",
+            "packages/documents/use-cases/test/Sync.test.ts",
+            "packages/documents/use-cases/test/SyncConflict.test.ts",
+            "packages/documents/use-cases/test/SyncCursor.test.ts",
+            "packages/documents/use-cases/test/SyncOperation.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/drizzle",
+          "workspaceRoot": "packages/drivers/drizzle",
+          "files": [
+            "packages/drivers/drizzle/src/Drizzle.errors.ts",
+            "packages/drivers/drizzle/test/Drizzle.errors.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/editor",
+          "workspaceRoot": "packages/foundation/ui-system/editor",
+          "files": [
+            "packages/foundation/ui-system/editor/src/capability/composer.tsx",
+            "packages/foundation/ui-system/editor/src/chat/attachment-model.ts",
+            "packages/foundation/ui-system/editor/src/chat/chat-composer.tsx",
+            "packages/foundation/ui-system/editor/src/code-block-node.tsx",
+            "packages/foundation/ui-system/editor/src/composer.tsx",
+            "packages/foundation/ui-system/editor/src/mermaid-node.tsx",
+            "packages/foundation/ui-system/editor/test/capability-catalog.test.ts",
+            "packages/foundation/ui-system/editor/test/capability-resolver.test.ts",
+            "packages/foundation/ui-system/editor/test/capability-schemas.test.ts",
+            "packages/foundation/ui-system/editor/test/chat-schema-parity.test.ts",
+            "packages/foundation/ui-system/editor/test/editor-nodes.test.ts",
+            "packages/foundation/ui-system/editor/test/style-node-matrix.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/effect-drizzle",
+          "workspaceRoot": "packages/ecosystem/effect-drizzle",
+          "files": [
+            "packages/ecosystem/effect-drizzle/src/core/assembly.ts",
+            "packages/ecosystem/effect-drizzle/src/internal/statics.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/epistemic-config",
+          "workspaceRoot": "packages/epistemic/config",
+          "files": ["packages/epistemic/config/test/Config.test.ts"]
+        },
+        {
+          "packageName": "@beep/epistemic-domain",
+          "workspaceRoot": "packages/epistemic/domain",
+          "files": [
+            "packages/epistemic/domain/test/Contradiction.test.ts",
+            "packages/epistemic/domain/test/EpistemicDomain.test.ts",
+            "packages/epistemic/domain/test/EvidenceVerification.test.ts",
+            "packages/epistemic/domain/test/ExecutionAuthority.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/epistemic-server",
+          "workspaceRoot": "packages/epistemic/server",
+          "files": [
+            "packages/epistemic/server/test/BoundedShaclValidator.test.ts",
+            "packages/epistemic/server/test/integration/ContradictionTriage.pg.test.ts",
+            "packages/epistemic/server/test/integration/ContradictionTriage.pglite.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/epistemic-tables",
+          "workspaceRoot": "packages/epistemic/tables",
+          "files": [
+            "packages/epistemic/tables/test/ContradictionTables.test.ts",
+            "packages/epistemic/tables/test/EpistemicTables.test.ts",
+            "packages/epistemic/tables/test/EvidenceVerificationTables.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/epistemic-ui",
+          "workspaceRoot": "packages/epistemic/ui",
+          "files": [
+            "packages/epistemic/ui/test/ContradictionTriageView.test.tsx",
+            "packages/epistemic/ui/test/EvidenceSourcePanel.test.tsx"
+          ]
+        },
+        {
+          "packageName": "@beep/epistemic-use-cases",
+          "workspaceRoot": "packages/epistemic/use-cases",
+          "files": [
+            "packages/epistemic/use-cases/src/ClaimProjection/ClaimProjection.ts",
+            "packages/epistemic/use-cases/test/ContradictionTriage.commands.test.ts",
+            "packages/epistemic/use-cases/test/ContradictionTriage.rpc.test.ts",
+            "packages/epistemic/use-cases/test/EdgeAuthorityCommands.test.ts",
+            "packages/epistemic/use-cases/test/EpistemicUseCases.test.ts",
+            "packages/epistemic/use-cases/test/ExecutionLedger.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/exiftool",
+          "workspaceRoot": "packages/drivers/exiftool",
+          "files": ["packages/drivers/exiftool/test/Exiftool.models.test.ts"]
+        },
+        {
+          "packageName": "@beep/face-detection",
+          "workspaceRoot": "packages/drivers/face-detection",
+          "files": [
+            "packages/drivers/face-detection/test/FaceDetection.service.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/ffmpeg",
+          "workspaceRoot": "packages/drivers/ffmpeg",
+          "files": [
+            "packages/drivers/ffmpeg/test/FFmpeg.capture.test.ts",
+            "packages/drivers/ffmpeg/test/FFmpeg.service.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/file-processing",
+          "workspaceRoot": "packages/foundation/capability/file-processing",
+          "files": [
+            "packages/foundation/capability/file-processing/src/test.ts",
+            "packages/foundation/capability/file-processing/test/FileProcessing.test.ts",
+            "packages/foundation/capability/file-processing/test/SourceText.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/firecrawl",
+          "workspaceRoot": "packages/drivers/firecrawl",
+          "files": [
+            "packages/drivers/firecrawl/src/Firecrawl.service.ts",
+            "packages/drivers/firecrawl/test/Firecrawl.service.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/freshbooks",
+          "workspaceRoot": "packages/drivers/freshbooks",
+          "files": ["packages/drivers/freshbooks/src/Freshbooks.service.ts"]
+        },
+        {
+          "packageName": "@beep/gov-legal-mcp",
+          "workspaceRoot": "packages/drivers/gov-legal-mcp",
+          "files": [
+            "packages/drivers/gov-legal-mcp/test/GovLegalMcp.equivalence.test.ts",
+            "packages/drivers/gov-legal-mcp/test/Server.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/govinfo",
+          "workspaceRoot": "packages/drivers/govinfo",
+          "files": ["packages/drivers/govinfo/test/Govinfo.service.test.ts"]
+        },
+        {
+          "packageName": "@beep/html",
+          "workspaceRoot": "packages/foundation/modeling/html",
+          "files": [
+            "packages/foundation/modeling/html/scripts/generate.ts",
+            "packages/foundation/modeling/html/src/Html.conformance.ts",
+            "packages/foundation/modeling/html/src/Html.meta.ts",
+            "packages/foundation/modeling/html/src/Html.model.ts",
+            "packages/foundation/modeling/html/src/Html.policy.ts",
+            "packages/foundation/modeling/html/src/Html.serialize.ts",
+            "packages/foundation/modeling/html/src/internal/conformance/Html.heading-conformance.ts",
+            "packages/foundation/modeling/html/test/Html.browser-conformance.test.ts",
+            "packages/foundation/modeling/html/test/Html.conformance-annotation.test.ts",
+            "packages/foundation/modeling/html/test/Html.conformance-hardening.test.ts",
+            "packages/foundation/modeling/html/test/Html.coverage-matrix.test.ts",
+            "packages/foundation/modeling/html/test/Html.form-control.test.ts",
+            "packages/foundation/modeling/html/test/Html.generator.test.ts",
+            "packages/foundation/modeling/html/test/Html.microsyntax.test.ts",
+            "packages/foundation/modeling/html/test/Html.script.test.ts",
+            "packages/foundation/modeling/html/test/Html.security.test.ts",
+            "packages/foundation/modeling/html/test/Html.source-size.test.ts",
+            "packages/foundation/modeling/html/test/Html.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/hubspot",
+          "workspaceRoot": "packages/drivers/hubspot",
+          "files": ["packages/drivers/hubspot/src/HubSpot.service.ts"]
+        },
+        {
+          "packageName": "@beep/identity",
+          "workspaceRoot": "packages/foundation/modeling/identity",
+          "files": [
+            "packages/foundation/modeling/identity/src/Id.ts",
+            "packages/foundation/modeling/identity/test/Curie.test.ts",
+            "packages/foundation/modeling/identity/test/Fibered.test.ts",
+            "packages/foundation/modeling/identity/test/Identity.test.ts",
+            "packages/foundation/modeling/identity/test/PnLocal.test.ts",
+            "packages/foundation/modeling/identity/test/Vocab.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/infra",
+          "workspaceRoot": "infra",
+          "files": [
+            "infra/test/AIMetrics.test.ts",
+            "infra/test/CiRunners.test.ts",
+            "infra/test/OipWeb.test.ts",
+            "infra/test/OpenClaw.test.ts",
+            "infra/test/Storybook.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/langextract",
+          "workspaceRoot": "packages/foundation/capability/langextract",
+          "files": [
+            "packages/foundation/capability/langextract/src/Extraction/Extraction.behavior.ts",
+            "packages/foundation/capability/langextract/test/Alignment.test.ts",
+            "packages/foundation/capability/langextract/test/Extraction.test.ts",
+            "packages/foundation/capability/langextract/test/VerifiedSpanHistory.test.ts",
+            "packages/foundation/capability/langextract/test/VerifiedSpanSpike.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/law-practice-domain",
+          "workspaceRoot": "packages/law-practice/domain",
+          "files": [
+            "packages/law-practice/domain/src/values/PatentDocument/PatentDocument.normalizer.ts",
+            "packages/law-practice/domain/test/CourtReporterVocabulary.test.ts",
+            "packages/law-practice/domain/test/LawPracticeDomain.test.ts",
+            "packages/law-practice/domain/test/LegalPositionTransitions.test.ts",
+            "packages/law-practice/domain/test/PatentDocument.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/law-practice-server",
+          "workspaceRoot": "packages/law-practice/server",
+          "files": [
+            "packages/law-practice/server/src/PracticeKg.claims.ts",
+            "packages/law-practice/server/test/CandorRecord.pglite.test.ts",
+            "packages/law-practice/server/test/CandorRecord.test.ts",
+            "packages/law-practice/server/test/CompetencyQuestions.test.ts",
+            "packages/law-practice/server/test/LawPracticeServer.test.ts",
+            "packages/law-practice/server/test/LegalPositionRecord.pglite.test.ts",
+            "packages/law-practice/server/test/LegalPositionRecord.test.ts",
+            "packages/law-practice/server/test/PracticeKg.projections.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/law-practice-tables",
+          "workspaceRoot": "packages/law-practice/tables",
+          "files": [
+            "packages/law-practice/tables/test/LegalPositionConverters.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/law-practice-use-cases",
+          "workspaceRoot": "packages/law-practice/use-cases",
+          "files": [
+            "packages/law-practice/use-cases/src/LegalPositionRelatorPolicy/LegalPositionRelatorPolicy.service.ts",
+            "packages/law-practice/use-cases/test/CandorPolicy.test.ts",
+            "packages/law-practice/use-cases/test/SchemaParity.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/lejeune-bolt-workbench",
+          "workspaceRoot": "apps/labs/lejeune-bolt-workbench",
+          "files": [
+            "apps/labs/lejeune-bolt-workbench/server/build-bundle.ts",
+            "apps/labs/lejeune-bolt-workbench/server/provider-smoke.ts",
+            "apps/labs/lejeune-bolt-workbench/src/domain/Bundle.ts",
+            "apps/labs/lejeune-bolt-workbench/src/domain/Ontology.ts",
+            "apps/labs/lejeune-bolt-workbench/test/Bundle.test.ts",
+            "apps/labs/lejeune-bolt-workbench/test/BundleBuilder.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/lexical-schema",
+          "workspaceRoot": "packages/foundation/modeling/lexical",
+          "files": [
+            "packages/foundation/modeling/lexical/src/Lexical.codec.ts",
+            "packages/foundation/modeling/lexical/test/Lexical.codec.test.ts",
+            "packages/foundation/modeling/lexical/test/Lexical.conformance-annotation.test.ts",
+            "packages/foundation/modeling/lexical/test/Lexical.model.test.ts",
+            "packages/foundation/modeling/lexical/test/Lexical.strict-invariants.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/libpff",
+          "workspaceRoot": "packages/drivers/libpff",
+          "files": [
+            "packages/drivers/libpff/src/Libpff.pffexport.ts",
+            "packages/drivers/libpff/src/Libpff.service.ts",
+            "packages/drivers/libpff/test/Libpff.pffexport.test.ts",
+            "packages/drivers/libpff/test/integration/Libpff.pffexport.live.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/lint-rules",
+          "workspaceRoot": "packages/tooling/policy-pack/lint-rules",
+          "files": [
+            "packages/tooling/policy-pack/lint-rules/src/rules/no-inline-schema-compile.ts",
+            "packages/tooling/policy-pack/lint-rules/test/oxlint-rules.test.ts",
+            "packages/tooling/policy-pack/lint-rules/test/oxlint-sources.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/m365",
+          "workspaceRoot": "packages/drivers/m365",
+          "files": [
+            "packages/drivers/m365/src/M365.service.ts",
+            "packages/drivers/m365/test/M365.service.test.ts",
+            "packages/drivers/m365/test/integration/M365.live.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/m365-mcp",
+          "workspaceRoot": "packages/drivers/m365-mcp",
+          "files": ["packages/drivers/m365-mcp/test/Server.test.ts"]
+        },
+        {
+          "packageName": "@beep/mcp-kit",
+          "workspaceRoot": "packages/foundation/capability/mcp-kit",
+          "files": [
+            "packages/foundation/capability/mcp-kit/test/ApiKeyRequired.test.ts",
+            "packages/foundation/capability/mcp-kit/test/SanitizedToolkit.test.ts",
+            "packages/foundation/capability/mcp-kit/test/TierGate.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/md",
+          "workspaceRoot": "packages/foundation/modeling/md",
+          "files": [
+            "packages/foundation/modeling/md/src/Md.ts",
+            "packages/foundation/modeling/md/test/Md.conformance-annotation.test.ts",
+            "packages/foundation/modeling/md/test/Md.conformance.test.ts",
+            "packages/foundation/modeling/md/test/Md.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/n3",
+          "workspaceRoot": "packages/drivers/n3",
+          "files": [
+            "packages/drivers/n3/src/N3.service.ts",
+            "packages/drivers/n3/test/N3TurtleCodec.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/nlp",
+          "workspaceRoot": "packages/foundation/modeling/nlp",
+          "files": [
+            "packages/foundation/modeling/nlp/src/Core/Pattern.ts",
+            "packages/foundation/modeling/nlp/src/Core/PatternParsers.ts",
+            "packages/foundation/modeling/nlp/test/Algebra/NLPMonoid.test.ts",
+            "packages/foundation/modeling/nlp/test/CoreModels.test.ts",
+            "packages/foundation/modeling/nlp/test/Graph/Schema.test.ts",
+            "packages/foundation/modeling/nlp/test/Handoff/Contract.test.ts",
+            "packages/foundation/modeling/nlp/test/Ontology/Kind.test.ts",
+            "packages/foundation/modeling/nlp/test/PatternCore.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/nlp-processing",
+          "workspaceRoot": "packages/foundation/capability/nlp-processing",
+          "files": [
+            "packages/foundation/capability/nlp-processing/test/Backend/NLPBackend.test.ts",
+            "packages/foundation/capability/nlp-processing/test/Graph/GraphOperations.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/observability",
+          "workspaceRoot": "packages/foundation/capability/observability",
+          "files": [
+            "packages/foundation/capability/observability/src/CauseRedaction.ts",
+            "packages/foundation/capability/observability/src/internal/decode.ts",
+            "packages/foundation/capability/observability/test/CauseRedaction.test.ts",
+            "packages/foundation/capability/observability/test/DevTools.test.ts",
+            "packages/foundation/capability/observability/test/ErrorReporting.test.ts",
+            "packages/foundation/capability/observability/test/HttpApiTelemetry.test.ts",
+            "packages/foundation/capability/observability/test/Logging.test.ts",
+            "packages/foundation/capability/observability/test/Metric.test.ts",
+            "packages/foundation/capability/observability/test/Observed.test.ts",
+            "packages/foundation/capability/observability/test/PhaseProfiler.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/oip-web",
+          "workspaceRoot": "apps/oip-web",
+          "files": ["apps/oip-web/test/oip-web.test.tsx"]
+        },
+        {
+          "packageName": "@beep/onepassword-cli",
+          "workspaceRoot": "packages/drivers/onepassword-cli",
+          "files": [
+            "packages/drivers/onepassword-cli/test/OnePasswordCli.service.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/ontology",
+          "workspaceRoot": "packages/foundation/modeling/ontology",
+          "files": [
+            "packages/foundation/modeling/ontology/test/Ontology.models.test.ts",
+            "packages/foundation/modeling/ontology/test/SemanticFoundation.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/ontology-server",
+          "workspaceRoot": "packages/ontology/server",
+          "files": [
+            "packages/ontology/server/test/OntoauthorMatCompetency.test.ts",
+            "packages/ontology/server/test/OntologyTools.test.ts",
+            "packages/ontology/server/test/SessionServer.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/ontology-use-cases",
+          "workspaceRoot": "packages/ontology/use-cases",
+          "files": [
+            "packages/ontology/use-cases/src/tools/OntologyToolService.ts",
+            "packages/ontology/use-cases/test/SchemaParity.test.ts",
+            "packages/ontology/use-cases/test/Session.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/openclaw",
+          "workspaceRoot": "packages/drivers/openclaw",
+          "files": [
+            "packages/drivers/openclaw/test/Openclaw.models.test.ts",
+            "packages/drivers/openclaw/test/OpenclawCli.service.test.ts",
+            "packages/drivers/openclaw/test/OpenclawIntent.models.test.ts",
+            "packages/drivers/openclaw/test/OpenclawRender.test.ts",
+            "packages/drivers/openclaw/test/OpenclawSystemd.service.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/pacer",
+          "workspaceRoot": "packages/drivers/pacer",
+          "files": [
+            "packages/drivers/pacer/src/Pacer.config.ts",
+            "packages/drivers/pacer/src/Pacer.mock-data.ts",
+            "packages/drivers/pacer/src/PclClient.service.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/pandoc-ast",
+          "workspaceRoot": "packages/foundation/modeling/pandoc-ast",
+          "files": [
+            "packages/foundation/modeling/pandoc-ast/src/Pandoc.mapping.ts",
+            "packages/foundation/modeling/pandoc-ast/test/Pandoc.codec.test.ts",
+            "packages/foundation/modeling/pandoc-ast/test/Pandoc.conformance-annotation.test.ts",
+            "packages/foundation/modeling/pandoc-ast/test/Pandoc.mapping.test.ts",
+            "packages/foundation/modeling/pandoc-ast/test/Pandoc.semantic-conformance.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/phoenix",
+          "workspaceRoot": "packages/drivers/phoenix",
+          "files": [
+            "packages/drivers/phoenix/src/Phoenix.errors.ts",
+            "packages/drivers/phoenix/test/Phoenix.service.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/postgres",
+          "workspaceRoot": "packages/drivers/postgres",
+          "files": ["packages/drivers/postgres/src/PostgresDrizzle.service.ts"]
+        },
+        {
+          "packageName": "@beep/pretext",
+          "workspaceRoot": "packages/drivers/pretext",
+          "files": ["packages/drivers/pretext/src/Pretext.models.ts"]
+        },
+        {
+          "packageName": "@beep/professional-desktop",
+          "workspaceRoot": "apps/professional-desktop",
+          "files": [
+            "apps/professional-desktop/src/contradiction/ContradictionQaSeed.ts",
+            "apps/professional-desktop/test/editor-contract-hardening.test.tsx",
+            "apps/professional-desktop/test/failure-message.test.ts",
+            "apps/professional-desktop/test/integration/execution-authority.pglite.test.ts",
+            "apps/professional-desktop/test/tauri-youtube-security.test.ts",
+            "apps/professional-desktop/test/vault-sync-disconnected-note.test.tsx"
+          ]
+        },
+        {
+          "packageName": "@beep/provenance",
+          "workspaceRoot": "packages/foundation/modeling/provenance",
+          "files": [
+            "packages/foundation/modeling/provenance/test/TextAnchor.test.ts",
+            "packages/foundation/modeling/provenance/test/VerifiedTextAnchor.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/rdf",
+          "workspaceRoot": "packages/foundation/modeling/rdf",
+          "files": [
+            "packages/foundation/modeling/rdf/test/IRI.test.ts",
+            "packages/foundation/modeling/rdf/test/ProvRdf.test.ts",
+            "packages/foundation/modeling/rdf/test/Rdf.test.ts",
+            "packages/foundation/modeling/rdf/test/SemanticSchemaConformance.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/rdf-canonize",
+          "workspaceRoot": "packages/drivers/rdf-canonize",
+          "files": [
+            "packages/drivers/rdf-canonize/src/adapters/canonicalization.ts",
+            "packages/drivers/rdf-canonize/test/CanonicalizationSecurity.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/repo-ai-metrics",
+          "workspaceRoot": "packages/tooling/library/ai-metrics",
+          "files": [
+            "packages/tooling/library/ai-metrics/src/archive.ts",
+            "packages/tooling/library/ai-metrics/src/otlp.ts",
+            "packages/tooling/library/ai-metrics/test/config-snapshot-bounds.test.ts",
+            "packages/tooling/library/ai-metrics/test/install.test.ts",
+            "packages/tooling/library/ai-metrics/test/sequence-break.test.ts",
+            "packages/tooling/library/ai-metrics/test/session-lease.test.ts",
+            "packages/tooling/library/ai-metrics/test/telemetry-v2-store.test.ts",
+            "packages/tooling/library/ai-metrics/test/telemetry-v2.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/repo-cli",
+          "workspaceRoot": "packages/tooling/tool/cli",
+          "files": [
+            "packages/tooling/tool/cli/src/commands/Architecture/Architecture.command.ts",
+            "packages/tooling/tool/cli/src/commands/Cache/Cache.command.ts",
+            "packages/tooling/tool/cli/src/commands/Ci/CiLane.ts",
+            "packages/tooling/tool/cli/src/commands/Ci/LaneTimings.ts",
+            "packages/tooling/tool/cli/src/commands/Corpus/Corpus.command.ts",
+            "packages/tooling/tool/cli/src/commands/Corpus/internal/RestorationTransformations.ts",
+            "packages/tooling/tool/cli/src/commands/Corpus/internal/ServicePrograms.ts",
+            "packages/tooling/tool/cli/src/commands/CreatePackage/CreatePackage.command.ts",
+            "packages/tooling/tool/cli/src/commands/DeletePackage/DeletePackage.command.ts",
+            "packages/tooling/tool/cli/src/commands/Files/Files.command.ts",
+            "packages/tooling/tool/cli/src/commands/Files/internal/MatchPerson.model-store.ts",
+            "packages/tooling/tool/cli/src/commands/Files/internal/Process.ts",
+            "packages/tooling/tool/cli/src/commands/Goals/Adopt.ts",
+            "packages/tooling/tool/cli/src/commands/Goals/Bootstrap.ts",
+            "packages/tooling/tool/cli/src/commands/Goals/Migration/Migration.command.ts",
+            "packages/tooling/tool/cli/src/commands/Goals/Migration/PacketMutation.ts",
+            "packages/tooling/tool/cli/src/commands/Knowledge/Knowledge.command-surface.ts",
+            "packages/tooling/tool/cli/src/commands/Qa/Control.ts",
+            "packages/tooling/tool/cli/src/commands/Qa/Extract.ts",
+            "packages/tooling/tool/cli/src/commands/Qa/JudgePack.ts",
+            "packages/tooling/tool/cli/src/commands/Qa/Qa.session.ts",
+            "packages/tooling/tool/cli/src/commands/Quality/Quality.command.ts",
+            "packages/tooling/tool/cli/src/commands/Quality/Tasks.ts",
+            "packages/tooling/tool/cli/src/commands/Quality/internal/CoverageRegression.ts",
+            "packages/tooling/tool/cli/src/commands/Quality/internal/LaneProofReuse.ts",
+            "packages/tooling/tool/cli/src/commands/Research/Research.command.ts",
+            "packages/tooling/tool/cli/src/commands/Research/internal/Daily.ts",
+            "packages/tooling/tool/cli/src/commands/Runners/Runners.service.ts",
+            "packages/tooling/tool/cli/src/commands/SyncDataToTs/targets/CldrTerritories.ts",
+            "packages/tooling/tool/cli/src/commands/SyncDataToTs/targets/IanaMediaTypes.ts",
+            "packages/tooling/tool/cli/src/commands/SyncDataToTs/targets/Iso4217.ts",
+            "packages/tooling/tool/cli/src/commands/TsconfigSync/TsconfigSync.plan.ts",
+            "packages/tooling/tool/cli/src/commands/Worktree/Reap.command.ts",
+            "packages/tooling/tool/cli/src/commands/Worktree/Reap.service.ts",
+            "packages/tooling/tool/cli/src/commands/Yeet/Yeet.command.ts",
+            "packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts",
+            "packages/tooling/tool/cli/src/commands/Yeet/internal/ProofDigest.ts",
+            "packages/tooling/tool/cli/src/commands/Yeet/internal/Provenance.ts",
+            "packages/tooling/tool/cli/src/commands/Yeet/internal/Resume.ts",
+            "packages/tooling/tool/cli/src/internal/jsdoc/JSDocSections.ts",
+            "packages/tooling/tool/cli/src/internal/repo-run/QualityScheduler.ts",
+            "packages/tooling/tool/cli/src/internal/repo-run/ResidueReap.ts",
+            "packages/tooling/tool/cli/test/agent-effectiveness-eval-scorer.test.ts",
+            "packages/tooling/tool/cli/test/allowlist-check.test.ts",
+            "packages/tooling/tool/cli/test/architecture-operation-plan.test.ts",
+            "packages/tooling/tool/cli/test/cli-kits.test.ts",
+            "packages/tooling/tool/cli/test/corpus-command.test.ts",
+            "packages/tooling/tool/cli/test/corpus-preservation.test.ts",
+            "packages/tooling/tool/cli/test/coverage-baseline-subtraction.test.ts",
+            "packages/tooling/tool/cli/test/create-package-lab.test.ts",
+            "packages/tooling/tool/cli/test/create-package.test.ts",
+            "packages/tooling/tool/cli/test/docgen.test.ts",
+            "packages/tooling/tool/cli/test/files-command.test.ts",
+            "packages/tooling/tool/cli/test/goals-bootstrap-plan.test.ts",
+            "packages/tooling/tool/cli/test/goals-packet-core.test.ts",
+            "packages/tooling/tool/cli/test/goals-set-status-stream.test.ts",
+            "packages/tooling/tool/cli/test/jsdoc-migrate.test.ts",
+            "packages/tooling/tool/cli/test/lint-judge-rubric.test.ts",
+            "packages/tooling/tool/cli/test/process-identity.test.ts",
+            "packages/tooling/tool/cli/test/proof-fact.test.ts",
+            "packages/tooling/tool/cli/test/qa-judge-contract-parity.test.ts",
+            "packages/tooling/tool/cli/test/quality-scheduler.test.ts",
+            "packages/tooling/tool/cli/test/quality-tasks.test.ts",
+            "packages/tooling/tool/cli/test/residue-reap.test.ts",
+            "packages/tooling/tool/cli/test/restoration-transformations-coverage.test.ts",
+            "packages/tooling/tool/cli/test/runners-bake.test.ts",
+            "packages/tooling/tool/cli/test/schema-first.test.ts",
+            "packages/tooling/tool/cli/test/step-capture-lifecycle.test.ts",
+            "packages/tooling/tool/cli/test/sync-data-to-ts.test.ts",
+            "packages/tooling/tool/cli/test/tmpfs-reap.test.ts",
+            "packages/tooling/tool/cli/test/tsconfig-sync.test.ts",
+            "packages/tooling/tool/cli/test/turbo-cache.test.ts",
+            "packages/tooling/tool/cli/test/version-sync-effect.test.ts",
+            "packages/tooling/tool/cli/test/yeet-artifact-writers.test.ts",
+            "packages/tooling/tool/cli/test/yeet-pr-provenance.test.ts",
+            "packages/tooling/tool/cli/test/yeet-provenance-footer.test.ts",
+            "packages/tooling/tool/cli/test/yeet-remediation.test.ts",
+            "packages/tooling/tool/cli/test/yeet-resume.test.ts",
+            "packages/tooling/tool/cli/test/yeet-status-triage.test.ts",
+            "packages/tooling/tool/cli/test/yeet-watch-mode.test.ts",
+            "packages/tooling/tool/cli/test/yeet-watch-stream.test.ts",
+            "packages/tooling/tool/cli/test/yeet.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/repo-configs",
+          "workspaceRoot": "packages/tooling/policy-pack/repo-configs",
+          "files": [
+            "packages/tooling/policy-pack/repo-configs/src/internal/eslint/generated/EffectLawsAllowlistSnapshot.ts",
+            "packages/tooling/policy-pack/repo-configs/test/NextConfig.schemas.test.ts",
+            "packages/tooling/policy-pack/repo-configs/test/NextModels.schema.test.ts",
+            "packages/tooling/policy-pack/repo-configs/test/SharedNextConfig.model.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/repo-docgen",
+          "workspaceRoot": "packages/tooling/tool/docgen",
+          "files": [
+            "packages/tooling/tool/docgen/test/Configuration.test.ts",
+            "packages/tooling/tool/docgen/test/SchemaParity.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/repo-utils",
+          "workspaceRoot": "packages/tooling/library/repo-utils",
+          "files": [
+            "packages/tooling/library/repo-utils/src/JSDoc/models/JSDocTagDefinition.model.ts",
+            "packages/tooling/library/repo-utils/src/JSDoc/models/TSCategory.model.ts",
+            "packages/tooling/library/repo-utils/src/TSMorph/TSMorph.model.ts",
+            "packages/tooling/library/repo-utils/src/schemas/JSDocCategories.ts",
+            "packages/tooling/library/repo-utils/test/JSDoc.model.test.ts",
+            "packages/tooling/library/repo-utils/test/JSDocTagDefinition.golden.test.ts",
+            "packages/tooling/library/repo-utils/test/TSMorph.model.test.ts",
+            "packages/tooling/library/repo-utils/test/TSMorph.service.test.ts",
+            "packages/tooling/library/repo-utils/test/schemas/PackageJson.test.ts",
+            "packages/tooling/library/repo-utils/test/schemas/TSConfig.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/runpod",
+          "workspaceRoot": "packages/drivers/runpod",
+          "files": [
+            "packages/drivers/runpod/src/Runpod.service.ts",
+            "packages/drivers/runpod/test/Runpod.service.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/sanity",
+          "workspaceRoot": "packages/drivers/sanity",
+          "files": ["packages/drivers/sanity/test/Sanity.service.test.ts"]
+        },
+        {
+          "packageName": "@beep/schema",
+          "workspaceRoot": "packages/foundation/modeling/schema",
+          "files": [
+            "packages/foundation/modeling/schema/src/CrossOriginEmbedderPolicy/CrossOriginEmbedderPolicy.schema.ts",
+            "packages/foundation/modeling/schema/src/CrossOriginOpenerPolicy/CrossOriginOpenerPolicy.schema.ts",
+            "packages/foundation/modeling/schema/src/CrossOriginResourcePolicy/CrossOriginResourcePolicy.schema.ts",
+            "packages/foundation/modeling/schema/src/Csp/Csp.schema.ts",
+            "packages/foundation/modeling/schema/src/ExpectCt/ExpectCt.schema.ts",
+            "packages/foundation/modeling/schema/src/ForceHttpsRedirect/ForceHttpsRedirect.schema.ts",
+            "packages/foundation/modeling/schema/src/JSONSchema/JSONSchema.shared.ts",
+            "packages/foundation/modeling/schema/src/Jsonc.ts",
+            "packages/foundation/modeling/schema/src/Jsonl.ts",
+            "packages/foundation/modeling/schema/src/Markdown.ts",
+            "packages/foundation/modeling/schema/src/NoOpen/NoOpen.schema.ts",
+            "packages/foundation/modeling/schema/src/NoSniff/NoSniff.schema.ts",
+            "packages/foundation/modeling/schema/src/PermissionsPolicy/PermissionsPolicy.schema.ts",
+            "packages/foundation/modeling/schema/src/PermittedCrossDomainPolicies/PermittedCrossDomainPolicies.schema.ts",
+            "packages/foundation/modeling/schema/src/ReferrerPolicy/ReferrerPolicy.schema.ts",
+            "packages/foundation/modeling/schema/src/SchemaUtils/withCodecStatics.ts",
+            "packages/foundation/modeling/schema/src/Toml.ts",
+            "packages/foundation/modeling/schema/src/URL.ts",
+            "packages/foundation/modeling/schema/src/Xml.ts",
+            "packages/foundation/modeling/schema/src/Yaml.ts",
+            "packages/foundation/modeling/schema/test/Address.test.ts",
+            "packages/foundation/modeling/schema/test/ArrayBuffer.test.ts",
+            "packages/foundation/modeling/schema/test/AtURI.test.ts",
+            "packages/foundation/modeling/schema/test/BinaryFileExtension.test.ts",
+            "packages/foundation/modeling/schema/test/BlockchainRedacted.test.ts",
+            "packages/foundation/modeling/schema/test/CaseStr.test.ts",
+            "packages/foundation/modeling/schema/test/Color.test.ts",
+            "packages/foundation/modeling/schema/test/Conformance.test.ts",
+            "packages/foundation/modeling/schema/test/Csp.test.ts",
+            "packages/foundation/modeling/schema/test/Cuid.test.ts",
+            "packages/foundation/modeling/schema/test/CurrencyCode.test.ts",
+            "packages/foundation/modeling/schema/test/DateTimeUtcFromValid.test.ts",
+            "packages/foundation/modeling/schema/test/Did.test.ts",
+            "packages/foundation/modeling/schema/test/Dom.test.ts",
+            "packages/foundation/modeling/schema/test/Duration.test.ts",
+            "packages/foundation/modeling/schema/test/Email.test.ts",
+            "packages/foundation/modeling/schema/test/EthAmount.test.ts",
+            "packages/foundation/modeling/schema/test/EthereumValidatorPublicKey.test.ts",
+            "packages/foundation/modeling/schema/test/EvmAddress.test.ts",
+            "packages/foundation/modeling/schema/test/FileInfo.test.ts",
+            "packages/foundation/modeling/schema/test/FileName.test.ts",
+            "packages/foundation/modeling/schema/test/FilePath.test.ts",
+            "packages/foundation/modeling/schema/test/FileTypeChecker.test.ts",
+            "packages/foundation/modeling/schema/test/Fn.test.ts",
+            "packages/foundation/modeling/schema/test/Glob.test.ts",
+            "packages/foundation/modeling/schema/test/Graph.test.ts",
+            "packages/foundation/modeling/schema/test/HttpHeaders.test.ts",
+            "packages/foundation/modeling/schema/test/HttpStatus.test.ts",
+            "packages/foundation/modeling/schema/test/Int.test.ts",
+            "packages/foundation/modeling/schema/test/JSONSchema.test.ts",
+            "packages/foundation/modeling/schema/test/Jsonc.test.ts",
+            "packages/foundation/modeling/schema/test/Jsonl.test.ts",
+            "packages/foundation/modeling/schema/test/LiteralKit.test.ts",
+            "packages/foundation/modeling/schema/test/LocalDate.test.ts",
+            "packages/foundation/modeling/schema/test/MappedLiteralKit.test.ts",
+            "packages/foundation/modeling/schema/test/Markdown.test.ts",
+            "packages/foundation/modeling/schema/test/Number.test.ts",
+            "packages/foundation/modeling/schema/test/Options.test.ts",
+            "packages/foundation/modeling/schema/test/ParserOptions.test.ts",
+            "packages/foundation/modeling/schema/test/Port.test.ts",
+            "packages/foundation/modeling/schema/test/PosixPath.test.ts",
+            "packages/foundation/modeling/schema/test/PromiseSchema.test.ts",
+            "packages/foundation/modeling/schema/test/ProtobufScalars.test.ts",
+            "packages/foundation/modeling/schema/test/RegExp.test.ts",
+            "packages/foundation/modeling/schema/test/SafeObject.test.ts",
+            "packages/foundation/modeling/schema/test/SchemaUtils.test.ts",
+            "packages/foundation/modeling/schema/test/Sha256.test.ts",
+            "packages/foundation/modeling/schema/test/Slug.test.ts",
+            "packages/foundation/modeling/schema/test/StatusCauseError.test.ts",
+            "packages/foundation/modeling/schema/test/TerritoryCode.test.ts",
+            "packages/foundation/modeling/schema/test/Timezone.test.ts",
+            "packages/foundation/modeling/schema/test/Toml.test.ts",
+            "packages/foundation/modeling/schema/test/TxnHash.test.ts",
+            "packages/foundation/modeling/schema/test/TypedArrays.test.ts",
+            "packages/foundation/modeling/schema/test/URL.test.ts",
+            "packages/foundation/modeling/schema/test/Xml.test.ts",
+            "packages/foundation/modeling/schema/test/Yaml.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/scratchpad",
+          "workspaceRoot": "scratchpad",
+          "files": [
+            "scratchpad/claudecode/Hook/Runner.ts",
+            "scratchpad/claudecode/Hook/Transcript.ts",
+            "scratchpad/claudecode/Mcp/JsonFile.ts",
+            "scratchpad/claudecode/Plugin/Define.ts",
+            "scratchpad/claudecode/Plugin/Load.ts",
+            "scratchpad/claudecode/Plugin/Validate.ts",
+            "scratchpad/claudecode/Settings/Loader.ts",
+            "scratchpad/claudecode/Testing.ts",
+            "scratchpad/codemode/Codemode.result.ts",
+            "scratchpad/codemode/Codemode.tool-runtime.ts",
+            "scratchpad/codemode/Codemode.tool-schema.ts",
+            "scratchpad/codemode/interpreter/Interpreter.errors.ts",
+            "scratchpad/codemode/interpreter/Interpreter.execute.ts",
+            "scratchpad/codemode/interpreter/Interpreter.methods.ts",
+            "scratchpad/codemode/interpreter/Interpreter.runtime.ts",
+            "scratchpad/codemode/openapi/OpenAPI.specification.ts",
+            "scratchpad/codemode/stdlib/StdLib.date.ts",
+            "scratchpad/codemode/stdlib/StdLib.json.ts",
+            "scratchpad/codemode/stdlib/StdLib.number.ts",
+            "scratchpad/codemode/stdlib/StdLib.value.ts",
+            "scratchpad/effect-ontology/Cli/Commands/Fetch.ts",
+            "scratchpad/effect-ontology/Domain/Schema/KnowledgeModel.ts",
+            "scratchpad/effect-ontology/Repository/Conflict.ts",
+            "scratchpad/effect-ontology/Repository/Embedding.ts",
+            "scratchpad/effect-ontology/Service/Agent/AgentCoordinator.ts",
+            "scratchpad/effect-ontology/Service/Nlp.ts",
+            "scratchpad/effect-ontology/Service/Ontology.ts",
+            "scratchpad/effect-ontology/Service/PubSubClient.ts",
+            "scratchpad/effect-ontology/Service/Retry.ts",
+            "scratchpad/effect-ontology/Service/Ticket.ts",
+            "scratchpad/effect-ontology/Workflow/StreamingExtraction.ts",
+            "scratchpad/effect-ontology/server.ts",
+            "scratchpad/effect-ontology/test/Cluster/BackpressureHandler.test.ts",
+            "scratchpad/effect-ontology/test/Domain/Error/All.test.ts",
+            "scratchpad/effect-ontology/test/Domain/Identity.test.ts",
+            "scratchpad/effect-ontology/test/Domain/Model/Behavior.test.ts",
+            "scratchpad/effect-ontology/test/Domain/Model/OutputType.test.ts",
+            "scratchpad/effect-ontology/test/Domain/Model/shared.test.ts",
+            "scratchpad/effect-ontology/test/Domain/PathLayout.test.ts",
+            "scratchpad/effect-ontology/test/Domain/Rdf/Types.test.ts",
+            "scratchpad/effect-ontology/test/Domain/Schema/CanonicalNumeric.test.ts",
+            "scratchpad/effect-ontology/test/Domain/Schema/DomainBehavior.test.ts",
+            "scratchpad/effect-ontology/test/Domain/Schema/PublicSchemas.test.ts",
+            "scratchpad/effect-ontology/test/Domain/Schema/Shacl.test.ts",
+            "scratchpad/effect-ontology/test/Prompt/RuleSet.test.ts",
+            "scratchpad/effect-ontology/test/Service/BatchStateEventBus.test.ts",
+            "scratchpad/effect-ontology/test/Service/ConflictRepository.test.ts",
+            "scratchpad/effect-ontology/test/Service/CorrectorAgent.test.ts",
+            "scratchpad/effect-ontology/test/Service/ExtractionTelemetry.test.ts",
+            "scratchpad/effect-ontology/test/Service/Nlp.test.ts",
+            "scratchpad/effect-ontology/test/Service/ProgressSchemaBoundaries.test.ts",
+            "scratchpad/effect-ontology/test/Service/R4SchemaClosure.test.ts",
+            "scratchpad/effect-ontology/test/Service/RepositoryOntologyIsolation.test.ts",
+            "scratchpad/effect-ontology/test/Service/RetryDeadline.test.ts",
+            "scratchpad/effect-ontology/test/Service/Round5Boundaries.test.ts",
+            "scratchpad/effect-ontology/test/Service/SchemaBoundaries.test.ts",
+            "scratchpad/effect-ontology/test/Service/ServiceErrors.test.ts",
+            "scratchpad/effect-ontology/test/Utils/Retrieval.test.ts",
+            "scratchpad/effect-ontology/test/Workflow/DurableActivities.test.ts",
+            "scratchpad/effect-ontology/test/Workflow/GroundingProvenance.test.ts",
+            "scratchpad/semver/SemVer.ts",
+            "scratchpad/test/beep-docs/ApiReference.test.ts",
+            "scratchpad/test/beep-docs/ApiReferenceDataset.test.ts",
+            "scratchpad/test/claudecode/Hook/Events/Tier1.test.ts",
+            "scratchpad/test/claudecode/Settings/Schema.test.ts",
+            "scratchpad/test/claudecode/Testing.test.ts",
+            "scratchpad/test/codemode/Codemode.runtime.test.ts",
+            "scratchpad/test/codemode/Codemode.schema.test.ts",
+            "scratchpad/toml/TomlFormat.ts",
+            "scratchpad/toml/internal/parser.ts",
+            "scratchpad/toml/internal/stringifyValue.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/semantic-web",
+          "workspaceRoot": "packages/foundation/capability/semantic-web",
+          "files": [
+            "packages/foundation/capability/semantic-web/test/IdentityRdfBinding.test.ts",
+            "packages/foundation/capability/semantic-web/test/ServicesAndSurface.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/semantica",
+          "workspaceRoot": "apps/labs/semantica",
+          "files": [
+            "apps/labs/semantica/src/layers/EmbedderLive.ts",
+            "apps/labs/semantica/src/layers/ExtractorLive.ts",
+            "apps/labs/semantica/src/layers/GoldSourceLive.ts",
+            "apps/labs/semantica/src/layers/VectorProjectionLive.ts",
+            "apps/labs/semantica/src/schema/Evidence.ts",
+            "apps/labs/semantica/test/C0Slice.test.ts",
+            "apps/labs/semantica/test/Canary.test.ts",
+            "apps/labs/semantica/test/Extractor.test.ts",
+            "apps/labs/semantica/test/Fixtures.test.ts",
+            "apps/labs/semantica/test/Gold.test.ts",
+            "apps/labs/semantica/test/GoldSource.test.ts",
+            "apps/labs/semantica/test/Projection.test.ts",
+            "apps/labs/semantica/test/ProjectionExpectation.test.ts",
+            "apps/labs/semantica/test/ProviderCache.test.ts",
+            "apps/labs/semantica/test/Reasoning.test.ts",
+            "apps/labs/semantica/test/Schema.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/shared-domain",
+          "workspaceRoot": "packages/shared/domain",
+          "files": [
+            "packages/shared/domain/src/values/LocalDate/LocalDate.behavior.ts",
+            "packages/shared/domain/test/EntityKernel.test.ts",
+            "packages/shared/domain/test/IdentityNamespaces.test.ts",
+            "packages/shared/domain/test/LocalDate.test.ts",
+            "packages/shared/domain/test/Organization.test.ts",
+            "packages/shared/domain/test/SchemaParity.test.ts",
+            "packages/shared/domain/test/UserMembership.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/shared-use-cases",
+          "workspaceRoot": "packages/shared/use-cases",
+          "files": ["packages/shared/use-cases/test/PromotionGate.test.ts"]
+        },
+        {
+          "packageName": "@beep/skill-contract",
+          "workspaceRoot": "packages/foundation/modeling/skill-contract",
+          "files": [
+            "packages/foundation/modeling/skill-contract/src/SkillProjection.ts",
+            "packages/foundation/modeling/skill-contract/test/EvidenceLadder.test.ts",
+            "packages/foundation/modeling/skill-contract/test/EvidenceReceipt.test.ts",
+            "packages/foundation/modeling/skill-contract/test/Gate.test.ts",
+            "packages/foundation/modeling/skill-contract/test/GateSummary.test.ts",
+            "packages/foundation/modeling/skill-contract/test/Recovery.test.ts",
+            "packages/foundation/modeling/skill-contract/test/SkillCompletion.test.ts",
+            "packages/foundation/modeling/skill-contract/test/SkillContract.test.ts",
+            "packages/foundation/modeling/skill-contract/test/SkillProjection.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/test-utils",
+          "workspaceRoot": "packages/tooling/test-kit/test-utils",
+          "files": ["packages/tooling/test-kit/test-utils/test/SqlTest.test.ts"]
+        },
+        {
+          "packageName": "@beep/tika",
+          "workspaceRoot": "packages/drivers/tika",
+          "files": [
+            "packages/drivers/tika/src/Tika.server.ts",
+            "packages/drivers/tika/test/Tika.server.test.ts",
+            "packages/drivers/tika/test/Tika.tikaapp.test.ts",
+            "packages/drivers/tika/test/fixtures.ts",
+            "packages/drivers/tika/test/integration/Tika.server.live.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/ui",
+          "workspaceRoot": "packages/foundation/ui-system/ui",
+          "files": [
+            "packages/foundation/ui-system/ui/src/hooks/useNumberInput.ts",
+            "packages/foundation/ui-system/ui/test/schema-parity.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/uspto",
+          "workspaceRoot": "packages/drivers/uspto",
+          "files": ["packages/drivers/uspto/test/Uspto.service.test.ts"]
+        },
+        {
+          "packageName": "@beep/uspto-mcp",
+          "workspaceRoot": "packages/drivers/uspto-mcp",
+          "files": ["packages/drivers/uspto-mcp/test/Server.test.ts"]
+        },
+        {
+          "packageName": "@beep/utils",
+          "workspaceRoot": "packages/foundation/modeling/utils",
+          "files": [
+            "packages/foundation/modeling/utils/src/Array.ts",
+            "packages/foundation/modeling/utils/src/Glob.ts",
+            "packages/foundation/modeling/utils/src/Schema.ts",
+            "packages/foundation/modeling/utils/src/Struct.ts",
+            "packages/foundation/modeling/utils/test/Glob.test.ts",
+            "packages/foundation/modeling/utils/test/Schema.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/venice-ai",
+          "workspaceRoot": "packages/drivers/venice-ai",
+          "files": ["packages/drivers/venice-ai/src/VeniceAI.service.ts"]
+        },
+        {
+          "packageName": "@beep/wink",
+          "workspaceRoot": "packages/drivers/wink",
+          "files": [
+            "packages/drivers/wink/src/WinkCorpus.service.ts",
+            "packages/drivers/wink/src/WinkTools.service.ts",
+            "packages/drivers/wink/src/WinkVectorizer.service.ts",
+            "packages/drivers/wink/test/ToolValidation.test.ts",
+            "packages/drivers/wink/test/Wink.models.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/workspace-domain",
+          "workspaceRoot": "packages/workspace/domain",
+          "files": ["packages/workspace/domain/test/WorkspaceDomain.test.ts"]
+        },
+        {
+          "packageName": "@beep/workspace-server",
+          "workspaceRoot": "packages/workspace/server",
+          "files": [
+            "packages/workspace/server/test/ThreadStore.test.ts",
+            "packages/workspace/server/test/WorkspaceSourceTextResolver.test.ts",
+            "packages/workspace/server/test/WorkspaceVaultStore.test.ts",
+            "packages/workspace/server/test/integration/ThreadStoreDrizzleRepository.pglite.test.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/workspace-tables",
+          "workspaceRoot": "packages/workspace/tables",
+          "files": ["packages/workspace/tables/test/WorkspaceTables.test.ts"]
+        },
+        {
+          "packageName": "@beep/workspace-use-cases",
+          "workspaceRoot": "packages/workspace/use-cases",
+          "files": ["packages/workspace/use-cases/test/ThreadTimeline.test.ts"]
+        },
+        {
+          "packageName": "@beep/xai",
+          "workspaceRoot": "packages/drivers/xai",
+          "files": ["packages/drivers/xai/test/XAi.service.test.ts"]
+        }
+      ],
+      "unownedPaths": [
+        ".changeset/hoist-inline-schema-compilers.md",
+        ".oxlintrc.json",
+        "goals/inline-schema-compile-hard-error/PLAN.md",
+        "goals/inline-schema-compile-hard-error/README.md",
+        "goals/inline-schema-compile-hard-error/ops/codemods/hoist-inline-schema-compilers.codemod.ts",
+        "goals/inline-schema-compile-hard-error/ops/manifest.json",
+        "goals/inline-schema-compile-hard-error/research/OPPORTUNITIES.md",
+        "goals/inline-schema-compile-hard-error/research/SOURCES.md",
+        "goals/inline-schema-compile-hard-error/research/manual-followup-migration.json",
+        "goals/inline-schema-compile-hard-error/research/mechanical-migration.json",
+        "goals/inline-schema-compile-hard-error/research/opening-census.json",
+        "goals/inline-schema-compile-hard-error/research/opening-census.md",
+        "goals/inline-schema-compile-hard-error/research/ordering-repair.json",
+        "goals/inline-schema-compile-hard-error/research/package-verification.json",
+        "goals/inline-schema-compile-hard-error/research/residual-census.json",
+        "goals/inline-schema-compile-hard-error/research/scripts/census.ts",
+        "goals/inline-schema-compile-hard-error/research/scripts/verify-packages-admitted.ts",
+        "goals/inline-schema-compile-hard-error/research/scripts/verify-packages.ts",
+        "osv-scanner.toml",
+        "research/2026-09-05/RUN.json",
+        "standards/effect-laws.allowlist.jsonc",
+        "standards/schema-first.inventory.jsonc"
+      ]
+    },
+    {
+      "number": 1022,
+      "headSha": "9ac60da26b09a2ada78c65ac31d645c9ab324bc4",
+      "mergeSha": "ed66cbce8f17111458f8b4801ec417d9adafaabd",
+      "changedFileCount": 6,
+      "owners": [
+        {
+          "packageName": "@beep/lint-rules",
+          "workspaceRoot": "packages/tooling/policy-pack/lint-rules",
+          "files": [
+            "packages/tooling/policy-pack/lint-rules/src/rules/no-inline-schema-compile.ts",
+            "packages/tooling/policy-pack/lint-rules/test/oxlint-sources.ts"
+          ]
+        },
+        {
+          "packageName": "@beep/repo-cli",
+          "workspaceRoot": "packages/tooling/tool/cli",
+          "files": [
+            "packages/tooling/tool/cli/src/commands/Quality/internal/LaneProofReuse.ts",
+            "packages/tooling/tool/cli/test/quality-tasks.test.ts"
+          ]
+        }
+      ],
+      "unownedPaths": [
+        ".changeset/review-inline-schema-static-args.md",
+        "goals/inline-schema-compile-hard-error/research/OPPORTUNITIES.md"
+      ]
+    },
+    {
+      "number": 1028,
+      "headSha": "02d88af51cff03dcbaeb50c3b6da663c1f99fd97",
+      "mergeSha": "39132ff64b24e851391624b8799f023495ae9cc2",
+      "changedFileCount": 11,
+      "owners": [],
+      "unownedPaths": [
+        "goals/inline-schema-compile-hard-error/GOAL.md",
+        "goals/inline-schema-compile-hard-error/PLAN.md",
+        "goals/inline-schema-compile-hard-error/README.md",
+        "goals/inline-schema-compile-hard-error/SPEC.md",
+        "goals/inline-schema-compile-hard-error/history/reflections/2026-09-08-codex.md",
+        "goals/inline-schema-compile-hard-error/ops/manifest.json",
+        "goals/inline-schema-compile-hard-error/research/OPPORTUNITIES.md",
+        "goals/inline-schema-compile-hard-error/research/closeout-evidence.md",
+        "goals/inline-schema-compile-hard-error/research/residual-census.json",
+        "goals/inline-schema-compile-hard-error/research/scripts/verify-packages.test.ts",
+        "goals/inline-schema-compile-hard-error/research/scripts/verify-packages.ts"
+      ]
+    }
+  ],
+  "packageNames": [
+    "@beep/acp",
+    "@beep/agents-client",
+    "@beep/agents-domain",
+    "@beep/agents-server",
+    "@beep/agents-tables",
+    "@beep/agents-use-cases",
+    "@beep/ai-provider-cli",
+    "@beep/ai-sync",
+    "@beep/anthropic",
+    "@beep/api-transport",
+    "@beep/architecture-lab-config",
+    "@beep/architecture-lab-proof",
+    "@beep/architecture-lab-ui",
+    "@beep/architecture-lab-use-cases",
+    "@beep/box",
+    "@beep/box-provisioning",
+    "@beep/brand",
+    "@beep/chalk",
+    "@beep/ciops",
+    "@beep/colors",
+    "@beep/db-admin",
+    "@beep/discord",
+    "@beep/doc-text",
+    "@beep/dock",
+    "@beep/documents-domain",
+    "@beep/documents-server",
+    "@beep/documents-tables",
+    "@beep/documents-use-cases",
+    "@beep/drizzle",
+    "@beep/editor",
+    "@beep/effect-drizzle",
+    "@beep/epistemic-config",
+    "@beep/epistemic-domain",
+    "@beep/epistemic-server",
+    "@beep/epistemic-tables",
+    "@beep/epistemic-ui",
+    "@beep/epistemic-use-cases",
+    "@beep/exiftool",
+    "@beep/face-detection",
+    "@beep/ffmpeg",
+    "@beep/file-processing",
+    "@beep/firecrawl",
+    "@beep/freshbooks",
+    "@beep/gov-legal-mcp",
+    "@beep/govinfo",
+    "@beep/html",
+    "@beep/hubspot",
+    "@beep/identity",
+    "@beep/infra",
+    "@beep/langextract",
+    "@beep/law-practice-domain",
+    "@beep/law-practice-server",
+    "@beep/law-practice-tables",
+    "@beep/law-practice-use-cases",
+    "@beep/lejeune-bolt-workbench",
+    "@beep/lexical-schema",
+    "@beep/libpff",
+    "@beep/lint-rules",
+    "@beep/m365",
+    "@beep/m365-mcp",
+    "@beep/mcp-kit",
+    "@beep/md",
+    "@beep/n3",
+    "@beep/nlp",
+    "@beep/nlp-processing",
+    "@beep/observability",
+    "@beep/oip-web",
+    "@beep/onepassword-cli",
+    "@beep/ontology",
+    "@beep/ontology-server",
+    "@beep/ontology-use-cases",
+    "@beep/openclaw",
+    "@beep/pacer",
+    "@beep/pandoc-ast",
+    "@beep/phoenix",
+    "@beep/postgres",
+    "@beep/pretext",
+    "@beep/professional-desktop",
+    "@beep/provenance",
+    "@beep/rdf",
+    "@beep/rdf-canonize",
+    "@beep/repo-ai-metrics",
+    "@beep/repo-cli",
+    "@beep/repo-configs",
+    "@beep/repo-docgen",
+    "@beep/repo-utils",
+    "@beep/runpod",
+    "@beep/sanity",
+    "@beep/schema",
+    "@beep/scratchpad",
+    "@beep/semantic-web",
+    "@beep/semantica",
+    "@beep/shared-domain",
+    "@beep/shared-use-cases",
+    "@beep/skill-contract",
+    "@beep/test-utils",
+    "@beep/tika",
+    "@beep/ui",
+    "@beep/uspto",
+    "@beep/uspto-mcp",
+    "@beep/utils",
+    "@beep/venice-ai",
+    "@beep/wink",
+    "@beep/workspace-domain",
+    "@beep/workspace-server",
+    "@beep/workspace-tables",
+    "@beep/workspace-use-cases",
+    "@beep/xai"
+  ]
+}

--- a/goals/inline-schema-compile-hard-error/research/package-verification-supplemental.json
+++ b/goals/inline-schema-compile-hard-error/research/package-verification-supplemental.json
@@ -1,0 +1,68 @@
+[
+  {
+    "headSha": "02d88af51cff03dcbaeb50c3b6da663c1f99fd97",
+    "packageName": "@beep/effect-drizzle",
+    "packageDir": "packages/ecosystem/effect-drizzle",
+    "quick": false,
+    "repoRoot": ".",
+    "results": [
+      {
+        "step": "audit",
+        "script": "beep:audit",
+        "skipped": false,
+        "ok": true,
+        "durationMillis": 17909,
+        "exitCode": {
+          "_tag": "Some",
+          "value": 0
+        },
+        "output": "\n$ biome check .\nChecked 60 files in 1505ms. No fixes applied.\n"
+      },
+      {
+        "step": "docgen",
+        "script": "docgen",
+        "skipped": false,
+        "ok": true,
+        "durationMillis": 3599,
+        "exitCode": {
+          "_tag": "Some",
+          "value": 0
+        },
+        "output": "[01:44:03.471] INFO (#333): Writing markdown files...\n[01:44:03.493] INFO (#332): Typechecking examples...\n[01:44:04.322] INFO (#2): ✓ Docs generation succeeded!\n"
+      }
+    ]
+  },
+  {
+    "headSha": "02d88af51cff03dcbaeb50c3b6da663c1f99fd97",
+    "packageName": "@beep/freshbooks",
+    "packageDir": "packages/drivers/freshbooks",
+    "quick": false,
+    "repoRoot": ".",
+    "results": [
+      {
+        "step": "audit",
+        "script": "beep:audit",
+        "skipped": false,
+        "ok": true,
+        "durationMillis": 13539,
+        "exitCode": {
+          "_tag": "Some",
+          "value": 0
+        },
+        "output": "[01:44:15.171] INFO (#2): ✓ Docs generation succeeded!\n$ biome check .\nChecked 14 files in 1234ms. No fixes applied.\n"
+      },
+      {
+        "step": "docgen",
+        "script": "docgen",
+        "skipped": false,
+        "ok": true,
+        "durationMillis": 3101,
+        "exitCode": {
+          "_tag": "Some",
+          "value": 0
+        },
+        "output": "[01:44:20.431] INFO (#105): Writing markdown files...\n[01:44:20.471] INFO (#104): Typechecking examples...\n[01:44:21.057] INFO (#2): ✓ Docs generation succeeded!\n"
+      }
+    ]
+  }
+]

--- a/goals/inline-schema-compile-hard-error/research/package-verification.json
+++ b/goals/inline-schema-compile-hard-error/research/package-verification.json
@@ -3,6 +3,7 @@
   "head": "02d88af51cff03dcbaeb50c3b6da663c1f99fd97",
   "committedTree": "786d98065f3a3628599a4691e0314b5fb004bff3",
   "treeDigest": "69d951bf1f63a91f8df942f3919fd65586f1f29e1cca2233e20eecda1bee3f0c",
+  "supplementalReceipts": ["package-verification-supplemental.json"],
   "startedAt": "2026-09-09T04:10:10.881Z",
   "updatedAt": "2026-09-09T04:50:14.183Z",
   "summary": {

--- a/goals/inline-schema-compile-hard-error/research/package-verification.json
+++ b/goals/inline-schema-compile-hard-error/research/package-verification.json
@@ -1,9 +1,10 @@
 {
-  "schemaVersion": "inline-schema-package-verification/v1",
-  "head": "45b422a58e75324c30d7d4e60e5ef0b91be35bab",
-  "treeDigest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-  "startedAt": "2026-09-04T01:18:59.318Z",
-  "updatedAt": "2026-09-04T01:18:59.322Z",
+  "schemaVersion": "inline-schema-package-verification/v2",
+  "head": "02d88af51cff03dcbaeb50c3b6da663c1f99fd97",
+  "committedTree": "786d98065f3a3628599a4691e0314b5fb004bff3",
+  "treeDigest": "69d951bf1f63a91f8df942f3919fd65586f1f29e1cca2233e20eecda1bee3f0c",
+  "startedAt": "2026-09-09T04:10:10.881Z",
+  "updatedAt": "2026-09-09T04:50:14.183Z",
   "summary": {
     "expected": 106,
     "completed": 106,
@@ -15,743 +16,743 @@
       "packageName": "@beep/acp",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 22194,
-      "output": "pkg-verify @beep/acp (./packages/drivers/acp)\n  ok audit 12.8s   ok docgen 4.9s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/acp"
+      "durationMillis": 19560,
+      "output": "pkg-verify @beep/acp (./packages/drivers/acp)\n  ok audit 12.0s   ok docgen 3.6s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/acp"
     },
     {
       "packageName": "@beep/agents-client",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 41095,
-      "output": "pkg-verify @beep/agents-client (./packages/agents/client)\n  ok audit 20.6s   ok docgen 6.8s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/agents-client"
+      "durationMillis": 30339,
+      "output": "pkg-verify @beep/agents-client (./packages/agents/client)\n  ok audit 12.2s   ok docgen 6.3s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/agents-client"
     },
     {
       "packageName": "@beep/agents-domain",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 27263,
-      "output": "pkg-verify @beep/agents-domain (./packages/agents/domain)\n  ok audit 8.9s   ok docgen 6.4s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/agents-domain"
+      "durationMillis": 26900,
+      "output": "pkg-verify @beep/agents-domain (./packages/agents/domain)\n  ok audit 8.8s   ok docgen 6.0s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/agents-domain"
     },
     {
       "packageName": "@beep/agents-server",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 34392,
-      "output": "pkg-verify @beep/agents-server (./packages/agents/server)\n  ok audit 11.6s   ok docgen 8.2s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/agents-server"
+      "durationMillis": 28804,
+      "output": "pkg-verify @beep/agents-server (./packages/agents/server)\n  ok audit 10.3s   ok docgen 6.3s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/agents-server"
     },
     {
       "packageName": "@beep/agents-tables",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 27720,
-      "output": "pkg-verify @beep/agents-tables (./packages/agents/tables)\n  ok audit 9.3s   ok docgen 3.8s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/agents-tables"
+      "durationMillis": 21213,
+      "output": "pkg-verify @beep/agents-tables (./packages/agents/tables)\n  ok audit 6.7s   ok docgen 3.0s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/agents-tables"
     },
     {
       "packageName": "@beep/agents-use-cases",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 38877,
-      "output": "pkg-verify @beep/agents-use-cases (./packages/agents/use-cases)\n  ok audit 12.4s   ok docgen 9.9s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/agents-use-cases"
+      "durationMillis": 27281,
+      "output": "pkg-verify @beep/agents-use-cases (./packages/agents/use-cases)\n  ok audit 9.2s   ok docgen 6.2s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/agents-use-cases"
     },
     {
       "packageName": "@beep/ai-provider-cli",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 17941,
-      "output": "pkg-verify @beep/ai-provider-cli (./packages/drivers/ai-provider-cli)\n  ok audit 8.1s   ok docgen 3.6s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/ai-provider-cli"
+      "durationMillis": 11580,
+      "output": "pkg-verify @beep/ai-provider-cli (./packages/drivers/ai-provider-cli)\n  ok audit 5.5s   ok docgen 2.5s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/ai-provider-cli"
     },
     {
       "packageName": "@beep/ai-sync",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 19852,
-      "output": "pkg-verify @beep/ai-sync (./packages/tooling/library/ai-sync)\n  ok audit 10.6s   ok docgen 4.4s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/ai-sync"
+      "durationMillis": 14487,
+      "output": "pkg-verify @beep/ai-sync (./packages/tooling/library/ai-sync)\n  ok audit 8.1s   ok docgen 2.8s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/ai-sync"
     },
     {
       "packageName": "@beep/anthropic",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 15442,
-      "output": "pkg-verify @beep/anthropic (./packages/drivers/anthropic)\n  ok audit 6.7s   ok docgen 3.6s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/anthropic"
+      "durationMillis": 13183,
+      "output": "pkg-verify @beep/anthropic (./packages/drivers/anthropic)\n  ok audit 5.8s   ok docgen 2.9s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/anthropic"
     },
     {
       "packageName": "@beep/api-transport",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 16452,
-      "output": "pkg-verify @beep/api-transport (./packages/foundation/capability/api-transport)\n  ok audit 8.6s   ok docgen 3.4s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/api-transport"
+      "durationMillis": 13394,
+      "output": "pkg-verify @beep/api-transport (./packages/foundation/capability/api-transport)\n  ok audit 6.7s   ok docgen 2.6s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/api-transport"
     },
     {
       "packageName": "@beep/architecture-lab-config",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 14057,
-      "output": "pkg-verify @beep/architecture-lab-config (./packages/architecture-lab/config)\n  ok audit 7.0s   ok docgen 2.6s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/architecture-lab-config"
+      "durationMillis": 12934,
+      "output": "pkg-verify @beep/architecture-lab-config (./packages/architecture-lab/config)\n  ok audit 6.4s   ok docgen 2.7s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/architecture-lab-config"
     },
     {
       "packageName": "@beep/architecture-lab-proof",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 13842,
-      "output": "pkg-verify @beep/architecture-lab-proof (./apps/architecture-lab-proof)\n  ok audit 6.2s   ok docgen 3.2s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/architecture-lab-proof"
+      "durationMillis": 14844,
+      "output": "pkg-verify @beep/architecture-lab-proof (./apps/architecture-lab-proof)\n  ok audit 7.5s   ok docgen 2.9s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/architecture-lab-proof"
     },
     {
       "packageName": "@beep/architecture-lab-ui",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 12991,
-      "output": "pkg-verify @beep/architecture-lab-ui (./packages/architecture-lab/ui)\n  ok audit 6.0s   ok docgen 2.8s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/architecture-lab-ui"
+      "durationMillis": 11749,
+      "output": "pkg-verify @beep/architecture-lab-ui (./packages/architecture-lab/ui)\n  ok audit 5.4s   ok docgen 2.4s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/architecture-lab-ui"
     },
     {
       "packageName": "@beep/architecture-lab-use-cases",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 14698,
-      "output": "pkg-verify @beep/architecture-lab-use-cases (./packages/architecture-lab/use-cases)\n  ok audit 6.6s   ok docgen 3.6s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/architecture-lab-use-cases"
+      "durationMillis": 13264,
+      "output": "pkg-verify @beep/architecture-lab-use-cases (./packages/architecture-lab/use-cases)\n  ok audit 6.0s   ok docgen 3.1s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/architecture-lab-use-cases"
     },
     {
       "packageName": "@beep/box",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 25397,
-      "output": "pkg-verify @beep/box (./packages/drivers/box)\n  ok audit 15.0s   ok docgen 4.8s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/box"
+      "durationMillis": 21080,
+      "output": "pkg-verify @beep/box (./packages/drivers/box)\n  ok audit 12.5s   ok docgen 4.3s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/box"
     },
     {
       "packageName": "@beep/box-provisioning",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 21361,
-      "output": "pkg-verify @beep/box-provisioning (./packages/drivers/box-provisioning)\n  ok audit 12.6s   ok docgen 4.1s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/box-provisioning"
+      "durationMillis": 22126,
+      "output": "pkg-verify @beep/box-provisioning (./packages/drivers/box-provisioning)\n  ok audit 13.3s   ok docgen 4.3s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/box-provisioning"
     },
     {
       "packageName": "@beep/brand",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 14285,
-      "output": "pkg-verify @beep/brand (./packages/foundation/ui-system/brand)\n  ok audit 7.2s   ok docgen 3.1s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/brand"
+      "durationMillis": 13407,
+      "output": "pkg-verify @beep/brand (./packages/foundation/ui-system/brand)\n  ok audit 7.0s   ok docgen 2.7s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/brand"
     },
     {
       "packageName": "@beep/chalk",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 12717,
-      "output": "pkg-verify @beep/chalk (./packages/foundation/capability/chalk)\n  ok audit 5.8s   ok docgen 3.0s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/chalk"
+      "durationMillis": 12011,
+      "output": "pkg-verify @beep/chalk (./packages/foundation/capability/chalk)\n  ok audit 5.6s   ok docgen 2.7s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/chalk"
     },
     {
       "packageName": "@beep/ciops",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 13203,
-      "output": "pkg-verify @beep/ciops (./apps/labs/ciops)\n  ok audit 6.3s   ok docgen 3.1s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/ciops"
+      "durationMillis": 10080,
+      "output": "pkg-verify @beep/ciops (./apps/labs/ciops)\n  ok audit 6.4s   skip docgen\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/ciops"
     },
     {
       "packageName": "@beep/colors",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 12123,
-      "output": "pkg-verify @beep/colors (./packages/foundation/capability/colors)\n  ok audit 5.7s   ok docgen 2.8s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/colors"
+      "durationMillis": 11311,
+      "output": "pkg-verify @beep/colors (./packages/foundation/capability/colors)\n  ok audit 5.4s   ok docgen 2.5s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/colors"
     },
     {
       "packageName": "@beep/db-admin",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 44584,
-      "output": "pkg-verify @beep/db-admin (./packages/_internal/db-admin)\n  ok audit 19.5s   ok docgen 9.7s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/db-admin"
+      "durationMillis": 40941,
+      "output": "pkg-verify @beep/db-admin (./packages/_internal/db-admin)\n  ok audit 18.0s   ok docgen 8.9s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/db-admin"
     },
     {
       "packageName": "@beep/discord",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 13077,
-      "output": "pkg-verify @beep/discord (./packages/drivers/discord)\n  ok audit 6.2s   ok docgen 2.9s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/discord"
+      "durationMillis": 12565,
+      "output": "pkg-verify @beep/discord (./packages/drivers/discord)\n  ok audit 6.3s   ok docgen 2.5s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/discord"
     },
     {
       "packageName": "@beep/doc-text",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 14248,
-      "output": "pkg-verify @beep/doc-text (./packages/drivers/doc-text)\n  ok audit 7.1s   ok docgen 3.0s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/doc-text"
+      "durationMillis": 13823,
+      "output": "pkg-verify @beep/doc-text (./packages/drivers/doc-text)\n  ok audit 7.1s   ok docgen 2.7s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/doc-text"
     },
     {
       "packageName": "@beep/dock",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 18066,
-      "output": "pkg-verify @beep/dock (./packages/foundation/ui-system/dock)\n  ok audit 8.5s   ok docgen 5.1s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/dock"
+      "durationMillis": 14522,
+      "output": "pkg-verify @beep/dock (./packages/foundation/ui-system/dock)\n  ok audit 7.2s   ok docgen 3.3s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/dock"
     },
     {
       "packageName": "@beep/documents-domain",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 19439,
-      "output": "pkg-verify @beep/documents-domain (./packages/documents/domain)\n  ok audit 9.2s   ok docgen 4.2s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/documents-domain"
+      "durationMillis": 14348,
+      "output": "pkg-verify @beep/documents-domain (./packages/documents/domain)\n  ok audit 7.1s   ok docgen 3.1s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/documents-domain"
     },
     {
       "packageName": "@beep/documents-server",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 28366,
-      "output": "pkg-verify @beep/documents-server (./packages/documents/server)\n  ok audit 14.5s   ok docgen 7.1s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/documents-server"
+      "durationMillis": 23305,
+      "output": "pkg-verify @beep/documents-server (./packages/documents/server)\n  ok audit 12.7s   ok docgen 5.3s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/documents-server"
     },
     {
       "packageName": "@beep/documents-tables",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 22623,
-      "output": "pkg-verify @beep/documents-tables (./packages/documents/tables)\n  ok audit 8.8s   ok docgen 8.5s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/documents-tables"
+      "durationMillis": 13579,
+      "output": "pkg-verify @beep/documents-tables (./packages/documents/tables)\n  ok audit 6.0s   ok docgen 3.3s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/documents-tables"
     },
     {
       "packageName": "@beep/documents-use-cases",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 33175,
-      "output": "pkg-verify @beep/documents-use-cases (./packages/documents/use-cases)\n  ok audit 20.0s   ok docgen 5.1s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/documents-use-cases"
+      "durationMillis": 17097,
+      "output": "pkg-verify @beep/documents-use-cases (./packages/documents/use-cases)\n  ok audit 7.6s   ok docgen 5.1s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/documents-use-cases"
     },
     {
       "packageName": "@beep/drizzle",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 18910,
-      "output": "pkg-verify @beep/drizzle (./packages/drivers/drizzle)\n  ok audit 11.0s   ok docgen 3.5s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/drizzle"
+      "durationMillis": 15109,
+      "output": "pkg-verify @beep/drizzle (./packages/drivers/drizzle)\n  ok audit 8.2s   ok docgen 2.8s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/drizzle"
     },
     {
       "packageName": "@beep/editor",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 48933,
-      "output": "pkg-verify @beep/editor (./packages/foundation/ui-system/editor)\n  ok audit 25.8s   ok docgen 7.7s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/editor"
+      "durationMillis": 42137,
+      "output": "pkg-verify @beep/editor (./packages/foundation/ui-system/editor)\n  ok audit 22.6s   ok docgen 6.3s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/editor"
     },
     {
       "packageName": "@beep/epistemic-config",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 15879,
-      "output": "pkg-verify @beep/epistemic-config (./packages/epistemic/config)\n  ok audit 7.4s   ok docgen 3.2s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/epistemic-config"
+      "durationMillis": 13767,
+      "output": "pkg-verify @beep/epistemic-config (./packages/epistemic/config)\n  ok audit 6.5s   ok docgen 2.8s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/epistemic-config"
     },
     {
       "packageName": "@beep/epistemic-domain",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 16151,
-      "output": "pkg-verify @beep/epistemic-domain (./packages/epistemic/domain)\n  ok audit 6.9s   ok docgen 4.1s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/epistemic-domain"
+      "durationMillis": 15058,
+      "output": "pkg-verify @beep/epistemic-domain (./packages/epistemic/domain)\n  ok audit 7.0s   ok docgen 3.7s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/epistemic-domain"
     },
     {
       "packageName": "@beep/epistemic-server",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 27076,
-      "output": "pkg-verify @beep/epistemic-server (./packages/epistemic/server)\n  ok audit 14.5s   ok docgen 5.5s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/epistemic-server"
+      "durationMillis": 25052,
+      "output": "pkg-verify @beep/epistemic-server (./packages/epistemic/server)\n  ok audit 14.2s   ok docgen 4.7s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/epistemic-server"
     },
     {
       "packageName": "@beep/epistemic-tables",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 17346,
-      "output": "pkg-verify @beep/epistemic-tables (./packages/epistemic/tables)\n  ok audit 8.1s   ok docgen 4.3s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/epistemic-tables"
+      "durationMillis": 15974,
+      "output": "pkg-verify @beep/epistemic-tables (./packages/epistemic/tables)\n  ok audit 7.7s   ok docgen 3.8s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/epistemic-tables"
     },
     {
       "packageName": "@beep/epistemic-ui",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 18639,
-      "output": "pkg-verify @beep/epistemic-ui (./packages/epistemic/ui)\n  ok audit 8.7s   ok docgen 3.3s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/epistemic-ui"
+      "durationMillis": 18544,
+      "output": "pkg-verify @beep/epistemic-ui (./packages/epistemic/ui)\n  ok audit 8.8s   ok docgen 3.2s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/epistemic-ui"
     },
     {
       "packageName": "@beep/epistemic-use-cases",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 19237,
-      "output": "pkg-verify @beep/epistemic-use-cases (./packages/epistemic/use-cases)\n  ok audit 8.7s   ok docgen 5.2s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/epistemic-use-cases"
+      "durationMillis": 17268,
+      "output": "pkg-verify @beep/epistemic-use-cases (./packages/epistemic/use-cases)\n  ok audit 7.9s   ok docgen 3.9s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/epistemic-use-cases"
     },
     {
       "packageName": "@beep/exiftool",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 18613,
-      "output": "pkg-verify @beep/exiftool (./packages/drivers/exiftool)\n  ok audit 10.8s   ok docgen 3.5s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/exiftool"
+      "durationMillis": 14600,
+      "output": "pkg-verify @beep/exiftool (./packages/drivers/exiftool)\n  ok audit 8.3s   ok docgen 2.6s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/exiftool"
     },
     {
       "packageName": "@beep/face-detection",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 15565,
-      "output": "pkg-verify @beep/face-detection (./packages/drivers/face-detection)\n  ok audit 7.4s   ok docgen 3.2s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/face-detection"
+      "durationMillis": 12915,
+      "output": "pkg-verify @beep/face-detection (./packages/drivers/face-detection)\n  ok audit 6.0s   ok docgen 2.7s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/face-detection"
     },
     {
       "packageName": "@beep/ffmpeg",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 26648,
-      "output": "pkg-verify @beep/ffmpeg (./packages/drivers/ffmpeg)\n  ok audit 14.9s   ok docgen 4.6s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/ffmpeg"
+      "durationMillis": 15862,
+      "output": "pkg-verify @beep/ffmpeg (./packages/drivers/ffmpeg)\n  ok audit 9.1s   ok docgen 2.9s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/ffmpeg"
     },
     {
       "packageName": "@beep/file-processing",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 24660,
-      "output": "pkg-verify @beep/file-processing (./packages/foundation/capability/file-processing)\n  ok audit 12.6s   ok docgen 5.3s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/file-processing"
+      "durationMillis": 13609,
+      "output": "pkg-verify @beep/file-processing (./packages/foundation/capability/file-processing)\n  ok audit 6.8s   ok docgen 3.0s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/file-processing"
     },
     {
       "packageName": "@beep/firecrawl",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 28182,
-      "output": "pkg-verify @beep/firecrawl (./packages/drivers/firecrawl)\n  ok audit 16.1s   ok docgen 5.8s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/firecrawl"
+      "durationMillis": 16691,
+      "output": "pkg-verify @beep/firecrawl (./packages/drivers/firecrawl)\n  ok audit 8.8s   ok docgen 3.6s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/firecrawl"
     },
     {
       "packageName": "@beep/gov-legal-mcp",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 25762,
-      "output": "pkg-verify @beep/gov-legal-mcp (./packages/drivers/gov-legal-mcp)\n  ok audit 12.9s   ok docgen 5.7s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/gov-legal-mcp"
+      "durationMillis": 14814,
+      "output": "pkg-verify @beep/gov-legal-mcp (./packages/drivers/gov-legal-mcp)\n  ok audit 7.8s   ok docgen 3.1s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/gov-legal-mcp"
     },
     {
       "packageName": "@beep/govinfo",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 28626,
-      "output": "pkg-verify @beep/govinfo (./packages/drivers/govinfo)\n  ok audit 15.9s   ok docgen 5.7s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/govinfo"
+      "durationMillis": 16331,
+      "output": "pkg-verify @beep/govinfo (./packages/drivers/govinfo)\n  ok audit 9.5s   ok docgen 2.9s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/govinfo"
     },
     {
       "packageName": "@beep/html",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 68516,
-      "output": "pkg-verify @beep/html (./packages/foundation/modeling/html)\n  ok audit 28.7s   ok docgen 22.0s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/html"
+      "durationMillis": 39732,
+      "output": "pkg-verify @beep/html (./packages/foundation/modeling/html)\n  ok audit 16.3s   ok docgen 12.8s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/html"
     },
     {
       "packageName": "@beep/hubspot",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 14062,
-      "output": "pkg-verify @beep/hubspot (./packages/drivers/hubspot)\n  ok audit 6.8s   ok docgen 3.1s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/hubspot"
+      "durationMillis": 11741,
+      "output": "pkg-verify @beep/hubspot (./packages/drivers/hubspot)\n  ok audit 5.7s   ok docgen 2.5s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/hubspot"
     },
     {
       "packageName": "@beep/identity",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 10431,
-      "output": "pkg-verify @beep/identity (./packages/foundation/modeling/identity)\n  ok audit 4.7s   ok docgen 3.1s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/identity"
+      "durationMillis": 8174,
+      "output": "pkg-verify @beep/identity (./packages/foundation/modeling/identity)\n  ok audit 4.0s   ok docgen 2.3s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/identity"
     },
     {
       "packageName": "@beep/infra",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 22564,
-      "output": "pkg-verify @beep/infra (./infra)\n  ok audit 8.7s   ok docgen 7.7s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/infra"
+      "durationMillis": 18780,
+      "output": "pkg-verify @beep/infra (./infra)\n  ok audit 8.1s   ok docgen 5.7s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/infra"
     },
     {
       "packageName": "@beep/langextract",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 18299,
-      "output": "pkg-verify @beep/langextract (./packages/foundation/capability/langextract)\n  ok audit 9.6s   ok docgen 4.0s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/langextract"
+      "durationMillis": 15620,
+      "output": "pkg-verify @beep/langextract (./packages/foundation/capability/langextract)\n  ok audit 8.7s   ok docgen 3.1s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/langextract"
     },
     {
       "packageName": "@beep/law-practice-domain",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 38900,
-      "output": "pkg-verify @beep/law-practice-domain (./packages/law-practice/domain)\n  ok audit 12.4s   ok docgen 10.8s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/law-practice-domain"
+      "durationMillis": 32645,
+      "output": "pkg-verify @beep/law-practice-domain (./packages/law-practice/domain)\n  ok audit 10.8s   ok docgen 8.9s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/law-practice-domain"
     },
     {
       "packageName": "@beep/law-practice-server",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 49658,
-      "output": "pkg-verify @beep/law-practice-server (./packages/law-practice/server)\n  ok audit 21.4s   ok docgen 10.2s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/law-practice-server"
+      "durationMillis": 45348,
+      "output": "pkg-verify @beep/law-practice-server (./packages/law-practice/server)\n  ok audit 20.4s   ok docgen 8.9s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/law-practice-server"
     },
     {
       "packageName": "@beep/law-practice-tables",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 35941,
-      "output": "pkg-verify @beep/law-practice-tables (./packages/law-practice/tables)\n  ok audit 15.1s   ok docgen 7.5s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/law-practice-tables"
+      "durationMillis": 34499,
+      "output": "pkg-verify @beep/law-practice-tables (./packages/law-practice/tables)\n  ok audit 14.7s   ok docgen 6.9s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/law-practice-tables"
     },
     {
       "packageName": "@beep/law-practice-use-cases",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 33691,
-      "output": "pkg-verify @beep/law-practice-use-cases (./packages/law-practice/use-cases)\n  ok audit 11.1s   ok docgen 7.7s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/law-practice-use-cases"
+      "durationMillis": 33488,
+      "output": "pkg-verify @beep/law-practice-use-cases (./packages/law-practice/use-cases)\n  ok audit 11.1s   ok docgen 8.0s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/law-practice-use-cases"
     },
     {
       "packageName": "@beep/lejeune-bolt-workbench",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 21558,
-      "output": "pkg-verify @beep/lejeune-bolt-workbench (./apps/labs/lejeune-bolt-workbench)\n  ok audit 15.4s   skip docgen\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/lejeune-bolt-workbench"
+      "durationMillis": 22718,
+      "output": "pkg-verify @beep/lejeune-bolt-workbench (./apps/labs/lejeune-bolt-workbench)\n  ok audit 15.1s   skip docgen\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/lejeune-bolt-workbench"
     },
     {
       "packageName": "@beep/lexical-schema",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 49822,
-      "output": "pkg-verify @beep/lexical-schema (./packages/foundation/modeling/lexical)\n  ok audit 28.3s   ok docgen 7.4s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/lexical-schema"
+      "durationMillis": 43679,
+      "output": "pkg-verify @beep/lexical-schema (./packages/foundation/modeling/lexical)\n  ok audit 23.1s   ok docgen 8.1s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/lexical-schema"
     },
     {
       "packageName": "@beep/libpff",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 22815,
-      "output": "pkg-verify @beep/libpff (./packages/drivers/libpff)\n  ok audit 13.3s   ok docgen 4.0s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/libpff"
+      "durationMillis": 19032,
+      "output": "pkg-verify @beep/libpff (./packages/drivers/libpff)\n  ok audit 10.9s   ok docgen 3.1s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/libpff"
     },
     {
       "packageName": "@beep/lint-rules",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 19326,
-      "output": "pkg-verify @beep/lint-rules (./packages/tooling/policy-pack/lint-rules)\n  ok audit 14.4s   skip docgen\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/lint-rules"
+      "durationMillis": 14860,
+      "output": "pkg-verify @beep/lint-rules (./packages/tooling/policy-pack/lint-rules)\n  ok audit 11.0s   skip docgen\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/lint-rules"
     },
     {
       "packageName": "@beep/m365",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 20651,
-      "output": "pkg-verify @beep/m365 (./packages/drivers/m365)\n  ok audit 11.0s   ok docgen 4.0s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify \"@beep/m365\""
+      "durationMillis": 15365,
+      "output": "pkg-verify @beep/m365 (./packages/drivers/m365)\n  ok audit 8.6s   ok docgen 3.0s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify \"@beep/m365\""
     },
     {
       "packageName": "@beep/m365-mcp",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 15357,
-      "output": "pkg-verify @beep/m365-mcp (./packages/drivers/m365-mcp)\n  ok audit 7.3s   ok docgen 3.6s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify \"@beep/m365-mcp\""
+      "durationMillis": 13916,
+      "output": "pkg-verify @beep/m365-mcp (./packages/drivers/m365-mcp)\n  ok audit 7.0s   ok docgen 3.1s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify \"@beep/m365-mcp\""
     },
     {
       "packageName": "@beep/mcp-kit",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 14902,
-      "output": "pkg-verify @beep/mcp-kit (./packages/foundation/capability/mcp-kit)\n  ok audit 7.5s   ok docgen 3.2s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/mcp-kit"
+      "durationMillis": 13081,
+      "output": "pkg-verify @beep/mcp-kit (./packages/foundation/capability/mcp-kit)\n  ok audit 6.6s   ok docgen 2.8s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/mcp-kit"
     },
     {
       "packageName": "@beep/md",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 20389,
-      "output": "pkg-verify @beep/md (./packages/foundation/modeling/md)\n  skip audit   ok docgen 7.6s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/md"
+      "durationMillis": 17812,
+      "output": "pkg-verify @beep/md (./packages/foundation/modeling/md)\n  skip audit   ok docgen 6.3s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/md"
     },
     {
       "packageName": "@beep/n3",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 14136,
-      "output": "pkg-verify @beep/n3 (./packages/drivers/n3)\n  ok audit 6.1s   ok docgen 3.6s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify \"@beep/n3\""
+      "durationMillis": 12196,
+      "output": "pkg-verify @beep/n3 (./packages/drivers/n3)\n  ok audit 5.4s   ok docgen 2.8s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify \"@beep/n3\""
     },
     {
       "packageName": "@beep/nlp",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 15173,
-      "output": "pkg-verify @beep/nlp (./packages/foundation/modeling/nlp)\n  ok audit 6.8s   ok docgen 3.9s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/nlp"
+      "durationMillis": 12661,
+      "output": "pkg-verify @beep/nlp (./packages/foundation/modeling/nlp)\n  ok audit 5.8s   ok docgen 3.2s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/nlp"
     },
     {
       "packageName": "@beep/nlp-processing",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 18000,
-      "output": "pkg-verify @beep/nlp-processing (./packages/foundation/capability/nlp-processing)\n  ok audit 6.9s   ok docgen 5.8s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/nlp-processing"
+      "durationMillis": 15273,
+      "output": "pkg-verify @beep/nlp-processing (./packages/foundation/capability/nlp-processing)\n  ok audit 6.0s   ok docgen 4.6s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/nlp-processing"
     },
     {
       "packageName": "@beep/observability",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 17024,
-      "output": "pkg-verify @beep/observability (./packages/foundation/capability/observability)\n  ok audit 8.6s   ok docgen 4.1s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/observability"
+      "durationMillis": 14922,
+      "output": "pkg-verify @beep/observability (./packages/foundation/capability/observability)\n  ok audit 7.6s   ok docgen 3.5s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/observability"
     },
     {
       "packageName": "@beep/oip-web",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 25665,
-      "output": "pkg-verify @beep/oip-web (./apps/oip-web)\n  ok audit 19.3s   skip docgen\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/oip-web"
+      "durationMillis": 30002,
+      "output": "pkg-verify @beep/oip-web (./apps/oip-web)\n  ok audit 24.5s   skip docgen\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/oip-web"
     },
     {
       "packageName": "@beep/onepassword-cli",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 13637,
-      "output": "pkg-verify @beep/onepassword-cli (./packages/drivers/onepassword-cli)\n  ok audit 6.3s   ok docgen 2.9s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/onepassword-cli"
+      "durationMillis": 12031,
+      "output": "pkg-verify @beep/onepassword-cli (./packages/drivers/onepassword-cli)\n  ok audit 5.5s   ok docgen 2.5s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/onepassword-cli"
     },
     {
       "packageName": "@beep/ontology",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 15870,
-      "output": "pkg-verify @beep/ontology (./packages/foundation/modeling/ontology)\n  ok audit 7.5s   ok docgen 3.5s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/ontology"
+      "durationMillis": 13771,
+      "output": "pkg-verify @beep/ontology (./packages/foundation/modeling/ontology)\n  ok audit 6.6s   ok docgen 3.0s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/ontology"
     },
     {
       "packageName": "@beep/ontology-server",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 18889,
-      "output": "pkg-verify @beep/ontology-server (./packages/ontology/server)\n  ok audit 8.5s   ok docgen 5.0s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/ontology-server"
+      "durationMillis": 16408,
+      "output": "pkg-verify @beep/ontology-server (./packages/ontology/server)\n  ok audit 7.6s   ok docgen 3.9s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/ontology-server"
     },
     {
       "packageName": "@beep/ontology-use-cases",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 16960,
-      "output": "pkg-verify @beep/ontology-use-cases (./packages/ontology/use-cases)\n  ok audit 7.8s   ok docgen 4.2s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/ontology-use-cases"
+      "durationMillis": 15062,
+      "output": "pkg-verify @beep/ontology-use-cases (./packages/ontology/use-cases)\n  ok audit 6.9s   ok docgen 3.7s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/ontology-use-cases"
     },
     {
       "packageName": "@beep/openclaw",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 20845,
-      "output": "pkg-verify @beep/openclaw (./packages/drivers/openclaw)\n  ok audit 13.3s   ok docgen 3.3s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/openclaw"
+      "durationMillis": 18531,
+      "output": "pkg-verify @beep/openclaw (./packages/drivers/openclaw)\n  ok audit 11.9s   ok docgen 2.9s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/openclaw"
     },
     {
       "packageName": "@beep/pacer",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 13650,
-      "output": "pkg-verify @beep/pacer (./packages/drivers/pacer)\n  ok audit 6.9s   ok docgen 3.0s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/pacer"
+      "durationMillis": 12938,
+      "output": "pkg-verify @beep/pacer (./packages/drivers/pacer)\n  ok audit 6.7s   ok docgen 2.8s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/pacer"
     },
     {
       "packageName": "@beep/pandoc-ast",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 34089,
-      "output": "pkg-verify @beep/pandoc-ast (./packages/foundation/modeling/pandoc-ast)\n  ok audit 14.9s   ok docgen 6.5s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/pandoc-ast"
+      "durationMillis": 31621,
+      "output": "pkg-verify @beep/pandoc-ast (./packages/foundation/modeling/pandoc-ast)\n  ok audit 14.1s   ok docgen 5.8s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/pandoc-ast"
     },
     {
       "packageName": "@beep/phoenix",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 13508,
-      "output": "pkg-verify @beep/phoenix (./packages/drivers/phoenix)\n  ok audit 5.9s   ok docgen 3.1s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/phoenix"
+      "durationMillis": 12107,
+      "output": "pkg-verify @beep/phoenix (./packages/drivers/phoenix)\n  ok audit 5.6s   ok docgen 2.8s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/phoenix"
     },
     {
       "packageName": "@beep/postgres",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 19389,
-      "output": "pkg-verify @beep/postgres (./packages/drivers/postgres)\n  ok audit 12.2s   ok docgen 3.2s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/postgres"
+      "durationMillis": 17861,
+      "output": "pkg-verify @beep/postgres (./packages/drivers/postgres)\n  ok audit 10.7s   ok docgen 3.4s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/postgres"
     },
     {
       "packageName": "@beep/pretext",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 15776,
-      "output": "pkg-verify @beep/pretext (./packages/drivers/pretext)\n  ok audit 8.5s   ok docgen 3.3s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/pretext"
+      "durationMillis": 12852,
+      "output": "pkg-verify @beep/pretext (./packages/drivers/pretext)\n  ok audit 6.6s   ok docgen 2.6s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/pretext"
     },
     {
       "packageName": "@beep/professional-desktop",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 58174,
-      "output": "pkg-verify @beep/professional-desktop (./apps/professional-desktop)\n  ok audit 21.6s   ok docgen 14.8s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/professional-desktop"
+      "durationMillis": 52879,
+      "output": "pkg-verify @beep/professional-desktop (./apps/professional-desktop)\n  ok audit 20.3s   ok docgen 12.3s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/professional-desktop"
     },
     {
       "packageName": "@beep/provenance",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 14711,
-      "output": "pkg-verify @beep/provenance (./packages/foundation/modeling/provenance)\n  ok audit 7.3s   ok docgen 3.1s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/provenance"
+      "durationMillis": 12755,
+      "output": "pkg-verify @beep/provenance (./packages/foundation/modeling/provenance)\n  ok audit 6.2s   ok docgen 2.8s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/provenance"
     },
     {
       "packageName": "@beep/rdf",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 16797,
-      "output": "pkg-verify @beep/rdf (./packages/foundation/modeling/rdf)\n  ok audit 8.4s   ok docgen 3.9s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/rdf"
+      "durationMillis": 17687,
+      "output": "pkg-verify @beep/rdf (./packages/foundation/modeling/rdf)\n  ok audit 9.0s   ok docgen 3.8s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/rdf"
     },
     {
       "packageName": "@beep/rdf-canonize",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 14201,
-      "output": "pkg-verify @beep/rdf-canonize (./packages/drivers/rdf-canonize)\n  ok audit 5.9s   ok docgen 3.1s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/rdf-canonize"
+      "durationMillis": 13090,
+      "output": "pkg-verify @beep/rdf-canonize (./packages/drivers/rdf-canonize)\n  ok audit 5.8s   ok docgen 2.8s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/rdf-canonize"
     },
     {
       "packageName": "@beep/repo-ai-metrics",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 24738,
-      "output": "pkg-verify @beep/repo-ai-metrics (./packages/tooling/library/ai-metrics)\n  ok audit 14.8s   ok docgen 4.9s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/repo-ai-metrics"
+      "durationMillis": 22685,
+      "output": "pkg-verify @beep/repo-ai-metrics (./packages/tooling/library/ai-metrics)\n  ok audit 12.5s   ok docgen 6.0s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/repo-ai-metrics"
     },
     {
       "packageName": "@beep/repo-cli",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 376152,
-      "output": "pkg-verify @beep/repo-cli (./packages/tooling/tool/cli)\n  ok audit 339.0s   ok docgen 18.3s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/repo-cli"
+      "durationMillis": 383710,
+      "output": "pkg-verify @beep/repo-cli (./packages/tooling/tool/cli)\n  ok audit 346.0s   ok docgen 16.8s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/repo-cli"
     },
     {
       "packageName": "@beep/repo-configs",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 18389,
-      "output": "pkg-verify @beep/repo-configs (./packages/tooling/policy-pack/repo-configs)\n  ok audit 9.8s   ok docgen 4.2s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/repo-configs"
+      "durationMillis": 16231,
+      "output": "pkg-verify @beep/repo-configs (./packages/tooling/policy-pack/repo-configs)\n  ok audit 8.8s   ok docgen 3.6s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/repo-configs"
     },
     {
       "packageName": "@beep/repo-docgen",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 31557,
-      "output": "pkg-verify @beep/repo-docgen (./packages/tooling/tool/docgen)\n  ok audit 11.9s   ok docgen 7.1s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/repo-docgen"
+      "durationMillis": 29849,
+      "output": "pkg-verify @beep/repo-docgen (./packages/tooling/tool/docgen)\n  ok audit 10.9s   ok docgen 7.5s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/repo-docgen"
     },
     {
       "packageName": "@beep/repo-utils",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 19133,
-      "output": "pkg-verify @beep/repo-utils (./packages/tooling/library/repo-utils)\n  ok audit 8.0s   ok docgen 6.3s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/repo-utils"
+      "durationMillis": 18281,
+      "output": "pkg-verify @beep/repo-utils (./packages/tooling/library/repo-utils)\n  ok audit 7.9s   ok docgen 5.7s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/repo-utils"
     },
     {
       "packageName": "@beep/runpod",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 17979,
-      "output": "pkg-verify @beep/runpod (./packages/drivers/runpod)\n  ok audit 10.6s   ok docgen 3.5s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/runpod"
+      "durationMillis": 16597,
+      "output": "pkg-verify @beep/runpod (./packages/drivers/runpod)\n  ok audit 9.8s   ok docgen 3.0s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/runpod"
     },
     {
       "packageName": "@beep/sanity",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 12680,
-      "output": "pkg-verify @beep/sanity (./packages/drivers/sanity)\n  ok audit 6.0s   ok docgen 2.8s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/sanity"
+      "durationMillis": 12049,
+      "output": "pkg-verify @beep/sanity (./packages/drivers/sanity)\n  ok audit 5.8s   ok docgen 2.7s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/sanity"
     },
     {
       "packageName": "@beep/schema",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 17276,
-      "output": "pkg-verify @beep/schema (./packages/foundation/modeling/schema)\n  ok audit 7.4s   ok docgen 6.3s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/schema"
+      "durationMillis": 15814,
+      "output": "pkg-verify @beep/schema (./packages/foundation/modeling/schema)\n  ok audit 7.0s   ok docgen 5.4s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/schema"
     },
     {
       "packageName": "@beep/scratchpad",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 41407,
-      "output": "pkg-verify @beep/scratchpad (./scratchpad)\n  skip audit   ok docgen 21.7s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/scratchpad"
+      "durationMillis": 37138,
+      "output": "pkg-verify @beep/scratchpad (./scratchpad)\n  skip audit   ok docgen 19.7s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/scratchpad"
     },
     {
       "packageName": "@beep/semantic-web",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 13486,
-      "output": "pkg-verify @beep/semantic-web (./packages/foundation/capability/semantic-web)\n  ok audit 6.0s   ok docgen 3.2s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/semantic-web"
+      "durationMillis": 13117,
+      "output": "pkg-verify @beep/semantic-web (./packages/foundation/capability/semantic-web)\n  ok audit 5.9s   ok docgen 3.1s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/semantic-web"
     },
     {
       "packageName": "@beep/semantica",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 23527,
-      "output": "pkg-verify @beep/semantica (./apps/labs/semantica)\n  ok audit 16.2s   skip docgen\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/semantica"
+      "durationMillis": 24511,
+      "output": "pkg-verify @beep/semantica (./apps/labs/semantica)\n  ok audit 16.4s   skip docgen\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/semantica"
     },
     {
       "packageName": "@beep/shared-domain",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 14792,
-      "output": "pkg-verify @beep/shared-domain (./packages/shared/domain)\n  ok audit 6.6s   ok docgen 4.2s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/shared-domain"
+      "durationMillis": 14216,
+      "output": "pkg-verify @beep/shared-domain (./packages/shared/domain)\n  ok audit 6.4s   ok docgen 3.8s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/shared-domain"
     },
     {
       "packageName": "@beep/shared-use-cases",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 12670,
-      "output": "pkg-verify @beep/shared-use-cases (./packages/shared/use-cases)\n  ok audit 6.3s   ok docgen 2.7s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/shared-use-cases"
+      "durationMillis": 12837,
+      "output": "pkg-verify @beep/shared-use-cases (./packages/shared/use-cases)\n  ok audit 6.4s   ok docgen 2.8s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/shared-use-cases"
     },
     {
       "packageName": "@beep/skill-contract",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 34694,
-      "output": "pkg-verify @beep/skill-contract (./packages/foundation/modeling/skill-contract)\n  ok audit 15.4s   ok docgen 7.0s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/skill-contract"
+      "durationMillis": 33121,
+      "output": "pkg-verify @beep/skill-contract (./packages/foundation/modeling/skill-contract)\n  ok audit 15.7s   ok docgen 5.5s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/skill-contract"
     },
     {
       "packageName": "@beep/test-utils",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 14359,
-      "output": "pkg-verify @beep/test-utils (./packages/tooling/test-kit/test-utils)\n  ok audit 7.3s   ok docgen 3.4s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/test-utils"
+      "durationMillis": 13089,
+      "output": "pkg-verify @beep/test-utils (./packages/tooling/test-kit/test-utils)\n  ok audit 6.5s   ok docgen 3.0s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/test-utils"
     },
     {
       "packageName": "@beep/tika",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 15480,
-      "output": "pkg-verify @beep/tika (./packages/drivers/tika)\n  ok audit 8.6s   ok docgen 2.9s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/tika"
+      "durationMillis": 15207,
+      "output": "pkg-verify @beep/tika (./packages/drivers/tika)\n  ok audit 8.7s   ok docgen 2.6s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/tika"
     },
     {
       "packageName": "@beep/ui",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 21541,
-      "output": "pkg-verify @beep/ui (./packages/foundation/ui-system/ui)\n  ok audit 9.0s   ok docgen 7.5s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/ui"
+      "durationMillis": 20530,
+      "output": "pkg-verify @beep/ui (./packages/foundation/ui-system/ui)\n  ok audit 8.5s   ok docgen 7.0s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/ui"
     },
     {
       "packageName": "@beep/uspto",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 13144,
-      "output": "pkg-verify @beep/uspto (./packages/drivers/uspto)\n  ok audit 6.6s   ok docgen 2.8s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/uspto"
+      "durationMillis": 13444,
+      "output": "pkg-verify @beep/uspto (./packages/drivers/uspto)\n  ok audit 6.5s   ok docgen 2.5s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/uspto"
     },
     {
       "packageName": "@beep/uspto-mcp",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 14042,
-      "output": "pkg-verify @beep/uspto-mcp (./packages/drivers/uspto-mcp)\n  ok audit 6.5s   ok docgen 3.8s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/uspto-mcp"
+      "durationMillis": 13250,
+      "output": "pkg-verify @beep/uspto-mcp (./packages/drivers/uspto-mcp)\n  ok audit 6.8s   ok docgen 2.8s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/uspto-mcp"
     },
     {
       "packageName": "@beep/utils",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 8576,
-      "output": "pkg-verify @beep/utils (./packages/foundation/modeling/utils)\n  ok audit 4.0s   ok docgen 2.5s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/utils"
+      "durationMillis": 8321,
+      "output": "pkg-verify @beep/utils (./packages/foundation/modeling/utils)\n  ok audit 3.9s   ok docgen 2.3s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/utils"
     },
     {
       "packageName": "@beep/venice-ai",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 15522,
-      "output": "pkg-verify @beep/venice-ai (./packages/drivers/venice-ai)\n  ok audit 8.7s   ok docgen 2.9s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/venice-ai"
+      "durationMillis": 15990,
+      "output": "pkg-verify @beep/venice-ai (./packages/drivers/venice-ai)\n  ok audit 9.1s   ok docgen 3.0s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/venice-ai"
     },
     {
       "packageName": "@beep/wink",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 17221,
-      "output": "pkg-verify @beep/wink (./packages/drivers/wink)\n  ok audit 8.4s   ok docgen 3.8s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/wink"
+      "durationMillis": 16400,
+      "output": "pkg-verify @beep/wink (./packages/drivers/wink)\n  ok audit 7.7s   ok docgen 3.5s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/wink"
     },
     {
       "packageName": "@beep/workspace-domain",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 33933,
-      "output": "pkg-verify @beep/workspace-domain (./packages/workspace/domain)\n  ok audit 9.8s   ok docgen 6.8s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/workspace-domain"
+      "durationMillis": 25944,
+      "output": "pkg-verify @beep/workspace-domain (./packages/workspace/domain)\n  ok audit 8.7s   ok docgen 5.6s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/workspace-domain"
     },
     {
       "packageName": "@beep/workspace-server",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 37280,
-      "output": "pkg-verify @beep/workspace-server (./packages/workspace/server)\n  ok audit 14.4s   ok docgen 7.9s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/workspace-server"
+      "durationMillis": 31772,
+      "output": "pkg-verify @beep/workspace-server (./packages/workspace/server)\n  ok audit 13.7s   ok docgen 6.3s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/workspace-server"
     },
     {
       "packageName": "@beep/workspace-tables",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 30859,
-      "output": "pkg-verify @beep/workspace-tables (./packages/workspace/tables)\n  ok audit 10.2s   ok docgen 7.4s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/workspace-tables"
+      "durationMillis": 26091,
+      "output": "pkg-verify @beep/workspace-tables (./packages/workspace/tables)\n  ok audit 8.8s   ok docgen 5.9s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/workspace-tables"
     },
     {
       "packageName": "@beep/workspace-use-cases",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 31764,
-      "output": "pkg-verify @beep/workspace-use-cases (./packages/workspace/use-cases)\n  ok audit 10.9s   ok docgen 6.6s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/workspace-use-cases"
+      "durationMillis": 26206,
+      "output": "pkg-verify @beep/workspace-use-cases (./packages/workspace/use-cases)\n  ok audit 9.1s   ok docgen 5.5s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/workspace-use-cases"
     },
     {
       "packageName": "@beep/xai",
       "ok": true,
       "exitCode": 0,
-      "durationMillis": 16104,
-      "output": "pkg-verify @beep/xai (./packages/drivers/xai)\n  ok audit 8.0s   ok docgen 3.8s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/xai"
+      "durationMillis": 14166,
+      "output": "pkg-verify @beep/xai (./packages/drivers/xai)\n  ok audit 7.4s   ok docgen 3.0s\n$ bun run packages/tooling/tool/cli/src/bin.ts -- quality package-verify @beep/xai"
     }
   ]
 }

--- a/goals/inline-schema-compile-hard-error/research/residual-census.json
+++ b/goals/inline-schema-compile-hard-error/research/residual-census.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": "inline-schema-compile-census/v1",
   "measuredTree": {
-    "commit": "ed66cbce8f17111458f8b4801ec417d9adafaabd",
-    "committedAt": "2026-09-08T21:41:53-05:00"
+    "commit": "88c4036de4817cd179d2e0d65af29e885eca9eb3",
+    "committedAt": "2026-09-09T00:10:26-05:00"
   },
   "predecessor": {
     "commit": "01d400f0323cfa25cddacdbef4f602e114ff6a17",

--- a/goals/inline-schema-compile-hard-error/research/scripts/package-verification.test.ts
+++ b/goals/inline-schema-compile-hard-error/research/scripts/package-verification.test.ts
@@ -5,8 +5,8 @@ import { Effect } from "effect";
 import * as A from "effect/Array";
 import * as O from "effect/Option";
 import * as Order from "effect/Order";
-import * as R from "effect/Record";
 import * as S from "effect/Schema";
+import * as Str from "effect/String";
 
 const $I = $RepoCliId.create("goals/inline-schema-compile-hard-error/PackageVerificationEvidence");
 
@@ -31,19 +31,46 @@ const Matrix = S.Struct({
   summary: MatrixSummary,
   results: S.Array(MatrixResult),
 }).annotate($I.annote("Matrix", { description: "Primary matrix and its explicitly linked supplemental receipts." }));
-const Census = S.Struct({ byOwnerFamily: S.Record(S.String, S.Finite) }).annotate(
-  $I.annote("Census", { description: "Opening package-owner inventory used by the original matrix." })
+const ImplementationOwner = S.Struct({
+  packageName: S.NonEmptyString,
+  workspaceRoot: S.NonEmptyString,
+  files: S.Array(S.NonEmptyString),
+}).annotate(
+  $I.annote("ImplementationOwner", { description: "Workspace owner and changed files from an implementation PR." })
+);
+const ImplementationPullRequest = S.Struct({
+  number: S.Finite,
+  headSha: S.NonEmptyString,
+  mergeSha: S.NonEmptyString,
+  changedFileCount: S.Finite,
+  owners: S.Array(ImplementationOwner),
+  unownedPaths: S.Array(S.NonEmptyString),
+}).annotate(
+  $I.annote("ImplementationPullRequest", {
+    description: "Complete paginated file inventory for a merged implementation PR.",
+  })
+);
+const ImplementationInventory = S.Struct({
+  schemaVersion: S.Literal("inline-schema-implementation-owners/v1"),
+  pullRequests: S.Array(ImplementationPullRequest),
+  packageNames: S.Array(S.NonEmptyString),
+}).annotate(
+  $I.annote("ImplementationInventory", {
+    description: "Affected owners derived independently from the shipped implementation diffs.",
+  })
 );
 const decodeMatrix = S.decodeUnknownEffect(S.fromJsonString(Matrix));
-const decodeCensus = S.decodeUnknownEffect(S.fromJsonString(Census));
+const decodeImplementationInventory = S.decodeUnknownEffect(S.fromJsonString(ImplementationInventory));
 const decodeSupplemental = S.decodeUnknownEffect(S.fromJsonString(S.toCodecJson(S.Array(PackageVerifyReport))));
 
 test("primary and linked canonical receipts cover all 108 affected owners on the same head", async () => {
   const matrix = await Effect.runPromise(
     decodeMatrix(await Bun.file(new URL("../package-verification.json", import.meta.url)).text())
   );
-  const census = await Effect.runPromise(
-    decodeCensus(await Bun.file(new URL("../opening-census.json", import.meta.url)).text())
+  const inventory = await Effect.runPromise(
+    decodeImplementationInventory(
+      await Bun.file(new URL("../implementation-owner-inventory.json", import.meta.url)).text()
+    )
   );
   expect(matrix.supplementalReceipts).toEqual(["package-verification-supplemental.json"]);
   const supplemental = await Effect.runPromise(
@@ -73,13 +100,22 @@ test("primary and linked canonical receipts cover all 108 affected owners on the
     }
   }
   const owners = A.map([...matrix.results, ...supplemental], (result) => result.packageName);
-  const expected = A.dedupe([
-    ...R.keys(census.byOwnerFamily),
-    "@beep/lint-rules",
-    "@beep/effect-drizzle",
-    "@beep/freshbooks",
-  ]);
+  expect(A.map(inventory.pullRequests, (pr) => pr.number)).toEqual([1019, 1022, 1028]);
+  for (const pr of inventory.pullRequests) {
+    const paths = [...A.flatMap(pr.owners, (owner) => owner.files), ...pr.unownedPaths];
+    expect(A.length(paths)).toBe(pr.changedFileCount);
+    expect(A.length(A.dedupe(paths))).toBe(pr.changedFileCount);
+    for (const owner of pr.owners) {
+      expect(A.isReadonlyArrayNonEmpty(owner.files)).toBe(true);
+      expect(A.every(owner.files, Str.startsWith(`${owner.workspaceRoot}/`))).toBe(true);
+    }
+  }
+  const expected = A.sort(
+    A.dedupe(A.flatMap(inventory.pullRequests, (pr) => A.map(pr.owners, (owner) => owner.packageName))),
+    Order.String
+  );
+  expect(inventory.packageNames).toEqual(expected);
   expect(A.length(owners)).toBe(108);
   expect(A.length(A.dedupe(owners))).toBe(108);
-  expect(A.sort(owners, Order.String)).toEqual(A.sort(expected, Order.String));
+  expect(A.sort(owners, Order.String)).toEqual(expected);
 });

--- a/goals/inline-schema-compile-hard-error/research/scripts/package-verification.test.ts
+++ b/goals/inline-schema-compile-hard-error/research/scripts/package-verification.test.ts
@@ -1,0 +1,85 @@
+import { expect, test } from "bun:test";
+import { $RepoCliId } from "@beep/identity/packages";
+import { PackageVerifyReport } from "@beep/repo-cli/test/Quality";
+import { Effect } from "effect";
+import * as A from "effect/Array";
+import * as O from "effect/Option";
+import * as Order from "effect/Order";
+import * as R from "effect/Record";
+import * as S from "effect/Schema";
+
+const $I = $RepoCliId.create("goals/inline-schema-compile-hard-error/PackageVerificationEvidence");
+
+// These private schemas decode the existing matrix's wire format. Supplemental
+// reports reuse the package verifier's canonical schema and derived JSON codec.
+const MatrixSummary = S.Struct({
+  expected: S.Finite,
+  completed: S.Finite,
+  passed: S.Finite,
+  failed: S.Finite,
+}).annotate($I.annote("MatrixSummary", { description: "Recorded primary package matrix counts." }));
+const MatrixResult = S.Struct({
+  packageName: S.NonEmptyString,
+  ok: S.Boolean,
+  exitCode: S.Finite,
+}).annotate($I.annote("MatrixResult", { description: "A primary package verifier's terminal result." }));
+const Matrix = S.Struct({
+  schemaVersion: S.Literal("inline-schema-package-verification/v2"),
+  head: S.NonEmptyString,
+  committedTree: S.NonEmptyString,
+  supplementalReceipts: S.Array(S.NonEmptyString),
+  summary: MatrixSummary,
+  results: S.Array(MatrixResult),
+}).annotate($I.annote("Matrix", { description: "Primary matrix and its explicitly linked supplemental receipts." }));
+const Census = S.Struct({ byOwnerFamily: S.Record(S.String, S.Finite) }).annotate(
+  $I.annote("Census", { description: "Opening package-owner inventory used by the original matrix." })
+);
+const decodeMatrix = S.decodeUnknownEffect(S.fromJsonString(Matrix));
+const decodeCensus = S.decodeUnknownEffect(S.fromJsonString(Census));
+const decodeSupplemental = S.decodeUnknownEffect(S.fromJsonString(S.toCodecJson(S.Array(PackageVerifyReport))));
+
+test("primary and linked canonical receipts cover all 108 affected owners on the same head", async () => {
+  const matrix = await Effect.runPromise(
+    decodeMatrix(await Bun.file(new URL("../package-verification.json", import.meta.url)).text())
+  );
+  const census = await Effect.runPromise(
+    decodeCensus(await Bun.file(new URL("../opening-census.json", import.meta.url)).text())
+  );
+  expect(matrix.supplementalReceipts).toEqual(["package-verification-supplemental.json"]);
+  const supplemental = await Effect.runPromise(
+    decodeSupplemental(await Bun.file(new URL("../package-verification-supplemental.json", import.meta.url)).text())
+  );
+  expect(matrix.summary).toEqual({ expected: 106, completed: 106, passed: 106, failed: 0 });
+  expect(A.length(matrix.results)).toBe(matrix.summary.completed);
+  for (const result of matrix.results) {
+    expect(result.ok).toBe(true);
+    expect(result.exitCode).toBe(0);
+  }
+  expect(
+    A.sort(
+      A.map(supplemental, (report) => report.packageName),
+      Order.String
+    )
+  ).toEqual(["@beep/effect-drizzle", "@beep/freshbooks"]);
+  for (const report of supplemental) {
+    expect(report.headSha).toBe(matrix.head);
+    expect(report.quick).toBe(false);
+    expect(A.map(report.results, (result) => result.step)).toEqual(["audit", "docgen"]);
+    for (const result of report.results) {
+      expect(result.ok).toBe(true);
+      expect(result.skipped).toBe(false);
+      expect(result.durationMillis).toBeGreaterThan(0);
+      expect(O.getOrNull(result.exitCode)).toBe(0);
+    }
+  }
+  const owners = A.map([...matrix.results, ...supplemental], (result) => result.packageName);
+  const expected = A.dedupe([
+    ...R.keys(census.byOwnerFamily),
+    "@beep/lint-rules",
+    "@beep/effect-drizzle",
+    "@beep/freshbooks",
+  ]);
+  expect(A.length(owners)).toBe(108);
+  expect(A.length(A.dedupe(owners))).toBe(108);
+  expect(A.sort(owners, Order.String)).toEqual(A.sort(expected, Order.String));
+});


### PR DESCRIPTION
## Summary

Publish the final evidence for the repository-wide inline Schema compiler cleanup and hard-error promotion shipped in #1019, #1022, and #1028.

- Record the clean v2 package matrix: 106 expected owners passed, with supplemental canonical verification covering the other two affected owners.
- Refresh the zero-finding census and retain both execution reflections.
- Record replies and resolutions for all nine predecessor review threads.

## Verification

The full Yeet publication run for 59bba09125 completed successfully, including all 23 local CI-parity stages. The reusable proof state and lane records pin that commit; the verdict header retains the starting SHA, which is a documented receipt-consistency issue. Package-scoped no-op stages do not replace the separate 108-owner evidence.

## Closeout gate

The operator approved this follow-up PR on 2026-09-09 because #1028 merged before final verification and lifecycle closeout. This is the explicit exception to the original same-PR publication sequence.

The packet currently remains active. Keep this PR open while Yeet establishes merge readiness, then include the final lifecycle update and the remaining opportunity note in this same PR and verify its final head. Do not merge before the final terminal merge-ready result.

The changes in this PR are goal artifacts only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1038"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791527842&installation_model_id=424656&pr_number=1038&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1038&signature=0dc2e9593f201d5d111cbca83e2b45d26b3dd1bb114c08ce01da68fe79236ee7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

---

<!-- yeet-provenance:start -->
## Provenance

- Workspace: <code>beep-effect13</code>
- Branch: <code>codex/inline-schema-final-evidence</code>
- Agents (newest first):
  - `codex` (tui) · `unknown` · pushed

Resume the publishing agent from any beep-effect checkout on the publishing workstation:

```sh
bun run beep yeet resume 1038
```

<!-- yeet-provenance
{
  "schemaVersion": 2,
  "pr": 1038,
  "branch": "codex/inline-schema-final-evidence",
  "workspace": "beep-effect13",
  "agents": [
    {
      "harness": "codex",
      "entrypoint": "codex-tui",
      "hostHarness": null,
      "model": "unknown",
      "label": null,
      "workspace": null,
      "role": "pushed"
    }
  ]
}
-->
<!-- yeet-provenance:end -->
