### PR TITLE
fix(repo-cli): ratchet JSDoc metadata in the full docgen proof

### DIFF
--- a/.changeset/docgen-full-proof-metadata-ratchet.md
+++ b/.changeset/docgen-full-proof-metadata-ratchet.md
@@ -1,0 +1,11 @@
+---
+"@beep/repo-cli": patch
+"@beep/utils": patch
+"@beep/test-utils": patch
+---
+
+Ratchet JSDoc metadata (required tags and canonical `@category` values) in the
+full docgen proof so the main-branch `Heavy / Docgen` run enforces the same
+check the PR-mode `docgen:local` run applies, fix the three inherited
+re-export findings that check now surfaces, and rename the remaining internal
+`@category rendering` tags to `formatting`.

--- a/packages/foundation/modeling/utils/src/Data.ts
+++ b/packages/foundation/modeling/utils/src/Data.ts
@@ -10,15 +10,7 @@
  */
 
 /**
- * Re-exports the `effect/Data` constructors and tagged-value helpers.
- *
- * **Example** (Import the re-exported module)
- *
- * ```ts
- * import * as Data from "@beep/utils/Data"
- *
- * console.log(Data)
- * ```
+ * `effect/Data` constructors and tagged-value helpers.
  *
  * @category models
  * @since 0.0.0

--- a/packages/foundation/modeling/utils/src/Data.ts
+++ b/packages/foundation/modeling/utils/src/Data.ts
@@ -9,4 +9,18 @@
  * @since 0.0.0
  */
 
+/**
+ * Re-exports the `effect/Data` constructors and tagged-value helpers.
+ *
+ * **Example** (Import the re-exported module)
+ *
+ * ```ts
+ * import * as Data from "@beep/utils/Data"
+ *
+ * console.log(Data)
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
 export * from "effect/Data";

--- a/packages/tooling/test-kit/test-utils/src/ConformanceLedger/index.ts
+++ b/packages/tooling/test-kit/test-utils/src/ConformanceLedger/index.ts
@@ -5,6 +5,12 @@
  * @since 0.0.0
  */
 
+/**
+ * Conformance ledger validation helper exports.
+ *
+ * @category testing
+ * @since 0.0.0
+ */
 export {
   validateConformanceAnnotationAgainstLedgerArtifacts,
   validateConformanceLedgerArtifacts,

--- a/packages/tooling/test-kit/test-utils/src/MemoryFileSystem/index.ts
+++ b/packages/tooling/test-kit/test-utils/src/MemoryFileSystem/index.ts
@@ -5,4 +5,10 @@
  * @since 0.0.0
  */
 
+/**
+ * In-memory filesystem layer and constructor exports.
+ *
+ * @category testing
+ * @since 0.0.0
+ */
 export { layer, make } from "./MemoryFileSystem.test-kit.ts";

--- a/packages/tooling/tool/cli/src/commands/Docgen/internal/Local.ts
+++ b/packages/tooling/tool/cli/src/commands/Docgen/internal/Local.ts
@@ -11,7 +11,7 @@ import { DomainError, findRepoRoot } from "@beep/repo-utils";
 import { LiteralKit } from "@beep/schema";
 import { UnknownFromJsonString } from "@beep/schema/Unknown";
 import { A, Str } from "@beep/utils";
-import { Console, Duration, Effect, flow, HashSet, Order, pipe } from "effect";
+import { Console, Duration, Effect, flow, HashSet, Order, pipe, Result } from "effect";
 import { dual } from "effect/Function";
 import * as O from "effect/Option";
 import * as P from "effect/Predicate";
@@ -66,6 +66,7 @@ export const renderDocgenIssueText: {
 const DEFAULT_LOCAL_PARALLEL = 1 as const;
 const DOCGEN_FULL_COMMAND = "bun run docgen" as const;
 const DOCGEN_FULL_AGGREGATE_ARGS = ["run", "docs:aggregate"] as const;
+const DOCGEN_FULL_METADATA_CHECK_SCOPE = "every package with a canonical docgen.json outDir" as const;
 const DOCGEN_LOCAL_PACKAGE_INPUT_EXTENSIONS = [".ts", ".tsx", ".mts", ".cts", ".md", ".mdx"] as const;
 const DOCGEN_LOCAL_PACKAGE_INPUT_PREFIXES = ["src/", "docs/"] as const;
 const DOCGEN_LOCAL_PACKAGE_INPUT_FILES = [
@@ -831,6 +832,7 @@ const renderPlan = Effect.fn("DocgenLocal.renderPlan")(function* (plan: DocgenLo
   if (plan.mode === "full") {
     yield* Console.log(`- full turbo command: node_modules/.bin/turbo ${A.join(fullTurboArgs(plan.parallel), " ")}`);
     yield* Console.log(`- full aggregate command: bun ${A.join(DOCGEN_FULL_AGGREGATE_ARGS, " ")}`);
+    yield* Console.log(`- full JSDoc metadata check: ${DOCGEN_FULL_METADATA_CHECK_SCOPE}`);
   }
   if (A.isReadonlyArrayNonEmpty(plan.fullReasons)) {
     yield* Console.log(`- full proof required:\n${renderFullReasons(plan.fullReasons)}`);
@@ -953,7 +955,42 @@ const verifyPackageProofManifest = (pkg: DocgenWorkspacePackage) =>
     )
   );
 
+type DocgenConfiguredPackage = readonly [pkg: DocgenWorkspacePackage, config: DocgenConfigDocument];
+
+const loadConfiguredPackage = (pkg: DocgenWorkspacePackage) =>
+  loadDocgenConfigDocument(pkg.absolutePath).pipe(Effect.map((config): DocgenConfiguredPackage => [pkg, config]));
+
+const canonicalConfigResult = ([pkg, config]: DocgenConfiguredPackage): Result.Result<
+  DocgenWorkspacePackage,
+  DocgenConfiguredPackage
+> => (isCanonicalDocgenAggregateConfigForTesting(config) ? Result.succeed(pkg) : Result.fail([pkg, config]));
+
+const logSkippedMetadataCheck = ([pkg, config]: DocgenConfiguredPackage) =>
+  Console.log(`docgen:local: skipped JSDoc metadata check for ${pkg.name} (non-canonical outDir: ${config.outDir})`);
+
+// The full proof ratchets every package whose generated docs are aggregated
+// into docs/generated, which is also the population the scoped planner can
+// select. A non-canonical outDir (the scratchpad's focused quality-analysis
+// output) is skipped exactly as the aggregate step skips it. Proof manifests
+// are deliberately not consulted: they prove generation, not metadata, and
+// generation alone let an unknown @category merge on main (#1054) that only
+// the next PR's scoped check paid for (#1057).
+const discoverFullMetadataCheckPackages = Effect.fn("DocgenLocal.discoverFullMetadataCheckPackages")(function* (
+  parallel: number
+) {
+  const packages = yield* discoverConfiguredPackages();
+  const configured = yield* Effect.forEach(packages, loadConfiguredPackage, { concurrency: localParallel(parallel) });
+  const [skipped, checked] = A.partition(configured, canonicalConfigResult);
+  yield* Effect.forEach(skipped, logSkippedMetadataCheck, { discard: true });
+  return checked;
+});
+
 const runFullDocgen = Effect.fn("DocgenLocal.runFullDocgen")(function* (repoRoot: string, parallel: number) {
+  // The scoped proof ratchets JSDoc metadata before it generates; the full
+  // proof must too, or main merges debt that only the next PR pays for.
+  const packages = yield* discoverFullMetadataCheckPackages(parallel);
+  yield* Console.log(`docgen:local: checking JSDoc metadata for ${A.length(packages)} package(s)`);
+  yield* checkPackageDocumentation(packages, parallel);
   // Run Turbo directly so the typed lane concurrency setting governs full and
   // affected proofs through the same local command surface. The full budget is
   // much larger because a cold full proof legitimately runs for tens of minutes.

--- a/packages/tooling/tool/cli/src/commands/Quality/internal/CoverageRegression.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/internal/CoverageRegression.ts
@@ -2556,7 +2556,7 @@ const failurePackageNames = (failures: ReadonlyArray<CoverageComparisonFailure>)
  *
  * @param result - Comparison result the ratchet is about to enforce.
  * @returns Remediation lines, empty when no package floor regressed.
- * @category rendering
+ * @category formatting
  * @since 0.0.0
  */
 export const renderCoverageRemediation = (result: CoverageComparisonResult): ReadonlyArray<string> => [

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Sweep.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Sweep.ts
@@ -1389,7 +1389,7 @@ const operatorCommands = (report: SweepReport): ReadonlyArray<string> =>
  *
  * @param report - Executed sweep report to render.
  * @returns Multi-line operator summary, ending with the handoff block when one is needed.
- * @category rendering
+ * @category formatting
  * @since 0.0.0
  */
 export const renderSweepReport = (report: SweepReport): string => {

--- a/packages/tooling/tool/cli/test/docgen.test.ts
+++ b/packages/tooling/tool/cli/test/docgen.test.ts
@@ -275,6 +275,30 @@ const seedDocgenPackage = Effect.fn("DocgenTest.seedDocgenPackage")(function* ()
 const schemaPackageSourcePath = (path: Path.Path): string =>
   path.join(process.cwd(), "packages", "foundation", "modeling", "schema", "src", "index.ts");
 
+const invalidCategorySource = `/**
+ * Probe module carrying an unknown category tag.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+/**
+ * Renders probe lines.
+ *
+ * **Example** (Render probe lines)
+ *
+ * \`\`\`ts
+ * import { renderProbeLines } from "@beep/schema"
+ *
+ * console.log(renderProbeLines())
+ * \`\`\`
+ *
+ * @category rendering
+ * @since 0.0.0
+ */
+export const renderProbeLines = (): ReadonlyArray<string> => [];
+`;
+
 const writeSchemaTsconfig = Effect.fn("DocgenTest.writeSchemaTsconfig")(function* () {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
@@ -1023,6 +1047,7 @@ export const ProofFixture = 1;
             )
           );
           expect(output).toContain("- full aggregate command: bun run docs:aggregate");
+          expect(output).toContain("- full JSDoc metadata check: every package with a canonical docgen.json outDir");
         })
       )
     )
@@ -1091,6 +1116,86 @@ export const ProofFixture = 1;
           "bun run docs:aggregate",
         ]);
       })
+    );
+  });
+
+  it.effect("fails full docgen on invalid JSDoc metadata before spawning Turbo", () => {
+    const spawned = A.empty<string>();
+    return withTempRepo(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        yield* seedDocgenPackage();
+        yield* fs.writeFileString(schemaPackageSourcePath(path), invalidCategorySource);
+
+        const exit = yield* Effect.exit(
+          runDocgenLocal({
+            allowFull: false,
+            base: "origin/main",
+            full: true,
+            head: "HEAD",
+            json: false,
+            packageSelector: O.some("@beep/schema"),
+            parallel: 6,
+            plan: false,
+          }).pipe(provideScopedLayer(recordingSpawnerLayer(spawned)))
+        );
+
+        expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isFailure(exit)) {
+          expect(Cause.squash(exit.cause)).toMatchObject({
+            _tag: "DomainError",
+            message: "docgen:local JSDoc check failed for 1 package(s).",
+          });
+        }
+        expect(spawned).toEqual([]);
+        const errors = A.join(A.filter(yield* TestConsole.errorLines, isString), "\n");
+        expect(errors).toContain(
+          "docgen:local: packages/foundation/modeling/schema has 1 export(s) missing docgen metadata"
+        );
+        expect(errors).toContain("renderProbeLines invalid category: Unknown @category value rendering.");
+      }).pipe(provideScopedLayer(TestConsole.layer))
+    );
+  });
+
+  it.effect("skips the full JSDoc metadata check for packages with a non-canonical docgen outDir", () => {
+    const spawned = A.empty<string>();
+    return withTempRepo(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        yield* seedDocgenPackage();
+        const probeDir = path.join(process.cwd(), "packages", "foundation", "modeling", "probe");
+        yield* fs.makeDirectory(path.join(probeDir, "src"), { recursive: true });
+        yield* fs.writeFileString(
+          path.join(probeDir, "package.json"),
+          encodeJson({ name: "@beep/probe", version: "0.0.0" })
+        );
+        yield* fs.writeFileString(
+          path.join(probeDir, "docgen.json"),
+          encodeJson({ srcDir: "src", outDir: ".jsdoc-loop/generated-docs" })
+        );
+        yield* fs.writeFileString(path.join(probeDir, "src", "index.ts"), invalidCategorySource);
+
+        const plan = yield* runDocgenLocal({
+          allowFull: false,
+          base: "origin/main",
+          full: true,
+          head: "HEAD",
+          json: false,
+          packageSelector: O.some("@beep/schema"),
+          parallel: 6,
+          plan: false,
+        }).pipe(provideScopedLayer(recordingSpawnerLayer(spawned)));
+
+        expect(plan.mode).toBe("full");
+        expect(A.length(spawned)).toBe(2);
+        const logs = A.join(A.filter(yield* TestConsole.logLines, isString), "\n");
+        expect(logs).toContain(
+          "docgen:local: skipped JSDoc metadata check for @beep/probe (non-canonical outDir: .jsdoc-loop/generated-docs)"
+        );
+        expect(logs).toContain("docgen:local: checking JSDoc metadata for 1 package(s)");
+      }).pipe(provideScopedLayer(TestConsole.layer))
     );
   });
 


### PR DESCRIPTION
## fix(repo-cli): ratchet JSDoc metadata in the full docgen proof

The hosted Heavy / Docgen check runs two programs: pull requests run
`docgen:local`, which checks required JSDoc tags and canonical @category
values for the selected packages before generating, while pushes to main run
`bun run docgen` (`docgen local --full`), whose `runFullDocgen` only ran the
Turbo docgen tasks and the aggregate. The repo-docgen generator never
validates @category, so main merged `@category rendering` (#1054) green and
the next PR touching @beep/repo-cli paid for it (#1057).

The full proof now discovers every configured package, skips the ones whose
docgen.json points at a non-canonical outDir (the scratchpad's focused
quality-analysis output, which the aggregate step already skips), and runs
the same `checkPackageDocumentation` ratchet before Turbo starts. Proof
manifests are deliberately not consulted: they prove generation, not
metadata. The plan output names the check, and two tests cover the fail-fast
(no Turbo spawn on an unknown category) and the non-canonical skip.

Turning the check on for main surfaces three inherited bare re-exports that
no PR had selected yet; they are fixed here so main stays green after merge:
`@beep/utils` `Data.ts` and the two `@beep/test-utils` subpath index files.
The two remaining internal `@category rendering` tags (Sweep.ts,
CoverageRegression.ts) are renamed to `formatting` to match the #1057 choice.

Local proof: `bun run beep ci lane docgen --mode full` on a tree that
reintroduces `@category rendering` in CheckCensus.ts now fails in ~100s at
the metadata check across 129 packages, before Turbo is spawned.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

## Root cause

`Heavy / Docgen` runs two programs. Pull requests run `ci lane docgen --mode auto`, which selects `docgen:local` (`runScopedDocgen`) and calls `checkPackageDocumentation` (required tags + canonical `@category`) on the selected packages before Turbo. Pushes to `main` run `--mode full`, i.e. `bun run docgen` = `beep docgen local --full` = `runFullDocgen`, which only ran `turbo run docgen` and `docs:aggregate`. The `@beep/repo-docgen` generator never validates `@category`, so `@category rendering` merged green in #1054 and the next PR touching `@beep/repo-cli` (#1057) paid for it.

## Fix

`runFullDocgen` now discovers every configured package, skips the ones whose `docgen.json` has a non-canonical `outDir` (only `scratchpad`, whose focused quality-analysis output the aggregate step already skips and which carries ~4,240 findings), and runs the same ratchet before Turbo starts. Proof manifests are deliberately not consulted: they prove generation, not metadata. The plan output names the check. `CiLane.ts` needs no change: the lane already routes full mode through the root `docgen` script.

Turning the check on for `main` surfaced three inherited bare re-exports that no PR had selected yet (`@beep/utils` `Data.ts`, the two `@beep/test-utils` subpath `index.ts` files); they are fixed here so `main` stays green after merge. The two remaining internal `@category rendering` tags (`Sweep.ts`, `CoverageRegression.ts`) are renamed to `formatting` to match the #1057 choice. The `docgen.json` exclude list still hides ~45 other non-canonical categories in `src/**/internal/**`; that is a separate cleanup, not started here.

## Proof

Red (tree with `@category rendering` reintroduced in `CheckCensus.ts`):

```
$ bun run beep ci lane docgen --mode full
- full JSDoc metadata check: every package with a canonical docgen.json outDir
docgen:local: skipped JSDoc metadata check for @beep/scratchpad (non-canonical outDir: .jsdoc-loop/generated-docs)
docgen:local: checking JSDoc metadata for 129 package(s)
docgen:local: packages/tooling/tool/cli has 1 export(s) missing docgen metadata
  src/commands/Quality/CheckCensus.ts:542 renderCheckCensusLines invalid category: Unknown @category value rendering.
docgen: docgen:local JSDoc check failed for 1 package(s).
[beep-cli] ci:docgen: failed in 100603ms
```

Turbo is never spawned on the red path. On the clean tree the same command passes the check for all 129 packages and completes end to end (`Tasks: 133 successful, 133 total`, `[beep-cli] ci:docgen: ok in 299688ms`).

Tests: `test/docgen.test.ts` 80/80 on Bun and the four full-mode cases on Node; `@beep/repo-cli` typecheck green; `beep docgen check --package` green for `@beep/utils`, `@beep/test-utils`, `@beep/repo-cli`.

This PR touches `commands/Docgen/`, so its own hosted `Heavy / Docgen` run resolves to full mode and exercises the new check across the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/claude_unruffled-gates-b2c071-73636bfca0fb/verdict.json

---

<!-- yeet-provenance:start -->
## Provenance

- Workspace: <code>beep-effect6</code>
- Branch: <code>claude/unruffled-gates-b2c071</code>
- Agents (newest first):
  - `claude-code` (desktop) · `claude-fable-5-1` · <code>unruffled-gates-b2c071-59</code> · pushed

Resume the publishing agent from any beep-effect checkout on the publishing workstation:

```sh
bun run beep yeet resume 1061
```

<!-- yeet-provenance
{
  "schemaVersion": 2,
  "pr": 1061,
  "branch": "claude/unruffled-gates-b2c071",
  "workspace": "beep-effect6",
  "agents": [
    {
      "harness": "claude-code",
      "entrypoint": "claude-desktop",
      "hostHarness": null,
      "model": "claude-fable-5-1",
      "label": "unruffled-gates-b2c071-59",
      "workspace": null,
      "role": "pushed"
    }
  ]
}
-->
<!-- yeet-provenance:end -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1061"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791563387&installation_model_id=424656&pr_number=1061&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1061&signature=bfdee3c020c5ab6ff5852fff0448db2dec19982bf733650384ea108c79541226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
