### PR TITLE
fix(infra): keep heavy CI on demand and repair runner cleanup

### DIFF
--- a/.changeset/steady-heavy-runners.md
+++ b/.changeset/steady-heavy-runners.md
@@ -1,0 +1,6 @@
+---
+"@beep/infra": patch
+---
+
+Use On-Demand capacity for the heavy CI runner pool and restore narrowly scoped
+KMS access for termination cleanup of GitHub App runners.

--- a/docs/runbooks/ci-runner-reliability.md
+++ b/docs/runbooks/ci-runner-reliability.md
@@ -74,7 +74,8 @@ runner workload identity.
    separate attribution before apply.
 4. Apply the reviewed plan with the operator attending. When migrating the
    initial three `github-app-ssm-decrypt` inline policies, create the six grants
-   first with a reviewed targeted apply. Allow five minutes for KMS propagation,
+   first with a saved plan that excludes those three policy URNs. Allow five
+   minutes for KMS propagation,
    then remove only those three policies with the reviewed remaining apply.
    Inspect the live scale-up configuration for
    On-Demand and cap 14. Newly launched matching EC2 instances must have no Spot
@@ -117,9 +118,17 @@ for each running VM until its ephemeral teardown completes.
   names, and absence of external role policies.
 - PR review identified the external-policy role-deletion hazard and ambient
   Lambda-region lookup. The source replaces those policies with six KMS grants
-  and explicit regional lookups. Migration of the initial production policies
-  requires the attended sequence above; the initial simulation results describe
-  those policies, not the replacement grants.
+  and explicit regional lookups. The attended migration created six grants,
+  verified their exact principals and contexts, allowed five minutes for
+  propagation, and removed the three initial policies at 09:56:32 UTC. AWS
+  confirmed all three policies were absent; the final
+  `pulumi preview --expect-no-changes` reported 201 unchanged resources.
+- At 09:57:25 UTC, after policy removal, CloudTrail recorded successful
+  `GetParameter` reads with decryption and corresponding KMS `Decrypt` events
+  for both App parameters by the notification role. The natural termination
+  handler reached GitHub and confirmed the runner was already deregistered.
+  This validates the replacement grants through real operations; the earlier
+  IAM simulations describe only the initial policies.
 
 At deployment, the AWS Price List API quoted $0.504/hour for `r6i.2xlarge`
 Linux shared-tenancy On-Demand in `us-east-1`. The four allowed instance types

--- a/docs/runbooks/ci-runner-reliability.md
+++ b/docs/runbooks/ci-runner-reliability.md
@@ -1,0 +1,111 @@
+# Heavy CI runner reliability
+
+The `beep-ec2-heavy` pool uses On-Demand EC2 capacity. The operator chose this
+permanent posture on 2026-09-09 after repeated Spot reclamations interrupted
+verification. Keep the 14-instance cap, 64 GiB instance choices, and ephemeral
+one-job-per-VM teardown. Changing the purchase model does not require replacing
+running workers; existing workers finish or are reclaimed and drain naturally.
+
+## Attribute a runner loss
+
+1. Read every relevant attempt with
+   `gh api 'repos/beep-effect/beep-effect/actions/runs/<run-id>/jobs?filter=all&per_page=100'`.
+   Follow pagination for larger runs. Record job, runner, step, and completion
+   times; GitHub's latest attempt alone hides earlier runner losses.
+2. Read the job's check annotations. A runner communication failure with an
+   unfinished step identifies runner loss, not a source assertion.
+3. Remove `beep-ci-` from the runner name to obtain the EC2 instance ID. Read
+   `aws ec2 describe-spot-instance-requests --filters Name=instance-id,Values=<instance-id>`.
+   `instance-terminated-no-capacity` proves Spot reclamation. Compare its
+   update time with GitHub's later failure time before inferring a timeout.
+4. Check CloudTrail and the scale-down/reaper logs for controller-initiated
+   termination. The dedicated reaper uses a 150-minute TTL. Inspect operating
+   system or runner diagnostics before attributing an unexplained loss to OOM.
+5. Count only the matching fleet instances. Terminated EC2 and Spot request
+   records have limited retention; preserve a sanitized incident receipt early.
+
+On 2026-09-09, four workflows supplied nine distinct runner-loss examples.
+Every matching Spot request reported capacity reclamation. A broader retained
+fleet snapshot contained 30 such interruptions. GitHub marked these jobs failed
+roughly 11 minutes after termination. This exceeded the former
+`>2 interruption reruns/week` tripwire; returning this heavy pool to Spot needs
+a new operator decision, not an automatic rollback timer.
+
+## Termination credential access
+
+The pinned `github-aws-runners/github-runner/aws` v7.10.1 module grants its
+termination roles `ssm:GetParameter` but does not forward `kms_key_arn` to the
+termination watcher. With an externally managed customer-key-encrypted GitHub
+App credential, deregistration therefore fails with `kms:Decrypt` denied.
+
+`CiFleetController` owns only an additional `github-app-ssm-decrypt` inline
+policy on these existing Lambda roles:
+
+- `beep-ci-spot-termination-notification`
+- `beep-ci-spot-termination-handler`
+- `beep-ci-deregister-retry`
+
+The grant allows only `kms:Decrypt` on the configured GitHub App key, through
+regional SSM, with encryption context naming the App ID or App private-key
+parameter. It does not grant access to the webhook secret, unrelated parameters,
+direct KMS decrypt calls, or other keys. The notification Lambda also consumes
+ordinary EC2 termination events, so this fix remains necessary on On-Demand.
+
+The upstream module still owns the roles and its existing policies. Keep the
+extra policy until an upstream upgrade supplies and validates an equivalent
+grant; do not hand-edit the generated SDK or broaden runner workload identity.
+
+## Deploy and verify
+
+1. Refresh AWS identity, the source branch, the current fleet cap, and running
+   jobs. Use the configured S3 Pulumi backend and production stack in
+   `infra/ci-runners`.
+2. For the existing `op://`-backed Pulumi env file, first test
+   `op run --env-file=<path> -- true >/dev/null`. Use that same wrapper for
+   Pulumi. Never print resolved credentials or export plaintext stack secrets.
+3. Run `bun run beep quality package-verify @beep/infra`. Review a saved Pulumi
+   preview: the purchase-model update and three narrow IAM grants are intended;
+   unexpected network, security-boundary, AMI, cap, or deletion changes need
+   separate attribution before apply.
+4. Apply the reviewed plan. Inspect the live scale-up configuration for
+   On-Demand and cap 14. Newly launched matching EC2 instances must have no Spot
+   request ID. Let existing busy instances drain naturally.
+5. Verify the three roles allow the exact SSM/KMS context and deny unrelated
+   contexts. Require a successful natural termination/deregistration log after
+   the policy update; an IAM simulation alone does not prove the real operation.
+6. Confirm a heavy verification job succeeds on a newly launched On-Demand
+   runner. Re-read the target run and SHA before any failed-job rerun; do not
+   replay superseded branches or healthy jobs.
+
+This fixes Spot-specific interruption and the known cleanup permission defect.
+Normal host, network, application, or timeout failures still require diagnosis.
+The 14-instance cap limits concurrency, not a monthly budget: billing continues
+for each running VM until its ephemeral teardown completes.
+
+## Deployment evidence — 2026-09-09
+
+- Production apply: three IAM policies created, two controller resources
+  updated, no deletions. The scale-up Lambda changed at 09:13:51 UTC and
+  reported On-Demand capacity with cap 14.
+- A second `pulumi preview --expect-no-changes` succeeded with 198 unchanged
+  resources. Each deployed policy matched the reviewed plan exactly.
+- IAM simulation against all three deployed roles allowed the intended
+  SSM/KMS context and denied unrelated parameters, other keys, and direct KMS
+  access: 12 expected results. CloudTrail then confirmed successful real
+  `GetParameter` operations with decryption by the previously failing
+  notification role; natural termination handling reached GitHub successfully.
+- Fresh workers launched as On-Demand `r6i.2xlarge` instances. The standard
+  [Fleet Shadow Check](https://github.com/beep-effect/beep-effect/actions/runs/34333728712)
+  succeeded on a new worker. This is boot, registration, and job-execution
+  proof; the separate
+  [Heavy / Docgen verification job](https://github.com/beep-effect/beep-effect/actions/runs/34332600371/job/102408052217)
+  also succeeded on a new On-Demand worker. The probe worker subsequently
+  terminated, confirming ephemeral teardown still works.
+- `bun run beep quality package-verify @beep/infra` passed audit and docgen.
+  The mock regression exercises a Pulumi-output region, On-Demand selection,
+  the unchanged cap, all three role bindings, and exact IAM scope.
+
+At deployment, the AWS Price List API quoted $0.504/hour for `r6i.2xlarge`
+Linux shared-tenancy On-Demand in `us-east-1`. The four allowed instance types
+ranged up to $0.92736/hour, excluding disks and networking. Refresh pricing
+before budgeting; the controller may choose any allowed type.

--- a/goals/ci-fleet-residue/research/OPPORTUNITIES.md
+++ b/goals/ci-fleet-residue/research/OPPORTUNITIES.md
@@ -2,6 +2,34 @@
 
 Record receipts at the moment friction happens; redact for the public repo.
 
+## 2026-09-09 — Spot reclamation and broken termination credential access
+
+- What: recent PR verification lanes repeatedly lost their EC2 runners. AWS
+  Spot request status confirmed `instance-terminated-no-capacity` for nine
+  distinct failed runners across Check, Coverage Regression, and Lint Policy
+  in runs 34326794784, 34328058384, 34328673593, and 34329733429.
+- Evidence: retained fleet records contained 30 capacity interruptions across
+  three instance types and both configured availability zones. GitHub reported
+  the losses about 11 minutes after EC2 recorded termination; an apparent
+  18-minute lane lifetime is not evidence of a fixed lane timeout. The
+  tag-based reaper reported an empty reap set with its 150-minute TTL.
+- Additional defect: the termination notification Lambda logged 164 failures
+  across 133 instances during 08:00–09:00 UTC. The minimal fingerprint is
+  `Failed to deregister runner from GitHub` with `kms:Decrypt` denied because
+  no identity policy allows it. The pinned upstream v7.10.1 watcher grants
+  SSM reads without forwarding the customer-managed KMS key grant.
+- Prevention: make the heavy pool permanently On-Demand, preserve its cap and
+  ephemeral teardown, and manage a separate key- and SSM-context-scoped decrypt
+  grant for all three cleanup roles. Verify resource wiring with Pulumi mocks,
+  preview the actual infrastructure diff, and require live capacity and
+  credential-operation evidence after deployment. The operational procedure is
+  in `docs/runbooks/ci-runner-reliability.md`.
+- Deployment-check friction: the initial preview exposed an `Output<T>` string
+  coercion in the new regional SSM condition, which a literal-region mock did
+  not exercise. The regression now passes the same Pulumi output form as the
+  real entrypoint and the policy uses `pulumi.interpolate`. Require inspection
+  of rendered condition values, not just the resource-count summary.
+
 ## Seed context (2026-08-13, from the split)
 
 - Spot evidence: 3 same-second reclaims killed 6 jobs on cutover evening

--- a/goals/ci-fleet-residue/research/OPPORTUNITIES.md
+++ b/goals/ci-fleet-residue/research/OPPORTUNITIES.md
@@ -34,8 +34,18 @@ Record receipts at the moment friction happens; redact for the public repo.
   deletion or fail to follow same-name role replacement. The final source owns
   six key grants instead, with exact parameter contexts and immutable role IDs
   in grant names. Lambda discovery explicitly uses the controller region. The
-  initial three deployed policies remain until the attended grant migration;
-  add grants before removing working access and verify real reads afterward.
+  attended migration created the grants before removing the three initial
+  policies. Final preview: 201 unchanged. Post-removal CloudTrail events prove
+  successful SSM reads and KMS decrypts for both parameters; natural cleanup
+  reached GitHub. Add access before removing working access and verify reads.
+- Migration preview friction: targeting only the six new grant URNs reported
+  `Target ... could not be found in the stack` before dependent invokes resolved.
+  A full program preview excluding the three existing policy URNs produced
+  exactly six creates. Save and constrain that creation plan, then preview the
+  three policy removals separately after the grants exist and have propagated.
+- Verification friction: concurrent AWS metadata commands briefly encountered
+  `CreateOAuth2Token: Rate exceeded`; a serialized retry completed. Let the CLI
+  refresh its login credentials before starting a metadata fan-out.
 
 ## Seed context (2026-08-13, from the split)
 

--- a/goals/time-to-certainty/research/OPPORTUNITIES.md
+++ b/goals/time-to-certainty/research/OPPORTUNITIES.md
@@ -618,3 +618,8 @@ subprocess diagnostics would make inventory stalls attributable.
   [Heavy / Docgen](https://github.com/beep-effect/beep-effect/actions/runs/34332600371/job/102408052217).
   The probe worker then terminated normally. Full deployment details and reproduction
   commands are in `docs/runbooks/ci-runner-reliability.md`.
+- Publication friction: `changeset-status --since origin/main` evaluates the committed
+  range. The pre-deployment dirty-tree check reported no product workspace, while the
+  first published range correctly required an `@beep/infra` release note. Add the
+  infrastructure changeset before publication; a dirty-tree zero count is not proof
+  that the committed change is exempt from the release-note rule.

--- a/goals/time-to-certainty/research/OPPORTUNITIES.md
+++ b/goals/time-to-certainty/research/OPPORTUNITIES.md
@@ -572,3 +572,49 @@ subprocess diagnostics would make inventory stalls attributable.
 - **Would have prevented it:** `package-verify` (or the C3 package-level `coverage` task) reporting
   "new files without baseline rows" as its own line regardless of package totals, and the brief's
   acceptance list naming the baseline write for any stage that adds source files.
+
+## 2026-09-09 — Two heavy lanes died mid-step on separate runners at the same second
+
+- **Doing:** babysitting PR #1029's sixth hosted round (head cb8236d37f).
+- **Evidence:** `Heavy / Check` and `Heavy / Coverage Regression` both reported `completed/failure`
+  at 07:36:01Z after 23 minutes with step 10 `Run verification lane` still `in_progress/null`, every
+  later step `pending`, and `BlobNotFound` for the job logs; two different `beep-ci-i-…` EC2 runners.
+  Nothing in the head explains a simultaneous stop, and the same lanes were green on the previous
+  head except for a baseline-row finding fixed in this push. The merge button refused on the
+  required checks, so the remedy was a fresh push (main merged forward) rather than a code change.
+- **Root cause (later the same night, second occurrence on #1046 at 08:38Z):** the fleet runs
+  spot capacity (`instance_target_capacity_type: "spot"`, price-capacity-optimized) with on-demand
+  failover only for launch-time capacity errors, so a mid-run reclaim wave takes every affected
+  runner at once and the two longest lanes are the ones exposed.
+- **Would have prevented it:** an on-demand pool for the long heavy lanes or the runner module's
+  job re-queue on spot interruption, a visible `runner reclaimed` marker on the job, and
+  `yeet monitor` classing "completed/failure with no failed step" as environment-only.
+
+### AWS investigation and permanent mitigation
+
+- The live AWS Spot request records confirm both PR #1029 workers were reclaimed at
+  **07:24:29 UTC**, about 11.5 minutes before GitHub recorded their failures. PR #1046's
+  matched runners also report `instance-terminated-no-capacity`. The apparent 18–23 minute
+  limit therefore includes runner-loss detection delay; it is not a lane timeout.
+- A retained fleet snapshot contained 30 capacity interruptions across three instance types
+  and both configured availability zones. Additional matched failures included Lint Policy
+  and very early Check execution. A 16-minute cutoff would not protect all observed losses.
+- The pinned module's `job_retry` input checks jobs that are still queued. It rescues launch
+  or pickup failures, not an in-progress job whose runner has disappeared. No mid-job resume
+  guarantee is supplied by enabling that existing input, which was already enabled.
+- The operator requested a permanent fix. The smallest implemented infrastructure change
+  moves the existing heavy pool to On-Demand while preserving the 14-runner cap, labels,
+  network, identity boundary, and ephemeral teardown. A second pool would preserve Spot
+  discounts for short lanes but also preserve their demonstrated interruption exposure.
+- The same investigation found the upstream v7.10.1 termination watcher missing its
+  customer-managed KMS decrypt grant: 164 credential-access failures in one hour. Three
+  Pulumi-managed inline policies now permit only the configured App key, through SSM,
+  for the two required parameter encryption contexts.
+- Production apply completed with three policy additions, two controller updates, and no
+  deletions. A subsequent preview reported 198 unchanged resources. Live CloudTrail reads
+  prove decryption now succeeds; 12 IAM simulations prove intended access and negative
+  cases. Fresh On-Demand workers completed the standard
+  [fleet probe](https://github.com/beep-effect/beep-effect/actions/runs/34333728712) and
+  [Heavy / Docgen](https://github.com/beep-effect/beep-effect/actions/runs/34332600371/job/102408052217).
+  The probe worker then terminated normally. Full deployment details and reproduction
+  commands are in `docs/runbooks/ci-runner-reliability.md`.

--- a/goals/time-to-certainty/research/OPPORTUNITIES.md
+++ b/goals/time-to-certainty/research/OPPORTUNITIES.md
@@ -622,15 +622,22 @@ subprocess diagnostics would make inventory stalls attributable.
   [Heavy / Docgen](https://github.com/beep-effect/beep-effect/actions/runs/34332600371/job/102408052217).
   The probe worker then terminated normally. Full deployment details and reproduction
   commands are in `docs/runbooks/ci-runner-reliability.md`.
-- Review migration: create the six KMS grants, allow their propagation, then remove the
-  initial three policies in attended applies. Verify real SSM reads after removal;
-  IAM simulation does not account for KMS grants. Preserve both this investigation and
-  the newly landed reap-claim settlement receipt when merging the shared ledger.
+- Review migration completed in attended stages: six KMS grants created, their scopes
+  checked, five minutes allowed for propagation, then three initial policies removed
+  at 09:56:32 UTC. Final preview: 201 unchanged. At 09:57:25 UTC, CloudTrail recorded
+  successful SSM reads and KMS decrypts for both App parameters after policy removal;
+  natural cleanup reached GitHub. IAM simulation does not account for KMS grants.
+  Both this investigation and the newly landed reap-claim settlement receipt are
+  preserved in the merged ledger.
 - Publication friction: `changeset-status --since origin/main` evaluates the committed
   range. The pre-deployment dirty-tree check reported no product workspace, while the
   first published range correctly required an `@beep/infra` release note. Add the
   infrastructure changeset before publication; a dirty-tree zero count is not proof
   that the committed change is exempt from the release-note rule.
+- Merge publication friction: Yeet's stale-base check runs before its commit step, so
+  a resolved but uncommitted merge still appears behind `origin/main`. Complete the
+  reviewed merge commit first, then resume normal Yeet publication; do not bypass
+  freshness checks or force-push a rebase.
 
 ## 2026-09-09 — The reap-claim settlement window was a 25 ms sleep
 

--- a/infra/src/CiFleetController.ts
+++ b/infra/src/CiFleetController.ts
@@ -731,9 +731,9 @@ type CiFleetControllerArgs = {
  * job whose runner died between launch and pickup (spot reclaim, boot
  * failure) — without it such a job waits on GitHub's six-hour queue timeout,
  * because nothing else re-delivers it. A capacity reclaim mid-job still fails
- * that job and only a workflow re-run recovers it; the fleet runs on-demand
- * for the bring-up window after cutover-night reclaim sweeps, with spot (a
- * ~3x cost saving) as the intended steady state. `runners_maximum_count` bounds
+ * that job and only a workflow re-run recovers it. The heavy pool uses
+ * on-demand capacity permanently after repeated interruption sweeps exceeded
+ * the fleet's reliability tripwire. `runners_maximum_count` bounds
  * concurrent instances only — jobs beyond the cap retry from SQS as capacity
  * frees rather than being dropped. `enable_job_queued_check` stays false: its
  * not-queued branch consumes the scale-up message with no retry, so GitHub
@@ -920,13 +920,11 @@ export class CiFleetController extends pulumi.ComponentResource {
           },
         },
         instance_allocation_strategy: "price-capacity-optimized",
-        // P1 spot revert (2026-08-16): the measured on-demand week was calm —
-        // 20/528 re-runs since 2026-08-11, all attributed to lane-wedge
-        // reruns, one glob-timeout flake, and supersede cancels; zero
-        // capacity-class. Tripwire stays armed: >2 interruption re-runs/week
-        // sends the longest lanes back to on-demand
-        // (goals/ci-fleet-residue/research/p1-spot-revert-baseline.md).
-        instance_target_capacity_type: "spot",
+        // Permanent heavy-pool posture: the 2026-09-09 interruption sweep
+        // exceeded the >2 interruption-reruns/week tripwire. Launch-time
+        // on-demand failover cannot recover a runner reclaimed mid-job.
+        // Keep the existing cap and ephemeral teardown to bound spending.
+        instance_target_capacity_type: "on-demand",
         instance_termination_watcher: {
           enable: true,
           enable_runner_deregistration: true,
@@ -996,6 +994,47 @@ export class CiFleetController extends pulumi.ComponentResource {
       },
       { dependsOn: [runnerAmiParameter], parent: this, provider }
     );
+
+    // Upstream v7.10.1 grants these roles ssm:GetParameter but does not pass
+    // kms_key_arn into the termination-watcher module. Own only the missing
+    // grant here; leave its role and existing policies under module control.
+    // The notification function also handles ordinary instance termination,
+    // so these credentials remain necessary for the on-demand fleet.
+    for (const functionName of [
+      "beep-ci-spot-termination-notification",
+      "beep-ci-spot-termination-handler",
+      "beep-ci-deregister-retry",
+    ]) {
+      const watcher = aws.lambda.getFunctionOutput({ functionName }, { dependsOn: [controller], parent: this });
+      new aws.iam.RolePolicy(
+        `${name}-${functionName}-app-decrypt`,
+        {
+          name: "github-app-ssm-decrypt",
+          role: watcher.role.apply(Str.replace(/^.*\//, "")),
+          policy: pulumi.jsonStringify({
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Sid: "DecryptGitHubAppParametersThroughSsm",
+                Effect: "Allow",
+                Action: "kms:Decrypt",
+                Resource: args.config.githubAppKmsKeyArn,
+                Condition: {
+                  StringEquals: {
+                    "kms:ViaService": pulumi.interpolate`ssm.${args.region}.amazonaws.com`,
+                    "kms:EncryptionContext:PARAMETER_ARN": [
+                      args.config.githubAppIdSsmParameterArn,
+                      args.config.githubAppKeyBase64SsmParameterArn,
+                    ],
+                  },
+                },
+              },
+            ],
+          }),
+        },
+        { parent: this }
+      );
+    }
 
     this.ssmParameters = controller.ssm_parameters;
     this.webhook = controller.webhook;

--- a/infra/test/CiFleetController.test.ts
+++ b/infra/test/CiFleetController.test.ts
@@ -265,10 +265,8 @@ describe("@beep/infra CiFleetController", () => {
       ]) {
         const policyName = `ci-fleet-controller-test-${functionName}-app-decrypt`;
         expect(MutableHashMap.get(rolePolicyRoles, policyName)).toEqual(O.some(`${functionName}-role`));
-        const document = MutableHashMap.get(policyDocuments, policyName);
-        assert.isTrue(O.isSome(document));
-        if (O.isSome(document)) {
-          expect(decodePolicyDocument(document.value)).toEqual(
+        expect(pipe(MutableHashMap.get(policyDocuments, policyName), O.map(decodePolicyDocument))).toEqual(
+          O.some(
             Result.succeed({
               Version: "2012-10-17",
               Statement: [
@@ -289,8 +287,8 @@ describe("@beep/infra CiFleetController", () => {
                 },
               ],
             })
-          );
-        }
+          )
+        );
       }
       expect(capturedMetadataOptions.value).toEqual({
         http_endpoint: "enabled",

--- a/infra/test/CiFleetController.test.ts
+++ b/infra/test/CiFleetController.test.ts
@@ -151,13 +151,21 @@ describe("@beep/infra CiFleetController", () => {
       const moduleMetadataOptions = MutableHashMap.empty<string, unknown>();
       const moduleOrganizationRunnerEnabled = MutableHashMap.empty<string, unknown>();
       const moduleRunnerGroupNames = MutableHashMap.empty<string, unknown>();
+      const moduleCapacityTypes = MutableHashMap.empty<string, unknown>();
+      const moduleRunnerCaps = MutableHashMap.empty<string, unknown>();
       const policyDocuments = MutableHashMap.empty<string, string>();
+      const rolePolicyRoles = MutableHashMap.empty<string, unknown>();
 
       yield* Effect.acquireUseRelease(
         Effect.tryPromise(() =>
           pulumi.runtime.setMocks(
             {
-              call: () => ({ accountId: "123456789012", partition: "aws" }),
+              call: (args) => {
+                if (args.token === "aws:lambda/getFunction:getFunction" && isString(args.inputs.functionName)) {
+                  return { role: `arn:aws:iam::123456789012:role/beep-ci/${args.inputs.functionName}-role` };
+                }
+                return { accountId: "123456789012", partition: "aws" };
+              },
               newResource: (args) => {
                 const postInstall = args.inputs.userdata_post_install;
                 if (args.type === "ghaRunners:index:Module" && isString(postInstall)) {
@@ -174,8 +182,14 @@ describe("@beep/infra CiFleetController", () => {
                     args.inputs.enable_organization_runners
                   );
                   MutableHashMap.set(moduleRunnerGroupNames, args.name, args.inputs.runner_group_name);
+                  MutableHashMap.set(moduleCapacityTypes, args.name, args.inputs.instance_target_capacity_type);
+                  MutableHashMap.set(moduleRunnerCaps, args.name, args.inputs.runners_maximum_count);
                 }
                 const policy = args.inputs.policy;
+                if (args.type === "aws:iam/rolePolicy:RolePolicy" && isString(policy)) {
+                  MutableHashMap.set(policyDocuments, args.name, policy);
+                  MutableHashMap.set(rolePolicyRoles, args.name, args.inputs.role);
+                }
                 if (args.type === "aws:iam/policy:Policy" && isString(policy)) {
                   MutableHashMap.set(policyDocuments, args.name, policy);
                   return {
@@ -202,7 +216,7 @@ describe("@beep/infra CiFleetController", () => {
                   amiId: "ami-07a5b367e8dc8bd92",
                 })
               ),
-              region: "us-east-1",
+              region: pulumi.output("us-east-1"),
               subnetIds: ["subnet-abc"],
               vpcId: "vpc-123",
               workerSecurityGroupId: "sg-456",
@@ -241,6 +255,43 @@ describe("@beep/infra CiFleetController", () => {
       expect(capturedManagedPolicyArns.value).toEqual(["arn:aws:iam::123456789012:policy/beep-ci-runner-imds-disable"]);
       expect(capturedOrganizationRunnerEnabled.value).toBe(true);
       expect(capturedRunnerGroupName.value).toBe("beep-ec2-heavy");
+      expect(MutableHashMap.get(moduleCapacityTypes, "ci-fleet-controller-test")).toEqual(O.some("on-demand"));
+      expect(MutableHashMap.get(moduleRunnerCaps, "ci-fleet-controller-test")).toEqual(O.some(14));
+      expect(MutableHashMap.size(rolePolicyRoles)).toBe(3);
+      for (const functionName of [
+        "beep-ci-spot-termination-notification",
+        "beep-ci-spot-termination-handler",
+        "beep-ci-deregister-retry",
+      ]) {
+        const policyName = `ci-fleet-controller-test-${functionName}-app-decrypt`;
+        expect(MutableHashMap.get(rolePolicyRoles, policyName)).toEqual(O.some(`${functionName}-role`));
+        const document = MutableHashMap.get(policyDocuments, policyName);
+        assert.isTrue(O.isSome(document));
+        if (O.isSome(document)) {
+          expect(decodePolicyDocument(document.value)).toEqual(
+            Result.succeed({
+              Version: "2012-10-17",
+              Statement: [
+                {
+                  Sid: "DecryptGitHubAppParametersThroughSsm",
+                  Effect: "Allow",
+                  Action: "kms:Decrypt",
+                  Resource: validConfigValues.githubAppKmsKeyArn,
+                  Condition: {
+                    StringEquals: {
+                      "kms:ViaService": "ssm.us-east-1.amazonaws.com",
+                      "kms:EncryptionContext:PARAMETER_ARN": [
+                        validConfigValues.githubAppIdSsmParameterArn,
+                        validConfigValues.githubAppKeyBase64SsmParameterArn,
+                      ],
+                    },
+                  },
+                },
+              ],
+            })
+          );
+        }
+      }
       expect(capturedMetadataOptions.value).toEqual({
         http_endpoint: "enabled",
         http_put_response_hop_limit: 1,


### PR DESCRIPTION
Repeated Spot capacity sweeps killed heavy verification jobs across both availability zones, including Check, Coverage Regression, and Lint Policy. AWS recorded `instance-terminated-no-capacity`; GitHub reported the losses roughly 11 minutes later. Keep the existing heavy pool permanently On-Demand, as requested by the operator, with its 14-instance cap and ephemeral teardown unchanged.

Also repair termination cleanup: the pinned runner module grants SSM reads without the customer-managed KMS access its GitHub App credentials require. Add six KMS-key grants: one exact App parameter encryption context for each of the three cleanup roles, with only Decrypt permitted. Include each role's immutable IAM ID in grant names so same-name role replacement renews access. Grants live on the key and do not attach external policies that could block module-owned role deletion. Lambda discovery and grants explicitly use the controller region. KMS grants cannot enforce ViaService, so matching parameter ciphertext can also be decrypted directly.

The existing `job_retry` option only rescues queued jobs and was already enabled; it cannot resume a job lost mid-execution. A second pool would leave the observed short-lane reclamations exposed. The runbook and original time-to-certainty receipt record the evidence and deployment sequence. Merged current main while preserving its adjacent scheduler receipt; both review findings are addressed in e2a3e2faf4.

Validation:

- `bun run beep quality package-verify @beep/infra`: audit, tests, and docgen passed.
- Pulumi mocks verify Output-valued regional inputs, On-Demand capacity, cap 14, six exact grant scopes, immutable role IDs, and absence of external role policies.
- Focused Fallow audit and health checks passed with no findings.
- Initial production apply: On-Demand plus three interim policies; 3 additions, 2 controller updates, no deletions; follow-up preview: 198 unchanged. All 12 IAM simulations matched their expected results, and CloudTrail confirmed real SSM reads with decryption by the previously failing cleanup role.
- Attended grant migration completed: created 6 grants, verified exact scopes, allowed five minutes for propagation, then removed the 3 initial policies at 09:56:32 UTC. The final no-change preview reports 201 unchanged resources. CloudTrail recorded successful SSM reads with decryption and KMS Decrypt events for both App parameters at 09:57:25 UTC, after policy removal; natural cleanup reached GitHub successfully. IAM simulations above describe the initial policies, not the replacement grants.
- New On-Demand workers passed [Fleet Shadow Check](https://github.com/beep-effect/beep-effect/actions/runs/34333728712) and [Heavy / Docgen](https://github.com/beep-effect/beep-effect/actions/runs/34332600371/job/102408052217); the probe worker terminated normally.
- The final-head [Check workflow](https://github.com/beep-effect/beep-effect/actions/runs/34337783466) passed, including all six heavy lanes on AWS-confirmed On-Demand workers. Review threads are resolved and Greptile reported 5/5. The remaining Vercel todox status was the repository-allowed build rate limit. Full local Yeet proof remained queued behind existing admitted runs; it was stopped after the operator merged the PR and is not claimed as a completed local proof.

On-Demand increases running-hour cost. At deployment, the allowed instance choices were $0.504–$0.92736/hour in us-east-1, excluding storage and networking; actual new workers selected r6i.2xlarge at $0.504/hour. The cap limits concurrency, not a monthly budget.

Merged by the operator as `de84d4218e935d1dae6519a9d537ba9468b18eff`. The merged infrastructure source matches the deployed configuration.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1050"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791537748&installation_model_id=424656&pr_number=1050&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1050&signature=edf2b9304b5aec1890b5b8fb24a968f19880f4f390d2aa0f25eba9b0f435708f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

---

<!-- yeet-provenance:start -->
## Provenance

- Workspace: <code>beep-effect</code>
- Branch: <code>codex/ci-runner-permanent-reliability</code>
- Agents (newest first):
  - `codex` (tui) · `unknown` · monitored

Resume the publishing agent from any beep-effect checkout on the publishing workstation:

```sh
bun run beep yeet resume 1050
```

<!-- yeet-provenance
{
  "schemaVersion": 2,
  "pr": 1050,
  "branch": "codex/ci-runner-permanent-reliability",
  "workspace": "beep-effect",
  "agents": [
    {
      "harness": "codex",
      "entrypoint": "codex-tui",
      "hostHarness": null,
      "model": "unknown",
      "label": null,
      "workspace": null,
      "role": "monitored"
    }
  ]
}
-->
<!-- yeet-provenance:end -->
