### PR TITLE
docs(packets): point operators at yeet repair for the ignored projections

### DIFF
--- a/explorations/README.md
+++ b/explorations/README.md
@@ -141,10 +141,12 @@ decodes the manifest fields required for projection and fails on underivable
 stream authority or generated README/Atlas drift, printing every underivable
 input or drifting path on stderr before it exits. `explorations/ATLAS.md` is
 git-ignored, so a stale local copy fails only local proofs (hosted lanes never
-carry one) and the `--write` rewrite never appears in `git diff`. The
-remaining v1 shape (`openQuestions`, links, and sources) is still
-conversational and checked by the skill; the fleet convention migration owns
-full-schema lint.
+carry one) and the `--write` rewrite never appears in `git diff`. Run
+`bun run beep yeet repair` after a pull that touches packet manifests: its
+last fixers regenerate the ignored Atlas and the README status regions before
+the cheap tier proves them. The remaining v1 shape (`openQuestions`, links,
+and sources) is still conversational and checked by the skill; the fleet
+convention migration owns full-schema lint.
 
 ## Graduation Contract
 

--- a/goals/README.md
+++ b/goals/README.md
@@ -189,6 +189,9 @@ bun run beep goals index --check   # prove generation and check a local copy whe
 
 Do not link `goals/INDEX.md` as tracked GitHub truth or stage it. Generate it
 locally when a portfolio table is useful; edit packet manifests instead.
+`bun run beep yeet repair` regenerates it as one of its last fixers, so a pull
+that moves goal manifests never leaves a stale copy behind for
+`goals:index-check`.
 
 ## Research Basis
 


### PR DESCRIPTION
## docs(packets): point operators at yeet repair for the ignored projections

Both packet READMEs describe the ignored projections and their `--check` gates but not how
a stale local copy gets refreshed after a pull. Name the repair step landed in #1063 next to
each gate so the fix for a local-only red is one command away from the text that explains it.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

## Local proof

- fallow-advisory-feedback: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/docs_repair-regenerates-projections-bcedcc29ac0c/verdict.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1065"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791568596&installation_model_id=424656&pr_number=1065&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1065&signature=a97f8f886b116af26de36aaa0a9aad89d74dbf37c3998a7747a6600dfbd6c6fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

---

<!-- yeet-provenance:start -->
## Provenance

- Workspace: <code>beep-effect6</code>
- Branch: <code>docs/repair-regenerates-projections</code>
- Agents (newest first):
  - `claude-code` (desktop) · `claude-fable-5-1` · <code>nice-ellis-1db28f-53</code> · created

Resume the publishing agent from any beep-effect checkout on the publishing workstation:

```sh
bun run beep yeet resume 1065
```

<!-- yeet-provenance
{
  "schemaVersion": 2,
  "pr": 1065,
  "branch": "docs/repair-regenerates-projections",
  "workspace": "beep-effect6",
  "agents": [
    {
      "harness": "claude-code",
      "entrypoint": "claude-desktop",
      "hostHarness": null,
      "model": "claude-fable-5-1",
      "label": "nice-ellis-1db28f-53",
      "workspace": null,
      "role": "created"
    }
  ]
}
-->
<!-- yeet-provenance:end -->

