### PR TITLE
perf(ci): refresh runner image without slow cache restores

### DIFF
--- a/.changeset/runner-toolchain-cache-cost.md
+++ b/.changeset/runner-toolchain-cache-cost.md
@@ -1,0 +1,7 @@
+---
+"@beep/repo-cli": patch
+---
+
+Stop baking and restoring the runner dependency-cache archive after timed EC2
+probes showed its verification and extraction cost more than a fresh frozen
+install. Preserve the baked Bun toolchain's integrity and freshness checks.

--- a/.changeset/runner-toolchain-cache-cost.md
+++ b/.changeset/runner-toolchain-cache-cost.md
@@ -1,7 +1,9 @@
 ---
 "@beep/repo-cli": patch
+"@beep/infra": patch
 ---
 
 Stop baking and restoring the runner dependency-cache archive after timed EC2
 probes showed its verification and extraction cost more than a fresh frozen
 install. Preserve the baked Bun toolchain's integrity and freshness checks.
+Pin the validated lean Bun 1.4.2 image for the attended production rollout.

--- a/.github/actions/setup-monorepo-ci/action.yml
+++ b/.github/actions/setup-monorepo-ci/action.yml
@@ -152,27 +152,24 @@ runs:
     - name: Detect baked runner
       id: baked
       shell: bash
-      # A `beep runners bake` image ships the Bun toolchain and a warmed
-      # package store, stamped with the lockfile sha, the Bun version, the
-      # verified Bun archive sha, and digests for the installed Bun binary and
-      # sealed package-store archive. The fast path activates only when the
-      # checkout keys match and both root-owned artifacts match their digests.
+      # A `beep runners bake` image ships the Bun toolchain, stamped with the
+      # lockfile sha, Bun version, verified release archive sha and installed
+      # binary digest. The fast path activates only when the checkout keys
+      # match and the root-owned executable matches its digest.
       # Any missing marker or mismatch fails open into the ordinary setup path.
       run: |
         set -euo pipefail
         hit=false
-        # Never trust a writable cache inherited from the image or an earlier
-        # step. A valid baked image restores it from the authenticated archive.
+        # Always discard inherited dependency caches. Restoring the measured
+        # 1.35 GB baked archive cost more time than a fresh frozen install.
         rm -rf -- "${HOME:?}/.bun/install/cache"
         if [ -f /etc/beep-ci/baked-runner ] \
           && [ -f /etc/beep-ci/bun-lock.sha256 ] \
           && [ -f /etc/beep-ci/bun-version ] \
           && [ -f /etc/beep-ci/bun-archive.sha256 ] \
           && [ -f /etc/beep-ci/bun-binary.sha256 ] \
-          && [ -f /etc/beep-ci/bun-install-cache.sha256 ] \
           && [ -x /usr/local/bin/bun ] \
-          && [ -L /usr/local/bin/bunx ] \
-          && [ -f /opt/beep-ci/bun-install-cache.tgz ]; then
+          && [ -L /usr/local/bin/bunx ]; then
           baked_lock="$(cat /etc/beep-ci/bun-lock.sha256)"
           checkout_lock="$(sha256sum bun.lock | cut -d ' ' -f 1)"
           baked_bun="$(cat /etc/beep-ci/bun-version)"
@@ -181,24 +178,17 @@ runs:
           checkout_archive="$(tr -d '[:space:]' < .bun-linux-x64.sha256)"
           baked_binary="$(cat /etc/beep-ci/bun-binary.sha256)"
           installed_binary="$(sha256sum /usr/local/bin/bun | cut -d ' ' -f 1)"
-          baked_cache="$(cat /etc/beep-ci/bun-install-cache.sha256)"
-          installed_cache="$(sha256sum /opt/beep-ci/bun-install-cache.tgz | cut -d ' ' -f 1)"
           bun_owner_mode="$(stat -c '%u:%g:%a' /usr/local/bin/bun)"
-          cache_owner_mode="$(stat -c '%u:%g:%a' /opt/beep-ci/bun-install-cache.tgz)"
           bunx_target="$(readlink /usr/local/bin/bunx)"
           if [ "$baked_lock" = "$checkout_lock" ] \
             && [ "$baked_bun" = "$checkout_bun" ] \
             && [ "$baked_archive" = "$checkout_archive" ] \
             && [ "$baked_binary" = "$installed_binary" ] \
-            && [ "$baked_cache" = "$installed_cache" ] \
             && [ "$bun_owner_mode" = "0:0:755" ] \
-            && [ "$cache_owner_mode" = "0:0:444" ] \
             && [ "$bunx_target" = "bun" ]; then
-            install -d -m 0755 "$HOME/.bun/install"
-            tar -xzf /opt/beep-ci/bun-install-cache.tgz -C "$HOME/.bun/install"
             hit=true
             echo "/usr/local/bin" >> "$GITHUB_PATH"
-            echo "baked runner fast path: bun $baked_bun, binary $baked_binary, lockfile $baked_lock, archive $baked_archive, cache $baked_cache"
+            echo "baked runner fast path: bun $baked_bun, binary $baked_binary, lockfile $baked_lock, archive $baked_archive"
           else
             echo "baked runner stale or failed integrity checks; using full setup"
           fi

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -89,7 +89,14 @@ jobs:
 
       - name: Install Playwright Chromium
         if: steps.lane-gate.outputs.should_run == 'true'
-        run: bunx playwright install --with-deps chromium
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Playwright downloads its own Chromium. The hosted image's unused
+          # Chrome feed can break apt update with inconsistent package hashes.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome*.list \
+            /etc/apt/sources.list.d/google-chrome*.sources
+          bunx playwright install --with-deps chromium
 
       - name: Save Playwright Chromium cache
         if: steps.lane-gate.outputs.should_run == 'true' && github.event_name == 'push' && steps.playwright-cache-restore.outputs.cache-hit != 'true'

--- a/docs/runbooks/aws-cost-operations.md
+++ b/docs/runbooks/aws-cost-operations.md
@@ -191,10 +191,10 @@ changed enrollment or a clean no-change preview. Revisit it when the provider
 supports this readback; do not repeatedly apply merely to clear the preview.
 
 For image freshness, reuse the freshness fields of the existing `BakeReport`
-as a tracked intended-image receipt. `infra/ci-runners/runner-image.json` was
-initialized from the current AMI's AWS tags on September 9. It records Bun 1.4.0
-and correctly reports stale against the checkout; it does not claim a new bake.
-The reader also accepts the complete report written by a future successful bake. The existing runner check compares that receipt with Bun,
+as a tracked intended-image receipt. `infra/ci-runners/runner-image.json` now
+records the September 9 Bun 1.4.2 bake and its intended production pin. It
+supersedes the initial receipt copied from the stale Bun 1.4.0 image's tags.
+The existing runner check compares that receipt with Bun,
 archive and lockfile keys plus the intended Pulumi AMI pin without AWS access.
 Emit an advisory warning in the existing hosted Repo Sanity job, outside the
 heavy dependency chain. This warns about intended-image drift; the live AWS
@@ -215,13 +215,22 @@ release digest, installed-binary digest, root ownership, version and lockfile
 checks remain required. Intended-image freshness alone is not a performance
 receipt.
 
-The modified setup path then passed on a fresh instance in 20 seconds, including
-a 9-second frozen install, versus the isolated baseline's 18 seconds. This
-removes the measured archive regression. It does not establish a hosted speedup:
-GitHub cache/action overhead and a complete production workflow remain part of
-the attended activation check. The baseline Check lane passed in 739 seconds,
-with a 10.36 GiB peak in 15-second VM-memory samples; this is not sufficient
-evidence to downsize every heavy lane.
+The modified setup path first passed on a fresh instance in 20 seconds, including
+a 9-second frozen install, versus the isolated baseline's 18 seconds. Baking
+without the archive then reduced the candidate's full snapshot data from
+8.024 GiB to 2.350 GiB. The resulting image passed the same setup detector in
+11 seconds, including a 9-second install, and confirmed that no dependency
+archive exists. Its full Check lane passed all 246 tasks in 541 seconds.
+
+These results remove the measured archive regression. They do not establish a
+hosted speedup: GitHub cache/action overhead and a complete production workflow
+remain part of the attended activation check. The final canary uses source
+`b9b6faa5a2`, which includes the newer Check overlay fix from PR #1058. Its
+541-second Check cannot be attributed to the image by comparison with the
+739-second baseline on `a2030c8bd9`. The matched original candidate passed in
+753 seconds on that earlier source. The final canary's peak VM-memory sample
+was 11.61 GiB, sampled every 15 seconds; this is not sufficient evidence to
+downsize every heavy lane.
 
 Repair the retired teardown script so it cannot terminate builders or current
 controller workers. Supersede historical Spot and $100 ceiling instructions at
@@ -446,13 +455,28 @@ The image refresh follows a separate validation and activation sequence:
 3. Keep these probes isolated from GitHub runner registration and both GitHub
    and remote Turbo caches. Their setup measurements compare the image paths;
    they do not establish hosted queue time or account-wide savings. Each guest
-   has a 40-minute termination backstop and a bounded verification command.
+   has a 40-minute shutdown backstop and a bounded verification command.
+   Stop the guest, capture its terminal console marker, then terminate it and
+   verify termination. Console output can lag shutdown and regress to an older
+   capture; retain the most complete result and bound the capture wait. The
+   September 9 final probe allowed 20 minutes after stop before cleanup.
 4. Review the intended manifest, AMI pin and refreshed Pulumi preview. Apply
    the saved plan only with the operator present. Prove the live SSM pin and
    run the existing Fleet Lane Probe on a newly launched production worker.
    Require a baked fast-path hit and successful verification before calling
    activation validated. Retain the old image until rollback is no longer
    needed.
+
+The September 9 replacement image is `ami-07af50c345b5ba065`, baked from pushed
+source `b9b6faa5a2`; the rollback image is `ami-0738c1b69711969bc`. The isolated
+probe passed and its guest and both builders were verified terminated. The
+refreshed full preview contains only the intended SSM image update and the
+previously documented Cost Optimization Hub provider discrepancy. The saved
+image-only plan targets `ci-fleet-controller-runner-ami`: one update, 83 unchanged
+resources, no replacements or deletions. It excludes the unrelated enrollment
+update. The intended pin is committed for review; production activation and
+the hosted Fleet Lane Probe still require the attended rollout. A passing
+isolated probe does not establish that production uses the new image.
 
 ## Current stack ownership and bounded operations
 

--- a/docs/runbooks/aws-cost-operations.md
+++ b/docs/runbooks/aws-cost-operations.md
@@ -462,10 +462,17 @@ The image refresh follows a separate validation and activation sequence:
    September 9 final probe allowed 20 minutes after stop before cleanup.
 4. Review the intended manifest, AMI pin and refreshed Pulumi preview. Apply
    the saved plan only with the operator present. Prove the live SSM pin and
-   run the existing Fleet Lane Probe on a newly launched production worker.
-   Require a baked fast-path hit and successful verification before calling
-   activation validated. Retain the old image until rollback is no longer
-   needed.
+   verify a newly launched production worker. Before merge, use the PR's
+   required Heavy / Check job: `check.yml` calls the approved reusable
+   `heavy.yml@main` definition while checking out the PR source. Correlate its
+   GitHub runner name with the EC2 image ID, then require a baked fast-path hit
+   and successful verification. Retain the old image for rollback.
+5. Fleet Lane Probe must be dispatched from `main`. The runner group restricts
+   allowed workflow definitions to that ref. A feature-branch dispatch can
+   reach the controller queue yet remain ineligible for assignment; do not
+   mistake that for a launch failure or relax the group restriction. Use this
+   probe after merge to verify deployed main, and inspect the group's allowed
+   workflow refs before choosing another dispatch ref.
 
 The September 9 replacement image is `ami-07af50c345b5ba065`, baked from pushed
 source `b9b6faa5a2`; the rollback image is `ami-0738c1b69711969bc`. The isolated
@@ -474,9 +481,12 @@ refreshed full preview contains only the intended SSM image update and the
 previously documented Cost Optimization Hub provider discrepancy. The saved
 image-only plan targets `ci-fleet-controller-runner-ami`: one update, 83 unchanged
 resources, no replacements or deletions. It excludes the unrelated enrollment
-update. The intended pin is committed for review; production activation and
-the hosted Fleet Lane Probe still require the attended rollout. A passing
-isolated probe does not establish that production uses the new image.
+update. The operator-approved apply completed at 17:49 UTC with exactly those
+changes. A direct AWS read confirmed the new image at SSM version 8; the live
+image check confirmed matching Bun, release-archive and lockfile keys. Save
+the hosted job's image identity, setup result and successful Check receipt in
+the rollout PR before declaring the activation validated. A matching manifest
+alone does not establish that production uses the new image.
 
 ## Current stack ownership and bounded operations
 

--- a/docs/runbooks/aws-cost-operations.md
+++ b/docs/runbooks/aws-cost-operations.md
@@ -367,10 +367,35 @@ minutes per successful lane, accounting for interruption waivers, setup,
 retries and idle cleanup, alongside queue and completion times. Spot remains
 the likely lower compute bill at the observed prices. The current decision
 remains On-Demand because the operator prioritizes reliability and speed.
-The next experiments are a fresh baked AMI and lane-specific resource
-measurement. A hybrid Spot pool or EKS migration needs a separate measured
+The lean AMI refresh is deployed; lane-specific resource measurement is next.
+A hybrid Spot pool or EKS migration needs a separate measured
 case that meets those same acceptance conditions; neither is deployed by
 this cost-control PR.
+
+### If Docker runner or application images are introduced
+
+The current fleet boots EC2 AMIs and runs verification directly on the host.
+For a future Docker/ECR implementation, consult the
+[Turborepo Docker guide](https://turborepo.dev/docs/guides/tools/docker)
+before designing the build. For an application image, evaluate
+`turbo prune <workspace-name> --docker` to retain the target workspace's
+dependency closure and prune its lockfile. Install from the generated package
+manifests and lockfile before copying `out/full` source, so source-only edits
+can reuse the dependency layer. Use a multi-stage build and exclude local
+`node_modules` from the build context.
+
+Application pruning does not establish the contents of a general CI runner
+image. A runner must support every lane assigned to it; validate any proposed
+pruned workspace against the lane's actual commands and required repository
+files. Adapt the guide's examples to this repo's pinned Bun/Turbo versions and
+frozen lockfile installation. Benchmark image build, pull, setup and successful
+lane costs against the deployed AMI before changing the fleet.
+
+For remote-cache credentials, use
+[Docker BuildKit secret mounts](https://docs.docker.com/build/building/secrets/)
+with runtime-resolved `op://` references. The guide's `TURBO_TOKEN` build-argument
+example does not meet this repo's secret-handling rules; never store a token in
+Dockerfile `ARG`/`ENV`, image layers or committed configuration.
 
 ## September 9 execution receipts
 

--- a/docs/runbooks/aws-cost-operations.md
+++ b/docs/runbooks/aws-cost-operations.md
@@ -204,6 +204,25 @@ AMI pin, attended Pulumi apply, controller SSM parameter and runner module.
 Coalesce lockfile churn and measure bake payback rather than rebuilding for
 every edit.
 
+The September 9 refresh canary found that a fresh image's dependency-cache
+archive made setup slower: 228 seconds versus 18 seconds for the existing
+image's isolated fallback. A diagnostic guest spent 163 seconds hashing the
+1.35 GB archive and 27 seconds extracting it, while a fresh frozen install
+took 9 seconds on the baseline guest. Future bakes therefore omit dependency
+archives. The setup fast path validates the baked Bun toolchain and clears
+inherited dependency caches; each job performs its own frozen install. Bun's
+release digest, installed-binary digest, root ownership, version and lockfile
+checks remain required. Intended-image freshness alone is not a performance
+receipt.
+
+The modified setup path then passed on a fresh instance in 20 seconds, including
+a 9-second frozen install, versus the isolated baseline's 18 seconds. This
+removes the measured archive regression. It does not establish a hosted speedup:
+GitHub cache/action overhead and a complete production workflow remain part of
+the attended activation check. The baseline Check lane passed in 739 seconds,
+with a 10.36 GiB peak in 15-second VM-memory samples; this is not sufficient
+evidence to downsize every heavy lane.
+
 Repair the retired teardown script so it cannot terminate builders or current
 controller workers. Supersede historical Spot and $100 ceiling instructions at
 their entry points, preserving dated experiment results. Add current image
@@ -404,11 +423,36 @@ asset distribution is preserved under the cutoff and has no base certificate
 charge. The five current CI/OIP buckets, current runner images and snapshots,
 current CI key, account identities and AWS-managed keys are preserved.
 
-The stale image refresh exposed an unrelated old IAM policy on the current
-operator login: `FreedomFramework-CI` denies `RunInstances` for every size except
-`t2.micro`. AWS rejected the launch before creating a worker. The policy is not
-owned by the CI stack; any access repair requires the operator's explicit
-decision. Do not weaken a fleet role or attempt the bake on an undersized VM.
+The stale image refresh exposed an unrelated old IAM policy on the operator
+login: `FreedomFramework-CI` denies `RunInstances` for every size except
+`t2.micro`. AWS rejected the original launch before creating a worker. After
+the operator approved continuation, the September 9 16:08 UTC repair detached
+only that policy from the operator user. The policy and its other attachment
+remain, and every other operator attachment was verified unchanged. Reattaching
+the retained policy restores the previous access configuration. No fleet role
+was changed. A subsequent `r6i.2xlarge` bake launched successfully.
+
+The image refresh follows a separate validation and activation sequence:
+
+1. Bake from a pushed source revision using the existing command. Preserve the
+   current production image as the rollback target and capture an encrypted
+   production checkpoint before changing the pin.
+2. Launch bounded probes from the current and candidate images on identical
+   `r6i.2xlarge` instances with the production root-volume settings. Both use
+   the same source revision, pinned Node archive, frozen Bun install and
+   `bun run beep ci lane check --summarize`. Run the setup action's actual
+   integrity detector: the current image must report a miss and the candidate
+   must report a hit. Capture setup time, lane result and sampled VM memory.
+3. Keep these probes isolated from GitHub runner registration and both GitHub
+   and remote Turbo caches. Their setup measurements compare the image paths;
+   they do not establish hosted queue time or account-wide savings. Each guest
+   has a 40-minute termination backstop and a bounded verification command.
+4. Review the intended manifest, AMI pin and refreshed Pulumi preview. Apply
+   the saved plan only with the operator present. Prove the live SSM pin and
+   run the existing Fleet Lane Probe on a newly launched production worker.
+   Require a baked fast-path hit and successful verification before calling
+   activation validated. Retain the old image until rollback is no longer
+   needed.
 
 ## Current stack ownership and bounded operations
 

--- a/goals/ci-fleet-residue/research/OPPORTUNITIES.md
+++ b/goals/ci-fleet-residue/research/OPPORTUNITIES.md
@@ -2,6 +2,25 @@
 
 Record receipts at the moment friction happens; redact for the public repo.
 
+## 2026-09-09 — An unused Chrome package feed blocked Storybook twice
+
+- What: final hosted proof for the lean runner-image PR #1062.
+- Evidence: Storybook run `34383237868`, attempts 1 and 2, failed at
+  `Install Playwright Chromium` before the build. APT reported `Hash Sum
+  mismatch` for Google's `chrome-stable/deb` package index. A bounded retry
+  reproduced the same expected and received digest mismatch.
+- Attribution: an external feed on the GitHub-hosted Ubuntu image, separate
+  from the EC2 image change. Playwright installs its own browser; its system
+  dependency installation does not need Google's Chrome package feed.
+- Repair: remove only Chrome feed definitions from the disposable runner
+  before the existing `playwright install --with-deps chromium` command.
+  Keep dependency installation and package integrity verification enabled.
+  GitHub's own [image installer](https://github.com/actions/runner-images/blob/main/images/ubuntu/scripts/build/install-google-chrome.sh)
+  already removes the older Chrome list name; cover current Chrome-prefixed
+  `.list` and `.sources` definitions in this workflow as well.
+- Prevention: scope job package sources to the dependencies the job needs,
+  and require a successful hosted rerun before closing the incident.
+
 ## 2026-09-09 — A fresh image passed integrity but regressed setup time
 
 - What: comparing the existing image with a fresh Bun 1.4.2 image before

--- a/goals/ci-fleet-residue/research/OPPORTUNITIES.md
+++ b/goals/ci-fleet-residue/research/OPPORTUNITIES.md
@@ -2,6 +2,26 @@
 
 Record receipts at the moment friction happens; redact for the public repo.
 
+## 2026-09-09 — A branch-dispatched probe passed routing but could not get a runner
+
+- What: validating the newly activated image with Fleet Lane Probe before
+  merging PR #1062.
+- Evidence: run `34385300906` was dispatched from the PR branch. The webhook
+  accepted its queued-job event and the dispatcher confirmed the build-queue
+  handoff. It remained queued while new-image workers handled other jobs.
+  The runner group's allowed workflow definitions are restricted to `main`,
+  including `fleet-lane-probe.yml@refs/heads/main`.
+- Attribution: the operator chose an ineligible workflow ref. Capacity was
+  also occupied, but queue acceptance and busy workers did not prove that this
+  particular workflow could be assigned. The image rollout was not the cause.
+- Response: cancel the unassigned probe. Validate PR code through its required
+  Heavy / Check job, which calls the approved `heavy.yml@main` reusable
+  workflow, and correlate its runner with the new EC2 image. Keep the runner
+  group restriction intact; dispatch Fleet Lane Probe from `main` after merge.
+- Prevention: check the allowed workflow refs before dispatching a probe.
+  Treat controller routing and GitHub runner-group eligibility as separate
+  checks so an ineligible job does not keep requesting capacity.
+
 ## 2026-09-09 — An unused Chrome package feed blocked Storybook twice
 
 - What: final hosted proof for the lean runner-image PR #1062.
@@ -20,6 +40,8 @@ Record receipts at the moment friction happens; redact for the public repo.
   `.list` and `.sources` definitions in this workflow as well.
 - Prevention: scope job package sources to the dependencies the job needs,
   and require a successful hosted rerun before closing the incident.
+- Hosted proof: run `34384268437` on `30d176e0fd` passed both Playwright
+  installation and the Storybook lane with the repair in place.
 
 ## 2026-09-09 — A fresh image passed integrity but regressed setup time
 
@@ -53,8 +75,11 @@ Record receipts at the moment friction happens; redact for the public repo.
   11.61 GiB. The guest was terminated after capturing its terminal success.
 - Rollout boundary: the refreshed saved image-only Pulumi plan has one SSM
   update, 83 unchanged resources and no replacements or deletions. It excludes
-  the known enrollment-provider discrepancy. The intended pin and image
-  receipt are reviewable; attended activation and a hosted probe remain.
+  the known enrollment-provider discrepancy. The operator approved the apply,
+  which completed at 17:49 UTC with exactly those changes. Direct AWS reads
+  confirmed the new image at SSM version 8 and matching live image keys.
+  Hosted acceptance uses the PR's approved Heavy / Check workflow; the
+  separate receipt above explains the cancelled branch-dispatched probe.
 - Prevention: require timed canaries as well as freshness and integrity checks
   before promoting an image intended to reduce setup cost.
 

--- a/goals/ci-fleet-residue/research/OPPORTUNITIES.md
+++ b/goals/ci-fleet-residue/research/OPPORTUNITIES.md
@@ -2,6 +2,32 @@
 
 Record receipts at the moment friction happens; redact for the public repo.
 
+## 2026-09-09 — A fresh image passed integrity but regressed setup time
+
+- What: comparing the existing image with a fresh Bun 1.4.2 image before
+  changing the production pin. Both probes used the same pushed revision,
+  `r6i.2xlarge`, root-volume settings and isolated setup procedure.
+- Evidence: the existing image missed the baked fast path and completed setup
+  in 18 seconds, including a 9-second frozen install. The new image passed the
+  exact setup integrity detector but took 228 seconds, including a 6-second
+  install. The successful integrity result alone did not establish a speedup.
+- Response: keep the production pin unchanged and instrument cache hashing,
+  extraction and Node setup separately before choosing the repair. AWS console
+  reads also returned older captures after newer ones; retain completed evidence
+  instead of letting a stale response erase an observed peak or result.
+- Isolation: a second fresh guest measured 163 seconds hashing the 1.35 GB
+  cache archive, 27 seconds extracting it and 2 seconds setting up Node. The
+  archive expands to 4.60 GB; the subsequent frozen install took 6 seconds.
+  The repair removes this archive from future bakes and skips its restore,
+  while retaining Bun's release digest, installed-binary digest, root ownership,
+  version and lockfile checks. Every job still runs a fresh frozen install.
+- Repair probe: the exact modified setup detector passed on another fresh
+  instance, with a fast-path hit, 20-second setup and 9-second frozen install.
+  This isolated result removes the archive regression; a production workflow
+  probe is still required to measure hosted setup and completion time.
+- Prevention: require timed canaries as well as freshness and integrity checks
+  before promoting an image intended to reduce setup cost.
+
 ## 2026-09-09 — Spot retry estimates must use billed usage
 
 - What: comparing Spot, autoscaled On-Demand EC2 and EKS after the operator
@@ -49,6 +75,12 @@ Record receipts at the moment friction happens; redact for the public repo.
 - Bake evidence: `RunInstances` was rejected before creation by the unrelated
   `FreedomFramework-CI` policy's explicit `LimitEC2Size` deny, which permits
   only `t2.micro` for the current operator login.
+- Bake access repair: after the operator approved continuation, the September 9
+  16:08 UTC operation detached only that obsolete policy from the operator
+  user. The policy remains available for rollback, its other attachment remains,
+  and every other operator policy attachment was verified unchanged. A fresh
+  `r6i.2xlarge` bake then launched successfully; image validation and activation
+  remain separate steps.
 - Prevention: capture the required operator identity and exact launch-policy
   preflight in the bake runbook. Keep the rejection distinct from a broken
   image or a capacity shortage; do not create credentials or weaken fleet

--- a/goals/ci-fleet-residue/research/OPPORTUNITIES.md
+++ b/goals/ci-fleet-residue/research/OPPORTUNITIES.md
@@ -25,6 +25,17 @@ Record receipts at the moment friction happens; redact for the public repo.
   instance, with a fast-path hit, 20-second setup and 9-second frozen install.
   This isolated result removes the archive regression; a production workflow
   probe is still required to measure hosted setup and completion time.
+- Lean-image proof: the replacement bake omits the archive and reduces full
+  snapshot data from 8.024 GiB to 2.350 GiB. Its fresh guest passed setup in
+  11 seconds, including a 9-second frozen install, and Check passed 246/246
+  tasks in 541 seconds. This uses pushed source `b9b6faa5a2`, including the
+  newer Check overlay repair; the earlier source's 739-second Check is not a
+  controlled image-only timing comparison. Peak sampled VM memory was
+  11.61 GiB. The guest was terminated after capturing its terminal success.
+- Rollout boundary: the refreshed saved image-only Pulumi plan has one SSM
+  update, 83 unchanged resources and no replacements or deletions. It excludes
+  the known enrollment-provider discrepancy. The intended pin and image
+  receipt are reviewable; attended activation and a hosted probe remain.
 - Prevention: require timed canaries as well as freshness and integrity checks
   before promoting an image intended to reduce setup cost.
 

--- a/goals/ci-fleet-residue/research/p0-baked-ami-design-brief.md
+++ b/goals/ci-fleet-residue/research/p0-baked-ami-design-brief.md
@@ -1,5 +1,12 @@
 # P0 design brief — `beep runners bake` (lockfile-keyed baked AMI)
 
+> September 9, 2026 supersession: the warm dependency-store recommendation below
+> is historical. A timed fresh-instance probe spent 163 seconds hashing its
+> archive and 27 seconds extracting it, while a fresh frozen install took
+> 9 seconds. Current bakes retain the verified Bun toolchain and omit the
+> dependency archive. Follow the measured image validation and attended rollout
+> procedure in [AWS cost operations](../../../docs/runbooks/aws-cost-operations.md).
+
 Status: design grounded in the live rails (2026-08-13). Implementation not
 started. Ships as its own scoped PR; the deploy that flips the fleet to the
 baked image is operator-gated (pulumi recipe + live probes).

--- a/infra/ci-runners/Pulumi.production.yaml
+++ b/infra/ci-runners/Pulumi.production.yaml
@@ -5,7 +5,7 @@ config:
   accountCostControls:anomalyImpactUsd: "10"
   ciRunners:amiId: ami-052355af2a014bd2c
   # The base image is pinned, while boot-time dnf upgrade-minimal still applies package security updates on every launch.
-  ciFleetController:amiId: ami-0738c1b69711969bc
+  ciFleetController:amiId: ami-07af50c345b5ba065
   ciFleetController:githubAppIdSsmParameterArn: arn:aws:ssm:us-east-1:832907639880:parameter/github-action-runners/app/github_app_id
   ciFleetController:githubAppKeyBase64SsmParameterArn: arn:aws:ssm:us-east-1:832907639880:parameter/github-action-runners/app/github_app_key_base64
   ciFleetController:githubAppWebhookSecretSsmParameterArn: arn:aws:ssm:us-east-1:832907639880:parameter/github-action-runners/app/github_app_webhook_secret

--- a/infra/ci-runners/runner-image.json
+++ b/infra/ci-runners/runner-image.json
@@ -1,6 +1,11 @@
 {
-  "amiId": "ami-0738c1b69711969bc",
-  "lockfileSha256": "f81ab29fdea01d653e3eb1025f8dae629f3768b658aae22b04aaa94c445fb372",
-  "bunArchiveSha256": "2d03fb5fb83ac8b567aca0a281b2ce1a1a19d488f56c2968d88c3f25e92fe452",
-  "bunVersion": "1.4.0"
+  "amiId": "ami-07af50c345b5ba065",
+  "lockfileSha256": "769ec9946aeb49d5e581acac05677086d2627b03bab8b3a119a5210cc50e8f25",
+  "bunArchiveSha256": "36368faef7527875d5ffa52e53cd48021741f2a83eb6208a8dd64068d422a913",
+  "bunVersion": "1.4.2",
+  "baseAmiId": "ami-081b0a6eac00b4f53",
+  "priorPin": "ami-0738c1b69711969bc",
+  "pulumiPinCommand": "cd infra/ci-runners && pulumi config set ciFleetController:amiId ami-07af50c345b5ba065 --stack production",
+  "startedAt": "2026-09-09T16:56:57.668Z",
+  "completedAt": "2026-09-09T17:07:00.035Z"
 }

--- a/packages/tooling/tool/cli/src/commands/Runners/Runners.service.ts
+++ b/packages/tooling/tool/cli/src/commands/Runners/Runners.service.ts
@@ -397,8 +397,7 @@ shutdown -P +350
 trap 'shutdown -P now' EXIT
 dnf install -y git unzip zip jq docker libicu
 systemctl enable --now docker
-install -d -o ec2-user -g ec2-user /home/ec2-user/.bun
-install -d -o root -g root -m 0755 /usr/local/bin /opt/beep-ci /etc/beep-ci
+install -d -o root -g root -m 0755 /usr/local/bin /etc/beep-ci
 curl --fail --location --proto '=https' --tlsv1.2 --retry 3 \
   --output /tmp/bun-linux-x64.zip \
   'https://github.com/oven-sh/bun/releases/download/bun-v${inputs.bunVersion}/bun-linux-x64.zip'
@@ -415,18 +414,10 @@ rm -rf /tmp/bun-linux-x64 /tmp/bun-linux-x64.zip
 git clone --filter=blob:none ${BAKE_CLONE_URL} /tmp/beep-effect
 git -C /tmp/beep-effect checkout --detach ${inputs.gitRevision}
 test "$(sha256sum /tmp/beep-effect/bun.lock | cut -d ' ' -f 1)" = "${inputs.lockfileSha256}"
-chown -R ec2-user:ec2-user /tmp/beep-effect
-sudo -u ec2-user env HOME=/home/ec2-user PATH=/usr/local/bin:/usr/bin:/bin \
-  /usr/local/bin/bun install --cwd /tmp/beep-effect --frozen-lockfile
-tar -C /home/ec2-user/.bun/install -czf /opt/beep-ci/bun-install-cache.tgz cache
-chown root:root /opt/beep-ci/bun-install-cache.tgz
-chmod 0444 /opt/beep-ci/bun-install-cache.tgz
-bun_install_cache_sha256="$(sha256sum /opt/beep-ci/bun-install-cache.tgz | cut -d ' ' -f 1)"
 printf '%s\n' '${inputs.lockfileSha256}' > /etc/beep-ci/bun-lock.sha256
 printf '%s\n' '${inputs.bunVersion}' > /etc/beep-ci/bun-version
 printf '%s\n' '${inputs.bunArchiveSha256}' > /etc/beep-ci/bun-archive.sha256
 printf '%s\n' "\${bun_binary_sha256}" > /etc/beep-ci/bun-binary.sha256
-printf '%s\n' "\${bun_install_cache_sha256}" > /etc/beep-ci/bun-install-cache.sha256
 printf '%s\n' '${inputs.gitRevision}' > /etc/beep-ci/source-revision
 install -o root -g root -m 0444 /dev/null /etc/beep-ci/baked-runner
 chmod 0444 /etc/beep-ci/*.sha256 /etc/beep-ci/bun-version /etc/beep-ci/source-revision
@@ -720,7 +711,7 @@ const makePlan = Effect.fn("Runners.plan")(function* () {
       "beep-ci:bake=true",
       "AssociatePublicIpAddress=true",
       "shutdown -P backstop",
-      "root-owned Bun binary + installed digest + authenticated warm cache",
+      "root-owned Bun binary + installed digest + fresh per-job dependency install",
       "lockfile-sha256 + bun-archive-sha256 + bun-version staleness key",
       "unconditional instance termination",
     ],

--- a/packages/tooling/tool/cli/test/runners-bake.test.ts
+++ b/packages/tooling/tool/cli/test/runners-bake.test.ts
@@ -781,24 +781,21 @@ describe("runner bake planning and argv", () => {
     expect(script).toContain("/tmp/bun-linux-x64/bun-linux-x64/bun /usr/local/bin/bun");
     expect(script).not.toContain("/tmp/bun-linux-x64/bun-linux-x64/bun /home/ec2-user/.bun/bin/bun");
     // The release zip ships only the bun binary. Both entrypoints must stay
-    // root-owned and execute before the bake trusts them to warm dependencies.
+    // root-owned and execute before the bake stamps the verified toolchain.
     expect(script).toContain("ln -sfn bun /usr/local/bin/bunx");
     expect(script).toContain("chown -h root:root /usr/local/bin/bunx");
     expect(script).toContain("/usr/local/bin/bunx --version");
     expect(script.indexOf("ln -sfn bun /usr/local/bin/bunx")).toBeLessThan(
       script.indexOf("git clone --filter=blob:none")
     );
-    expect(script).toContain("/usr/local/bin/bun install --cwd /tmp/beep-effect --frozen-lockfile");
+    expect(script).not.toContain("bun install --cwd");
     expect(script).toContain("git -C /tmp/beep-effect checkout --detach 0123456789abcdef0123456789abcdef01234567");
     expect(script).toContain(`= "${digest}"`);
     expect(script).toContain(`'1.3.14' > /etc/beep-ci/bun-version`);
     expect(script).toContain(`'${bunArchiveDigest}' > /etc/beep-ci/bun-archive.sha256`);
     expect(script).toContain('bun_binary_sha256="$(sha256sum /usr/local/bin/bun');
     expect(script).toContain('"${bun_binary_sha256}" > /etc/beep-ci/bun-binary.sha256');
-    expect(script).toContain("tar -C /home/ec2-user/.bun/install -czf /opt/beep-ci/bun-install-cache.tgz cache");
-    expect(script).toContain("chown root:root /opt/beep-ci/bun-install-cache.tgz");
-    expect(script).toContain("chmod 0444 /opt/beep-ci/bun-install-cache.tgz");
-    expect(script).toContain('"${bun_install_cache_sha256}" > /etc/beep-ci/bun-install-cache.sha256');
+    expect(script).not.toContain("bun-install-cache");
     expect(script).toContain("install -o root -g root -m 0444 /dev/null /etc/beep-ci/baked-runner");
     expect(script).toContain("/home/ec2-user/.bun/bin /home/ec2-user/.bun/install/cache");
     // AL2023's cloud-init lacks the newer --machine-id flag; the reset is
@@ -879,7 +876,7 @@ describe("runner bake planning and argv", () => {
   );
 
   it.effect(
-    "authenticates baked Bun and restores only the sealed dependency cache",
+    "authenticates baked Bun and discards inherited dependency caches",
     Effect.fnUntraced(function* () {
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
@@ -888,19 +885,17 @@ describe("runner bake planning and argv", () => {
 
       expect(action).toContain('rm -rf -- "${HOME:?}/.bun/install/cache"');
       expect(action).toContain("sha256sum /usr/local/bin/bun");
-      expect(action).toContain("sha256sum /opt/beep-ci/bun-install-cache.tgz");
+      expect(action).not.toContain("bun-install-cache");
       expect(action).toContain('[ "$bun_owner_mode" = "0:0:755" ]');
-      expect(action).toContain('[ "$cache_owner_mode" = "0:0:444" ]');
       expect(action).toContain('[ "$bunx_target" = "bun" ]');
       expect(action).toContain('echo "/usr/local/bin" >> "$GITHUB_PATH"');
       expect(action).not.toContain('echo "$HOME/.bun/bin" >> "$GITHUB_PATH"');
 
-      const binaryDigestCheck = action.indexOf('[ "$baked_binary" = "$installed_binary" ]');
-      const cacheDigestCheck = action.indexOf('[ "$baked_cache" = "$installed_cache" ]');
-      const cacheRestore = action.indexOf("tar -xzf /opt/beep-ci/bun-install-cache.tgz");
-      expect(binaryDigestCheck).toBeGreaterThan(-1);
-      expect(cacheDigestCheck).toBeGreaterThan(binaryDigestCheck);
-      expect(cacheRestore).toBeGreaterThan(cacheDigestCheck);
+      expect(action).toContain('[ "$baked_binary" = "$installed_binary" ]');
+      expect(action).toContain('[ "$baked_lock" = "$checkout_lock" ]');
+      expect(action).toContain('[ "$baked_bun" = "$checkout_bun" ]');
+      expect(action).toContain('[ "$baked_archive" = "$checkout_archive" ]');
+      expect(action).toContain("bun install --frozen-lockfile");
     }, provideScopedLayer(PlatformLayer))
   );
 });


### PR DESCRIPTION
A fresh runner-image canary exposed a setup regression: validating and extracting the baked
dependency archive took much longer than a fresh frozen install. This PR removes that archive
from image creation and setup, retains the verified Bun toolchain, and pins the validated lean
Bun 1.4.2 image, now deployed through an attended production rollout.

- Keep release and installed-binary digests, root ownership, Bun version, lockfile checks and
  inherited-cache cleanup; every job still runs `bun install --frozen-lockfile`.
- Record the complete bake receipt and intended image pin, with the prior image retained for rollback.
- Correct the historical warm-cache guidance and document the measurements and activation procedure.
- Link Turborepo's Docker guide in the cost runbook for a future container implementation,
  covering pruned application builds, CI runner scope and BuildKit secret mounts.
- Remove unused Google Chrome APT feed definitions before Storybook installs Playwright. Two
  hosted attempts failed on the feed's inconsistent package-index hashes; dependency installation
  and integrity verification remain enabled. Shell syntax and all 14 CI security tests pass.

Measured on isolated fresh `r6i.2xlarge` guests using production root-volume settings:

| Probe | Setup | Frozen install | Check |
| --- | ---: | ---: | --- |
| Existing image fallback | 18 s | 9 s | Passed in 739 s |
| Initial fresh image with archive | 228 s | 6 s | Passed in 753 s |
| Revised setup on initial candidate | 20 s | 9 s | Setup-only probe |
| Lean replacement image | 11 s | 9 s | 246/246 tasks passed in 541 s |

The archive diagnostic measured 163 s hashing and 27 s extraction. Omitting it reduced full
snapshot data from 8.024 GiB to 2.350 GiB. The final canary used source `b9b6faa5a2`, including
PR #1058's Check overlay repair; its Check duration is not a controlled image-only comparison
with the earlier source. The setup result is isolated evidence, not a hosted latency or monthly
savings claim. All temporary probe instances and builders were verified terminated.

Validation: 39 focused runner-bake/security tests passed; full CLI and infra package verification
passed, with infra verification repeated for the pin. The intended-image check reports all keys
fresh. Full local proof and hosted checks are running against the final commit.

The operator-approved attended rollout succeeded at 17:49 UTC on September 9. The saved plan
updated only `ci-fleet-controller-runner-ami`: one update, 83 unchanged resources, no replacements
or deletions. It excluded the known Cost Optimization Hub provider discrepancy. AWS directly
reports `ami-07af50c345b5ba065` at SSM version 8, and the live image check reports all keys fresh.
The [final-head Heavy / Check job](https://github.com/beep-effect/beep-effect/actions/runs/34388552342/job/102591437410)
passed on `38930bb7d9`. Runner `beep-ci-i-030b52359594dd57e` used the new AMI
`ami-07af50c345b5ba065`; its logs record the baked Bun fast path, 23 s setup and an
11.34 s frozen install. Its selected Turbo tasks reported 35/35 successful, 33 cached.
This proves hosted operation rather than a cold full-repository timing comparison.
[Storybook also passed on that head](https://github.com/beep-effect/beep-effect/actions/runs/34388551873/job/102591011062).
[Coverage Regression passed on the same head](https://github.com/beep-effect/beep-effect/actions/runs/34388552342/job/102591437496),
using `beep-ci-i-08432d5617d775110` on the new AMI: 24 s setup and a 26 min 40 s
verification step, with no worker loss. All 18 required checks passed. Greptile reviewed the
same commit at 5/5 with no actionable findings, and Yeet reports zero unresolved threads.
Full local proof and the downstream hosted Build are still in progress.

The separate branch-dispatched Fleet Lane Probe was cancelled: the runner group intentionally
allows that workflow only from `main`. Pre-merge validation uses this PR's Heavy / Check through
the approved reusable workflow. The runbook now documents that restriction.
The production pool remains On-Demand, with the previous image retained for rollback.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1062"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791564881&installation_model_id=424656&pr_number=1062&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1062&signature=fa3ea94a1d55b1b27d27dce7e0e4fde896aa1027acb88ae491dc6c9185cb8a49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

---

<!-- yeet-provenance:start -->
## Provenance

- Workspace: <code>beep-effect</code>
- Branch: <code>codex/runner-image-refresh</code>
- Agents (newest first):
  - `codex` (tui) · `unknown` · monitored

Resume the publishing agent from any beep-effect checkout on the publishing workstation:

```sh
bun run beep yeet resume 1062
```

<!-- yeet-provenance
{
  "schemaVersion": 2,
  "pr": 1062,
  "branch": "codex/runner-image-refresh",
  "workspace": "beep-effect",
  "agents": [
    {
      "harness": "codex",
      "entrypoint": "codex-tui",
      "hostHarness": null,
      "model": "unknown",
      "label": null,
      "workspace": null,
      "role": "monitored"
    }
  ]
}
-->
<!-- yeet-provenance:end -->




