### PR TITLE
ci(runners): record lane resource and cost evidence

### DIFF
--- a/.changeset/runner-resource-evidence.md
+++ b/.changeset/runner-resource-evidence.md
@@ -3,4 +3,5 @@
 ---
 
 Verify that runner resource reporting preserves lane failures and executes jobs
-when measurement storage is unavailable.
+when measurement storage is unavailable. Keep full verification working for older
+PR checkouts that do not yet contain the optional resource helper.

--- a/.changeset/runner-resource-evidence.md
+++ b/.changeset/runner-resource-evidence.md
@@ -1,0 +1,6 @@
+---
+"@beep/repo-cli": patch
+---
+
+Verify that runner resource reporting preserves lane failures and executes jobs
+when measurement storage is unavailable.

--- a/.github/workflows/heavy.yml
+++ b/.github/workflows/heavy.yml
@@ -196,7 +196,7 @@ jobs:
           # session and reap the entire process group once the lane process
           # finishes, success and failure alike.
           run_lane() {
-            setsid bun run beep "$@" < /dev/null &
+            setsid bash scripts/ci-runner-resources.sh "${{ matrix.id }}" bun run beep "$@" < /dev/null &
             local pgid=$!
             local status=0
             wait "$pgid" || status=$?

--- a/.github/workflows/heavy.yml
+++ b/.github/workflows/heavy.yml
@@ -196,7 +196,15 @@ jobs:
           # session and reap the entire process group once the lane process
           # finishes, success and failure alike.
           run_lane() {
-            setsid bash scripts/ci-runner-resources.sh "${{ matrix.id }}" bun run beep "$@" < /dev/null &
+            local -a lane_command=(bun run beep "$@")
+            # The reusable workflow runs from main, but older PR checkouts
+            # may not contain the optional measurement helper yet.
+            if [[ -f scripts/ci-runner-resources.sh ]]; then
+              lane_command=(bash scripts/ci-runner-resources.sh "${{ matrix.id }}" "${lane_command[@]}")
+            else
+              echo '::notice::Runner resource helper unavailable in this checkout; running the requested lane.'
+            fi
+            setsid "${lane_command[@]}" < /dev/null &
             local pgid=$!
             local status=0
             wait "$pgid" || status=$?

--- a/docs/runbooks/aws-cost-operations.md
+++ b/docs/runbooks/aws-cost-operations.md
@@ -541,3 +541,88 @@ Refresh the tracked receipt through the existing bake path with
 saved Pulumi plan with the operator present. Then run the live
 `bun run beep runners bake --check --region us-east-1` in addition to the
 AWS-free manifest check. A matching intended manifest never proves deployment.
+
+
+## September 9 runner efficiency follow-up
+
+The Build-routing repair is verified on PR #1066. Its
+[Heavy / Build job](https://github.com/beep-effect/beep-effect/actions/runs/34392200611/job/102603399324)
+ran on an EC2 worker and passed after PR #1064 moved the lane into the approved
+reusable workflow. Its verification step ran for 25 seconds, after 19 seconds
+of setup. Old workflow runs retain their original job definitions; the queued
+Build on PR #1062 is not evidence that the repaired route still fails.
+
+A read-only sample of the latest 50 Check workflow runs captured 303 completed
+EC2 jobs from runs created between 15:00:52 and 19:38:31 UTC. There were 231
+successful, 36 failed and 36 cancelled job attempts. This is a same-day
+operational sample, not a representative month or a matched performance trial.
+Across those attempts, Coverage used 942.8 job-minutes and Lint Policy used
+430.6, compared with 266.2 for Check. Those lanes are the first sizing targets.
+
+Successful setup steps in the pre-activation window had a 76-second median
+across 147 observations. The post-activation window had a 21-second median
+across 115 observations. Source changes, selected tasks and cache state differ,
+so these medians describe the sample without attributing the entire difference
+to the image. Sixty-two jobs could be joined to the retained EC2 inventory;
+all used the new image on `r6i.2xlarge`.
+
+Do not convert job wall time into an AWS invoice. Checkout/setup, boot and queue
+residence, shutdown lag, failed attempts, EBS and public IPv4 also matter.
+Workers usually terminate themselves through guest shutdown, which does not
+produce a `TerminateInstances` CloudTrail API event. Only five sampled jobs
+had a complete launch/API-termination pair; their observed post-job lag was
+1–5 seconds. Missing termination timestamps stay unknown rather than becoming
+zero idle time. Compare cost per successful completion only when the measured
+lifetime coverage and workload equivalence are stated.
+
+### Skipped-lane routing decision
+
+Seventeen completed jobs skipped verification, using 506 seconds of job time,
+plus their unmeasured boot/assignment time. Avoiding those launches remains a
+valid savings opportunity, but adding a planner as a prerequisite is held.
+Reusing the existing PR Size Label job does not eliminate the queue penalty:
+it completed 7–361 seconds after run creation in the no-op sample, and up to
+359 seconds after an EC2 job had already started. An existing job still adds
+latency when it becomes a new dependency.
+
+Keep direct heavy-lane admission until a canary preserves required contexts,
+trusted main workflow definitions, conservative diff handling and useful-lane
+completion times. Do not infer eligibility from mutable PR labels or truncate
+a changed-files API response to make routing appear faster.
+
+### Resource evidence and sizing acceptance
+
+`scripts/ci-runner-resources.sh` wraps each executed heavy lane and appends its
+resource summary to the existing job log and GitHub step summary. It samples
+host memory every five seconds, records elapsed time, CPU busy percentage and
+swap-page deltas, and preserves the lane exit status. It neither enables paid
+CloudWatch metrics nor records command arguments, environment variables or
+process command lines. Its host-wide peak can miss short bursts; it is not an
+exact child-process peak or sufficient evidence to downsize on its own.
+
+Compare the same pinned source and lane shape on isolated workers with the
+same image, storage, CPU count and cache posture. Keep production On-Demand,
+its cap and memory choices until successful canaries establish a safe smaller
+configuration. The initial comparison is `r6i.2xlarge` versus `m6i.2xlarge`:
+both have eight vCPUs, with 64 versus 32 GiB memory. September 9 AWS Price List
+quotes in us-east-1 are $0.504 and $0.384 per hour respectively. The 23.8%
+hourly reduction is a candidate saving, not a measured monthly saving.
+
+### Billing and recommendation readiness
+
+A fresh read confirms the $500 budget and all six activated allocation tags.
+The budget reports $144.666 month-to-date and a $337.113 monthly forecast.
+These are provisional AWS values from September 9; they do not establish the
+post-rollout steady-state cost. The queried forecast returned the September
+1–October 1 monthly period, so do not add month-to-date spend to that figure.
+Cost Explorer currently includes only partial September 9 usage. AWS documents
+that [Cost Explorer refreshes at least daily and some data arrives later](https://docs.aws.amazon.com/cost-management/latest/userguide/ce-what-is.html).
+
+Compute Optimizer and Cost Optimization Hub are Active, with empty EC2 and
+consolidated recommendation lists at this read. There are no CWAgent metrics.
+[Compute Optimizer requires at least 30 hours of EC2 metrics in 14 days](https://docs.aws.amazon.com/compute-optimizer/latest/ug/requirements.html),
+which an individual ephemeral job worker never accumulates. Use the lane
+measurements for runner sizing; account recommendations still help with
+eligible persistent resources. [Hub recommendation import can take 24 hours](https://docs.aws.amazon.com/cost-management/latest/userguide/coh-getting-started.html).
+An empty list is not an optimality certificate. Paid extended history and
+purchase commitments remain disabled.

--- a/docs/runbooks/aws-cost-operations.md
+++ b/docs/runbooks/aws-cost-operations.md
@@ -599,6 +599,9 @@ swap-page deltas, and preserves the lane exit status. It neither enables paid
 CloudWatch metrics nor records command arguments, environment variables or
 process command lines. Its host-wide peak can miss short bursts; it is not an
 exact child-process peak or sufficient evidence to downsize on its own.
+Older PR checkouts may not contain the helper even though they call the updated
+reusable workflow from `main`. In that case the workflow emits a notice and
+runs the same requested lane directly, preserving its arguments and exit status.
 
 Compare the same pinned source and lane shape on isolated workers with the
 same image, storage, CPU count and cache posture. Keep production On-Demand,
@@ -607,6 +610,48 @@ configuration. The initial comparison is `r6i.2xlarge` versus `m6i.2xlarge`:
 both have eight vCPUs, with 64 versus 32 GiB memory. September 9 AWS Price List
 quotes in us-east-1 are $0.504 and $0.384 per hour respectively. The 23.8%
 hourly reduction is a candidate saving, not a measured monthly saving.
+
+The isolated comparison uses source `e8b92a61c3`, the activated lean image,
+eight vCPUs, 100 GiB gp3 volumes and local-only Turbo caching. Check starts
+without a local task cache; subsequent lanes share the preceding lanes' local
+outputs. This is a matched sequential suite, not the fresh-worker cache state
+of every hosted job. Compare corresponding lanes, and report cache hits with
+their results. The additional `r6a.2xlarge` candidate retains 64 GiB and has a
+$0.4536 hourly quote, 10% below the baseline's rate.
+
+The first full Check comparison passed 246 of 246 tasks with no cache hits on
+both `r6i.2xlarge` and `m6i.2xlarge`, taking 528.85 and 534.58 seconds. Full Lint
+Policy also passed on both, taking 517.36 and 528.63 seconds. Its sampled host
+memory peaked at 28.44 and 27.22 GiB respectively, leaving only 3.59 GiB
+available on the smaller worker. That result does not justify moving the
+entire pool to 32 GiB under the reliability-first decision.
+
+Full Docgen also passed on both, taking 810.69 and 837.98 seconds with the
+configured concurrency of six. Its sampled peak was 27.06 GiB on the baseline
+and 29.93 GiB on the smaller worker, leaving only 0.89 GiB available there.
+This further rules out adopting 32 GiB for the entire pool on these results.
+
+The 64 GiB `r6a.2xlarge` trial passed Check in 542.97 seconds, Lint Policy in
+535.69 seconds and Build in 53.87 seconds. The corresponding baseline times
+were 528.85, 517.36 and 53.42 seconds. Its hourly rate is lower, but Check and
+Lint Policy were 2.7% and 3.5% slower in this single trial. These observations
+do not establish a performance-neutral replacement. Keep the existing
+64 GiB On-Demand production choices and cap; collect repeated representative
+results before proposing a family change or a separate pool for smaller lanes.
+
+The initial full Coverage trials on the baseline and 32 GiB candidate finished
+in 25m35s and 25m55s with a failing SQL-helper coverage floor. The isolated user
+lacked Docker socket access, so container tests were skipped. Those are failed
+diagnostic runs, not successful cost-per-completion benchmarks. Repair the
+test user's Docker access, start a fresh user process and rerun the affected
+package without cache reuse; preserve the original failures and coverage floors.
+The experiment's final validation and temporary-resource cleanup receipts are
+recorded with [PR #1071](https://github.com/beep-effect/beep-effect/pull/1071).
+
+The [code-focused memory burndown opportunity](../../goals/ci-fleet-residue/research/OPPORTUNITIES.md#2026-09-09--burn-down-ci-check-memory-in-code-before-reducing-runner-ram)
+starts with profiling Lint Policy and Docgen implementations. It requires unchanged
+checks, diagnostics and completion-time acceptance, with repeated before/after
+measurements. Reducing concurrency or adding swap alone does not complete it.
 
 ### Billing and recommendation readiness
 

--- a/goals/ci-fleet-residue/research/OPPORTUNITIES.md
+++ b/goals/ci-fleet-residue/research/OPPORTUNITIES.md
@@ -17,6 +17,11 @@ Record receipts at the moment friction happens; redact for the public repo.
   full Check arguments reach the command and that the workflow returns 7.
 - Prevention: test reusable-workflow changes against a caller checkout that
   predates newly introduced repository helpers, as well as the current branch.
+- Validation gap: the runtime fixture and quick package proof passed, but
+  hosted Check caught `TS377077` (`processEnvInEffect`) for the new test's
+  direct `process.env.PATH` read. Use the existing `Config.string("PATH")`
+  pattern and run `bun run beep quality test-tsgo` for new Effect test code;
+  runtime execution alone does not enforce the test project's Effect diagnostics.
 
 ## 2026-09-09 — Burn down CI check memory in code before reducing runner RAM
 

--- a/goals/ci-fleet-residue/research/OPPORTUNITIES.md
+++ b/goals/ci-fleet-residue/research/OPPORTUNITIES.md
@@ -2,6 +2,62 @@
 
 Record receipts at the moment friction happens; redact for the public repo.
 
+## 2026-09-09 — A reusable workflow can outpace helpers in older PR checkouts
+
+- What: pre-publication review found that `heavy.yml@main` would invoke the
+  new resource helper from a caller PR checkout that may not contain it.
+- Evidence: the reusable workflow's checkout step has no override to the
+  caller's source ref. An older branch can therefore lack
+  `scripts/ci-runner-resources.sh` while receiving the new workflow body.
+- Repair: make the observer optional at orchestration time. When it is absent,
+  run the identical lane command and arguments directly in the same managed
+  process group. Keep failures and required checks intact.
+- Verification: execute the workflow's actual shell body in a temporary
+  checkout with no helper and a test command that exits 7. Assert that the
+  full Check arguments reach the command and that the workflow returns 7.
+- Prevention: test reusable-workflow changes against a caller checkout that
+  predates newly introduced repository helpers, as well as the current branch.
+
+## 2026-09-09 — Burn down CI check memory in code before reducing runner RAM
+
+- Operator direction: capture a later code-focused memory burndown. The main
+  work is improving check implementations, rather than changing runner sizes
+  or reducing concurrency to fit a smaller machine.
+- Evidence: matched, full Lint Policy runs on source `e8b92a61c3` passed in
+  517.36 seconds on `r6i.2xlarge` and 528.63 seconds on `m6i.2xlarge`. The
+  five-second host samples peaked at 28.44 and 27.22 GiB respectively. The
+  smaller worker had only 3.59 GiB available at its low point, despite passing.
+  These are sampled host values, not exact process peaks. Both used the same
+  image, eight vCPUs, source and lane commands. There was no swap.
+- Full Docgen then passed in 810.69 and 837.98 seconds respectively, using
+  the same configured concurrency of six. Its sampled peak was 27.06 GiB on
+  the baseline and 29.93 GiB on the 32 GiB candidate, whose minimum available
+  memory was only 0.89 GiB. Include the docgen implementation in the initial
+  profiling scope; a passing exit code alone concealed very little headroom.
+- Scope: profile the implementations invoked by full Lint Policy and Docgen,
+  then Check and Coverage as their measured peaks warrant. The Lint Policy entry point
+  is `runRootLintPolicyTaskInternal` in
+  `packages/tooling/tool/cli/src/commands/Quality/Tasks.ts`; it currently runs
+  three policy steps concurrently. Attribute memory to individual steps and
+  their child processes before selecting a refactor.
+- Investigate repeated TypeScript Program/AST construction, duplicate workspace
+  graph or index construction, unnecessary whole-repository file retention,
+  and results retained after a check has consumed them. Prefer reusing an
+  existing representation, streaming bounded inputs, or releasing completed
+  work over adding another cache. These are investigation targets, not yet
+  established causes.
+- Acceptance: run the same full check set on pinned source and matched cache
+  state before and after each change. Preserve diagnostics, failure behavior
+  and required contexts. Record peak memory, available-memory headroom, CPU,
+  wall time and outcomes across repeated trials. A smaller runner must retain
+  a reviewed safety margin during representative peak workloads; one passing
+  low-memory trial is insufficient.
+- Do not close this opportunity by lowering check coverage, skipping policy
+  work, adding swap, or reducing concurrency alone. A concurrency change can
+  support a code fix, but must keep the operator's completion-time requirement.
+- Scheduling: a later implementation effort, as requested. The current cost
+  PR records the evidence and retains the production memory safety boundary.
+
 ## 2026-09-09 — Canary user data was encoded twice
 
 - What: the first pair of isolated sizing canaries stopped without running
@@ -19,6 +75,19 @@ Record receipts at the moment friction happens; redact for the public repo.
   `./typos`. Correct the exact member name. Empty console responses required
   a temporary SSM-channel-only diagnostics role on the isolated test workers;
   capture local logs and remove that role/profile with the canaries.
+- The isolated test user also lacked the `docker` group. Both comparison
+  machines failed to build the PGLite integration image, and an explicit Docker
+  probe returned `connect: permission denied` for the daemon socket. Add the
+  group and start a fresh user process for matched integration reruns. Treat
+  those first attempts as harness failures, not runner-size failures; verify
+  Docker access during future canary preflight.
+- The same unavailable Docker path made the first two Coverage runs skip
+  SQL container tests. Their only reported floor regressions were in
+  `SqlTest.ts`: lines `78.85 < 79.56`, statements `78.32 < 79.02`. Preserve
+  those failed full-run receipts and rerun `@beep/test-utils` coverage without
+  task-cache reuse after repairing the environment. A focused recovery does
+  not turn the original full run into a passing timing benchmark, and does
+  not authorize changing its coverage floors.
 
 ## 2026-09-09 — Standard rightsizing recommendations cannot size ephemeral workers
 

--- a/goals/ci-fleet-residue/research/OPPORTUNITIES.md
+++ b/goals/ci-fleet-residue/research/OPPORTUNITIES.md
@@ -2,6 +2,40 @@
 
 Record receipts at the moment friction happens; redact for the public repo.
 
+## 2026-09-09 — Canary user data was encoded twice
+
+- What: the first pair of isolated sizing canaries stopped without running
+  their verification suite or producing console receipts.
+- Evidence: decoding `describe-instance-attribute --attribute userData` once
+  yielded another base64 string, rather than the expected `#!/usr/bin/env bash`.
+  The launcher had pre-encoded the JSON user-data field before the CLI encoded it.
+- Attribution: experiment harness failure; no conclusion about either instance
+  size or the production image follows from these attempts.
+- Repair: terminate only the two tagged test instances, pass the script through
+  `--user-data file://...`, and verify the decoded remote attribute against the
+  local script immediately after launch. Retain their bounded cost in the
+  experiment receipt instead of omitting failed attempts.
+
+## 2026-09-09 — Standard rightsizing recommendations cannot size ephemeral workers
+
+- What: the approved second cost pass checked recommendation readiness before
+  selecting smaller runner canaries.
+- Evidence: Compute Optimizer and Cost Optimization Hub are Active; their EC2
+  and consolidated recommendation lists are empty. The `CWAgent` namespace has
+  no metrics. AWS requires at least 30 hours of metrics in 14 days for an EC2
+  instance recommendation; individual job workers terminate far earlier.
+- Consequence: waiting for enrollment alone will not provide useful per-lane
+  sizing evidence. Daily billing is also provisional and currently predates
+  much of the same-day rollout.
+- Response: compare identical pinned workloads on isolated On-Demand workers,
+  preserving CPU count while testing memory capacity; collect memory, CPU,
+  elapsed time and exact outcomes. Add inexpensive job-level measurements to
+  the existing workflow rather than enabling paid extended metrics.
+- Prevention: document the ephemeral-instance eligibility limitation alongside
+  account visibility. Do not interpret an empty recommendation list as proof
+  that the fleet is already optimal.
+- Reference: [Compute Optimizer resource requirements](https://docs.aws.amazon.com/compute-optimizer/latest/ug/requirements.html).
+
 ## 2026-09-09 — A branch-dispatched probe passed routing but could not get a runner
 
 - What: validating the newly activated image with Fleet Lane Probe before

--- a/goals/ci-fleet-residue/research/OPPORTUNITIES.md
+++ b/goals/ci-fleet-residue/research/OPPORTUNITIES.md
@@ -15,6 +15,10 @@ Record receipts at the moment friction happens; redact for the public repo.
   `--user-data file://...`, and verify the decoded remote attribute against the
   local script immediately after launch. Retain their bounded cost in the
   experiment receipt instead of omitting failed attempts.
+- A second setup failure used `typos` when the verified release archive stores
+  `./typos`. Correct the exact member name. Empty console responses required
+  a temporary SSM-channel-only diagnostics role on the isolated test workers;
+  capture local logs and remove that role/profile with the canaries.
 
 ## 2026-09-09 — Standard rightsizing recommendations cannot size ephemeral workers
 

--- a/packages/tooling/tool/cli/test/ci-runner-security.test.ts
+++ b/packages/tooling/tool/cli/test/ci-runner-security.test.ts
@@ -259,6 +259,42 @@ const assertTurboJobSetup = (jobs: WorkflowJobs, jobId: string, appSecrets: bool
 
 describe("CI runner security", () => {
   it.effect(
+    "preserves the requested PR lane when an older checkout has no resource helper",
+    Effect.fnUntraced(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const repoRoot = yield* findRepoRoot();
+      const tempRoot = yield* fs.makeTempDirectoryScoped();
+      const workflow = parsedDocument(yield* fs.readFileString(path.join(repoRoot, ".github/workflows/heavy.yml")));
+      const run = pipe(
+        stepRun(jobSteps(workflowJobs(workflow), "verify"), "Run verification lane"),
+        Str.replaceAll("${{ matrix.id }}", "check"),
+        Str.replaceAll("${{ steps.lane-gate.outputs.doctest_mode }}", "full")
+      );
+      const fakeBun = path.join(tempRoot, "bun");
+      yield* fs.writeFileString(fakeBun, '#!/usr/bin/env bash\nprintf "<%s>\\n" "$@"\nexit 7\n');
+      yield* fs.chmod(fakeBun, 0o755);
+      const result = Bun.spawnSync(["bash", "-c", run], {
+        cwd: tempRoot,
+        env: {
+          ...process.env,
+          PATH: `${tempRoot}:${process.env.PATH ?? ""}`,
+          GITHUB_EVENT_NAME: "pull_request",
+          GITHUB_BASE_REF: "main",
+        },
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      assert.strictEqual(result.exitCode, 7);
+      assert.include(result.stdout.toString(), "Runner resource helper unavailable");
+      assert.include(
+        result.stdout.toString(),
+        "<run>\n<beep>\n<ci>\n<lane>\n<check>\n<--affected>\n<--base>\n<origin/main>\n<--summarize>\n"
+      );
+    }, provideScopedLayer(NodeServices.layer))
+  );
+
+  it.effect(
     "preserves lane failure while emitting resource evidence without command arguments",
     Effect.fnUntraced(function* () {
       const fs = yield* FileSystem.FileSystem;

--- a/packages/tooling/tool/cli/test/ci-runner-security.test.ts
+++ b/packages/tooling/tool/cli/test/ci-runner-security.test.ts
@@ -259,6 +259,57 @@ const assertTurboJobSetup = (jobs: WorkflowJobs, jobId: string, appSecrets: bool
 
 describe("CI runner security", () => {
   it.effect(
+    "preserves lane failure while emitting resource evidence without command arguments",
+    Effect.fnUntraced(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const repoRoot = yield* findRepoRoot();
+      const tempRoot = yield* fs.makeTempDirectoryScoped();
+      const summaryPath = path.join(tempRoot, "summary.md");
+      const result = Bun.spawnSync(
+        [
+          "bash",
+          path.join(repoRoot, "scripts/ci-runner-resources.sh"),
+          "check",
+          "bash",
+          "-c",
+          "exit 7",
+          "private-argument",
+        ],
+        {
+          env: { ...process.env, RUNNER_TEMP: tempRoot, GITHUB_STEP_SUMMARY: summaryPath },
+          stderr: "pipe",
+          stdout: "pipe",
+        }
+      );
+      assert.strictEqual(result.exitCode, 7);
+      const summary = yield* fs.readFileString(summaryPath);
+      assert.include(summary, "| Lane exit status | 7 |");
+      assert.include(summary, "Sampled used-memory peak GiB");
+      assert.notInclude(summary, "private-argument");
+      assert.notInclude(result.stdout.toString(), "private-argument");
+    }, provideScopedLayer(NodeServices.layer))
+  );
+
+  it.effect(
+    "executes the lane when resource output storage is unavailable",
+    Effect.fnUntraced(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const repoRoot = yield* findRepoRoot();
+      const tempRoot = yield* fs.makeTempDirectoryScoped();
+      const blockedPath = path.join(tempRoot, "not-a-directory");
+      yield* fs.writeFileString(blockedPath, "occupied");
+      const result = Bun.spawnSync(
+        ["bash", path.join(repoRoot, "scripts/ci-runner-resources.sh"), "check", "bash", "-c", "exit 9"],
+        { env: { ...process.env, RUNNER_TEMP: blockedPath }, stderr: "pipe", stdout: "pipe" }
+      );
+      assert.strictEqual(result.exitCode, 9);
+      assert.include(result.stderr.toString(), "resource measurement unavailable");
+    }, provideScopedLayer(NodeServices.layer))
+  );
+
+  it.effect(
     "classifies goals-only pull requests without suppressing mixed or push runs",
     Effect.fnUntraced(function* () {
       const fs = yield* FileSystem.FileSystem;

--- a/packages/tooling/tool/cli/test/ci-runner-security.test.ts
+++ b/packages/tooling/tool/cli/test/ci-runner-security.test.ts
@@ -3,7 +3,7 @@ import { provideScopedLayer } from "@beep/test-utils";
 import { A } from "@beep/utils";
 import { NodeServices } from "@effect/platform-node";
 import { assert, describe, it } from "@effect/vitest";
-import { Effect, FileSystem, Order, Path, pipe } from "effect";
+import { Config, Effect, FileSystem, Order, Path, pipe } from "effect";
 import * as O from "effect/Option";
 import * as R from "effect/Record";
 import * as S from "effect/Schema";
@@ -263,6 +263,7 @@ describe("CI runner security", () => {
     Effect.fnUntraced(function* () {
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
+      const ambientPath = yield* Config.string("PATH");
       const repoRoot = yield* findRepoRoot();
       const tempRoot = yield* fs.makeTempDirectoryScoped();
       const workflow = parsedDocument(yield* fs.readFileString(path.join(repoRoot, ".github/workflows/heavy.yml")));
@@ -278,7 +279,7 @@ describe("CI runner security", () => {
         cwd: tempRoot,
         env: {
           ...process.env,
-          PATH: `${tempRoot}:${process.env.PATH ?? ""}`,
+          PATH: `${tempRoot}:${ambientPath}`,
           GITHUB_EVENT_NAME: "pull_request",
           GITHUB_BASE_REF: "main",
         },

--- a/packages/tooling/tool/cli/test/ci-runner-security.test.ts
+++ b/packages/tooling/tool/cli/test/ci-runner-security.test.ts
@@ -310,6 +310,52 @@ describe("CI runner security", () => {
   );
 
   it.effect(
+    "discards resource evidence when sample or summary files become unwritable",
+    Effect.fnUntraced(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const repoRoot = yield* findRepoRoot();
+      for (const filename of ["check.tsv", "check.md"]) {
+        const tempRoot = yield* fs.makeTempDirectoryScoped();
+        const result = Bun.spawnSync(
+          [
+            "bash",
+            path.join(repoRoot, "scripts/ci-runner-resources.sh"),
+            "check",
+            "bash",
+            "-c",
+            'target="$RUNNER_TEMP/beep-runner-resources/$1"; rm "$target"; mkdir "$target"; exit 7',
+            "fixture",
+            filename,
+          ],
+          { env: { ...process.env, RUNNER_TEMP: tempRoot }, stderr: "pipe", stdout: "pipe" }
+        );
+        assert.strictEqual(result.exitCode, 7);
+        assert.include(result.stderr.toString(), "resource measurement unavailable");
+        assert.notInclude(result.stdout.toString(), "### Runner resources:");
+      }
+    }, provideScopedLayer(NodeServices.layer))
+  );
+
+  it.effect(
+    "executes the lane when its sample file cannot be created",
+    Effect.fnUntraced(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const repoRoot = yield* findRepoRoot();
+      const tempRoot = yield* fs.makeTempDirectoryScoped();
+      yield* fs.makeDirectory(path.join(tempRoot, "beep-runner-resources", "check.tsv"), { recursive: true });
+      const result = Bun.spawnSync(
+        ["bash", path.join(repoRoot, "scripts/ci-runner-resources.sh"), "check", "bash", "-c", "exit 9"],
+        { env: { ...process.env, RUNNER_TEMP: tempRoot }, stderr: "pipe", stdout: "pipe" }
+      );
+      assert.strictEqual(result.exitCode, 9);
+      assert.include(result.stderr.toString(), "resource measurement unavailable");
+      assert.notInclude(result.stdout.toString(), "### Runner resources:");
+    }, provideScopedLayer(NodeServices.layer))
+  );
+
+  it.effect(
     "classifies goals-only pull requests without suppressing mixed or push runs",
     Effect.fnUntraced(function* () {
       const fs = yield* FileSystem.FileSystem;

--- a/scripts/ci-runner-resources.sh
+++ b/scripts/ci-runner-resources.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Measure the host around one lane without changing the lane's exit status.
+# MemTotal - MemAvailable includes the host and overlapping processes; it is a
+# sampled capacity signal, not an exact process peak or a billing measurement.
+set -uo pipefail
+
+lane="${1:-}"
+if [[ ! "$lane" =~ ^[a-z][a-z0-9-]{0,63}$ ]] || (( $# < 2 )); then
+  echo 'usage: ci-runner-resources.sh <lane> <command> [args...]' >&2
+  exit 64
+fi
+shift
+
+metrics_dir="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/beep-runner-resources"
+if ! mkdir -p "$metrics_dir"; then
+  echo '::warning::Runner resource measurement unavailable; executing lane.' >&2
+  exec "$@"
+fi
+samples="$metrics_dir/$lane.tsv"
+summary="$metrics_dir/$lane.md"
+started="$(date +%s)"
+cpu_before="$(awk '/^cpu / {for(i=2;i<=9;i++) total+=$i; print total, $5+$6}' /proc/stat)"
+swap_before="$(awk '/^pswpin / {input=$2} /^pswpout / {output=$2} END {print input+0, output+0}' /proc/vmstat)"
+printf 'epoch\ttotal_kib\tavailable_kib\tused_kib\n' > "$samples"
+
+sample() {
+  awk -v epoch="$(date +%s)" '
+    /^MemTotal:/ {total=$2}
+    /^MemAvailable:/ {available=$2}
+    END {if (total > 0) printf "%d\t%d\t%d\t%d\n", epoch, total, available, total-available}
+  ' /proc/meminfo >> "$samples"
+}
+sample
+(
+  while sleep 5; do sample; done
+) &
+sampler_pid=$!
+
+finish() {
+  local status=$?
+  trap - EXIT
+  kill "$sampler_pid" 2>/dev/null || true
+  wait "$sampler_pid" 2>/dev/null || true
+  sample
+  local ended cpu_after swap_after
+  ended="$(date +%s)"
+  cpu_after="$(awk '/^cpu / {for(i=2;i<=9;i++) total+=$i; print total, $5+$6}' /proc/stat)"
+  swap_after="$(awk '/^pswpin / {input=$2} /^pswpout / {output=$2} END {print input+0, output+0}' /proc/vmstat)"
+  awk -v lane="$lane" -v status="$status" -v seconds="$((ended-started))" \
+    -v before="$cpu_before" -v after="$cpu_after" \
+    -v swap_before="$swap_before" -v swap_after="$swap_after" '
+    NR > 1 {count++; total=$2; if ($4 > peak) peak=$4; if (count==1 || $3 < available) available=$3}
+    END {
+      split(before,b," "); split(after,a," "); delta=a[1]-b[1]
+      split(swap_before,sb," "); split(swap_after,sa," ")
+      print "### Runner resources: " lane
+      print ""
+      print "| Measurement | Value |"
+      print "| --- | --- |"
+      printf "| Lane exit status | %d |\n| Elapsed seconds | %d |\n", status, seconds
+      printf "| Memory samples (5-second interval) | %d |\n", count
+      printf "| Host memory GiB | %.2f |\n| Sampled used-memory peak GiB | %.2f |\n", total/1048576, peak/1048576
+      printf "| Minimum available memory GiB | %.2f |\n", available/1048576
+      if (delta > 0) printf "| Host CPU busy percent (excluding I/O wait) | %.1f |\n", 100*(delta-(a[2]-b[2]))/delta
+      printf "| Swap-in / swap-out pages | %d / %d |\n", sa[1]-sb[1], sa[2]-sb[2]
+      print ""
+      print "Host-wide samples include the OS and other processes. Peaks between samples may be missed."
+      print "Elapsed time excludes checkout/setup and is not billed instance lifetime."
+    }
+  ' "$samples" > "$summary"
+  cat "$summary"
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    cat "$summary" >> "$GITHUB_STEP_SUMMARY" || true
+  fi
+  exit "$status"
+}
+trap finish EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+"$@"
+exit "$?"

--- a/scripts/ci-runner-resources.sh
+++ b/scripts/ci-runner-resources.sh
@@ -12,8 +12,11 @@ fi
 shift
 
 metrics_dir="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/beep-runner-resources"
+unavailable() {
+  echo '::warning::Runner resource measurement unavailable; lane exit status is preserved.' >&2
+}
 if ! mkdir -p "$metrics_dir"; then
-  echo '::warning::Runner resource measurement unavailable; executing lane.' >&2
+  unavailable
   exec "$@"
 fi
 samples="$metrics_dir/$lane.tsv"
@@ -21,18 +24,41 @@ summary="$metrics_dir/$lane.md"
 started="$(date +%s)"
 cpu_before="$(awk '/^cpu / {for(i=2;i<=9;i++) total+=$i; print total, $5+$6}' /proc/stat)"
 swap_before="$(awk '/^pswpin / {input=$2} /^pswpout / {output=$2} END {print input+0, output+0}' /proc/vmstat)"
-printf 'epoch\ttotal_kib\tavailable_kib\tused_kib\n' > "$samples"
+if ! printf 'epoch\ttotal_kib\tavailable_kib\tused_kib\n' > "$samples" || ! : > "$summary"; then
+  unavailable
+  exec "$@"
+fi
 
 sample() {
   awk -v epoch="$(date +%s)" '
     /^MemTotal:/ {total=$2}
     /^MemAvailable:/ {available=$2}
-    END {if (total > 0) printf "%d\t%d\t%d\t%d\n", epoch, total, available, total-available}
+    END {
+      if (total <= 0 || available <= 0) exit 1
+      printf "%d\t%d\t%d\t%d\n", epoch, total, available, total-available
+    }
   ' /proc/meminfo >> "$samples"
 }
-sample
+if ! sample; then
+  unavailable
+  exec "$@"
+fi
 (
-  while sleep 5; do sample; done
+  sleeper_pid=""
+  stop_sampler() {
+    if [[ -n "$sleeper_pid" ]]; then
+      kill "$sleeper_pid" 2>/dev/null || true
+      wait "$sleeper_pid" 2>/dev/null || true
+    fi
+    exit 0
+  }
+  trap stop_sampler TERM INT
+  while true; do
+    sleep 5 &
+    sleeper_pid=$!
+    wait "$sleeper_pid" || exit 1
+    sample || exit 1
+  done
 ) &
 sampler_pid=$!
 
@@ -40,13 +66,18 @@ finish() {
   local status=$?
   trap - EXIT
   kill "$sampler_pid" 2>/dev/null || true
-  wait "$sampler_pid" 2>/dev/null || true
-  sample
+  local sampler_status=0
+  wait "$sampler_pid" 2>/dev/null || sampler_status=$?
+  # 143 also covers a stop arriving before the sampler installed its trap.
+  if (( sampler_status != 0 && sampler_status != 143 )) || ! sample; then
+    unavailable
+    exit "$status"
+  fi
   local ended cpu_after swap_after
   ended="$(date +%s)"
   cpu_after="$(awk '/^cpu / {for(i=2;i<=9;i++) total+=$i; print total, $5+$6}' /proc/stat)"
   swap_after="$(awk '/^pswpin / {input=$2} /^pswpout / {output=$2} END {print input+0, output+0}' /proc/vmstat)"
-  awk -v lane="$lane" -v status="$status" -v seconds="$((ended-started))" \
+  if ! awk -v lane="$lane" -v status="$status" -v seconds="$((ended-started))" \
     -v before="$cpu_before" -v after="$cpu_after" \
     -v swap_before="$swap_before" -v swap_after="$swap_after" '
     NR > 1 {count++; total=$2; if ($4 > peak) peak=$4; if (count==1 || $3 < available) available=$3}
@@ -67,10 +98,16 @@ finish() {
       print "Host-wide samples include the OS and other processes. Peaks between samples may be missed."
       print "Elapsed time excludes checkout/setup and is not billed instance lifetime."
     }
-  ' "$samples" > "$summary"
-  cat "$summary"
+  ' "$samples" > "$summary"; then
+    unavailable
+    exit "$status"
+  fi
+  if ! cat "$summary"; then
+    unavailable
+    exit "$status"
+  fi
   if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-    cat "$summary" >> "$GITHUB_STEP_SUMMARY" || true
+    cat "$summary" >> "$GITHUB_STEP_SUMMARY" || unavailable
   fi
   exit "$status"
 }


### PR DESCRIPTION
Heavy CI jobs lacked resource measurements, which made safe sizing difficult. This PR records host memory, CPU, swap and elapsed time in each executed lane's log and step summary while preserving its exit status and process-group cleanup. Measurement-storage failures still run the command, and older PR checkouts without the helper retain the same requested verification lane.

The follow-up confirms the repaired Build route on an existing PR, records a 303-job operational sample, evaluates skipped-lane routing, refreshes account cost controls, and completes an isolated comparison of three On-Demand instance types. The 32 GiB candidate left only 0.89 GiB available during full Docgen. Production keeps its existing 64 GiB choices and cap; the committed future memory-burndown opportunity targets Lint Policy and Docgen implementations while preserving checks and completion times.

[Complete comparison, failure attribution and AWS cleanup receipt](https://github.com/beep-effect/beep-effect/pull/1071#issuecomment-5609201771).

Validation: 20 focused CI security/resource tests, `bun run beep quality test-tsgo`, and `bun run beep quality package-verify @beep/repo-cli --quick` passed. The full local pre-push suite passed all 31 lanes, including coverage for 134 packages. Hosted CI passed on `3bf7832df8`; Vercel build-rate-limit failures were acknowledged under the operator's instruction. Greptile gave 5/5 and no review threads remained unresolved. The operator merged this PR as `b9265cda6d` at 22:12:43 UTC on 2026-09-09. The additional merged-branch preview was then intentionally stopped (exit 130); it is not claimed as a completed proof. All six changed files match the merged main commit, and the temporary preview worktree was removed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791576780&installation_model_id=424656&pr_number=1071&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1071&signature=f8a5147f79cb03db3e4f393e3c5b278ada963b506ad095693e7ab99498562842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

---

<!-- yeet-provenance:start -->
## Provenance

- Workspace: <code>beep-effect</code>
- Branch: <code>codex/runner-cost-evidence</code>
- Agents (newest first):
  - `codex` (tui) · `unknown` · monitored

Resume the publishing agent from any beep-effect checkout on the publishing workstation:

```sh
bun run beep yeet resume 1071
```

<!-- yeet-provenance
{
  "schemaVersion": 2,
  "pr": 1071,
  "branch": "codex/runner-cost-evidence",
  "workspace": "beep-effect",
  "agents": [
    {
      "harness": "codex",
      "entrypoint": "codex-tui",
      "hostHarness": null,
      "model": "unknown",
      "label": null,
      "workspace": null,
      "role": "monitored"
    }
  ]
}
-->
<!-- yeet-provenance:end -->
