### PR TITLE
feat(yeet): regenerate the ignored projections during repair

### DIFF
--- a/.claude/skills/yeet/SKILL.md
+++ b/.claude/skills/yeet/SKILL.md
@@ -276,7 +276,11 @@ schema-first, goals checks, Knip, Fallow, changeset status, and the JSDoc
 ratchet against the committed inventory. It reports every failure before any
 build, lint, check, test, or docgen lane starts. `yeet repair` applies its
 deterministic fixers, runs the same collected tier, and stops before heavy
-feedback if a cheap gate still fails.
+feedback if a cheap gate still fails. The fixers end by regenerating the
+git-ignored local projections (`goals/INDEX.md`, `explorations/ATLAS.md`, and
+the generated README status regions), so a stale copy left behind by a pull
+never fails `goals:index-check` or `explore:atlas-check`; hosted lanes never
+carry those ignored files, so that red was always local-only.
 
 The full proof then dispatches the *hosted lane bodies themselves* — `beep ci lane`
 `check`, bare `lint`, `lint-policy`, bare `test-unit`, and `test-integration`,

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts
@@ -241,10 +241,15 @@ export const emptyTurboPlanSnapshot = (warnings: ReadonlyArray<string>): TurboPl
   });
 
 // Deterministic auto-fixers run sequentially (runPhase concurrency:1). Code
-// rewriters run first, then config generation. The collected cheap tier runs
-// before formatting, docgen, or affected feedback can consume heavyweight work.
-// terse-effect applies only safe rewrites here; its manual candidates stay
-// advisory during verification. Schema-first remains excluded from repair.
+// rewriters run first, then config generation, then the git-ignored local
+// projections (`goals/INDEX.md`, `explorations/ATLAS.md` plus the generated
+// README status regions). Those projections are regenerated here so their
+// cheap gates prove current bytes instead of a stale copy left behind by a
+// pull; hosted lanes never carry the ignored files, so only local proofs were
+// going red on them. The collected cheap tier runs before formatting, docgen,
+// or affected feedback can consume heavyweight work. terse-effect applies only
+// safe rewrites here; its manual candidates stay advisory during verification.
+// Schema-first remains excluded from repair.
 const repairSteps = (context: RepoRunContext): ReadonlyArray<RepoPlanStep> => [
   bunRunStep(
     context,
@@ -267,6 +272,26 @@ const repairSteps = (context: RepoRunContext): ReadonlyArray<RepoPlanStep> => [
     "repo"
   ),
   bunRunStep(context, "prepare:03-config-sync", "prepare:config-sync", "prepare", "config-sync", [], "write", "repo"),
+  bunRunStep(
+    context,
+    "prepare:04-goals-index",
+    "prepare:goals:index",
+    "prepare",
+    "beep",
+    ["goals", "index", "--write"],
+    "write",
+    "repo"
+  ),
+  bunRunStep(
+    context,
+    "prepare:05-explore-atlas",
+    "prepare:explore:atlas",
+    "prepare",
+    "beep",
+    ["explore", "atlas", "--write"],
+    "write",
+    "repo"
+  ),
 ];
 
 const packageNameForFeedbackTask =

--- a/packages/tooling/tool/cli/test/yeet.test.ts
+++ b/packages/tooling/tool/cli/test/yeet.test.ts
@@ -1287,6 +1287,8 @@ describe("yeet planner", () => {
       "prepare:laws:effect-imports",
       "prepare:laws:terse-effect",
       "prepare:config-sync",
+      "prepare:goals:index",
+      "prepare:explore:atlas",
       "feedback:cheap-gates",
       "feedback:lint:fix",
       "feedback:docgen",
@@ -1302,6 +1304,20 @@ describe("yeet planner", () => {
       "effect-imports",
       "--write",
     ]);
+    // The ignored projections are regenerated before the cheap tier proves them,
+    // so a stale local copy left behind by a pull never fails repair.
+    expect(findStep(plan.steps, "prepare:goals:index")).toMatchObject({
+      args: ["run", "beep", "goals", "index", "--write"],
+      mutability: "write",
+      phase: "prepare",
+      scope: "repo",
+    });
+    expect(findStep(plan.steps, "prepare:explore:atlas")).toMatchObject({
+      args: ["run", "beep", "explore", "atlas", "--write"],
+      mutability: "write",
+      phase: "prepare",
+      scope: "repo",
+    });
     expect(findStep(plan.steps, "feedback:cheap-gates").args).toEqual([
       "run",
       "beep",
@@ -1410,6 +1426,8 @@ describe("yeet planner", () => {
       "prepare:laws:effect-imports",
       "prepare:laws:terse-effect",
       "prepare:config-sync",
+      "prepare:goals:index",
+      "prepare:explore:atlas",
       "feedback:cheap-gates",
       "feedback:lint:fix",
       "feedback:docgen",


### PR DESCRIPTION
## feat(yeet): regenerate the ignored projections during repair

`goals/INDEX.md` and `explorations/ATLAS.md` are git-ignored local projections, yet the
cheap-gates tier proves them byte-for-byte. Every pull that touches a goal or exploration
manifest therefore left a stale local copy behind and turned `goals:index-check` and
`explore:atlas-check` red on the next local proof, while hosted lanes (which never carry the
ignored files) stayed green. Publish already re-renders the goals index before commit; repair
had no fixer for either projection.

Add `prepare:goals:index` and `prepare:explore:atlas` as the last deterministic repair steps,
so `yeet repair` regenerates both projections (and the generated README status regions)
before the collected cheap tier proves them.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

## Local proof

- fallow-advisory-feedback: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/feat_yeet-repair-regenerates-projections-bff6cb790ab4/verdict.json

---

<!-- yeet-provenance:start -->
## Provenance

- Workspace: <code>beep-effect6</code>
- Branch: <code>feat/yeet-repair-regenerates-projections</code>
- Agents (newest first):
  - `claude-code` (desktop) · `claude-fable-5-1` · <code>nice-ellis-1db28f-53</code> · created

Resume the publishing agent from any beep-effect checkout on the publishing workstation:

```sh
bun run beep yeet resume 1063
```

<!-- yeet-provenance
{
  "schemaVersion": 2,
  "pr": 1063,
  "branch": "feat/yeet-repair-regenerates-projections",
  "workspace": "beep-effect6",
  "agents": [
    {
      "harness": "claude-code",
      "entrypoint": "claude-desktop",
      "hostHarness": null,
      "model": "claude-fable-5-1",
      "label": "nice-ellis-1db28f-53",
      "workspace": null,
      "role": "created"
    }
  ]
}
-->
<!-- yeet-provenance:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1063"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791564954&installation_model_id=424656&pr_number=1063&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1063&signature=343d45e08aaee66853d3fea50dbc542247debdae2c3eee15737f127f0aa8ea5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
