### PR TITLE
docs(agent-config): document Graft drift recovery

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,9 @@ Tracked, authored documentation for the beep-effect monorepo.
 | `docs/generated/` | **no** (gitignored) | Docgen aggregate output. Produced by `bun run docgen` / `bun run docs:aggregate`; safe to delete, regenerable. |
 | `docs/_internal/` | **no** (gitignored) | Private working notes. This repository is public — never commit anything under `_internal/`. |
 
+Operational guidance includes [recovering from local Graft configuration
+drift](runbooks/graft-local-recovery.md).
+
 ## Rules
 
 - Authored documents live here and are committed like code.

--- a/docs/runbooks/graft-local-recovery.md
+++ b/docs/runbooks/graft-local-recovery.md
@@ -1,0 +1,113 @@
+# Recover from local Graft configuration drift
+
+Use this runbook when `@beep/ai-sync#check` rejects Graft permissions or the
+CLI's Graft hook trust tests fail after Graft initialization. Both failures can
+come from local configuration changes even when the committed source is correct.
+
+The repository owns `.claude/helpers/graft-hooks.cjs`,
+`.claude/helpers/graft-statusline.cjs`, and their settings. Both shims delegate
+to [graft-loader.cjs](../../.claude/helpers/graft-loader.cjs), which resolves a
+trusted installation from `PATH`. Graft initialization can replace these shims
+with generated loaders that contain an installation path and project fallbacks.
+It can also broaden the command permissions in `.claude/settings.json`.
+
+## Keep the existing integration
+
+Use `graft build` to refresh the index and the named query commands to inspect
+code. The checked-in integration is already installed. Do not rerun `graft init`
+as an indexing or routine troubleshooting step: it can rewrite tracked hooks
+and settings. Review any intentional integration update against the repository
+loader and the [configuration policy](../../packages/tooling/library/ai-sync/src/validation.ts).
+
+## Identify the drift
+
+Run these commands from the affected checkout's root:
+
+```sh
+git status --short --branch
+git diff HEAD -- .claude/settings.json .claude/helpers/graft-hooks.cjs .claude/helpers/graft-statusline.cjs
+bun run ai-sync check
+bun run --cwd packages/tooling/tool/cli test -- test/graft-hooks.test.ts
+```
+
+The configuration failure names these initializer-added permissions:
+
+```text
+Bash(graft:*)
+Bash(npx graft:*)
+Bash(graft-dev:*)
+Bash(node dist/cli.js:*)
+```
+
+The hook tests may fail to receive `trusted:session-start`, or receive a Graft
+status message where the test expects no output. Confirm that the local shims
+were replaced before treating these assertions as defects in the trust loader.
+
+Messages about invalid `ReflectionFrontmatter` can be expected output from
+negative tests. Check the test summary: a passing `reflection-lint.test.ts` does
+not call for changing real goal reflections.
+
+## Back up and repair the affected files
+
+Preserve the current files outside the repository before editing them:
+
+```sh
+mkdir -p "${XDG_CACHE_HOME:-$HOME/.cache}/beep"
+graft_repair_backup=$(mktemp -d "${XDG_CACHE_HOME:-$HOME/.cache}/beep/graft-repair.XXXXXX")
+cp -p .claude/settings.json "$graft_repair_backup/settings.json"
+cp -p .claude/helpers/graft-hooks.cjs "$graft_repair_backup/graft-hooks.cjs"
+cp -p .claude/helpers/graft-statusline.cjs "$graft_repair_backup/graft-statusline.cjs"
+```
+
+Inspect both the staged and unstaged changes. If the shims contain only
+initializer-generated drift and `HEAD` contains the repository loader calls,
+restore those two working files:
+
+```sh
+git diff --cached -- .claude/helpers/graft-hooks.cjs .claude/helpers/graft-statusline.cjs
+git show HEAD:.claude/helpers/graft-hooks.cjs
+git show HEAD:.claude/helpers/graft-statusline.cjs
+git restore --source=HEAD --worktree -- .claude/helpers/graft-hooks.cjs .claude/helpers/graft-statusline.cjs
+```
+
+If either shim has intentional changes, reconcile it manually. Do not overwrite
+that work or change the index. The restore command above leaves staged content
+unchanged, so staged drift must also be reviewed before a later commit.
+
+Edit `.claude/settings.json` selectively:
+
+- Remove the four broad permissions listed above if initialization added them.
+  Keep the repository's named Graft command permissions.
+- Compare Graft hook timeouts with the committed settings. The repository uses
+  `8`, `10`, and `15` seconds; initialization drift has produced `8000`, `10000`,
+  and `15000`. Restore the committed values for the affected hooks.
+- Preserve unrelated settings, including any intentional footer-link setting,
+  and leave local backup files alone.
+
+Do not replace the whole settings file just to remove these additions. Review
+the resulting diff, then format the edited JSON:
+
+```sh
+bunx biome format --write .claude/settings.json
+git diff HEAD -- .claude/settings.json .claude/helpers/graft-hooks.cjs .claude/helpers/graft-statusline.cjs
+git diff --check
+```
+
+## Verify the repair
+
+Repeat the configuration and hook checks above for quick feedback. Then run the
+complete commands from the affected checkout:
+
+```sh
+bun run lint
+bun run check
+bun run coverage
+```
+
+Require a successful exit from each command. The root check includes additional
+TypeScript rule, test, and smoke checks after Turbo finishes. Coverage must also
+finish its regression check after the test shards pass.
+
+A local repair that restores already-correct committed files does not require
+a source PR. If a failure also reproduces from a clean current base, attribute
+it and use the [Yeet workflow](../../.claude/skills/yeet/SKILL.md) for the source fix.

--- a/docs/runbooks/graft-local-recovery.md
+++ b/docs/runbooks/graft-local-recovery.md
@@ -57,6 +57,8 @@ graft_repair_backup=$(mktemp -d "${XDG_CACHE_HOME:-$HOME/.cache}/beep/graft-repa
 cp -p .claude/settings.json "$graft_repair_backup/settings.json"
 cp -p .claude/helpers/graft-hooks.cjs "$graft_repair_backup/graft-hooks.cjs"
 cp -p .claude/helpers/graft-statusline.cjs "$graft_repair_backup/graft-statusline.cjs"
+git diff --binary --cached -- .claude/settings.json .claude/helpers/graft-hooks.cjs .claude/helpers/graft-statusline.cjs > "$graft_repair_backup/staged.patch"
+git diff --binary -- .claude/settings.json .claude/helpers/graft-hooks.cjs .claude/helpers/graft-statusline.cjs > "$graft_repair_backup/unstaged.patch"
 ```
 
 Inspect both the staged and unstaged changes. If the shims contain only
@@ -70,9 +72,9 @@ git show HEAD:.claude/helpers/graft-statusline.cjs
 git restore --source=HEAD --worktree -- .claude/helpers/graft-hooks.cjs .claude/helpers/graft-statusline.cjs
 ```
 
-If either shim has intentional changes, reconcile it manually. Do not overwrite
-that work or change the index. The restore command above leaves staged content
-unchanged, so staged drift must also be reviewed before a later commit.
+If either shim has intentional changes, reconcile it manually. Preserve those
+hunks and their staged or unstaged state. The restore command above leaves the
+index unchanged; the staged repair below is a separate required step.
 
 Edit `.claude/settings.json` selectively:
 
@@ -92,6 +94,39 @@ bunx biome format --write .claude/settings.json
 git diff HEAD -- .claude/settings.json .claude/helpers/graft-hooks.cjs .claude/helpers/graft-statusline.cjs
 git diff --check
 ```
+
+## Remove confirmed drift from the index
+
+Tests exercise the working files. A clean `git diff HEAD` can therefore hide
+initializer drift that remains staged and would return in the next commit.
+Inspect the index separately for all three affected files:
+
+```sh
+git diff --cached -- .claude/settings.json .claude/helpers/graft-hooks.cjs .claude/helpers/graft-statusline.cjs
+```
+
+If these staged changes contain only confirmed initializer drift, restore their
+index entries from `HEAD`. This leaves the repaired working files untouched:
+
+```sh
+git restore --source=HEAD --staged -- .claude/settings.json .claude/helpers/graft-hooks.cjs .claude/helpers/graft-statusline.cjs
+git diff --cached --exit-code -- .claude/settings.json .claude/helpers/graft-hooks.cjs .claude/helpers/graft-statusline.cjs
+```
+
+The final command must exit successfully with no diff for this drift-only case.
+If intentional changes are also staged, use patch selection to remove only the
+confirmed drift hunks:
+
+```sh
+git restore --source=HEAD --staged --patch -- .claude/settings.json .claude/helpers/graft-hooks.cjs .claude/helpers/graft-statusline.cjs
+git diff --cached -- .claude/settings.json .claude/helpers/graft-hooks.cjs .claude/helpers/graft-statusline.cjs
+git diff --cached --check
+```
+
+Every remaining staged hunk must be an intentional change. If a hunk mixes both
+kinds of change, split or edit that hunk instead of discarding the intentional
+part. Keep the saved patches until both the working files and the index have
+been reviewed.
 
 ## Verify the repair
 


### PR DESCRIPTION
Graft initialization can overwrite the repository hook shims, broaden Claude command permissions, and change hook timeout values. That local drift causes `@beep/ai-sync#check` and the Graft hook trust tests to fail even when the committed code is correct.

Add a recovery runbook covering diagnosis, backups, selective restoration, and the complete lint, check, and coverage acceptance commands. Link it from the docs index and explain how to refresh the Graft index without reinitializing the integration. This PR changes documentation only.

Validation: all five Graft hook tests passed, agent configuration validation passed, spelling and relative-link checks passed, and every shell block passed `bash -n`. The documented local repair was also verified with successful root `bun run lint`, `bun run check`, and `bun run coverage` runs before this documentation change. Yeet and hosted checks provide the PR-head verification.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1043"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791531764&installation_model_id=424656&pr_number=1043&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1043&signature=5937a8afecddbed1b18e1fc8b4490a5fb81797a919cf7e9e375ffb9fb3c1a6d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

---

<!-- yeet-provenance:start -->
## Provenance

- Workspace: <code>graft-recovery-runbook</code>
- Branch: <code>codex/graft-recovery-runbook</code>
- Agents (newest first):
  - `codex` (tui) · `unknown` · pushed

Resume the publishing agent from any beep-effect checkout on the publishing workstation:

```sh
bun run beep yeet resume 1043
```

<!-- yeet-provenance
{
  "schemaVersion": 2,
  "pr": 1043,
  "branch": "codex/graft-recovery-runbook",
  "workspace": "graft-recovery-runbook",
  "agents": [
    {
      "harness": "codex",
      "entrypoint": "codex-tui",
      "hostHarness": null,
      "model": "unknown",
      "label": null,
      "workspace": null,
      "role": "pushed"
    }
  ]
}
-->
<!-- yeet-provenance:end -->
