### PR TITLE
docs(graft): record the first deep build with measured numbers and rules

### DIFF
--- a/docs/runbooks/graft-local-recovery.md
+++ b/docs/runbooks/graft-local-recovery.md
@@ -211,14 +211,33 @@ pass over 4,138 files took 80 min. Coverage ended at 98% (38,520 symbols);
 the remainder is one 800 KB generated file whose single request cannot finish
 inside the proxy's 5 min limit.
 
+Prerequisite: the installed Graft must carry the repo's dist patches (the
+crux id normalization is what keeps grok's crux pass above 31% coverage):
+
 ```sh
-install -m 600 /dev/null "${XDG_CACHE_HOME:-$HOME/.cache}/beep/graft-deep-grok-low.env"
+scripts/graft/apply-dist-patches.sh --check   # every line must read "applied"
+```
+
+Run the build in two phases with two environment files. Phase A covers the
+summary and synthesis passes at the model's default effort (an unsuffixed
+grok request reasons at roughly the xhigh rate; `gpt-6-astra(high)` is the
+equivalent on the Codex pool) because the concept map is what every later
+query ranks on. Phase B runs the crux pass at `(low)`. The switch happens the
+moment the log shows `summarizing 1/…`, before any crux file has completed,
+so nothing is lost; do not switch later (see the restart rule below).
+
+```sh
+install -m 600 /dev/null "${XDG_CACHE_HOME:-$HOME/.cache}/beep/graft-deep-grok.env"
 # GRAFT_PROVIDER=openai, GRAFT_BASE_URL=http://127.0.0.1:8317/v1, GRAFT_API_KEY=<proxy client token>,
-# GRAFT_MODEL=grok-4.6(low), GRAFT_LLM_RETRIES=12, GRAFT_CRUX_EMPTY_RETRIES=2, DO_NOT_TRACK=1
-systemd-run --user --unit graft-deep --working-directory="$PWD" --collect \
-  -p EnvironmentFile="${XDG_CACHE_HOME:-$HOME/.cache}/beep/graft-deep-grok-low.env" \
+# GRAFT_MODEL=grok-4.6, GRAFT_LLM_RETRIES=12, DO_NOT_TRACK=1
+# graft-deep-grok-low.env: the same file with GRAFT_MODEL=grok-4.6(low) and GRAFT_CRUX_EMPTY_RETRIES=2
+systemd-run --user --unit graft-deep-A --working-directory="$PWD" --collect \
+  -p EnvironmentFile="${XDG_CACHE_HOME:-$HOME/.cache}/beep/graft-deep-grok.env" \
   -p StandardOutput=append:"$HOME/data-home/graft-cache/deep-build.log" -p StandardError=inherit \
   graft build --deep -j 16
+# when the log shows `summarizing 1/…`: systemctl --user stop graft-deep-A, then the same
+# command as graft-deep-B with graft-deep-grok-low.env; it resumes from the cache and runs
+# the crux pass to completion
 ```
 
 Rules learned from that run:
@@ -230,12 +249,15 @@ Rules learned from that run:
 - grok-4.6 returns the whole target row (`id | kind | lines Lx-Ly`) as the
   entry id instead of the id verbatim, which drops every symbol of the file
   and reports `no usable symbol summaries [empty-parsed, finish_reason=null]`.
-  The first crux pass ended at 31% coverage because of it. The installed
-  `dist/ai/crux.js` carries a local patch that keeps the segment before the
-  separator (352 of 352 fixture ids match after it, 84 before) plus a bounded
-  retry for prose answers; `dist/context/build.js` retries an empty synthesis
-  batch and checkpoints after every batch. Astra honors the id contract
-  without the patch. All of these die on `graft upgrade`.
+  The first crux pass ended at 31% coverage because of it. The repo records
+  the fix and its companions as unified diffs under
+  `scripts/graft/patches/<graft version>/`: `ai-crux` keeps the segment before
+  the separator (352 of 352 fixture ids match after it, 84 before) and retries
+  a prose answer a bounded number of times; `context-build` retries an empty
+  synthesis batch and checkpoints the synthesis cache after every batch;
+  `ai-llm-openai` adds the `GRAFT_DUMP_DIR` response dump used below.
+  `scripts/graft/apply-dist-patches.sh` applies whatever is missing and is
+  safe to rerun; astra honors the id contract without the crux patch.
 - Never restart the crux pass to tune it. A file is skipped on resume only
   when every symbol in it is already ready; one omitted symbol keeps the whole
   file dirty, so a restart re-requests most finished files (909 reported, 239
@@ -264,10 +286,17 @@ workstation:
 npm install -g --prefix "$HOME/.local" @nanonets/graft@0.16.0
 graft --version
 ```
- The workstation also carries a local patch to the installed
-`dist/context/build.js` that checkpoints the synthesis cache after every batch
-(the original is kept beside it as `build.js.orig-<version>`); a reinstall or
-upgrade removes it, so re-apply it before the next deep build. The loader's
-stamp guard keeps upkeep quiet across upgrades, so an upgrade needs no
-`graft init`: run `graft --version`, re-apply the patch, and run the two
-focused checks above.
+The deep build depends on three workstation-local patches to the installed
+`dist/` (`ai/crux.js`, `ai/llm/openai.js`, `context/build.js`), recorded as
+unified diffs under `scripts/graft/patches/<graft version>/`. A reinstall or
+upgrade removes them, and a new Graft version needs them ported into a new
+version directory first. After the install, apply and verify them, then run
+the two focused checks above:
+
+```sh
+scripts/graft/apply-dist-patches.sh          # applies what is missing, keeps *.orig-<version> backups
+scripts/graft/apply-dist-patches.sh --check  # exit 0 only when every recorded patch is present
+```
+
+The loader's stamp guard keeps upkeep quiet across upgrades, so an upgrade
+needs no `graft init`.

--- a/docs/runbooks/graft-local-recovery.md
+++ b/docs/runbooks/graft-local-recovery.md
@@ -191,32 +191,68 @@ The meaning tier (`graft build --deep`) adds the concept map and the per-symbol
 summary and crux. It spends model quota through the local proxy, so it is an
 operator batch job, never something an agent runs. It has three model-backed
 passes: per-file summaries (one request per file, content-hash cached, cheap
-to repeat), concept synthesis (142 sequential batches on this repo; effort
-barely changes their duration because the time goes to writing nodes), and the
-per-symbol crux pass (one batched request per file, checkpointed every 15 s).
-Run it as two systemd user services so a closed terminal cannot kill it and
-the proxy token stays in an environment file rather than on a command line:
-phase A at medium effort until the crux pass starts (the synthesis quality is
-what every later query ranks on), then phase B at low effort to completion
-(synthesis replays from cache; the crux pass is mechanical).
+to repeat), concept synthesis (143 sequential batches on this repo; the time
+goes to writing nodes, so effort barely changes it), and the per-symbol crux
+pass (one batched request per file, checkpointed every 15 s). Run each pass
+as a systemd user service so a closed terminal cannot kill it and the proxy
+token stays in an environment file rather than on a command line. The first
+full build of this repo (2026-09-09) measured:
+
+| Pass | Model | Concurrency | Measured |
+| --- | --- | --- | --- |
+| Summaries + synthesis | `gpt-6-astra(high)` then `grok-4.6` | sequential batches | 105 to 125 s per batch at high effort, about 150 s on grok; 7 of 143 grok batches came back empty and were refilled by a retry |
+| Crux pass | `grok-4.6` (default effort) | `-j 8` | 10 files/min, 23 s mean request latency |
+| Crux pass | `grok-4.6(low)` | `-j 8` | 25 files/min, 10 s mean latency |
+| Crux pass | `grok-4.6(low)` | `-j 16` | 40 to 80 files/min, no rate limiting across 15,000 requests |
+
+Whole run: 5,216 files, 39,115 symbols, 143 synthesis batches, about 10 h of
+wall clock including two restarts and one full crux re-pass; the final crux
+pass over 4,138 files took 80 min. Coverage ended at 98% (38,520 symbols);
+the remainder is one 800 KB generated file whose single request cannot finish
+inside the proxy's 5 min limit.
 
 ```sh
-install -m 600 /dev/null "${XDG_CACHE_HOME:-$HOME/.cache}/beep/graft-deep-medium.env"
+install -m 600 /dev/null "${XDG_CACHE_HOME:-$HOME/.cache}/beep/graft-deep-grok-low.env"
 # GRAFT_PROVIDER=openai, GRAFT_BASE_URL=http://127.0.0.1:8317/v1, GRAFT_API_KEY=<proxy client token>,
-# GRAFT_MODEL=gpt-6-astra(medium), GRAFT_LLM_RETRIES=12, DO_NOT_TRACK=1; same file with (low) for phase B
-systemd-run --user --unit graft-deep-A --working-directory="$PWD" --collect \
-  -p EnvironmentFile="${XDG_CACHE_HOME:-$HOME/.cache}/beep/graft-deep-medium.env" \
+# GRAFT_MODEL=grok-4.6(low), GRAFT_LLM_RETRIES=12, GRAFT_CRUX_EMPTY_RETRIES=2, DO_NOT_TRACK=1
+systemd-run --user --unit graft-deep --working-directory="$PWD" --collect \
+  -p EnvironmentFile="${XDG_CACHE_HOME:-$HOME/.cache}/beep/graft-deep-grok-low.env" \
   -p StandardOutput=append:"$HOME/data-home/graft-cache/deep-build.log" -p StandardError=inherit \
-  graft build --deep -j 4
-# when the log shows `summarizing 1/…`: systemctl --user stop graft-deep-A, then the same
-# command as graft-deep-B with the (low) environment file; it runs to completion
+  graft build --deep -j 16
 ```
 
-Leave `--allow-partial` off so an incomplete meaning tier fails loudly; rerun
-the same command to retry only the failed files. `-j` reaches the crux pass
-only; the concept pass runs eight summaries in parallel regardless. The
-synthesis checkpoint patch described below must be present before phase A, or
-a provider error discards every finished batch.
+Rules learned from that run:
+
+- The proxy's `model(effort)` suffix works for grok as well as astra; the
+  registry lists `low|medium|high|xhigh` for grok-4.6 and an unsuffixed
+  request reasons at roughly the xhigh rate. Use `(low)` for the crux pass;
+  it is mechanical and the tool call is what matters.
+- grok-4.6 returns the whole target row (`id | kind | lines Lx-Ly`) as the
+  entry id instead of the id verbatim, which drops every symbol of the file
+  and reports `no usable symbol summaries [empty-parsed, finish_reason=null]`.
+  The first crux pass ended at 31% coverage because of it. The installed
+  `dist/ai/crux.js` carries a local patch that keeps the segment before the
+  separator (352 of 352 fixture ids match after it, 84 before) plus a bounded
+  retry for prose answers; `dist/context/build.js` retries an empty synthesis
+  batch and checkpoints after every batch. Astra honors the id contract
+  without the patch. All of these die on `graft upgrade`.
+- Never restart the crux pass to tune it. A file is skipped on resume only
+  when every symbol in it is already ready; one omitted symbol keeps the whole
+  file dirty, so a restart re-requests most finished files (909 reported, 239
+  skipped). Read the end-of-run `computed / cached / pending` line instead and
+  run `graft build --deep` again, which touches only dirty files.
+- Leave `--allow-partial` off so an incomplete meaning tier fails loudly. `-j`
+  reaches the crux pass only; the concept pass runs sequentially regardless.
+- Diagnose a bad pass on a copy, not the real graph: copy a failing directory
+  into a throwaway repo, `git init`, `graft build`, then `graft build --deep`
+  with `GRAFT_DUMP_DIR=<dir>` set (local patch in `dist/ai/llm/openai.js`)
+  and read `responses.jsonl` for what the model actually returned.
+- After seeding, `graft check` in a clone at a different commit reports
+  `STALE` with the changed files listed. That is the concept layer's snapshot
+  digest disagreeing with the tree, not a broken graph; queries keep working
+  with the old summaries as hints. Refresh by running `graft build --deep` in
+  one clone (it re-summarizes only changed files and re-synthesizes only the
+  batches they belong to) and seeding again.
 
 ## After a Graft upgrade
 

--- a/scripts/graft/apply-dist-patches.sh
+++ b/scripts/graft/apply-dist-patches.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Re-apply the workstation-local Graft dist patches after an install or upgrade.
+#
+# The patches live in scripts/graft/patches/<graft version>/ as unified diffs
+# rooted at the installed package's dist/ directory. Each one is applied at
+# most once: a patch that already matches the installed file is reported as
+# applied and skipped, so the script is safe to run repeatedly.
+#
+#   scripts/graft/apply-dist-patches.sh            # apply what is missing
+#   scripts/graft/apply-dist-patches.sh --check    # report only; exit 1 if any is missing
+#
+# GRAFT_PACKAGE_ROOT overrides the package location (the directory that holds
+# package.json and dist/); by default it is resolved from the `graft` on PATH.
+set -euo pipefail
+
+mode="${1:---apply}"
+case "$mode" in
+  --apply | --check) ;;
+  *)
+    echo "usage: $0 [--apply|--check]" >&2
+    exit 2
+    ;;
+esac
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ -n "${GRAFT_PACKAGE_ROOT:-}" ]; then
+  pkg="$GRAFT_PACKAGE_ROOT"
+else
+  bin="$(command -v graft || true)"
+  if [ -z "$bin" ]; then
+    echo "graft is not on PATH; set GRAFT_PACKAGE_ROOT to the installed package directory" >&2
+    exit 2
+  fi
+  # ~/.local/bin/graft -> <package>/dist/cli.js
+  pkg="$(cd "$(dirname "$(readlink -f "$bin")")/.." && pwd)"
+fi
+
+if [ ! -f "$pkg/package.json" ] || [ ! -d "$pkg/dist" ]; then
+  echo "no Graft package at $pkg (expected package.json and dist/)" >&2
+  exit 2
+fi
+
+version="$(sed -n 's/^[[:space:]]*"version":[[:space:]]*"\([^"]*\)".*/\1/p' "$pkg/package.json" | head -n 1)"
+patches="$here/patches/$version"
+if [ ! -d "$patches" ]; then
+  echo "no dist patches recorded for graft $version under $here/patches/; port them before the next deep build" >&2
+  exit 1
+fi
+
+missing=0
+for patch_file in "$patches"/*.patch; do
+  name="$(basename "$patch_file" .patch)"
+  if patch -p1 -d "$pkg/dist" -R --dry-run --silent <"$patch_file" >/dev/null 2>&1; then
+    echo "applied  $name"
+    continue
+  fi
+  if ! patch -p1 -d "$pkg/dist" --forward --dry-run --silent <"$patch_file" >/dev/null 2>&1; then
+    echo "CONFLICT $name (does not apply to graft $version cleanly; port it by hand)"
+    missing=$((missing + 1))
+    continue
+  fi
+  if [ "$mode" = "--check" ]; then
+    echo "missing  $name"
+    missing=$((missing + 1))
+    continue
+  fi
+  patch -p1 -d "$pkg/dist" --forward --silent -b -z ".orig-$version" <"$patch_file" >/dev/null
+  echo "patched  $name"
+done
+
+if [ "$missing" -gt 0 ]; then
+  echo "$missing patch(es) not applied to graft $version at $pkg/dist" >&2
+  exit 1
+fi
+echo "graft $version at $pkg/dist carries every recorded dist patch"

--- a/scripts/graft/patches/0.16.0/ai-crux.patch
+++ b/scripts/graft/patches/0.16.0/ai-crux.patch
@@ -1,0 +1,48 @@
+--- a/ai/crux.js
++++ b/ai/crux.js
+@@ -79,8 +79,10 @@
+     return obj.symbols
+         .map((s) => s)
+         .filter((s) => typeof s.id === "string")
++        // Local patch (2026-09-09): grok echoes the whole target row ("id | kind | lines Lx-Ly")
++        // as the id; keep the verbatim id segment so entries match graph node ids.
+         .map((s) => ({
+-        id: s.id,
++        id: s.id.split(" | ")[0].trim(),
+         summary: typeof s.summary === "string" ? s.summary.trim() : "",
+         crux_start: num(s.crux_start),
+         crux_end: num(s.crux_end),
+@@ -117,7 +119,7 @@
+         this.lastMiss = null;
+         if (input.nodes.length === 0)
+             return [];
+-        const res = await this.model.create({
++        const request = {
+             temperature: 0,
+             maxTokens: 8192,
+             tools: [
+@@ -132,9 +134,21 @@
+                 { role: "system", content: SYSTEM_PROMPT },
+                 { role: "user", content: userContent(input) },
+             ],
+-        });
+-        const parsed = parseResults(argsFromResponse(res));
+-        this.lastMiss = classifyCruxMiss(res, parsed);
++        };
++        // Local patch (2026-09-09): grok-class models ignore the forced tool call on a
++        // share of crux requests and answer in prose; retry those before recording a miss.
++        const emptyRetries = Number(process.env.GRAFT_CRUX_EMPTY_RETRIES ?? 2);
++        const isEmpty = (r) => ((r && (r.size ?? r.length)) ?? 0) === 0;
++        let res = await this.model.create(request);
++        let parsed = parseResults(argsFromResponse(res));
++        let miss = classifyCruxMiss(res, parsed);
++        for (let attempt = 1; isEmpty(parsed) && miss && miss.kind !== "truncated" && attempt <= emptyRetries; attempt++) {
++            console.error(`  crux ${input.path ?? ""}: ${miss.kind}, retry ${attempt}/${emptyRetries}`);
++            res = await this.model.create(request);
++            parsed = parseResults(argsFromResponse(res));
++            miss = classifyCruxMiss(res, parsed);
++        }
++        this.lastMiss = miss;
+         return parsed;
+     }
+ }

--- a/scripts/graft/patches/0.16.0/ai-llm-openai.patch
+++ b/scripts/graft/patches/0.16.0/ai-llm-openai.patch
@@ -1,0 +1,18 @@
+--- a/ai/llm/openai.js
++++ b/ai/llm/openai.js
+@@ -1,3 +1,4 @@
++import { appendFileSync as __dumpAppend } from "node:fs";
+ /**
+  * OpenAI-compatible transport. Wraps the `openai` SDK pointed at any
+  * OpenAI-compatible endpoint (OpenAI, OpenRouter, Fireworks, a LiteLLM proxy,
+@@ -187,6 +188,10 @@
+         return this.client.chat.completions.create(attempt);
+     }
+     fromResponse(resp, format) {
++        // Local patch (2026-09-09): raw response dump for diagnosing empty-parsed cruxes.
++        if (process.env.GRAFT_DUMP_DIR) {
++            try { __dumpAppend(process.env.GRAFT_DUMP_DIR + "/responses.jsonl", JSON.stringify(resp) + "\n"); } catch {}
++        }
+         const choice = resp.choices[0];
+         const msg = choice?.message;
+         const rawCalls = (msg?.tool_calls ?? []).filter((c) => c.type === "function");

--- a/scripts/graft/patches/0.16.0/context-build.patch
+++ b/scripts/graft/patches/0.16.0/context-build.patch
@@ -1,0 +1,23 @@
+--- a/context/build.js
++++ b/context/build.js
+@@ -162,10 +162,20 @@
+         const cached = Array.isArray(nodes) && nodes.length > 0;
+         if (!cached) {
+             nodes = await opts.synthesizer.synthesize(batches[b]);
++            // Local patch (2026-09-09): an empty batch is usually the model ignoring
++            // tool_choice; retry a bounded number of times before accepting the hole.
++            const emptyRetries = Number(process.env.GRAFT_SYNTH_EMPTY_RETRIES ?? 2);
++            for (let attempt = 1; nodes.length === 0 && attempt <= emptyRetries; attempt++) {
++                console.error(`  synthesis batch ${b + 1}/${batches.length}: empty, retry ${attempt}/${emptyRetries}`);
++                nodes = await opts.synthesizer.synthesize(batches[b]);
++            }
+             if (nodes.length > 0)
+                 cache.synth[key] = nodes;
+             else
+                 delete cache.synth[key];
++            // Local patch (2026-09-09): checkpoint after every batch so a thrown
++            // provider error cannot discard hours of finished synthesis.
++            saveCache(outDir, cache);
+         }
+         const links = nodes.reduce((n, node) => n + node.links.length, 0);
+         console.error(`  synthesis batch ${b + 1}/${batches.length}: ${nodes.length} nodes, ${links} links${cached ? " (cached)" : ""}`);


### PR DESCRIPTION
## docs(graft): record the first deep build with measured numbers and rules

Replace the projected two-phase astra procedure in the Graft recovery runbook
with what the 2026-09-09 build measured: per-pass throughput on astra and
grok, the effort suffix behaviour, the grok id-echo defect that dropped the
first crux pass to 31% coverage and the local dist patches that fixed it, the
restart cost of the crux pass, how to diagnose a bad pass on a copy, and what
STALE means in a seeded clone.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

## Local proof

- fallow-advisory-feedback: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/docs_graft-deep-build-record-3343c0b714a4/verdict.json

---

<!-- yeet-provenance:start -->
## Provenance

- Workspace: <code>beep-effect6</code>
- Branch: <code>docs/graft-deep-build-record</code>
- Agents (newest first):
  - `unknown` (unknown) · `unknown` · pushed

Resume the publishing agent from any beep-effect checkout on the publishing workstation:

```sh
bun run beep yeet resume 1073
```

<!-- yeet-provenance
{
  "schemaVersion": 2,
  "pr": 1073,
  "branch": "docs/graft-deep-build-record",
  "workspace": "beep-effect6",
  "agents": [
    {
      "harness": "unknown",
      "entrypoint": "unknown",
      "hostHarness": null,
      "model": "unknown",
      "label": null,
      "workspace": null,
      "role": "pushed"
    }
  ]
}
-->
<!-- yeet-provenance:end -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1073"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791585271&installation_model_id=424656&pr_number=1073&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1073&signature=fbe4577f2fee6de6a96705943816e16cbe2189a6decf420e022c7e939f94ebdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->