### PR TITLE
fix(repo-cli): poll for the origin stamp in the legacy ticket scheduler tests

### DIFF
--- a/packages/tooling/tool/cli/test/quality-scheduler.test.ts
+++ b/packages/tooling/tool/cli/test/quality-scheduler.test.ts
@@ -2928,16 +2928,20 @@ describe("quality-scheduler", () => {
               )
             );
 
-            yield* Effect.sleep("100 millis");
+            // Loaded runners can enqueue and stamp the contender later than a fixed
+            // sleep allows, so poll for the ticket and then for its origin stamp.
+            const currentName = yield* Effect.repeat(
+              listDirectory(tempRoot.queue).pipe(Effect.map(A.findFirst((name) => !Str.startsWith("legacy-")(name)))),
+              { until: O.isSome, schedule: Schedule.spaced(Duration.millis(10)) }
+            ).pipe(Effect.timeout(Duration.seconds(5)), Effect.map(O.getOrThrow));
+            const currentTicket = yield* Effect.repeat(
+              fs.readFileString(path.join(tempRoot.queue, currentName)).pipe(Effect.flatMap(decodeTicket)),
+              {
+                until: (ticket) => ticket.blockedOnOriginAtMillis > 0,
+                schedule: Schedule.spaced(Duration.millis(10)),
+              }
+            ).pipe(Effect.timeout(Duration.seconds(5)));
             expect(current.pollUnsafe()).toBeUndefined();
-            const currentName = pipe(
-              yield* listDirectory(tempRoot.queue),
-              A.findFirst((name) => !Str.startsWith("legacy-")(name)),
-              O.getOrThrow
-            );
-            const currentTicket = yield* fs
-              .readFileString(path.join(tempRoot.queue, currentName))
-              .pipe(Effect.flatMap(decodeTicket));
             expect(currentTicket.coordinationProtocol).toBe("scheduler-origin-concurrency/v1");
             expect(currentTicket.blockedOnOriginAtMillis).toBeGreaterThan(0);
 
@@ -2965,8 +2969,10 @@ describe("quality-scheduler", () => {
               )
             );
 
-            yield* Effect.sleep("80 millis");
-            const currentName = pipe(yield* listDirectory(tempRoot.queue), A.head, O.getOrThrow);
+            const currentName = yield* Effect.repeat(listDirectory(tempRoot.queue).pipe(Effect.map(A.head)), {
+              until: O.isSome,
+              schedule: Schedule.spaced(Duration.millis(10)),
+            }).pipe(Effect.timeout(Duration.seconds(5)), Effect.map(O.getOrThrow));
             const currentPath = path.join(tempRoot.queue, currentName);
             const firstCurrent = yield* fs.readFileString(currentPath).pipe(Effect.flatMap(decodeTicket));
             expect(firstCurrent.coordinationProtocol).toBe("scheduler-origin-concurrency/v1");


### PR DESCRIPTION
## fix(repo-cli): poll for the origin stamp in the legacy ticket scheduler tests

The legacy-ticket admission tests slept a fixed 100 ms (and 80 ms) before
reading the contender ticket from the queue, which raced the scheduler
heartbeat pass that stamps blockedOnOriginAtMillis on loaded hosted runners
(Property Laws on #1033). Both reads now poll every 10 ms under a 5 second
timeout, first for the ticket file and then for its origin-blocked stamp,
matching the polling pattern already used elsewhere in the spec.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/claude_sweet-tereshkova-3b261b-99204eb4c553/verdict.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1039"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791528052&installation_model_id=424656&pr_number=1039&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1039&signature=2f1e9e32dce0343100bc8948d06fd6d7947e1b6d497918c27db7fc815c25269c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

---

<!-- yeet-provenance:start -->
## Provenance

- Workspace: <code>beep-effect5</code>
- Branch: <code>claude/sweet-tereshkova-3b261b</code>
- Agents (newest first):
  - `claude-code` (desktop) · `claude-fable-5-1` · <code>vigilant-khorana-0c8658-3c</code> · created

Resume the publishing agent from any beep-effect checkout on the publishing workstation:

```sh
bun run beep yeet resume 1039
```

<!-- yeet-provenance
{
  "schemaVersion": 2,
  "pr": 1039,
  "branch": "claude/sweet-tereshkova-3b261b",
  "workspace": "beep-effect5",
  "agents": [
    {
      "harness": "claude-code",
      "entrypoint": "claude-desktop",
      "hostHarness": null,
      "model": "claude-fable-5-1",
      "label": "vigilant-khorana-0c8658-3c",
      "workspace": null,
      "role": "created"
    }
  ]
}
-->
<!-- yeet-provenance:end -->

