### PR TITLE
ci(release): prune third-party apt sources before the desktop release apt update

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -163,6 +163,11 @@ jobs:
         if: runner.os == 'Linux'
         shell: bash
         run: |
+          set -euo pipefail
+          # The image's third-party apt sources (Google Chrome, Microsoft) fail apt-get
+          # update with "Hash Sum mismatch" / "403 Forbidden" for minutes at a time;
+          # keep only the Ubuntu archive, which is where these packages come from.
+          scripts/ci-prune-apt-sources.sh
           sudo apt-get update
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev \

--- a/packages/tooling/tool/cli/test/ci-runner-security.test.ts
+++ b/packages/tooling/tool/cli/test/ci-runner-security.test.ts
@@ -415,6 +415,31 @@ describe("CI runner security", () => {
     }, provideScopedLayer(NodeServices.layer))
   );
 
+  // Release lanes run only on `professional-desktop-v*` tags, so this parse is
+  // the standing proof that the ubuntu-22.04 matrix leg prunes the third-party
+  // apt sources before its first apt-get update, once checkout has put the
+  // script in place.
+  it.effect(
+    "prunes third-party apt sources before the release desktop Linux apt update",
+    Effect.fnUntraced(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const repoRoot = yield* findRepoRoot();
+      const workflow = parsedDocument(
+        yield* fs.readFileString(path.join(repoRoot, ".github/workflows/release-desktop.yml"))
+      );
+      const steps = jobSteps(workflowJobs(workflow), "release-desktop");
+      const install = "Install Tauri Linux system dependencies";
+      assert.strictEqual(stepByName(steps, install).if, "runner.os == 'Linux'");
+      assertPrunesAptSourcesBefore(stepRun(steps, install), "sudo apt-get update");
+      const checkoutIndex = O.getOrThrowWith(
+        A.findFirstIndex(steps, (step) => Str.startsWith("actions/checkout@")(step.uses ?? "")),
+        () => new Error("Job release-desktop declares no checkout step.")
+      );
+      assert.isBelow(checkoutIndex, stepIndexByName(steps, install));
+    }, provideScopedLayer(NodeServices.layer))
+  );
+
   // Quality-lane audit D13 (revised in PR #1054 review): the workflow gates
   // Storybook only on goals_only and lets the lane decide through Turbo's
   // dependency-aware affected probe, restores the Playwright browser cache on

--- a/scripts/ci-prune-apt-sources.sh
+++ b/scripts/ci-prune-apt-sources.sh
@@ -1,16 +1,19 @@
 #!/usr/bin/env bash
-# Keep only the Ubuntu archive apt sources on a hosted ubuntu-24.04 runner.
+# Keep only the Ubuntu archive apt sources on a hosted Ubuntu runner.
 #
-# The image preinstalls third-party apt sources under /etc/apt/sources.list.d
-# (Google Chrome's google-chrome.sources, Microsoft's microsoft-prod.list) whose
-# indexes fail `apt-get update` for many minutes at a time, so retries do not
-# help:
+# The ubuntu-24.04 and ubuntu-22.04 images preinstall third-party apt sources
+# under /etc/apt/sources.list.d (Google Chrome's google-chrome.sources from the
+# Chrome .deb, Microsoft's microsoft-prod.list from packages-microsoft-prod.deb)
+# whose indexes fail `apt-get update` for many minutes at a time, so retries do
+# not help:
 #   E: Failed to fetch https://dl.google.com/linux/chrome-stable/deb/... Hash Sum mismatch
 #   E: Failed to fetch https://packages.microsoft.com/ubuntu/24.04/prod/dists/noble/InRelease  403  Forbidden
 # Nothing the lanes install comes from those repositories (Playwright ships its
 # own Chromium; Tauri needs webkit2gtk and friends from the Ubuntu archive), so
 # every .list/.sources file except the Ubuntu archive's ubuntu.sources (which
-# points at the image's mirror list) is removed before apt-get update. The
+# points at the image's mirror list) is removed before apt-get update. On
+# ubuntu-22.04 the archive lives in /etc/apt/sources.list instead, which this
+# script never touches, so the ubuntu.sources exclusion is moot there. The
 # listing before and after is printed so the job log records what the image
 # shipped.
 set -euo pipefail


### PR DESCRIPTION
## ci(release): prune third-party apt sources before the desktop release apt update

The ubuntu-22.04 release matrix leg ran a bare `sudo apt-get update`, inheriting the
image's Google Chrome and Microsoft apt sources that fail index fetches for minutes at a
time. Call scripts/ci-prune-apt-sources.sh first, as check.yml and storybook.yml already
do, and widen the script's header for 22.04, where the Ubuntu archive lives in
/etc/apt/sources.list (runner-images configure-apt-sources.sh, is_ubuntu22 branch), so the
ubuntu.sources exclusion is moot there but harmless. ci-runner-security.test.ts now parses
release-desktop.yml and asserts the Linux step prunes before apt-get update and after
checkout; release lanes only run on tags, so that test is the hosted proof.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

## What changed

- `.github/workflows/release-desktop.yml`: the `release-desktop` job's "Install Tauri Linux system dependencies" step (matrix `ubuntu-22.04`, `if: runner.os == 'Linux'`) now runs `scripts/ci-prune-apt-sources.sh` before `sudo apt-get update`, in the same `set -euo pipefail` + comment form that check.yml and storybook.yml use.
- `scripts/ci-prune-apt-sources.sh`: the header now covers ubuntu-22.04.
- `packages/tooling/tool/cli/test/ci-runner-security.test.ts`: a new case parses release-desktop.yml and asserts the Linux step is gated on `runner.os == 'Linux'`, calls the prune script before `sudo apt-get update`, and follows the `actions/checkout` step.

## ubuntu-22.04 image facts

Verified from actions/runner-images tag `ubuntu22/20260907.292`, sparse checkout of `images/ubuntu/scripts/build`:

- `configure-apt-sources.sh` takes its `is_ubuntu22` branch: the Ubuntu archive is rewritten in `/etc/apt/sources.list`, not in `sources.list.d/ubuntu.sources`. The prune script only deletes under `sources.list.d`, so the archive survives and the `ubuntu.sources` exclusion is moot there but harmless.
- The persisting `sources.list.d` writers are the same two as on 24.04: `install-ms-repos.sh` (`packages-microsoft-prod.deb` writes `microsoft-prod.list`) and `install-google-chrome.sh` (the Chrome .deb postinst writes its source; the script removes only the legacy `google-chrome.list`). Every other writer (docker, mono, heroku, kubernetes, pgdg, git-lfs, adoptium/zulu, rlang, google-cloud-sdk, azure-cli, edge, the sqlpackage focal-security list, the git-core and mozillateam PPAs) removes its own file in the same script.

## Proof

Release lanes run only on `professional-desktop-v*` tags or `workflow_dispatch`, so this change has no hosted run on the PR. The parse test is the proof.

- `bun run beep:test test/ci-runner-security.test.ts` in packages/tooling/tool/cli: 15 passed. Negative check: with the prune line removed, the new case fails on the `assertPrunesAptSourcesBefore` include.
- `bun run package-test-typecheck`: exit 0.
- `bun run beep knowledge refs --check`: 0 live gated observations.

## keytar: investigation and recommendation (no dependency change in this PR)

**Chain.** `keytar@7.9.0` enters through `@azure/msal-node-extensions@5.5.0`, which declares `keytar ^7.8.0` as a hard dependency. Every published version of the extension depends on keytar; the latest, 5.5.0, is from 2026-08-28. keytar's last release is from 2022-02-17 out of the archived `atom/node-keytar` repository. Its install script is `prebuild-install || npm run build`; the fallback is a node-gyp build that needs `libsecret-1`, which the image lacks, so every prebuild miss fails the attempt.

**Already optional and lazy.** The extension is an `optionalDependencies` entry of `@beep/m365` and is loaded only through `import("@azure/msal-node-extensions")` when `tokenCachePath` is set (`M365.auth.ts`). That does not keep keytar out of the graph: bun installs optional dependencies by default and keytar is the extension's hard dependency, so it sits in `bun.lock` and in every `bun install --frozen-lockfile`. Its script runs because keytar is on bun's default trust list (`bun pm default-trusted`, entry 217 of 368 on bun 1.4.2) and the root manifest declares no `trustedDependencies`. Nothing in the repo sets `M365_TOKEN_CACHE_PATH` except the live integration test reading it from the environment; the unit tests only decode the config field. No CI lane exercises the extension.

**Frequency.** Scanning the last 30 failed check.yml runs finds the keytar install script failing "Setup monorepo CI" three times in about 24 hours, all before the #1066 retry merged (2026-09-09 19:38Z), each about 45 s into the step:

| Job | Branch | Log line |
| --- | --- | --- |
| Lint (lint-b), 2026-09-09 18:02Z | PR #1066 | `prebuild-install warn install Request timed out` |
| Labs, 2026-09-09 11:51Z | main | `prebuild-install warn install No prebuilt binaries found (target=3 runtime=napi arch=x64 libc= platform=linux)` |
| SAST, 2026-09-08 21:07Z | main | same "No prebuilt binaries found" |

The two main-branch hits are not timeouts: the GitHub release asset request returned a non-200. The scan is a lower bound, since runs that went green on rerun are excluded.

**Other levers checked.**

- Declaring any `trustedDependencies` in package.json replaces bun's default list (bun 1.4.2, verified in a scratch package: keytar's script was blocked and no `build/Release/keytar.node` appeared, while the control without the field produced it). That would silence keytar without `--ignore-scripts`, but it also blocks every other default-trusted script unless each is enumerated, and it leaves keytar unbuilt for anyone using the encrypted cache from this checkout.
- `optional = false` or `--omit=optional` is out: 57 packages in bun.lock carry `optionalDependencies`, mostly platform binaries (`@esbuild/*`, `@next/swc-*`, `@turbo/*`, `@tauri-apps/cli-*`, `lightningcss-*`, `@oxc-*/binding-*`, `@tailwindcss/oxide-*`).
- The baked runner fast path ships only the Bun toolchain, never `node_modules`, so keytar's binary is never pre-baked.

**Options.**

- (a) as written is already in place and does not remove keytar. Completing it means removing `@azure/msal-node-extensions` from the `@beep/m365` manifest and the root catalog so keytar, `@azure/msal-node-runtime`, and the `prebuild-install` subtree leave `bun.lock` (`@azure/msal-common@16.14.0` stays for `@azure/msal-node`). The driver keeps its dynamic import and its existing `M365Error` config path for a failed import; a host that wants the encrypted cache declares the extension itself, which is how the m365 README already frames it. Types come from a vendored shim in the pattern of `packages/drivers/cosmos/src/vendor.d.ts`, covering the three symbols used (`PersistenceCreator.createPersistence`, `DataProtectionScope.CurrentUser`, `PersistenceCachePlugin`). The alternative design injects an `ICachePlugin` option into the driver the way the interactive authorizer is injected and moves `tokenCachePath` to the host, a larger refactor of `M365.config`, `M365.service`, and their tests.
- (b) An Effect-native encrypted cache replaces what keytar exists for, OS keychain access. It either shells out to `secret-tool` / `security` / DPAPI (re-implementing the plugin per OS, unprovable in Linux CI) or AES-GCM-encrypts a file with a key stored beside it, which is no stronger than a 0600 plaintext file. That is product work to fix an install flake; not now.
- (c) Keeping it with the retry is refuted as sufficient: three hits in 24 hours, two of them asset misses on main pushes that a 15 s / 30 s retry may not clear, on an unmaintained native package the extension will keep pulling.

**Recommendation: complete (a).** One follow-up PR: drop the extension from `packages/drivers/m365/package.json` and the root catalog, add the vendored type shim, note the host-side opt-in in the m365 README, regenerate `bun.lock`, check `bun pm untrusted`, and run `bun run beep quality package-verify @beep/m365`. Not done here because it changes a product package's dependency surface and the shim-versus-injection design is the owner's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/ci_apt-sources-followups-5acc13c9a988/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1070"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791576093&installation_model_id=424656&pr_number=1070&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1070&signature=eef51625d11a37266c3b74d494d3a98b6c8698037fa657669057c8301109f995"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

---

<!-- yeet-provenance:start -->
## Provenance

- Workspace: <code>beep-effect3</code>
- Branch: <code>ci/apt-sources-followups</code>
- Agents (newest first):
  - `claude-code` (desktop) · `claude-fable-5-1` · <code>happy-yonath-326ada-6a</code> · monitored

Resume the publishing agent from any beep-effect checkout on the publishing workstation:

```sh
bun run beep yeet resume 1070
```

<!-- yeet-provenance
{
  "schemaVersion": 2,
  "pr": 1070,
  "branch": "ci/apt-sources-followups",
  "workspace": "beep-effect3",
  "agents": [
    {
      "harness": "claude-code",
      "entrypoint": "claude-desktop",
      "hostHarness": null,
      "model": "claude-fable-5-1",
      "label": "happy-yonath-326ada-6a",
      "workspace": null,
      "role": "monitored"
    }
  ]
}
-->
<!-- yeet-provenance:end -->

