### PR TITLE
ci(coverage): scope the Float16Array flag to vitest test workers

### DIFF
--- a/.changeset/coverage-flag-scope-next-guard.md
+++ b/.changeset/coverage-flag-scope-next-guard.md
@@ -1,9 +1,13 @@
 ---
 "@beep/todox": patch
 "@beep/oip-web": patch
+"@beep/editor": patch
 ---
 
 Strip the coverage lane's `--js-float16array` flag from `process.execArgv` at
 `next.config.ts` load time so Next.js build workers never receive it through
 `NODE_OPTIONS`, where V8 rejects it. Transitional: a no-op once the job-wide
 node wrapper is removed from `heavy.yml`.
+
+The editor package adds direct contract tests for its viewer decorator
+nodes so both Node runtimes attribute their function coverage.

--- a/.changeset/coverage-flag-scope-next-guard.md
+++ b/.changeset/coverage-flag-scope-next-guard.md
@@ -1,0 +1,9 @@
+---
+"@beep/todox": patch
+"@beep/oip-web": patch
+---
+
+Strip the coverage lane's `--js-float16array` flag from `process.execArgv` at
+`next.config.ts` load time so Next.js build workers never receive it through
+`NODE_OPTIONS`, where V8 rejects it. Transitional: a no-op once the job-wide
+node wrapper is removed from `heavy.yml`.

--- a/.github/workflows/heavy.yml
+++ b/.github/workflows/heavy.yml
@@ -162,21 +162,17 @@ jobs:
           security-trusted-origins: ${{ github.event_name == 'push' && secrets.SECURITY_TRUSTED_ORIGINS || '' }}
           liveblocks-secret-key: ${{ github.event_name == 'push' && secrets.LIVEBLOCKS_SECRET_KEY || '' }}
 
-      - name: Enable coverage runtime features
+      - name: Verify coverage runtime features
         if: steps.lane-gate.outputs.should_run == 'true' && matrix.id == 'coverage'
         shell: bash
         run: |
           set -euo pipefail
-          # Node 22 needs this flag for the Float16Array contract exercised by coverage.
-          # V8 does not allow --js-float16array in NODE_OPTIONS, so wrap the selected binary.
-          coverage_node_binary="$(command -v node)"
-          coverage_node_dir="$RUNNER_TEMP/beep-coverage-node"
-          mkdir -p "$coverage_node_dir"
-          printf '#!/usr/bin/env bash\nexec %q --js-float16array "$@"\n' \
-            "$coverage_node_binary" > "$coverage_node_dir/node"
-          chmod +x "$coverage_node_dir/node"
-          "$coverage_node_dir/node" -p "'Node ' + process.versions.node + ', ' + Float16Array.name"
-          printf '%s\n' "$coverage_node_dir" >> "$GITHUB_PATH"
+          # Node 22 gates Float16Array behind --js-float16array. The flag must
+          # NOT be granted job-wide (a wrapped node leaks it into Next.js build
+          # workers via NODE_OPTIONS, which V8 rejects); vitest.shared.ts scopes
+          # it to forked test workers instead. This step only proves the pinned
+          # runtime supports the flag the workers will request.
+          node --js-float16array -p "'Node ' + process.versions.node + ', ' + Float16Array.name"
 
       # PRs may restore the post-main local fallback without saving it. Same-
       # repository PRs can also read the remote cache; forks remain tokenless.

--- a/apps/oip-web/next.config.ts
+++ b/apps/oip-web/next.config.ts
@@ -2,6 +2,14 @@ import { fileURLToPath } from "node:url";
 import { defineBeepNextConfig } from "@beep/repo-configs/next";
 import { oipRedirects } from "./src/config/OipRedirects.ts";
 
+// Transitional guard for the coverage lane's job-wide node wrapper (removed
+// from heavy.yml by this branch, but PR runs resolve heavy.yml@main): the
+// wrapper injects --js-float16array into every node process, and Next copies
+// process.execArgv into its build workers' NODE_OPTIONS, where V8 rejects
+// feature flags. Strip it before any worker spawns; once the wrapper is gone
+// from main this filter matches nothing.
+process.execArgv = process.execArgv.filter((flag) => flag !== "--js-float16array");
+
 const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
 
 const securityHeaders = [

--- a/apps/todox/next.config.ts
+++ b/apps/todox/next.config.ts
@@ -1,5 +1,13 @@
 import type { NextConfig } from "next";
 
+// Transitional guard for the coverage lane's job-wide node wrapper (removed
+// from heavy.yml by this branch, but PR runs resolve heavy.yml@main): the
+// wrapper injects --js-float16array into every node process, and Next copies
+// process.execArgv into its build workers' NODE_OPTIONS, where V8 rejects
+// feature flags. Strip it before any worker spawns; once the wrapper is gone
+// from main this filter matches nothing.
+process.execArgv = process.execArgv.filter((flag) => flag !== "--js-float16array");
+
 const nextConfig: NextConfig = {};
 
 export default nextConfig;

--- a/packages/foundation/ui-system/editor/test/decorator-node-contracts.test.ts
+++ b/packages/foundation/ui-system/editor/test/decorator-node-contracts.test.ts
@@ -41,9 +41,7 @@ describe("viewer decorator node contracts", () => {
 
   it("rejects a malformed serialized mermaid payload", () => {
     withNodeContext(() => {
-      expect(() =>
-        MermaidNode.importJSON({ type: "mermaid", version: 1, format: "", source: 42 } as never)
-      ).toThrowError();
+      expect(() => MermaidNode.importJSON({ type: "mermaid", version: 1, format: "", source: 42 } as never)).toThrow();
     });
   });
 
@@ -77,7 +75,7 @@ describe("viewer decorator node contracts", () => {
     withNodeContext(() => {
       expect(() =>
         CodeBlockNode.importJSON({ type: "codeblock", version: 1, format: "", code: "x" } as never)
-      ).toThrowError();
+      ).toThrow();
     });
   });
 });

--- a/packages/foundation/ui-system/editor/test/decorator-node-contracts.test.ts
+++ b/packages/foundation/ui-system/editor/test/decorator-node-contracts.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+
+import { $createCodeBlockNode, $isCodeBlockNode, CodeBlockNode } from "@beep/editor/code-block-node";
+import { $createMermaidNode, $isMermaidNode, MermaidNode } from "@beep/editor/mermaid-node";
+import { describe, expect, it } from "@effect/vitest";
+import { createHeadlessEditor } from "@lexical/headless";
+
+const withNodeContext = (assertions: () => void): void => {
+  const editor = createHeadlessEditor({
+    nodes: [MermaidNode, CodeBlockNode],
+    onError: (error) => {
+      throw error;
+    },
+  });
+  editor.update(assertions, { discrete: true });
+};
+
+describe("viewer decorator node contracts", () => {
+  it("round-trips a mermaid node through its serialized shape", () => {
+    withNodeContext(() => {
+      const node = $createMermaidNode("graph TD\n  A --> B");
+
+      expect(MermaidNode.getType()).toBe("mermaid");
+      expect(node.getTextContent()).toBe("graph TD\n  A --> B");
+      expect($isMermaidNode(node)).toBe(true);
+      expect($isMermaidNode({ source: "graph TD" })).toBe(false);
+
+      const serialized = node.exportJSON();
+      expect(serialized.type).toBe("mermaid");
+      expect(serialized.version).toBe(1);
+      expect(serialized.source).toBe("graph TD\n  A --> B");
+
+      const imported = MermaidNode.importJSON({ ...serialized });
+      expect(imported.getTextContent()).toBe("graph TD\n  A --> B");
+
+      const cloned = MermaidNode.clone(node);
+      expect(cloned.getTextContent()).toBe("graph TD\n  A --> B");
+      expect(cloned.getKey()).toBe(node.getKey());
+    });
+  });
+
+  it("rejects a malformed serialized mermaid payload", () => {
+    withNodeContext(() => {
+      expect(() =>
+        MermaidNode.importJSON({ type: "mermaid", version: 1, format: "", source: 42 } as never)
+      ).toThrowError();
+    });
+  });
+
+  it("round-trips a code-block node through its serialized shape", () => {
+    withNodeContext(() => {
+      const node = $createCodeBlockNode({ code: 'console.log("beep")', language: "typescript" });
+
+      expect(CodeBlockNode.getType()).toBe("codeblock");
+      expect(node.getTextContent()).toBe('console.log("beep")');
+      expect($isCodeBlockNode(node)).toBe(true);
+      expect($isCodeBlockNode("console.log")).toBe(false);
+
+      const serialized = node.exportJSON();
+      expect(serialized.type).toBe("codeblock");
+      expect(serialized.version).toBe(1);
+      expect(serialized.code).toBe('console.log("beep")');
+      expect(serialized.language).toBe("typescript");
+
+      const imported = CodeBlockNode.importJSON({ ...serialized });
+      expect(imported.getTextContent()).toBe('console.log("beep")');
+      expect(imported.__language).toBe("typescript");
+
+      const cloned = CodeBlockNode.clone(node);
+      expect(cloned.getTextContent()).toBe('console.log("beep")');
+      expect(cloned.__language).toBe("typescript");
+      expect(cloned.getKey()).toBe(node.getKey());
+    });
+  });
+
+  it("rejects a malformed serialized code-block payload", () => {
+    withNodeContext(() => {
+      expect(() =>
+        CodeBlockNode.importJSON({ type: "codeblock", version: 1, format: "", code: "x" } as never)
+      ).toThrowError();
+    });
+  });
+});

--- a/packages/tooling/tool/cli/test/lint-command.test.ts
+++ b/packages/tooling/tool/cli/test/lint-command.test.ts
@@ -310,1294 +310,1154 @@ const runSchemaFirstAndExpectNoErrors = Effect.fn("runSchemaFirstAndExpectNoErro
 });
 
 describe("schema-first lint command", { concurrent: false }, () => {
-  it(
-    "reports redundant LiteralKit const assertions",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstSourceFixture([
-              'import { LiteralKit } from "@beep/schema";',
-              'const Status = LiteralKit(["active", "inactive"] as const);',
-              "void Status;",
-              "",
-            ]);
-
-            const exit = yield* Effect.exit(runLintCommand(["schema-first"]));
-
-            const errorLines = yield* TestConsole.errorLines;
-            expectReportedExit(exit);
-            expect(errorLines).toContain("[schema-first] redundant LiteralKit const assertions:");
-            expect(errorLines).toContain(
-              "- packages/example/src/Example.ts:2 arg1 [literal-kit-const-assertion] Inline LiteralKit array arguments do not need as const."
-            );
-            const structuredIssueLine =
-              '[schema-first:issue] {"category":"schema-first-policy","ruleId":"literal-kit-const-assertion",' +
-              '"severity":"error","file":"packages/example/src/Example.ts","line":2,"symbol":"LiteralKit",' +
-              '"message":"Inline LiteralKit array arguments do not need as const.",' +
-              '"remediation":"Remove the redundant as const assertion; LiteralKit already uses const type parameters."}';
-            expect(errorLines).toContain(structuredIssueLine);
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
-
-  it(
-    "accepts direct LiteralKit inline arrays without const assertions",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstSourceFixture([
-              'import { LiteralKit } from "@beep/schema";',
-              'const Status = LiteralKit(["active", "inactive"]);',
-              "void Status;",
-              "",
-            ]);
-
-            yield* runSchemaFirstAndExpectNoErrors();
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
-
-  it(
-    "reports untracked SFV4 numeric-domain advisories",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstSourceFixture([
-              'import * as S from "effect/Schema";',
-              'export class WorkerOptions extends S.Class<WorkerOptions>("WorkerOptions")({',
-              "  timeoutMs: S.Number,",
-              "  accountId: S.Number,",
-              "  retryCount: S.Int,",
-              "}) {}",
-              "",
-            ]);
-
-            const exit = yield* Effect.exit(runLintCommand(["schema-first"]));
-
-            const errorLines = yield* TestConsole.errorLines;
-            expectReportedExit(exit);
-            expect(errorLines).toContain("[schema-first] untracked live findings:");
-            expect(errorLines).toContain(
-              '- packages/example/src/Example.ts :: WorkerOptions.timeoutMs [schema-policy-advisory] Broad numeric schema field "timeoutMs" should use S.Finite, S.Int, or a range check unless NaN and infinity are intentional.'
-            );
-            const structuredIssueLine =
-              '[schema-first:issue] {"category":"schema-first-policy","ruleId":"SFV4-numeric-domain",' +
-              '"severity":"warning","file":"packages/example/src/Example.ts","line":3,' +
-              '"symbol":"WorkerOptions.timeoutMs",' +
-              '"message":"Broad numeric schema field \\"timeoutMs\\" should use S.Finite, S.Int, or a range check unless NaN and infinity are intentional.",' +
-              '"remediation":"Review the numeric domain and replace broad S.Number/S.NumberFromString with S.Finite, S.Int, or checks; then run bun run beep lint schema-first --write if the broad domain is intentional."}';
-            expect(errorLines).toContain(structuredIssueLine);
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
-
-  it(
-    "reports untracked SFV4 static-api discriminator switch advisories",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstSourceFixture([
-              'import * as S from "effect/Schema";',
-              "const JobEvent = S.TaggedUnion({});",
-              'export const render = (event: { readonly _tag: "Created" | "Failed"; readonly id?: string; readonly reason?: string }) => {',
-              "  switch (event._tag) {",
-              '    case "Created":',
-              '      return event.id ?? "";',
-              '    case "Failed":',
-              '      return event.reason ?? "";',
-              "  }",
-              "};",
-              "void JobEvent;",
-              "",
-            ]);
-
-            const exit = yield* Effect.exit(runLintCommand(["schema-first"]));
-
-            const errorLines = yield* TestConsole.errorLines;
-            expectReportedExit(exit);
-            expect(errorLines).toContain("[schema-first] untracked live findings:");
-            expect(errorLines).toContain(
-              '- packages/example/src/Example.ts :: render.switch(event._tag) [schema-policy-advisory] Schema-modeled discriminator switch "event._tag" should use schema-derived .match/.guards or LiteralKit.$match when semantics match.'
-            );
-            const structuredIssueLine =
-              '[schema-first:issue] {"category":"schema-first-policy","ruleId":"SFV4-static-api",' +
-              '"severity":"warning","file":"packages/example/src/Example.ts","line":4,' +
-              '"symbol":"render.switch(event._tag)",' +
-              '"message":"Schema-modeled discriminator switch \\"event._tag\\" should use schema-derived .match/.guards or LiteralKit.$match when semantics match.",' +
-              '"remediation":"Prefer schema-derived .match/.guards/.cases or LiteralKit helpers, or run bun run beep lint schema-first --write with a justification when behavior intentionally differs."}';
-            expect(errorLines).toContain(structuredIssueLine);
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
-
-  it(
-    "reports untracked SFV4 precision-audit broad email advisories",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstSourceFixture([
-              'import * as S from "effect/Schema";',
-              'export class Contact extends S.Class<Contact>("Contact")({',
-              "  email: S.String,",
-              "}) {}",
-              "",
-            ]);
-
-            const exit = yield* Effect.exit(runLintCommand(["schema-first"]));
-
-            const errorLines = yield* TestConsole.errorLines;
-            expectReportedExit(exit);
-            expect(errorLines).toContain("[schema-first] untracked live findings:");
-            expect(errorLines).toContain(
-              '- packages/example/src/Example.ts :: Contact.email [schema-policy-advisory] Broad string field "email" should use @beep/schema Email, a local precise email schema, or a documented external-protocol exception.'
-            );
-            const structuredIssueLine =
-              '[schema-first:issue] {"category":"schema-first-policy","ruleId":"SFV4-precision-audit",' +
-              '"severity":"warning","file":"packages/example/src/Example.ts","line":3,' +
-              '"symbol":"Contact.email",' +
-              '"message":"Broad string field \\"email\\" should use @beep/schema Email, a local precise email schema, or a documented external-protocol exception.",' +
-              '"remediation":"Replace broad email S.String fields with @beep/schema Email or a local precise email schema; inventory only external protocol fields that intentionally allow non-email strings."}';
-            expect(errorLines).toContain(structuredIssueLine);
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
-
-  it(
-    "accepts precise email schemas without precision-audit advisories",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstSourceFixture([
-              'import { Email } from "@beep/schema";',
-              'import * as S from "effect/Schema";',
-              'export class Contact extends S.Class<Contact>("Contact")({',
-              "  email: Email,",
-              "}) {}",
-              "",
-            ]);
-
-            yield* runSchemaFirstAndExpectNoErrors();
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
-
-  it(
-    "reports untracked SFV4 fn-schema advisories for a .ts function (R17-2 still-fires case)",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstSourceFixture([
-              'import * as S from "effect/Schema";',
-              'export class Widget extends S.Class<Widget>("Widget")({',
-              "  id: S.String,",
-              "}) {}",
-              "export function updateWidget(input: { id: string; name: string }): void {}",
-              "",
-            ]);
-
-            const exit = yield* Effect.exit(runLintCommand(["schema-first"]));
-
-            const errorLines = yield* TestConsole.errorLines;
-            expectReportedExit(exit);
-            expect(errorLines).toContain("[schema-first] untracked live findings:");
-            expect(errorLines).toContain(
-              '- packages/example/src/Example.ts :: updateWidget [schema-policy-advisory] Exported function "updateWidget" carries inline object contracts in a schema-modeled file; model them with Fn({ input, output }) from @beep/schema or an S.Class so the contract is executable.'
-            );
-            const structuredIssueLine =
-              '[schema-first:issue] {"category":"schema-first-policy","ruleId":"SFV4-fn-schema",' +
-              '"severity":"warning","file":"packages/example/src/Example.ts","line":5,' +
-              '"symbol":"updateWidget",' +
-              '"message":"Exported function \\"updateWidget\\" carries inline object contracts in a schema-modeled file; model them with Fn({ input, output }) from @beep/schema or an S.Class so the contract is executable.",' +
-              '"remediation":"Model inline object parameter/return contracts with Fn({ input, output }) from @beep/schema or an S.Class, or run bun run beep lint schema-first --write with a justification when the shape intentionally stays inline."}';
-            expect(errorLines).toContain(structuredIssueLine);
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
-
-  it(
-    "does not report SFV4 fn-schema advisories for a .tsx component (R17-2 newly-excluded case)",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstFileFixture("packages/example/src/Example.tsx", [
-              'import * as S from "effect/Schema";',
-              'export class Widget extends S.Class<Widget>("Widget")({',
-              "  id: S.String,",
-              "}) {}",
-              "export function UpdateWidgetDemo(input: { id: string; name: string }): void {}",
-              "",
-            ]);
-
-            yield* runSchemaFirstAndExpectNoErrors();
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
-
-  it(
-    "excludes inventoried precision-audit exceptions from active advisory counts",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstSourceFixture([
-              'import * as S from "effect/Schema";',
-              'export class Contact extends S.Class<Contact>("Contact")({',
-              "  email: S.String,",
-              "}) {}",
-              "",
-            ]);
-            yield* writePrecisionAuditInventory(
-              "exception",
-              "External protocol preserves raw email text before domain validation."
-            );
-
-            yield* runLintCommand(["schema-first"]);
-
-            const logLines = yield* TestConsole.logLines;
-            const errorLines = yield* TestConsole.errorLines;
-            expect(logLines).toContain("[schema-first] sfv4_precision_audit_advisories=0");
-            expect(errorLines).toEqual([]);
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
-
-  it(
-    "blocks tracked active schema-first advisories",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstSourceFixture([
-              'import * as S from "effect/Schema";',
-              'export class Contact extends S.Class<Contact>("Contact")({',
-              "  email: S.String,",
-              "}) {}",
-              "",
-            ]);
-            yield* writePrecisionAuditInventory(
-              "advisory",
-              'Broad string field "email" should use @beep/schema Email, a local precise email schema, or a documented external-protocol exception.'
-            );
-
-            const exit = yield* Effect.exit(runLintCommand(["schema-first"]));
-
-            const logLines = yield* TestConsole.logLines;
-            const errorLines = yield* TestConsole.errorLines;
-            expectReportedExit(exit);
-            expect(logLines).toContain("[schema-first] sfv4_precision_audit_advisories=1");
-            expect(errorLines).toContain("[schema-first] repo still contains advisory findings:");
-            expect(errorLines).toContain(
-              '- packages/example/src/Example.ts :: Contact.email [schema-policy-advisory] Broad string field "email" should use @beep/schema Email, a local precise email schema, or a documented external-protocol exception.'
-            );
-            const structuredIssueLine =
-              '[schema-first:issue] {"category":"schema-first-policy","ruleId":"SFV4-precision-audit",' +
-              '"severity":"warning","file":"packages/example/src/Example.ts","line":3,' +
-              '"symbol":"Contact.email",' +
-              '"message":"Broad string field \\"email\\" should use @beep/schema Email, a local precise email schema, or a documented external-protocol exception.",' +
-              '"remediation":"Resolve the schema-first advisory or move the entry to exception with a documented reason."}';
-            expect(errorLines).toContain(structuredIssueLine);
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
-
-  it(
-    "reports untracked SFV4 arbitrary-tests static-only schema test advisories",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstFileFixture("packages/example/test/Example.test.ts", [
-              'import * as S from "effect/Schema";',
-              "const Worker = S.Struct({ id: S.String, retryCount: S.Int });",
-              "export const staticChecks = [",
-              '  S.decodeUnknownEffect(Worker)({ id: "a", retryCount: 1 }),',
-              '  S.decodeUnknownEffect(Worker)({ id: "b", retryCount: 2 }),',
-              '  S.encodeEffect(Worker)({ id: "c", retryCount: 3 }),',
-              "];",
-              "",
-            ]);
-
-            const exit = yield* Effect.exit(runLintCommand(["schema-first"]));
-
-            const errorLines = yield* TestConsole.errorLines;
-            expectReportedExit(exit);
-            expect(errorLines).toContain("[schema-first] untracked live findings:");
-            expect(errorLines).toContain(
-              "- packages/example/test/Example.test.ts :: schema-codec-tests [schema-policy-advisory] Schema-heavy test file has 3 Schema codec assertions but no schema-derived property coverage."
-            );
-            const structuredIssueLine =
-              '[schema-first:issue] {"category":"schema-first-policy","ruleId":"SFV4-arbitrary-tests",' +
-              '"severity":"warning","file":"packages/example/test/Example.test.ts","line":4,' +
-              '"symbol":"schema-codec-tests",' +
-              '"message":"Schema-heavy test file has 3 Schema codec assertions but no schema-derived property coverage.",' +
-              '"remediation":"Add a focused property test using S.toArbitrary(sourceSchema)(fc) and fast-check, or keep the inventory entry when the file is intentionally golden/snapshot/regression-only coverage."}';
-            expect(errorLines).toContain(structuredIssueLine);
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
-
-  it(
-    "accepts schema-derived property tests without arbitrary-tests advisories",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstFileFixture("packages/example/test/Example.test.ts", [
-              'import * as fc from "fast-check";',
-              'import * as S from "effect/Schema";',
-              "const Worker = S.Struct({ id: S.String, retryCount: S.Int });",
-              "const WorkerArbitrary = S.toArbitrary(Worker)(fc);",
-              "export const staticChecks = [",
-              '  S.decodeUnknownEffect(Worker)({ id: "a", retryCount: 1 }),',
-              '  S.decodeUnknownEffect(Worker)({ id: "b", retryCount: 2 }),',
-              '  S.encodeEffect(Worker)({ id: "c", retryCount: 3 }),',
-              "];",
-              "export const property = fc.property(WorkerArbitrary, (worker) => worker.retryCount === Math.trunc(worker.retryCount));",
-              "",
-            ]);
-
-            yield* runSchemaFirstAndExpectNoErrors();
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
-
-  it(
-    "does not treat a non-schema-derived fast-check property as arbitrary-tests coverage",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstFileFixture("packages/example/test/Example.test.ts", [
-              'import * as fc from "fast-check";',
-              'import * as S from "effect/Schema";',
-              "const Worker = S.Struct({ id: S.String, retryCount: S.Int });",
-              "export const staticChecks = [",
-              '  S.decodeUnknownEffect(Worker)({ id: "a", retryCount: 1 }),',
-              '  S.decodeUnknownEffect(Worker)({ id: "b", retryCount: 2 }),',
-              '  S.encodeEffect(Worker)({ id: "c", retryCount: 3 }),',
-              "];",
-              'export const property = fc.property(fc.string(), (id) => typeof id === "string");',
-              "",
-            ]);
-
-            const exit = yield* Effect.exit(runLintCommand(["schema-first"]));
-
-            const errorLines = yield* TestConsole.errorLines;
-            expectReportedExit(exit);
-            expect(errorLines).toContain(
-              "- packages/example/test/Example.test.ts :: schema-codec-tests [schema-policy-advisory] Schema-heavy test file has 3 Schema codec assertions but no schema-derived property coverage."
-            );
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
-
-  it(
-    "counts class-local static codec calls toward the arbitrary-tests threshold",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstFileFixture("packages/example/test/Example.test.ts", [
-              'import * as S from "effect/Schema";',
-              'class Worker extends S.Class<Worker>("Worker")({ id: S.String }) {',
-              "  static readonly decodeUnknownSync = S.decodeUnknownSync(Worker);",
-              "}",
-              "export const staticChecks = [",
-              '  Worker.decodeUnknownSync({ id: "a" }),',
-              '  Worker.decodeUnknownSync({ id: "b" }),',
-              '  Worker.decodeUnknownSync({ id: "c" }),',
-              "];",
-              "",
-            ]);
-
-            const exit = yield* Effect.exit(runLintCommand(["schema-first"]));
-
-            const errorLines = yield* TestConsole.errorLines;
-            expectReportedExit(exit);
-            expect(errorLines).toContain(
-              "- packages/example/test/Example.test.ts :: schema-codec-tests [schema-policy-advisory] Schema-heavy test file has 4 Schema codec assertions but no schema-derived property coverage."
-            );
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
-
-  it(
-    "reports SFV4 arbitrary-tests advisories for synchronous schema codec helpers",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstFileFixture("packages/example/test/Sync.test.ts", [
-              'import * as S from "effect/Schema";',
-              "const Worker = S.Struct({ id: S.String, retryCount: S.Int });",
-              "export const staticChecks = [",
-              '  S.decodeUnknownSync(Worker)({ id: "a", retryCount: 1 }),',
-              '  S.decodeSync(Worker)({ id: "b", retryCount: 2 }),',
-              '  S.encodeSync(Worker)({ id: "c", retryCount: 3 }),',
-              "];",
-              "",
-            ]);
-
-            const exit = yield* Effect.exit(runLintCommand(["schema-first"]));
-
-            const errorLines = yield* TestConsole.errorLines;
-            expectReportedExit(exit);
-            expect(errorLines).toContain(
-              "- packages/example/test/Sync.test.ts :: schema-codec-tests [schema-policy-advisory] Schema-heavy test file has 3 Schema codec assertions but no schema-derived property coverage."
-            );
-            const structuredIssueLine =
-              '[schema-first:issue] {"category":"schema-first-policy","ruleId":"SFV4-arbitrary-tests",' +
-              '"severity":"warning","file":"packages/example/test/Sync.test.ts","line":4,' +
-              '"symbol":"schema-codec-tests",' +
-              '"message":"Schema-heavy test file has 3 Schema codec assertions but no schema-derived property coverage.",' +
-              '"remediation":"Add a focused property test using S.toArbitrary(sourceSchema)(fc) and fast-check, or keep the inventory entry when the file is intentionally golden/snapshot/regression-only coverage."}';
-            expect(errorLines).toContain(structuredIssueLine);
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
-
-  it(
-    "accepts schema-derived static match usage without static-api advisories",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstSourceFixture([
-              'import * as S from "effect/Schema";',
-              "const JobEvent = S.TaggedUnion({});",
-              "export const render = (event: unknown) =>",
-              "  JobEvent.match(event, {",
-              '    Created: () => "created",',
-              '    Failed: () => "failed",',
-              "  });",
-              "",
-            ]);
-
-            yield* runSchemaFirstAndExpectNoErrors();
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
-
-  it(
-    "reports untracked SFV4 equivalence manual equals advisories",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstSourceFixture([
-              'import * as S from "effect/Schema";',
-              'export class Worker extends S.Class<Worker>("Worker")({',
-              "  id: S.String,",
-              "  name: S.String,",
-              "}) {}",
-              "export const equals = (left: Worker, right: Worker) => left.id === right.id && left.name === right.name;",
-              "",
-            ]);
-
-            const exit = yield* Effect.exit(runLintCommand(["schema-first"]));
-
-            const errorLines = yield* TestConsole.errorLines;
-            expectReportedExit(exit);
-            expect(errorLines).toContain("[schema-first] untracked live findings:");
-            expect(errorLines).toContain(
-              '- packages/example/src/Example.ts :: equals [schema-policy-advisory] Exported schema-modeled equality helper "equals" should derive from S.toEquivalence(schema) unless comparison intentionally differs from schema semantics.'
-            );
-            const structuredIssueLine =
-              '[schema-first:issue] {"category":"schema-first-policy","ruleId":"SFV4-equivalence",' +
-              '"severity":"warning","file":"packages/example/src/Example.ts","line":6,' +
-              '"symbol":"equals",' +
-              '"message":"Exported schema-modeled equality helper \\"equals\\" should derive from S.toEquivalence(schema) unless comparison intentionally differs from schema semantics.",' +
-              '"remediation":"Derive comparison from S.toEquivalence(schema) or SchemaUtils.toEquivalence(schema); use S.overrideToEquivalence only when schema semantics intentionally differ."}';
-            expect(errorLines).toContain(structuredIssueLine);
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
-
-  it(
-    "accepts schema-derived equivalence helpers without equivalence advisories",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstSourceFixture([
-              'import * as S from "effect/Schema";',
-              'export class Worker extends S.Class<Worker>("Worker")({',
-              "  id: S.String,",
-              "  name: S.String,",
-              "}) {}",
-              "export const equals = S.toEquivalence(Worker);",
-              "",
-            ]);
-
-            yield* runSchemaFirstAndExpectNoErrors();
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
-
-  it(
-    "reports S.TaggedError declarations without declared equivalence",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstSourceFixture([
-              'import * as S from "effect/Schema";',
-              "export class WorkerError extends S.TaggedError<WorkerError>()(",
-              '  "WorkerError",',
-              "  { workerId: S.String },",
-              '  { description: "Worker execution failed." }',
-              ") {}",
-              "",
-            ]);
-
-            const exit = yield* Effect.exit(runLintCommand(["schema-first"]));
-
-            const logLines = yield* TestConsole.logLines;
-            const errorLines = yield* TestConsole.errorLines;
-            expectReportedExit(exit);
-            expect(logLines).toContain("[schema-first] sfv4_tagged_error_equivalence_advisories=1");
-            expect(errorLines).toContain("[schema-first] untracked live findings:");
-            expect(errorLines).toContain(
-              '- packages/example/src/Example.ts :: WorkerError [schema-policy-advisory] S.TaggedError declaration "WorkerError" must declare fields-only equivalence at the class declaration: pass $I.annoteError<WorkerError>(...) as its annotations (or a toEquivalence hook that adopts the declared struct equivalence). Otherwise declaration equivalence falls back to Equal.equals over Error runtime metadata, causing seed-dependent property flakes.'
-            );
-            const structuredIssueLine =
-              '[schema-first:issue] {"category":"schema-first-policy","ruleId":"SFV4-tagged-error-equivalence",' +
-              '"severity":"warning","file":"packages/example/src/Example.ts","line":2,' +
-              '"symbol":"WorkerError",' +
-              '"message":"S.TaggedError declaration \\"WorkerError\\" must declare fields-only equivalence at the class declaration: pass $I.annoteError<WorkerError>(...) as its annotations (or a toEquivalence hook that adopts the declared struct equivalence). Otherwise declaration equivalence falls back to Equal.equals over Error runtime metadata, causing seed-dependent property flakes.",' +
-              '"remediation":"Annotate the class with $I.annoteError<Self>(...) so it adopts the declared struct equivalence; opaque causes use Defect from @beep/schema, which declares its own always-equal equivalence."}';
-            expect(errorLines).toContain(structuredIssueLine);
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
-
-  it(
-    "reports named effect/Schema TaggedError imports without declared equivalence",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstFileFixture("packages/ecosystem/effect-drizzle/src/Example.ts", [
-              'import { String as StringSchema, TaggedError } from "effect/Schema";',
-              "export class WorkerError extends TaggedError<WorkerError>()(",
-              '  "WorkerError",',
-              "  { workerId: StringSchema },",
-              '  { description: "Worker execution failed." }',
-              ") {}",
-              "",
-            ]);
-
-            const exit = yield* Effect.exit(runLintCommand(["schema-first"]));
-
-            const logLines = yield* TestConsole.logLines;
-            const errorLines = yield* TestConsole.errorLines;
-            expectReportedExit(exit);
-            expect(logLines).toContain("[schema-first] sfv4_tagged_error_equivalence_advisories=1");
-            expect(errorLines).toContain(
-              '- packages/ecosystem/effect-drizzle/src/Example.ts :: WorkerError [schema-policy-advisory] S.TaggedError declaration "WorkerError" must declare fields-only equivalence at the class declaration: pass $I.annoteError<WorkerError>(...) as its annotations (or a toEquivalence hook that adopts the declared struct equivalence). Otherwise declaration equivalence falls back to Equal.equals over Error runtime metadata, causing seed-dependent property flakes.'
-            );
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
-
-  it(
-    "ignores unrelated local TaggedError factories",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstSourceFixture([
-              "const TaggedError = <Self>() => (_tag: string, _fields: unknown) => class {};",
-              'class LocalError extends TaggedError<LocalError>()("LocalError", {}) {}',
-              "void LocalError;",
-              "",
-            ]);
-
-            yield* runSchemaFirstAndExpectNoErrors();
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
-
-  it(
-    "accepts direct and annoteClass tagged-error equivalence annotations",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstSourceFixture([
-              'import * as S from "effect/Schema";',
-              "const sameWorkerError = (_self: WorkerError, _that: WorkerError): boolean => true;",
-              "export class WorkerError extends S.TaggedError<WorkerError>()(",
-              '  "WorkerError",',
-              "  { workerId: S.String },",
-              '  { description: "Worker execution failed.", toEquivalence: () => sameWorkerError }',
-              ") {}",
-              "const sameTaskError = (_self: TaskError, _that: TaskError): boolean => true;",
-              "const taskErrorAnnotations = { toEquivalence: () => sameTaskError };",
-              "class TaskError extends S.TaggedError<TaskError>()(",
-              '  "TaskError",',
-              "  { taskId: S.String },",
-              '  $I.annoteClass("TaskError", taskErrorAnnotations)',
-              ") {}",
-              "void TaskError;",
-              "",
-            ]);
-
-            yield* runSchemaFirstAndExpectNoErrors();
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
-
-  it(
-    "accepts annoteError tagged-error annotations",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstSourceFixture([
-              'import * as S from "effect/Schema";',
-              "export class WorkerError extends S.TaggedError<WorkerError>()(",
-              '  "WorkerError",',
-              "  { workerId: S.String },",
-              '  $I.annoteError<WorkerError>("WorkerError", { description: "Worker execution failed." })',
-              ") {}",
-              "",
-            ]);
-
-            yield* runSchemaFirstAndExpectNoErrors();
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
-
-  it(
-    "preserves existing tagged-error exceptions without excepting new write findings",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstSourceFixture([
-              'import * as S from "effect/Schema";',
-              "export class ExistingError extends S.TaggedError<ExistingError>()(",
-              '  "ExistingError",',
-              "  { workerId: S.String },",
-              '  { description: "Existing documented failure." }',
-              ") {}",
-              "export class WorkerError extends S.TaggedError<WorkerError>()(",
-              '  "WorkerError",',
-              "  { workerId: S.String },",
-              '  { description: "Worker execution failed." }',
-              ") {}",
-              "",
-            ]);
-
-            const fs = yield* FileSystem.FileSystem;
-            yield* fs.makeDirectory("standards");
-            yield* fs.writeFileString(
-              "standards/schema-first.inventory.jsonc",
-              `${encodeJson({
-                version: 1,
-                generatedOn: "2026-06-08",
-                scope: ["apps/**/*.{ts,tsx}", "packages/**/*.{ts,tsx}", "infra/{src,test}/**/*.ts"],
-                entries: [
-                  {
-                    file: "packages/example/src/Example.ts",
-                    symbol: "ExistingError",
-                    kind: "schema-policy-advisory",
-                    status: "exception",
-                    ruleId: "SFV4-tagged-error-equivalence",
-                    line: 2,
-                    owner: "@beep/example",
-                    reason: "Existing documented exception.",
-                  },
-                ],
-              })}\n`
-            );
-
-            const exit = yield* Effect.exit(runLintCommand(["schema-first", "--write"]));
-            expectReportedExit(exit);
-
-            const inventory = yield* fs.readFileString("standards/schema-first.inventory.jsonc");
-            expect(inventory).toContain(
-              '"symbol": "ExistingError",\n      "kind": "schema-policy-advisory",\n      "status": "exception"'
-            );
-            expect(inventory).toContain(
-              '"symbol": "WorkerError",\n      "kind": "schema-policy-advisory",\n      "status": "advisory"'
-            );
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
-
-  it(
-    "reports untracked SFV4 boundary-codec JSON.parse advisories",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstSourceFixture([
-              "export const parseConfig = (text: string) => {",
-              "  return JSON.parse(text);",
-              "};",
-              "",
-            ]);
-
-            const exit = yield* Effect.exit(runLintCommand(["schema-first"]));
-
-            const errorLines = yield* TestConsole.errorLines;
-            expectReportedExit(exit);
-            expect(errorLines).toContain("[schema-first] untracked live findings:");
-            expect(errorLines).toContain(
-              "- packages/example/src/Example.ts :: parseConfig.JSON.parse [schema-policy-advisory] Direct JSON.parse boundary should use S.fromJsonString(schema) so parsing and validation stay schema-owned."
-            );
-            const structuredIssueLine =
-              '[schema-first:issue] {"category":"schema-first-policy","ruleId":"SFV4-boundary-codec",' +
-              '"severity":"warning","file":"packages/example/src/Example.ts","line":2,' +
-              '"symbol":"parseConfig.JSON.parse",' +
-              '"message":"Direct JSON.parse boundary should use S.fromJsonString(schema) so parsing and validation stay schema-owned.",' +
-              '"remediation":"Replace direct JSON.parse with S.fromJsonString(schema) plus an Effect/Result/Option decoder, or inventory the exception when the protocol is intentionally non-standard."}';
-            expect(errorLines).toContain(structuredIssueLine);
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
-
-  it(
-    "accepts schema JSON codecs without boundary-codec advisories",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstSourceFixture([
-              'import * as S from "effect/Schema";',
-              "const UnknownFromJsonString = S.fromJsonString(S.Unknown);",
-              "export const decodeConfig = S.decodeUnknownEffect(UnknownFromJsonString);",
-              "",
-            ]);
-
-            yield* runSchemaFirstAndExpectNoErrors();
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
-
-  it(
-    "reports untracked SFV4 defaults parameter object advisories",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstSourceFixture([
-              'import * as S from "effect/Schema";',
-              'export class WorkerOptions extends S.Class<WorkerOptions>("WorkerOptions")({',
-              "  timeoutMs: S.Finite,",
-              "}) {}",
-              "export const runWorker = (params = { timeoutMs: 5000 }) => params.timeoutMs;",
-              "",
-            ]);
-
-            const exit = yield* Effect.exit(runLintCommand(["schema-first"]));
-
-            const errorLines = yield* TestConsole.errorLines;
-            expectReportedExit(exit);
-            expect(errorLines).toContain("[schema-first] untracked live findings:");
-            expect(errorLines).toContain(
-              '- packages/example/src/Example.ts :: runWorker.params [schema-policy-advisory] Parameter default object for "params" should move fallback values into schema defaults so construction, decoding, and tests share one source of truth.'
-            );
-            const structuredIssueLine =
-              '[schema-first:issue] {"category":"schema-first-policy","ruleId":"SFV4-defaults",' +
-              '"severity":"warning","file":"packages/example/src/Example.ts","line":5,' +
-              '"symbol":"runWorker.params",' +
-              '"message":"Parameter default object for \\"params\\" should move fallback values into schema defaults so construction, decoding, and tests share one source of truth.",' +
-              '"remediation":"Move option/request fallback values into schema fields with S.withConstructorDefault, S.withDecodingDefault*, or SchemaUtils.withKeyDefaults; inventory the exception only when the fallback intentionally differs from schema construction semantics."}';
-            expect(errorLines).toContain(structuredIssueLine);
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
-
-  it(
-    "accepts schema-owned constructor defaults without defaults advisories",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstSourceFixture([
-              'import { Effect } from "effect";',
-              'import * as S from "effect/Schema";',
-              'export class WorkerOptions extends S.Class<WorkerOptions>("WorkerOptions")({',
-              "  timeoutMs: S.Finite.pipe(S.withConstructorDefault(Effect.succeed(5000))),",
-              "}) {}",
-              "export const runWorker = (params = WorkerOptions.make({})) => params.timeoutMs;",
-              "",
-            ]);
-
-            yield* runSchemaFirstAndExpectNoErrors();
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
-
-  it(
-    "writes SFV4 numeric-domain advisories to the schema-first inventory",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstSourceFixture([
-              'import * as S from "effect/Schema";',
-              'export class WorkerOptions extends S.Class<WorkerOptions>("WorkerOptions")({',
-              "  timeoutMs: S.Number,",
-              "  retryCount: S.Int,",
-              "}) {}",
-              "",
-            ]);
-
-            const fs = yield* FileSystem.FileSystem;
-            const path = yield* Path.Path;
-
-            yield* fs.makeDirectory("standards");
-            const exit = yield* Effect.exit(runLintCommand(["schema-first", "--write"]));
-
-            const inventory = yield* fs.readFileString(path.join("standards", "schema-first.inventory.jsonc"));
-            const errorLines = yield* TestConsole.errorLines;
-            expectReportedExit(exit);
-            expect(errorLines).toContain("[schema-first] untracked live findings:");
-            expect(errorLines).toContain("[schema-first] repo still contains advisory findings:");
-            expect(inventory).toContain('"ruleId": "SFV4-numeric-domain"');
-            expect(inventory).toContain('"symbol": "WorkerOptions.timeoutMs"');
-            expect(inventory).not.toContain("retryCount");
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
-
-  it(
-    "filters generic and wholly runtime declarations before inventory comparison",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstSourceFixture([
-              "interface BaseData { readonly inheritedId: string }",
-              "interface GenericBase<Value> { readonly value: Value }",
-              "interface AstNode { readonly type: string }",
-              "declare namespace O {",
-              '  type Option<Value> = { readonly _tag: "None" } | { readonly _tag: "Some"; readonly value: Value };',
-              "}",
-              "declare namespace pulumi { type Input<Value> = Value | Promise<Value> }",
-              "export interface Generic<Value> { readonly value: Value }",
-              "export interface GenericDerived<Value extends string = string> extends GenericBase<Value> {}",
-              "export type GenericAlias<Value = string> = { readonly value: Value };",
-              "export type PureAlias = { readonly id: string };",
-              "export type RuntimeAlias = { readonly node: AstNode; readonly visit: () => void };",
-              "export interface RuntimeOnly {",
-              "  readonly layer: Layer.Layer<never>;",
-              "  readonly run: (input: string) => Effect.Effect<void>;",
-              "}",
-              "interface D3Only extends d3.SimulationNodeDatum {}",
-              "export { D3Only };",
-              "export interface D3Mixed extends d3.SimulationNodeDatum { readonly id: string }",
-              "export interface OptionalRuntimeOnly {",
-              "  readonly signal?: AbortSignal;",
-              "  readonly secret?: pulumi.Input<string>;",
-              "}",
-              "export interface RpcRuntimeOnly {",
-              '  readonly client: RpcClient.Protocol["Service"];',
-              "  readonly incoming: Stream.Stream<string>;",
-              "  readonly notify: { (value: string): Effect.Effect<void> };",
-              "}",
-              "export type AstTraversal = {",
-              "  readonly object: O.Option<AstNode>;",
-              "  readonly property: AstNode | null;",
-              "};",
-              "export interface RuntimeContainers {",
-              "  readonly array: ReadonlyArray<AstNode>;",
-              "  readonly mutableArray: AstNode[];",
-              "  readonly tuple: readonly [AstNode];",
-              "  readonly set: ReadonlySet<AstNode>;",
-              "}",
-              "export interface PrimitiveContainers {",
-              "  readonly array: ReadonlyArray<string>;",
-              "  readonly mutableArray: number[];",
-              "  readonly tuple: readonly [string, number];",
-              "  readonly map: ReadonlyMap<string, number>;",
-              "}",
-              "export type RuntimeRecord = { readonly values: Readonly<Record<string, AstNode>> };",
-              "export type PrimitiveRecord = { readonly values: Readonly<Record<string, string>> };",
-              "export interface MixedContract {",
-              "  readonly id: string;",
-              "  readonly run: () => Effect.Effect<void>;",
-              "}",
-              "export interface CallableOnly { (): void }",
-              "export interface CallableMixed { (): void; readonly id: string }",
-              "export interface ConstructOnly { new (): RuntimeOnly }",
-              "export interface ConstructMixed { new (): RuntimeOnly; readonly id: string }",
-              "export interface UnionMixed { readonly state: string | AbortSignal }",
-              "export interface NestedMixed {",
-              "  readonly state: { readonly id: string; readonly signal: AbortSignal };",
-              "}",
-              "export interface ImmutableCollections {",
-              "  readonly map: HashMap.HashMap<string, string>;",
-              "  readonly set: HashSet.HashSet<string>;",
-              "}",
-              "declare function makePayload(): { readonly id: string };",
-              "export interface ReturnTypePayload { readonly payload: ReturnType<typeof makePayload> }",
-              "class SchemaFlags { readonly enabled!: boolean }",
-              "export interface InheritedMixed extends SchemaFlags { readonly run: () => Effect.Effect<void> }",
-              "export interface DerivedData extends BaseData {}",
-              "export interface BinaryPayload { readonly bytes: Uint8Array }",
-              "export interface JournalPayload { readonly entry: EventJournal.Entry }",
-              "export interface SuccessPayload { readonly success: Effect.Success<string, Error> }",
-              "export interface ResultPayload { readonly result: OperationResult }",
-              "export interface SchemaOwned { readonly id: string }",
-              'export const SchemaOwned: SchemaOwned = Field({ id: "schema" });',
-              "",
-            ]);
-
-            const fs = yield* FileSystem.FileSystem;
-            const path = yield* Path.Path;
-            yield* fs.makeDirectory("standards");
-            const exit = yield* Effect.exit(runLintCommand(["schema-first", "--write"]));
-            const inventory = yield* fs.readFileString(path.join("standards", "schema-first.inventory.jsonc"));
-
-            expectReportedExit(exit);
-            expect(inventory).toContain('"symbol": "MixedContract"');
-            expect(inventory).toContain('"symbol": "D3Mixed"');
-            expect(inventory).toContain('"symbol": "CallableMixed"');
-            expect(inventory).toContain('"symbol": "ConstructMixed"');
-            expect(inventory).toContain('"symbol": "UnionMixed"');
-            expect(inventory).toContain('"symbol": "NestedMixed"');
-            expect(inventory).toContain('"symbol": "ImmutableCollections"');
-            expect(inventory).toContain('"symbol": "ReturnTypePayload"');
-            expect(inventory).toContain('"symbol": "InheritedMixed"');
-            expect(inventory).toContain('"symbol": "PrimitiveContainers"');
-            expect(inventory).toContain('"symbol": "PrimitiveRecord"');
-            expect(inventory).toContain('"symbol": "DerivedData"');
-            expect(inventory).toContain('"symbol": "BinaryPayload"');
-            expect(inventory).toContain('"symbol": "JournalPayload"');
-            expect(inventory).toContain('"symbol": "SuccessPayload"');
-            expect(inventory).toContain('"symbol": "ResultPayload"');
-            expect(inventory).toContain('"symbol": "PureAlias"');
-            expect(inventory).not.toContain('"symbol": "Generic"');
-            expect(inventory).not.toContain('"symbol": "GenericDerived"');
-            expect(inventory).not.toContain('"symbol": "GenericAlias"');
-            expect(inventory).not.toContain('"symbol": "CallableOnly"');
-            expect(inventory).not.toContain('"symbol": "ConstructOnly"');
-            expect(inventory).not.toContain('"symbol": "OptionalRuntimeOnly"');
-            expect(inventory).not.toContain('"symbol": "RpcRuntimeOnly"');
-            expect(inventory).not.toContain('"symbol": "AstTraversal"');
-            expect(inventory).not.toContain('"symbol": "RuntimeContainers"');
-            expect(inventory).not.toContain('"symbol": "RuntimeRecord"');
-            expect(inventory).not.toContain('"symbol": "RuntimeOnly"');
-            expect(inventory).not.toContain('"symbol": "D3Only"');
-            expect(inventory).not.toContain('"symbol": "RuntimeAlias"');
-            expect(inventory).not.toContain('"symbol": "SchemaOwned"');
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
-
-  it(
-    "limits normalization advisories to exported schema-boundary helpers",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstSourceFixture([
-              'import * as S from "effect/Schema";',
-              "const Model = S.Struct({ value: S.String });",
-              "const privateToken = (value: string): string => value.toLowerCase();",
-              "const unrelated = (value: string): string => value.trim();",
-              "const normalizeValue = (input: unknown): string =>",
-              "  S.decodeUnknownSync(Model)(input).value.trim();",
-              "class Normalizer {",
-              "  public normalize(input: unknown): string {",
-              "    return S.decodeUnknownSync(Model)(input).value.toUpperCase();",
-              "  }",
-              "  private privateNormalize(input: unknown): string {",
-              "    return S.decodeUnknownSync(Model)(input).value.toLowerCase();",
-              "  }",
-              "  protected protectedNormalize(input: unknown): string {",
-              "    return S.decodeUnknownSync(Model)(input).value.trim();",
-              "  }",
-              "}",
-              "export { Normalizer, normalizeValue, unrelated };",
-              "void privateToken;",
-              "",
-            ]);
-
-            const fs = yield* FileSystem.FileSystem;
-            const path = yield* Path.Path;
-            yield* fs.makeDirectory("standards");
-            const exit = yield* Effect.exit(runLintCommand(["schema-first", "--write"]));
-            const inventory = yield* fs.readFileString(path.join("standards", "schema-first.inventory.jsonc"));
-
-            expectReportedExit(exit);
-            expect(inventory).toContain('"symbol": "normalizeValue.trim"');
-            expect(inventory).toContain('"symbol": "Normalizer.toUpperCase"');
-            expect(inventory).not.toContain("privateToken.toLowerCase");
-            expect(inventory).not.toContain("unrelated.trim");
-            expect(inventory).not.toContain("privateNormalize");
-            expect(inventory).not.toContain("protectedNormalize");
-            expect(inventory).not.toContain("Normalizer.toLowerCase");
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
-
-  it(
-    "omits render contracts without hiding pure data declared in TSX",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstFileFixture("packages/example/src/Example.tsx", [
-              "export interface WidgetProps {",
-              "  readonly label: string;",
-              "  readonly children: React.ReactNode;",
-              "}",
-              "export type PanelProps = { readonly title: string };",
-              "export interface DataPayload { readonly id: string }",
-              "",
-            ]);
-            const fs = yield* FileSystem.FileSystem;
-            yield* fs.writeFileString(
-              "packages/example/src/ReactProps.ts",
-              [
-                'import type React from "react";',
-                "export type RendererProps = {",
-                "  readonly title: string;",
-                "  readonly component: React.FunctionComponent;",
-                "};",
-                "",
-              ].join("\n")
-            );
-
-            yield* fs.makeDirectory("standards");
-            const exit = yield* Effect.exit(runLintCommand(["schema-first", "--write"]));
-            const inventory = yield* fs.readFileString("standards/schema-first.inventory.jsonc");
-
-            expectReportedExit(exit);
-            expect(inventory).toContain('"symbol": "DataPayload"');
-            expect(inventory).not.toContain('"symbol": "WidgetProps"');
-            expect(inventory).not.toContain('"symbol": "PanelProps"');
-            expect(inventory).not.toContain('"symbol": "RendererProps"');
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
-
-  it(
-    "recognizes local export lists for declarations, schema companions, structs, and functions",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstSourceFixture([
-              'import * as S from "effect/Schema";',
-              "interface ListedData { readonly id: string }",
-              "type ListedAlias = { readonly id: string };",
-              "interface AliasedData { readonly id: string }",
-              "export default interface DefaultData { readonly id: string }",
-              "interface ListedSchemaOwned { readonly id: string }",
-              'class ListedSchemaOwned extends S.Class<ListedSchemaOwned>("ListedSchemaOwned")({',
-              "  id: S.String,",
-              "}) {}",
-              "const ListedStruct = S.Struct({ id: S.String });",
-              "const AliasedStruct = S.Struct({ id: S.String });",
-              "function listedFunction(input: { readonly id: string }): void { void input; }",
-              "function aliasedFunction(input: { readonly id: string }): void { void input; }",
-              "const listedArrow = (input: { readonly id: string }): void => { void input; };",
-              "export {",
-              "  AliasedData as PublicData,",
-              "  AliasedStruct as PublicStruct,",
-              "  ListedAlias,",
-              "  ListedData,",
-              "  ListedSchemaOwned,",
-              "  ListedStruct,",
-              "  aliasedFunction as publicFunction,",
-              "  listedArrow,",
-              "  listedFunction,",
+  it("reports redundant LiteralKit const assertions", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstSourceFixture([
+            'import { LiteralKit } from "@beep/schema";',
+            'const Status = LiteralKit(["active", "inactive"] as const);',
+            "void Status;",
+            "",
+          ]);
+
+          const exit = yield* Effect.exit(runLintCommand(["schema-first"]));
+
+          const errorLines = yield* TestConsole.errorLines;
+          expectReportedExit(exit);
+          expect(errorLines).toContain("[schema-first] redundant LiteralKit const assertions:");
+          expect(errorLines).toContain(
+            "- packages/example/src/Example.ts:2 arg1 [literal-kit-const-assertion] Inline LiteralKit array arguments do not need as const."
+          );
+          const structuredIssueLine =
+            '[schema-first:issue] {"category":"schema-first-policy","ruleId":"literal-kit-const-assertion",' +
+            '"severity":"error","file":"packages/example/src/Example.ts","line":2,"symbol":"LiteralKit",' +
+            '"message":"Inline LiteralKit array arguments do not need as const.",' +
+            '"remediation":"Remove the redundant as const assertion; LiteralKit already uses const type parameters."}';
+          expect(errorLines).toContain(structuredIssueLine);
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
+
+  it("accepts direct LiteralKit inline arrays without const assertions", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstSourceFixture([
+            'import { LiteralKit } from "@beep/schema";',
+            'const Status = LiteralKit(["active", "inactive"]);',
+            "void Status;",
+            "",
+          ]);
+
+          yield* runSchemaFirstAndExpectNoErrors();
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
+
+  it("reports untracked SFV4 numeric-domain advisories", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstSourceFixture([
+            'import * as S from "effect/Schema";',
+            'export class WorkerOptions extends S.Class<WorkerOptions>("WorkerOptions")({',
+            "  timeoutMs: S.Number,",
+            "  accountId: S.Number,",
+            "  retryCount: S.Int,",
+            "}) {}",
+            "",
+          ]);
+
+          const exit = yield* Effect.exit(runLintCommand(["schema-first"]));
+
+          const errorLines = yield* TestConsole.errorLines;
+          expectReportedExit(exit);
+          expect(errorLines).toContain("[schema-first] untracked live findings:");
+          expect(errorLines).toContain(
+            '- packages/example/src/Example.ts :: WorkerOptions.timeoutMs [schema-policy-advisory] Broad numeric schema field "timeoutMs" should use S.Finite, S.Int, or a range check unless NaN and infinity are intentional.'
+          );
+          const structuredIssueLine =
+            '[schema-first:issue] {"category":"schema-first-policy","ruleId":"SFV4-numeric-domain",' +
+            '"severity":"warning","file":"packages/example/src/Example.ts","line":3,' +
+            '"symbol":"WorkerOptions.timeoutMs",' +
+            '"message":"Broad numeric schema field \\"timeoutMs\\" should use S.Finite, S.Int, or a range check unless NaN and infinity are intentional.",' +
+            '"remediation":"Review the numeric domain and replace broad S.Number/S.NumberFromString with S.Finite, S.Int, or checks; then run bun run beep lint schema-first --write if the broad domain is intentional."}';
+          expect(errorLines).toContain(structuredIssueLine);
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
+
+  it("reports untracked SFV4 static-api discriminator switch advisories", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstSourceFixture([
+            'import * as S from "effect/Schema";',
+            "const JobEvent = S.TaggedUnion({});",
+            'export const render = (event: { readonly _tag: "Created" | "Failed"; readonly id?: string; readonly reason?: string }) => {',
+            "  switch (event._tag) {",
+            '    case "Created":',
+            '      return event.id ?? "";',
+            '    case "Failed":',
+            '      return event.reason ?? "";',
+            "  }",
+            "};",
+            "void JobEvent;",
+            "",
+          ]);
+
+          const exit = yield* Effect.exit(runLintCommand(["schema-first"]));
+
+          const errorLines = yield* TestConsole.errorLines;
+          expectReportedExit(exit);
+          expect(errorLines).toContain("[schema-first] untracked live findings:");
+          expect(errorLines).toContain(
+            '- packages/example/src/Example.ts :: render.switch(event._tag) [schema-policy-advisory] Schema-modeled discriminator switch "event._tag" should use schema-derived .match/.guards or LiteralKit.$match when semantics match.'
+          );
+          const structuredIssueLine =
+            '[schema-first:issue] {"category":"schema-first-policy","ruleId":"SFV4-static-api",' +
+            '"severity":"warning","file":"packages/example/src/Example.ts","line":4,' +
+            '"symbol":"render.switch(event._tag)",' +
+            '"message":"Schema-modeled discriminator switch \\"event._tag\\" should use schema-derived .match/.guards or LiteralKit.$match when semantics match.",' +
+            '"remediation":"Prefer schema-derived .match/.guards/.cases or LiteralKit helpers, or run bun run beep lint schema-first --write with a justification when behavior intentionally differs."}';
+          expect(errorLines).toContain(structuredIssueLine);
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
+
+  it("reports untracked SFV4 precision-audit broad email advisories", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstSourceFixture([
+            'import * as S from "effect/Schema";',
+            'export class Contact extends S.Class<Contact>("Contact")({',
+            "  email: S.String,",
+            "}) {}",
+            "",
+          ]);
+
+          const exit = yield* Effect.exit(runLintCommand(["schema-first"]));
+
+          const errorLines = yield* TestConsole.errorLines;
+          expectReportedExit(exit);
+          expect(errorLines).toContain("[schema-first] untracked live findings:");
+          expect(errorLines).toContain(
+            '- packages/example/src/Example.ts :: Contact.email [schema-policy-advisory] Broad string field "email" should use @beep/schema Email, a local precise email schema, or a documented external-protocol exception.'
+          );
+          const structuredIssueLine =
+            '[schema-first:issue] {"category":"schema-first-policy","ruleId":"SFV4-precision-audit",' +
+            '"severity":"warning","file":"packages/example/src/Example.ts","line":3,' +
+            '"symbol":"Contact.email",' +
+            '"message":"Broad string field \\"email\\" should use @beep/schema Email, a local precise email schema, or a documented external-protocol exception.",' +
+            '"remediation":"Replace broad email S.String fields with @beep/schema Email or a local precise email schema; inventory only external protocol fields that intentionally allow non-email strings."}';
+          expect(errorLines).toContain(structuredIssueLine);
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
+
+  it("accepts precise email schemas without precision-audit advisories", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstSourceFixture([
+            'import { Email } from "@beep/schema";',
+            'import * as S from "effect/Schema";',
+            'export class Contact extends S.Class<Contact>("Contact")({',
+            "  email: Email,",
+            "}) {}",
+            "",
+          ]);
+
+          yield* runSchemaFirstAndExpectNoErrors();
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
+
+  it("reports untracked SFV4 fn-schema advisories for a .ts function (R17-2 still-fires case)", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstSourceFixture([
+            'import * as S from "effect/Schema";',
+            'export class Widget extends S.Class<Widget>("Widget")({',
+            "  id: S.String,",
+            "}) {}",
+            "export function updateWidget(input: { id: string; name: string }): void {}",
+            "",
+          ]);
+
+          const exit = yield* Effect.exit(runLintCommand(["schema-first"]));
+
+          const errorLines = yield* TestConsole.errorLines;
+          expectReportedExit(exit);
+          expect(errorLines).toContain("[schema-first] untracked live findings:");
+          expect(errorLines).toContain(
+            '- packages/example/src/Example.ts :: updateWidget [schema-policy-advisory] Exported function "updateWidget" carries inline object contracts in a schema-modeled file; model them with Fn({ input, output }) from @beep/schema or an S.Class so the contract is executable.'
+          );
+          const structuredIssueLine =
+            '[schema-first:issue] {"category":"schema-first-policy","ruleId":"SFV4-fn-schema",' +
+            '"severity":"warning","file":"packages/example/src/Example.ts","line":5,' +
+            '"symbol":"updateWidget",' +
+            '"message":"Exported function \\"updateWidget\\" carries inline object contracts in a schema-modeled file; model them with Fn({ input, output }) from @beep/schema or an S.Class so the contract is executable.",' +
+            '"remediation":"Model inline object parameter/return contracts with Fn({ input, output }) from @beep/schema or an S.Class, or run bun run beep lint schema-first --write with a justification when the shape intentionally stays inline."}';
+          expect(errorLines).toContain(structuredIssueLine);
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
+
+  it("does not report SFV4 fn-schema advisories for a .tsx component (R17-2 newly-excluded case)", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstFileFixture("packages/example/src/Example.tsx", [
+            'import * as S from "effect/Schema";',
+            'export class Widget extends S.Class<Widget>("Widget")({',
+            "  id: S.String,",
+            "}) {}",
+            "export function UpdateWidgetDemo(input: { id: string; name: string }): void {}",
+            "",
+          ]);
+
+          yield* runSchemaFirstAndExpectNoErrors();
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
+
+  it("excludes inventoried precision-audit exceptions from active advisory counts", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstSourceFixture([
+            'import * as S from "effect/Schema";',
+            'export class Contact extends S.Class<Contact>("Contact")({',
+            "  email: S.String,",
+            "}) {}",
+            "",
+          ]);
+          yield* writePrecisionAuditInventory(
+            "exception",
+            "External protocol preserves raw email text before domain validation."
+          );
+
+          yield* runLintCommand(["schema-first"]);
+
+          const logLines = yield* TestConsole.logLines;
+          const errorLines = yield* TestConsole.errorLines;
+          expect(logLines).toContain("[schema-first] sfv4_precision_audit_advisories=0");
+          expect(errorLines).toEqual([]);
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
+
+  it("blocks tracked active schema-first advisories", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstSourceFixture([
+            'import * as S from "effect/Schema";',
+            'export class Contact extends S.Class<Contact>("Contact")({',
+            "  email: S.String,",
+            "}) {}",
+            "",
+          ]);
+          yield* writePrecisionAuditInventory(
+            "advisory",
+            'Broad string field "email" should use @beep/schema Email, a local precise email schema, or a documented external-protocol exception.'
+          );
+
+          const exit = yield* Effect.exit(runLintCommand(["schema-first"]));
+
+          const logLines = yield* TestConsole.logLines;
+          const errorLines = yield* TestConsole.errorLines;
+          expectReportedExit(exit);
+          expect(logLines).toContain("[schema-first] sfv4_precision_audit_advisories=1");
+          expect(errorLines).toContain("[schema-first] repo still contains advisory findings:");
+          expect(errorLines).toContain(
+            '- packages/example/src/Example.ts :: Contact.email [schema-policy-advisory] Broad string field "email" should use @beep/schema Email, a local precise email schema, or a documented external-protocol exception.'
+          );
+          const structuredIssueLine =
+            '[schema-first:issue] {"category":"schema-first-policy","ruleId":"SFV4-precision-audit",' +
+            '"severity":"warning","file":"packages/example/src/Example.ts","line":3,' +
+            '"symbol":"Contact.email",' +
+            '"message":"Broad string field \\"email\\" should use @beep/schema Email, a local precise email schema, or a documented external-protocol exception.",' +
+            '"remediation":"Resolve the schema-first advisory or move the entry to exception with a documented reason."}';
+          expect(errorLines).toContain(structuredIssueLine);
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
+
+  it("reports untracked SFV4 arbitrary-tests static-only schema test advisories", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstFileFixture("packages/example/test/Example.test.ts", [
+            'import * as S from "effect/Schema";',
+            "const Worker = S.Struct({ id: S.String, retryCount: S.Int });",
+            "export const staticChecks = [",
+            '  S.decodeUnknownEffect(Worker)({ id: "a", retryCount: 1 }),',
+            '  S.decodeUnknownEffect(Worker)({ id: "b", retryCount: 2 }),',
+            '  S.encodeEffect(Worker)({ id: "c", retryCount: 3 }),',
+            "];",
+            "",
+          ]);
+
+          const exit = yield* Effect.exit(runLintCommand(["schema-first"]));
+
+          const errorLines = yield* TestConsole.errorLines;
+          expectReportedExit(exit);
+          expect(errorLines).toContain("[schema-first] untracked live findings:");
+          expect(errorLines).toContain(
+            "- packages/example/test/Example.test.ts :: schema-codec-tests [schema-policy-advisory] Schema-heavy test file has 3 Schema codec assertions but no schema-derived property coverage."
+          );
+          const structuredIssueLine =
+            '[schema-first:issue] {"category":"schema-first-policy","ruleId":"SFV4-arbitrary-tests",' +
+            '"severity":"warning","file":"packages/example/test/Example.test.ts","line":4,' +
+            '"symbol":"schema-codec-tests",' +
+            '"message":"Schema-heavy test file has 3 Schema codec assertions but no schema-derived property coverage.",' +
+            '"remediation":"Add a focused property test using S.toArbitrary(sourceSchema)(fc) and fast-check, or keep the inventory entry when the file is intentionally golden/snapshot/regression-only coverage."}';
+          expect(errorLines).toContain(structuredIssueLine);
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
+
+  it("accepts schema-derived property tests without arbitrary-tests advisories", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstFileFixture("packages/example/test/Example.test.ts", [
+            'import * as fc from "fast-check";',
+            'import * as S from "effect/Schema";',
+            "const Worker = S.Struct({ id: S.String, retryCount: S.Int });",
+            "const WorkerArbitrary = S.toArbitrary(Worker)(fc);",
+            "export const staticChecks = [",
+            '  S.decodeUnknownEffect(Worker)({ id: "a", retryCount: 1 }),',
+            '  S.decodeUnknownEffect(Worker)({ id: "b", retryCount: 2 }),',
+            '  S.encodeEffect(Worker)({ id: "c", retryCount: 3 }),',
+            "];",
+            "export const property = fc.property(WorkerArbitrary, (worker) => worker.retryCount === Math.trunc(worker.retryCount));",
+            "",
+          ]);
+
+          yield* runSchemaFirstAndExpectNoErrors();
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
+
+  it("does not treat a non-schema-derived fast-check property as arbitrary-tests coverage", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstFileFixture("packages/example/test/Example.test.ts", [
+            'import * as fc from "fast-check";',
+            'import * as S from "effect/Schema";',
+            "const Worker = S.Struct({ id: S.String, retryCount: S.Int });",
+            "export const staticChecks = [",
+            '  S.decodeUnknownEffect(Worker)({ id: "a", retryCount: 1 }),',
+            '  S.decodeUnknownEffect(Worker)({ id: "b", retryCount: 2 }),',
+            '  S.encodeEffect(Worker)({ id: "c", retryCount: 3 }),',
+            "];",
+            'export const property = fc.property(fc.string(), (id) => typeof id === "string");',
+            "",
+          ]);
+
+          const exit = yield* Effect.exit(runLintCommand(["schema-first"]));
+
+          const errorLines = yield* TestConsole.errorLines;
+          expectReportedExit(exit);
+          expect(errorLines).toContain(
+            "- packages/example/test/Example.test.ts :: schema-codec-tests [schema-policy-advisory] Schema-heavy test file has 3 Schema codec assertions but no schema-derived property coverage."
+          );
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
+
+  it("counts class-local static codec calls toward the arbitrary-tests threshold", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstFileFixture("packages/example/test/Example.test.ts", [
+            'import * as S from "effect/Schema";',
+            'class Worker extends S.Class<Worker>("Worker")({ id: S.String }) {',
+            "  static readonly decodeUnknownSync = S.decodeUnknownSync(Worker);",
+            "}",
+            "export const staticChecks = [",
+            '  Worker.decodeUnknownSync({ id: "a" }),',
+            '  Worker.decodeUnknownSync({ id: "b" }),',
+            '  Worker.decodeUnknownSync({ id: "c" }),',
+            "];",
+            "",
+          ]);
+
+          const exit = yield* Effect.exit(runLintCommand(["schema-first"]));
+
+          const errorLines = yield* TestConsole.errorLines;
+          expectReportedExit(exit);
+          expect(errorLines).toContain(
+            "- packages/example/test/Example.test.ts :: schema-codec-tests [schema-policy-advisory] Schema-heavy test file has 4 Schema codec assertions but no schema-derived property coverage."
+          );
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
+
+  it("reports SFV4 arbitrary-tests advisories for synchronous schema codec helpers", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstFileFixture("packages/example/test/Sync.test.ts", [
+            'import * as S from "effect/Schema";',
+            "const Worker = S.Struct({ id: S.String, retryCount: S.Int });",
+            "export const staticChecks = [",
+            '  S.decodeUnknownSync(Worker)({ id: "a", retryCount: 1 }),',
+            '  S.decodeSync(Worker)({ id: "b", retryCount: 2 }),',
+            '  S.encodeSync(Worker)({ id: "c", retryCount: 3 }),',
+            "];",
+            "",
+          ]);
+
+          const exit = yield* Effect.exit(runLintCommand(["schema-first"]));
+
+          const errorLines = yield* TestConsole.errorLines;
+          expectReportedExit(exit);
+          expect(errorLines).toContain(
+            "- packages/example/test/Sync.test.ts :: schema-codec-tests [schema-policy-advisory] Schema-heavy test file has 3 Schema codec assertions but no schema-derived property coverage."
+          );
+          const structuredIssueLine =
+            '[schema-first:issue] {"category":"schema-first-policy","ruleId":"SFV4-arbitrary-tests",' +
+            '"severity":"warning","file":"packages/example/test/Sync.test.ts","line":4,' +
+            '"symbol":"schema-codec-tests",' +
+            '"message":"Schema-heavy test file has 3 Schema codec assertions but no schema-derived property coverage.",' +
+            '"remediation":"Add a focused property test using S.toArbitrary(sourceSchema)(fc) and fast-check, or keep the inventory entry when the file is intentionally golden/snapshot/regression-only coverage."}';
+          expect(errorLines).toContain(structuredIssueLine);
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
+
+  it("accepts schema-derived static match usage without static-api advisories", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstSourceFixture([
+            'import * as S from "effect/Schema";',
+            "const JobEvent = S.TaggedUnion({});",
+            "export const render = (event: unknown) =>",
+            "  JobEvent.match(event, {",
+            '    Created: () => "created",',
+            '    Failed: () => "failed",',
+            "  });",
+            "",
+          ]);
+
+          yield* runSchemaFirstAndExpectNoErrors();
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
+
+  it("reports untracked SFV4 equivalence manual equals advisories", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstSourceFixture([
+            'import * as S from "effect/Schema";',
+            'export class Worker extends S.Class<Worker>("Worker")({',
+            "  id: S.String,",
+            "  name: S.String,",
+            "}) {}",
+            "export const equals = (left: Worker, right: Worker) => left.id === right.id && left.name === right.name;",
+            "",
+          ]);
+
+          const exit = yield* Effect.exit(runLintCommand(["schema-first"]));
+
+          const errorLines = yield* TestConsole.errorLines;
+          expectReportedExit(exit);
+          expect(errorLines).toContain("[schema-first] untracked live findings:");
+          expect(errorLines).toContain(
+            '- packages/example/src/Example.ts :: equals [schema-policy-advisory] Exported schema-modeled equality helper "equals" should derive from S.toEquivalence(schema) unless comparison intentionally differs from schema semantics.'
+          );
+          const structuredIssueLine =
+            '[schema-first:issue] {"category":"schema-first-policy","ruleId":"SFV4-equivalence",' +
+            '"severity":"warning","file":"packages/example/src/Example.ts","line":6,' +
+            '"symbol":"equals",' +
+            '"message":"Exported schema-modeled equality helper \\"equals\\" should derive from S.toEquivalence(schema) unless comparison intentionally differs from schema semantics.",' +
+            '"remediation":"Derive comparison from S.toEquivalence(schema) or SchemaUtils.toEquivalence(schema); use S.overrideToEquivalence only when schema semantics intentionally differ."}';
+          expect(errorLines).toContain(structuredIssueLine);
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
+
+  it("accepts schema-derived equivalence helpers without equivalence advisories", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstSourceFixture([
+            'import * as S from "effect/Schema";',
+            'export class Worker extends S.Class<Worker>("Worker")({',
+            "  id: S.String,",
+            "  name: S.String,",
+            "}) {}",
+            "export const equals = S.toEquivalence(Worker);",
+            "",
+          ]);
+
+          yield* runSchemaFirstAndExpectNoErrors();
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
+
+  it("reports S.TaggedError declarations without declared equivalence", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstSourceFixture([
+            'import * as S from "effect/Schema";',
+            "export class WorkerError extends S.TaggedError<WorkerError>()(",
+            '  "WorkerError",',
+            "  { workerId: S.String },",
+            '  { description: "Worker execution failed." }',
+            ") {}",
+            "",
+          ]);
+
+          const exit = yield* Effect.exit(runLintCommand(["schema-first"]));
+
+          const logLines = yield* TestConsole.logLines;
+          const errorLines = yield* TestConsole.errorLines;
+          expectReportedExit(exit);
+          expect(logLines).toContain("[schema-first] sfv4_tagged_error_equivalence_advisories=1");
+          expect(errorLines).toContain("[schema-first] untracked live findings:");
+          expect(errorLines).toContain(
+            '- packages/example/src/Example.ts :: WorkerError [schema-policy-advisory] S.TaggedError declaration "WorkerError" must declare fields-only equivalence at the class declaration: pass $I.annoteError<WorkerError>(...) as its annotations (or a toEquivalence hook that adopts the declared struct equivalence). Otherwise declaration equivalence falls back to Equal.equals over Error runtime metadata, causing seed-dependent property flakes.'
+          );
+          const structuredIssueLine =
+            '[schema-first:issue] {"category":"schema-first-policy","ruleId":"SFV4-tagged-error-equivalence",' +
+            '"severity":"warning","file":"packages/example/src/Example.ts","line":2,' +
+            '"symbol":"WorkerError",' +
+            '"message":"S.TaggedError declaration \\"WorkerError\\" must declare fields-only equivalence at the class declaration: pass $I.annoteError<WorkerError>(...) as its annotations (or a toEquivalence hook that adopts the declared struct equivalence). Otherwise declaration equivalence falls back to Equal.equals over Error runtime metadata, causing seed-dependent property flakes.",' +
+            '"remediation":"Annotate the class with $I.annoteError<Self>(...) so it adopts the declared struct equivalence; opaque causes use Defect from @beep/schema, which declares its own always-equal equivalence."}';
+          expect(errorLines).toContain(structuredIssueLine);
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
+
+  it("reports named effect/Schema TaggedError imports without declared equivalence", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstFileFixture("packages/ecosystem/effect-drizzle/src/Example.ts", [
+            'import { String as StringSchema, TaggedError } from "effect/Schema";',
+            "export class WorkerError extends TaggedError<WorkerError>()(",
+            '  "WorkerError",',
+            "  { workerId: StringSchema },",
+            '  { description: "Worker execution failed." }',
+            ") {}",
+            "",
+          ]);
+
+          const exit = yield* Effect.exit(runLintCommand(["schema-first"]));
+
+          const logLines = yield* TestConsole.logLines;
+          const errorLines = yield* TestConsole.errorLines;
+          expectReportedExit(exit);
+          expect(logLines).toContain("[schema-first] sfv4_tagged_error_equivalence_advisories=1");
+          expect(errorLines).toContain(
+            '- packages/ecosystem/effect-drizzle/src/Example.ts :: WorkerError [schema-policy-advisory] S.TaggedError declaration "WorkerError" must declare fields-only equivalence at the class declaration: pass $I.annoteError<WorkerError>(...) as its annotations (or a toEquivalence hook that adopts the declared struct equivalence). Otherwise declaration equivalence falls back to Equal.equals over Error runtime metadata, causing seed-dependent property flakes.'
+          );
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
+
+  it("ignores unrelated local TaggedError factories", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstSourceFixture([
+            "const TaggedError = <Self>() => (_tag: string, _fields: unknown) => class {};",
+            'class LocalError extends TaggedError<LocalError>()("LocalError", {}) {}',
+            "void LocalError;",
+            "",
+          ]);
+
+          yield* runSchemaFirstAndExpectNoErrors();
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
+
+  it("accepts direct and annoteClass tagged-error equivalence annotations", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstSourceFixture([
+            'import * as S from "effect/Schema";',
+            "const sameWorkerError = (_self: WorkerError, _that: WorkerError): boolean => true;",
+            "export class WorkerError extends S.TaggedError<WorkerError>()(",
+            '  "WorkerError",',
+            "  { workerId: S.String },",
+            '  { description: "Worker execution failed.", toEquivalence: () => sameWorkerError }',
+            ") {}",
+            "const sameTaskError = (_self: TaskError, _that: TaskError): boolean => true;",
+            "const taskErrorAnnotations = { toEquivalence: () => sameTaskError };",
+            "class TaskError extends S.TaggedError<TaskError>()(",
+            '  "TaskError",',
+            "  { taskId: S.String },",
+            '  $I.annoteClass("TaskError", taskErrorAnnotations)',
+            ") {}",
+            "void TaskError;",
+            "",
+          ]);
+
+          yield* runSchemaFirstAndExpectNoErrors();
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
+
+  it("accepts annoteError tagged-error annotations", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstSourceFixture([
+            'import * as S from "effect/Schema";',
+            "export class WorkerError extends S.TaggedError<WorkerError>()(",
+            '  "WorkerError",',
+            "  { workerId: S.String },",
+            '  $I.annoteError<WorkerError>("WorkerError", { description: "Worker execution failed." })',
+            ") {}",
+            "",
+          ]);
+
+          yield* runSchemaFirstAndExpectNoErrors();
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
+
+  it("preserves existing tagged-error exceptions without excepting new write findings", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstSourceFixture([
+            'import * as S from "effect/Schema";',
+            "export class ExistingError extends S.TaggedError<ExistingError>()(",
+            '  "ExistingError",',
+            "  { workerId: S.String },",
+            '  { description: "Existing documented failure." }',
+            ") {}",
+            "export class WorkerError extends S.TaggedError<WorkerError>()(",
+            '  "WorkerError",',
+            "  { workerId: S.String },",
+            '  { description: "Worker execution failed." }',
+            ") {}",
+            "",
+          ]);
+
+          const fs = yield* FileSystem.FileSystem;
+          yield* fs.makeDirectory("standards");
+          yield* fs.writeFileString(
+            "standards/schema-first.inventory.jsonc",
+            `${encodeJson({
+              version: 1,
+              generatedOn: "2026-06-08",
+              scope: ["apps/**/*.{ts,tsx}", "packages/**/*.{ts,tsx}", "infra/{src,test}/**/*.ts"],
+              entries: [
+                {
+                  file: "packages/example/src/Example.ts",
+                  symbol: "ExistingError",
+                  kind: "schema-policy-advisory",
+                  status: "exception",
+                  ruleId: "SFV4-tagged-error-equivalence",
+                  line: 2,
+                  owner: "@beep/example",
+                  reason: "Existing documented exception.",
+                },
+              ],
+            })}\n`
+          );
+
+          const exit = yield* Effect.exit(runLintCommand(["schema-first", "--write"]));
+          expectReportedExit(exit);
+
+          const inventory = yield* fs.readFileString("standards/schema-first.inventory.jsonc");
+          expect(inventory).toContain(
+            '"symbol": "ExistingError",\n      "kind": "schema-policy-advisory",\n      "status": "exception"'
+          );
+          expect(inventory).toContain(
+            '"symbol": "WorkerError",\n      "kind": "schema-policy-advisory",\n      "status": "advisory"'
+          );
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
+
+  it("reports untracked SFV4 boundary-codec JSON.parse advisories", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstSourceFixture([
+            "export const parseConfig = (text: string) => {",
+            "  return JSON.parse(text);",
+            "};",
+            "",
+          ]);
+
+          const exit = yield* Effect.exit(runLintCommand(["schema-first"]));
+
+          const errorLines = yield* TestConsole.errorLines;
+          expectReportedExit(exit);
+          expect(errorLines).toContain("[schema-first] untracked live findings:");
+          expect(errorLines).toContain(
+            "- packages/example/src/Example.ts :: parseConfig.JSON.parse [schema-policy-advisory] Direct JSON.parse boundary should use S.fromJsonString(schema) so parsing and validation stay schema-owned."
+          );
+          const structuredIssueLine =
+            '[schema-first:issue] {"category":"schema-first-policy","ruleId":"SFV4-boundary-codec",' +
+            '"severity":"warning","file":"packages/example/src/Example.ts","line":2,' +
+            '"symbol":"parseConfig.JSON.parse",' +
+            '"message":"Direct JSON.parse boundary should use S.fromJsonString(schema) so parsing and validation stay schema-owned.",' +
+            '"remediation":"Replace direct JSON.parse with S.fromJsonString(schema) plus an Effect/Result/Option decoder, or inventory the exception when the protocol is intentionally non-standard."}';
+          expect(errorLines).toContain(structuredIssueLine);
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
+
+  it("accepts schema JSON codecs without boundary-codec advisories", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstSourceFixture([
+            'import * as S from "effect/Schema";',
+            "const UnknownFromJsonString = S.fromJsonString(S.Unknown);",
+            "export const decodeConfig = S.decodeUnknownEffect(UnknownFromJsonString);",
+            "",
+          ]);
+
+          yield* runSchemaFirstAndExpectNoErrors();
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
+
+  it("reports untracked SFV4 defaults parameter object advisories", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstSourceFixture([
+            'import * as S from "effect/Schema";',
+            'export class WorkerOptions extends S.Class<WorkerOptions>("WorkerOptions")({',
+            "  timeoutMs: S.Finite,",
+            "}) {}",
+            "export const runWorker = (params = { timeoutMs: 5000 }) => params.timeoutMs;",
+            "",
+          ]);
+
+          const exit = yield* Effect.exit(runLintCommand(["schema-first"]));
+
+          const errorLines = yield* TestConsole.errorLines;
+          expectReportedExit(exit);
+          expect(errorLines).toContain("[schema-first] untracked live findings:");
+          expect(errorLines).toContain(
+            '- packages/example/src/Example.ts :: runWorker.params [schema-policy-advisory] Parameter default object for "params" should move fallback values into schema defaults so construction, decoding, and tests share one source of truth.'
+          );
+          const structuredIssueLine =
+            '[schema-first:issue] {"category":"schema-first-policy","ruleId":"SFV4-defaults",' +
+            '"severity":"warning","file":"packages/example/src/Example.ts","line":5,' +
+            '"symbol":"runWorker.params",' +
+            '"message":"Parameter default object for \\"params\\" should move fallback values into schema defaults so construction, decoding, and tests share one source of truth.",' +
+            '"remediation":"Move option/request fallback values into schema fields with S.withConstructorDefault, S.withDecodingDefault*, or SchemaUtils.withKeyDefaults; inventory the exception only when the fallback intentionally differs from schema construction semantics."}';
+          expect(errorLines).toContain(structuredIssueLine);
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
+
+  it("accepts schema-owned constructor defaults without defaults advisories", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstSourceFixture([
+            'import { Effect } from "effect";',
+            'import * as S from "effect/Schema";',
+            'export class WorkerOptions extends S.Class<WorkerOptions>("WorkerOptions")({',
+            "  timeoutMs: S.Finite.pipe(S.withConstructorDefault(Effect.succeed(5000))),",
+            "}) {}",
+            "export const runWorker = (params = WorkerOptions.make({})) => params.timeoutMs;",
+            "",
+          ]);
+
+          yield* runSchemaFirstAndExpectNoErrors();
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
+
+  it("writes SFV4 numeric-domain advisories to the schema-first inventory", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstSourceFixture([
+            'import * as S from "effect/Schema";',
+            'export class WorkerOptions extends S.Class<WorkerOptions>("WorkerOptions")({',
+            "  timeoutMs: S.Number,",
+            "  retryCount: S.Int,",
+            "}) {}",
+            "",
+          ]);
+
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+
+          yield* fs.makeDirectory("standards");
+          const exit = yield* Effect.exit(runLintCommand(["schema-first", "--write"]));
+
+          const inventory = yield* fs.readFileString(path.join("standards", "schema-first.inventory.jsonc"));
+          const errorLines = yield* TestConsole.errorLines;
+          expectReportedExit(exit);
+          expect(errorLines).toContain("[schema-first] untracked live findings:");
+          expect(errorLines).toContain("[schema-first] repo still contains advisory findings:");
+          expect(inventory).toContain('"ruleId": "SFV4-numeric-domain"');
+          expect(inventory).toContain('"symbol": "WorkerOptions.timeoutMs"');
+          expect(inventory).not.toContain("retryCount");
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
+
+  it("filters generic and wholly runtime declarations before inventory comparison", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstSourceFixture([
+            "interface BaseData { readonly inheritedId: string }",
+            "interface GenericBase<Value> { readonly value: Value }",
+            "interface AstNode { readonly type: string }",
+            "declare namespace O {",
+            '  type Option<Value> = { readonly _tag: "None" } | { readonly _tag: "Some"; readonly value: Value };',
+            "}",
+            "declare namespace pulumi { type Input<Value> = Value | Promise<Value> }",
+            "export interface Generic<Value> { readonly value: Value }",
+            "export interface GenericDerived<Value extends string = string> extends GenericBase<Value> {}",
+            "export type GenericAlias<Value = string> = { readonly value: Value };",
+            "export type PureAlias = { readonly id: string };",
+            "export type RuntimeAlias = { readonly node: AstNode; readonly visit: () => void };",
+            "export interface RuntimeOnly {",
+            "  readonly layer: Layer.Layer<never>;",
+            "  readonly run: (input: string) => Effect.Effect<void>;",
+            "}",
+            "interface D3Only extends d3.SimulationNodeDatum {}",
+            "export { D3Only };",
+            "export interface D3Mixed extends d3.SimulationNodeDatum { readonly id: string }",
+            "export interface OptionalRuntimeOnly {",
+            "  readonly signal?: AbortSignal;",
+            "  readonly secret?: pulumi.Input<string>;",
+            "}",
+            "export interface RpcRuntimeOnly {",
+            '  readonly client: RpcClient.Protocol["Service"];',
+            "  readonly incoming: Stream.Stream<string>;",
+            "  readonly notify: { (value: string): Effect.Effect<void> };",
+            "}",
+            "export type AstTraversal = {",
+            "  readonly object: O.Option<AstNode>;",
+            "  readonly property: AstNode | null;",
+            "};",
+            "export interface RuntimeContainers {",
+            "  readonly array: ReadonlyArray<AstNode>;",
+            "  readonly mutableArray: AstNode[];",
+            "  readonly tuple: readonly [AstNode];",
+            "  readonly set: ReadonlySet<AstNode>;",
+            "}",
+            "export interface PrimitiveContainers {",
+            "  readonly array: ReadonlyArray<string>;",
+            "  readonly mutableArray: number[];",
+            "  readonly tuple: readonly [string, number];",
+            "  readonly map: ReadonlyMap<string, number>;",
+            "}",
+            "export type RuntimeRecord = { readonly values: Readonly<Record<string, AstNode>> };",
+            "export type PrimitiveRecord = { readonly values: Readonly<Record<string, string>> };",
+            "export interface MixedContract {",
+            "  readonly id: string;",
+            "  readonly run: () => Effect.Effect<void>;",
+            "}",
+            "export interface CallableOnly { (): void }",
+            "export interface CallableMixed { (): void; readonly id: string }",
+            "export interface ConstructOnly { new (): RuntimeOnly }",
+            "export interface ConstructMixed { new (): RuntimeOnly; readonly id: string }",
+            "export interface UnionMixed { readonly state: string | AbortSignal }",
+            "export interface NestedMixed {",
+            "  readonly state: { readonly id: string; readonly signal: AbortSignal };",
+            "}",
+            "export interface ImmutableCollections {",
+            "  readonly map: HashMap.HashMap<string, string>;",
+            "  readonly set: HashSet.HashSet<string>;",
+            "}",
+            "declare function makePayload(): { readonly id: string };",
+            "export interface ReturnTypePayload { readonly payload: ReturnType<typeof makePayload> }",
+            "class SchemaFlags { readonly enabled!: boolean }",
+            "export interface InheritedMixed extends SchemaFlags { readonly run: () => Effect.Effect<void> }",
+            "export interface DerivedData extends BaseData {}",
+            "export interface BinaryPayload { readonly bytes: Uint8Array }",
+            "export interface JournalPayload { readonly entry: EventJournal.Entry }",
+            "export interface SuccessPayload { readonly success: Effect.Success<string, Error> }",
+            "export interface ResultPayload { readonly result: OperationResult }",
+            "export interface SchemaOwned { readonly id: string }",
+            'export const SchemaOwned: SchemaOwned = Field({ id: "schema" });',
+            "",
+          ]);
+
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          yield* fs.makeDirectory("standards");
+          const exit = yield* Effect.exit(runLintCommand(["schema-first", "--write"]));
+          const inventory = yield* fs.readFileString(path.join("standards", "schema-first.inventory.jsonc"));
+
+          expectReportedExit(exit);
+          expect(inventory).toContain('"symbol": "MixedContract"');
+          expect(inventory).toContain('"symbol": "D3Mixed"');
+          expect(inventory).toContain('"symbol": "CallableMixed"');
+          expect(inventory).toContain('"symbol": "ConstructMixed"');
+          expect(inventory).toContain('"symbol": "UnionMixed"');
+          expect(inventory).toContain('"symbol": "NestedMixed"');
+          expect(inventory).toContain('"symbol": "ImmutableCollections"');
+          expect(inventory).toContain('"symbol": "ReturnTypePayload"');
+          expect(inventory).toContain('"symbol": "InheritedMixed"');
+          expect(inventory).toContain('"symbol": "PrimitiveContainers"');
+          expect(inventory).toContain('"symbol": "PrimitiveRecord"');
+          expect(inventory).toContain('"symbol": "DerivedData"');
+          expect(inventory).toContain('"symbol": "BinaryPayload"');
+          expect(inventory).toContain('"symbol": "JournalPayload"');
+          expect(inventory).toContain('"symbol": "SuccessPayload"');
+          expect(inventory).toContain('"symbol": "ResultPayload"');
+          expect(inventory).toContain('"symbol": "PureAlias"');
+          expect(inventory).not.toContain('"symbol": "Generic"');
+          expect(inventory).not.toContain('"symbol": "GenericDerived"');
+          expect(inventory).not.toContain('"symbol": "GenericAlias"');
+          expect(inventory).not.toContain('"symbol": "CallableOnly"');
+          expect(inventory).not.toContain('"symbol": "ConstructOnly"');
+          expect(inventory).not.toContain('"symbol": "OptionalRuntimeOnly"');
+          expect(inventory).not.toContain('"symbol": "RpcRuntimeOnly"');
+          expect(inventory).not.toContain('"symbol": "AstTraversal"');
+          expect(inventory).not.toContain('"symbol": "RuntimeContainers"');
+          expect(inventory).not.toContain('"symbol": "RuntimeRecord"');
+          expect(inventory).not.toContain('"symbol": "RuntimeOnly"');
+          expect(inventory).not.toContain('"symbol": "D3Only"');
+          expect(inventory).not.toContain('"symbol": "RuntimeAlias"');
+          expect(inventory).not.toContain('"symbol": "SchemaOwned"');
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
+
+  it("limits normalization advisories to exported schema-boundary helpers", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstSourceFixture([
+            'import * as S from "effect/Schema";',
+            "const Model = S.Struct({ value: S.String });",
+            "const privateToken = (value: string): string => value.toLowerCase();",
+            "const unrelated = (value: string): string => value.trim();",
+            "const normalizeValue = (input: unknown): string =>",
+            "  S.decodeUnknownSync(Model)(input).value.trim();",
+            "class Normalizer {",
+            "  public normalize(input: unknown): string {",
+            "    return S.decodeUnknownSync(Model)(input).value.toUpperCase();",
+            "  }",
+            "  private privateNormalize(input: unknown): string {",
+            "    return S.decodeUnknownSync(Model)(input).value.toLowerCase();",
+            "  }",
+            "  protected protectedNormalize(input: unknown): string {",
+            "    return S.decodeUnknownSync(Model)(input).value.trim();",
+            "  }",
+            "}",
+            "export { Normalizer, normalizeValue, unrelated };",
+            "void privateToken;",
+            "",
+          ]);
+
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          yield* fs.makeDirectory("standards");
+          const exit = yield* Effect.exit(runLintCommand(["schema-first", "--write"]));
+          const inventory = yield* fs.readFileString(path.join("standards", "schema-first.inventory.jsonc"));
+
+          expectReportedExit(exit);
+          expect(inventory).toContain('"symbol": "normalizeValue.trim"');
+          expect(inventory).toContain('"symbol": "Normalizer.toUpperCase"');
+          expect(inventory).not.toContain("privateToken.toLowerCase");
+          expect(inventory).not.toContain("unrelated.trim");
+          expect(inventory).not.toContain("privateNormalize");
+          expect(inventory).not.toContain("protectedNormalize");
+          expect(inventory).not.toContain("Normalizer.toLowerCase");
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
+
+  it("omits render contracts without hiding pure data declared in TSX", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstFileFixture("packages/example/src/Example.tsx", [
+            "export interface WidgetProps {",
+            "  readonly label: string;",
+            "  readonly children: React.ReactNode;",
+            "}",
+            "export type PanelProps = { readonly title: string };",
+            "export interface DataPayload { readonly id: string }",
+            "",
+          ]);
+          const fs = yield* FileSystem.FileSystem;
+          yield* fs.writeFileString(
+            "packages/example/src/ReactProps.ts",
+            [
+              'import type React from "react";',
+              "export type RendererProps = {",
+              "  readonly title: string;",
+              "  readonly component: React.FunctionComponent;",
               "};",
               "",
-            ]);
+            ].join("\n")
+          );
 
-            const fs = yield* FileSystem.FileSystem;
-            yield* fs.makeDirectory("standards");
-            const exit = yield* Effect.exit(runLintCommand(["schema-first", "--write"]));
-            const inventory = yield* fs.readFileString("standards/schema-first.inventory.jsonc");
+          yield* fs.makeDirectory("standards");
+          const exit = yield* Effect.exit(runLintCommand(["schema-first", "--write"]));
+          const inventory = yield* fs.readFileString("standards/schema-first.inventory.jsonc");
 
-            expectReportedExit(exit);
-            expect(inventory).toContain('"symbol": "ListedData"');
-            expect(inventory).toContain('"symbol": "ListedAlias"');
-            expect(inventory).toContain('"symbol": "AliasedData"');
-            expect(inventory).toContain('"symbol": "DefaultData"');
-            expect(inventory).toContain('"symbol": "ListedStruct"');
-            expect(inventory).toContain('"symbol": "AliasedStruct"');
-            expect(inventory).toContain('"symbol": "listedFunction"');
-            expect(inventory).toContain('"symbol": "aliasedFunction"');
-            expect(inventory).toContain('"symbol": "listedArrow"');
-            expect(inventory).not.toContain('"symbol": "ListedSchemaOwned"');
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
+          expectReportedExit(exit);
+          expect(inventory).toContain('"symbol": "DataPayload"');
+          expect(inventory).not.toContain('"symbol": "WidgetProps"');
+          expect(inventory).not.toContain('"symbol": "PanelProps"');
+          expect(inventory).not.toContain('"symbol": "RendererProps"');
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
 
-  it(
-    "recognizes anonymous direct default exports with stable fallback symbols",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstFileFixture("packages/example/src/DefaultInterface.ts", [
-              "export default interface { readonly id: string }",
-              "",
-            ]);
-            const fs = yield* FileSystem.FileSystem;
-            yield* fs.writeFileString(
-              "packages/example/src/DefaultFunction.ts",
-              [
-                'import * as S from "effect/Schema";',
-                "const Model = S.Struct({ id: S.String });",
-                "export default function(input: { readonly id: string }): void { void input; }",
-                "void Model;",
-                "",
-              ].join("\n")
-            );
-            yield* fs.writeFileString(
-              "packages/example/src/DefaultArrow.ts",
-              [
-                'import * as S from "effect/Schema";',
-                "const Model = S.Struct({ id: S.String });",
-                "export default (input: { readonly id: string }): void => { void input; };",
-                "void Model;",
-                "",
-              ].join("\n")
-            );
-            yield* fs.writeFileString(
-              "packages/example/src/DefaultStruct.ts",
-              ['import * as S from "effect/Schema";', "export default S.Struct({ id: S.String });", ""].join("\n")
-            );
+  it("recognizes local export lists for declarations, schema companions, structs, and functions", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstSourceFixture([
+            'import * as S from "effect/Schema";',
+            "interface ListedData { readonly id: string }",
+            "type ListedAlias = { readonly id: string };",
+            "interface AliasedData { readonly id: string }",
+            "export default interface DefaultData { readonly id: string }",
+            "interface ListedSchemaOwned { readonly id: string }",
+            'class ListedSchemaOwned extends S.Class<ListedSchemaOwned>("ListedSchemaOwned")({',
+            "  id: S.String,",
+            "}) {}",
+            "const ListedStruct = S.Struct({ id: S.String });",
+            "const AliasedStruct = S.Struct({ id: S.String });",
+            "function listedFunction(input: { readonly id: string }): void { void input; }",
+            "function aliasedFunction(input: { readonly id: string }): void { void input; }",
+            "const listedArrow = (input: { readonly id: string }): void => { void input; };",
+            "export {",
+            "  AliasedData as PublicData,",
+            "  AliasedStruct as PublicStruct,",
+            "  ListedAlias,",
+            "  ListedData,",
+            "  ListedSchemaOwned,",
+            "  ListedStruct,",
+            "  aliasedFunction as publicFunction,",
+            "  listedArrow,",
+            "  listedFunction,",
+            "};",
+            "",
+          ]);
 
-            yield* fs.makeDirectory("standards");
-            const exit = yield* Effect.exit(runLintCommand(["schema-first", "--write"]));
-            const inventory = yield* fs.readFileString("standards/schema-first.inventory.jsonc");
+          const fs = yield* FileSystem.FileSystem;
+          yield* fs.makeDirectory("standards");
+          const exit = yield* Effect.exit(runLintCommand(["schema-first", "--write"]));
+          const inventory = yield* fs.readFileString("standards/schema-first.inventory.jsonc");
 
-            expectReportedExit(exit);
-            expect(inventory.match(/"symbol": "default@\d+"/g)).toHaveLength(4);
-            expect(inventory).not.toContain('"symbol": ""');
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
+          expectReportedExit(exit);
+          expect(inventory).toContain('"symbol": "ListedData"');
+          expect(inventory).toContain('"symbol": "ListedAlias"');
+          expect(inventory).toContain('"symbol": "AliasedData"');
+          expect(inventory).toContain('"symbol": "DefaultData"');
+          expect(inventory).toContain('"symbol": "ListedStruct"');
+          expect(inventory).toContain('"symbol": "AliasedStruct"');
+          expect(inventory).toContain('"symbol": "listedFunction"');
+          expect(inventory).toContain('"symbol": "aliasedFunction"');
+          expect(inventory).toContain('"symbol": "listedArrow"');
+          expect(inventory).not.toContain('"symbol": "ListedSchemaOwned"');
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
 
-  it(
-    "inventories only exported top-level plain S.Struct object models",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            yield* writeSchemaFirstSourceFixture([
+  it("recognizes anonymous direct default exports with stable fallback symbols", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstFileFixture("packages/example/src/DefaultInterface.ts", [
+            "export default interface { readonly id: string }",
+            "",
+          ]);
+          const fs = yield* FileSystem.FileSystem;
+          yield* fs.writeFileString(
+            "packages/example/src/DefaultFunction.ts",
+            [
               'import * as S from "effect/Schema";',
-              "const fields = { id: S.String };",
-              "const internal = S.Struct({ id: S.String });",
-              "const nested = S.Struct({ child: S.Struct({ id: S.String }) });",
-              "const dynamic = S.Struct(fields);",
-              "const spread = S.Struct({ ...fields });",
-              "export const build = () => S.Struct({ id: S.String });",
-              "export const PublicModel = S.Struct({ id: S.String });",
-              "void internal;",
-              "void nested;",
-              "void dynamic;",
-              "void spread;",
+              "const Model = S.Struct({ id: S.String });",
+              "export default function(input: { readonly id: string }): void { void input; }",
+              "void Model;",
               "",
-            ]);
+            ].join("\n")
+          );
+          yield* fs.writeFileString(
+            "packages/example/src/DefaultArrow.ts",
+            [
+              'import * as S from "effect/Schema";',
+              "const Model = S.Struct({ id: S.String });",
+              "export default (input: { readonly id: string }): void => { void input; };",
+              "void Model;",
+              "",
+            ].join("\n")
+          );
+          yield* fs.writeFileString(
+            "packages/example/src/DefaultStruct.ts",
+            ['import * as S from "effect/Schema";', "export default S.Struct({ id: S.String });", ""].join("\n")
+          );
 
-            const fs = yield* FileSystem.FileSystem;
-            const path = yield* Path.Path;
-            yield* fs.makeDirectory("standards");
-            const exit = yield* Effect.exit(runLintCommand(["schema-first", "--write"]));
-            const inventory = yield* fs.readFileString(path.join("standards", "schema-first.inventory.jsonc"));
-            const errorLines = yield* TestConsole.errorLines;
+          yield* fs.makeDirectory("standards");
+          const exit = yield* Effect.exit(runLintCommand(["schema-first", "--write"]));
+          const inventory = yield* fs.readFileString("standards/schema-first.inventory.jsonc");
 
-            expectReportedExit(exit);
-            expect(errorLines).toContain("[schema-first] untracked live findings:");
-            expect(inventory).toContain('"symbol": "PublicModel"');
-            expect(inventory).not.toContain('"symbol": "internal"');
-            expect(inventory).not.toContain('"symbol": "nested"');
-            expect(inventory).not.toContain('"symbol": "dynamic"');
-            expect(inventory).not.toContain('"symbol": "spread"');
-            expect(inventory).not.toContain('"symbol": "build"');
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
+          expectReportedExit(exit);
+          expect(inventory.match(/"symbol": "default@\d+"/g)).toHaveLength(4);
+          expect(inventory).not.toContain('"symbol": ""');
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
+
+  it("inventories only exported top-level plain S.Struct object models", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          yield* writeSchemaFirstSourceFixture([
+            'import * as S from "effect/Schema";',
+            "const fields = { id: S.String };",
+            "const internal = S.Struct({ id: S.String });",
+            "const nested = S.Struct({ child: S.Struct({ id: S.String }) });",
+            "const dynamic = S.Struct(fields);",
+            "const spread = S.Struct({ ...fields });",
+            "export const build = () => S.Struct({ id: S.String });",
+            "export const PublicModel = S.Struct({ id: S.String });",
+            "void internal;",
+            "void nested;",
+            "void dynamic;",
+            "void spread;",
+            "",
+          ]);
+
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          yield* fs.makeDirectory("standards");
+          const exit = yield* Effect.exit(runLintCommand(["schema-first", "--write"]));
+          const inventory = yield* fs.readFileString(path.join("standards", "schema-first.inventory.jsonc"));
+          const errorLines = yield* TestConsole.errorLines;
+
+          expectReportedExit(exit);
+          expect(errorLines).toContain("[schema-first] untracked live findings:");
+          expect(inventory).toContain('"symbol": "PublicModel"');
+          expect(inventory).not.toContain('"symbol": "internal"');
+          expect(inventory).not.toContain('"symbol": "nested"');
+          expect(inventory).not.toContain('"symbol": "dynamic"');
+          expect(inventory).not.toContain('"symbol": "spread"');
+          expect(inventory).not.toContain('"symbol": "build"');
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
 });
 
 describe("package test import lint command", { concurrent: false }, () => {
@@ -1622,164 +1482,144 @@ describe("package test import lint command", { concurrent: false }, () => {
       ).pipe(provideScopedLayer(testLayer))
     ));
 
-  it(
-    "scopes the scan to one package root",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            const fs = yield* FileSystem.FileSystem;
-            const path = yield* Path.Path;
-            const selected = path.join("packages", "foundation", "modeling", "selected");
-            const ignored = path.join("packages", "foundation", "modeling", "ignored");
+  it("scopes the scan to one package root", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const selected = path.join("packages", "foundation", "modeling", "selected");
+          const ignored = path.join("packages", "foundation", "modeling", "ignored");
 
-            yield* writePackage(selected, "@beep/selected");
-            yield* writePackage(ignored, "@beep/ignored");
-            yield* fs.makeDirectory(path.join(ignored, "test"), { recursive: true });
-            yield* fs.writeFileString(
-              path.join(ignored, "test", "Ignored.test.ts"),
-              `import { ignored } from "../src/index.ts";\nvoid ignored;\n`
-            );
+          yield* writePackage(selected, "@beep/selected");
+          yield* writePackage(ignored, "@beep/ignored");
+          yield* fs.makeDirectory(path.join(ignored, "test"), { recursive: true });
+          yield* fs.writeFileString(
+            path.join(ignored, "test", "Ignored.test.ts"),
+            `import { ignored } from "../src/index.ts";\nvoid ignored;\n`
+          );
 
-            yield* runLintCommand(["package-test-imports", "--include-root", selected]);
+          yield* runLintCommand(["package-test-imports", "--include-root", selected]);
 
-            expect(yield* TestConsole.logLines).toEqual([
-              "[check-package-test-imports] OK: package test imports use package aliases.",
-            ]);
-            expect(yield* TestConsole.errorLines).toEqual([]);
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
+          expect(yield* TestConsole.logLines).toEqual([
+            "[check-package-test-imports] OK: package test imports use package aliases.",
+          ]);
+          expect(yield* TestConsole.errorLines).toEqual([]);
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
 
-  it(
-    "reports same-package relative imports into src",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            const fs = yield* FileSystem.FileSystem;
-            const path = yield* Path.Path;
-            const packageDir = path.join("packages", "foundation", "modeling", "example");
+  it("reports same-package relative imports into src", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const packageDir = path.join("packages", "foundation", "modeling", "example");
 
-            yield* writePackage(packageDir, "@beep/example");
-            yield* fs.makeDirectory(path.join(packageDir, "test"), { recursive: true });
-            yield* fs.writeFileString(
-              path.join(packageDir, "test", "Example.test.ts"),
-              `import { example } from "../src/index.ts";\nvoid example;\n`
-            );
+          yield* writePackage(packageDir, "@beep/example");
+          yield* fs.makeDirectory(path.join(packageDir, "test"), { recursive: true });
+          yield* fs.writeFileString(
+            path.join(packageDir, "test", "Example.test.ts"),
+            `import { example } from "../src/index.ts";\nvoid example;\n`
+          );
 
-            const exit = yield* Effect.exit(runLintCommand(["package-test-imports"]));
+          const exit = yield* Effect.exit(runLintCommand(["package-test-imports"]));
 
-            const errorLines = yield* TestConsole.errorLines;
-            expectReportedExit(exit);
-            expect(errorLines).toContain(
-              "[check-package-test-imports] relative imports from package test files into workspace src are not allowed. Use @beep/* package aliases."
-            );
-            expect(errorLines).toContain(
-              "packages/foundation/modeling/example/test/Example.test.ts:1 ../src/index.ts -> @beep/example"
-            );
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
+          const errorLines = yield* TestConsole.errorLines;
+          expectReportedExit(exit);
+          expect(errorLines).toContain(
+            "[check-package-test-imports] relative imports from package test files into workspace src are not allowed. Use @beep/* package aliases."
+          );
+          expect(errorLines).toContain(
+            "packages/foundation/modeling/example/test/Example.test.ts:1 ../src/index.ts -> @beep/example"
+          );
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
 
-  it(
-    "allows relative imports to local test fixtures",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            const fs = yield* FileSystem.FileSystem;
-            const path = yield* Path.Path;
-            const packageDir = path.join("packages", "foundation", "modeling", "example");
+  it("allows relative imports to local test fixtures", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const packageDir = path.join("packages", "foundation", "modeling", "example");
 
-            yield* writePackage(packageDir, "@beep/example");
-            yield* fs.makeDirectory(path.join(packageDir, "test", "fixtures"), { recursive: true });
-            yield* fs.writeFileString(
-              path.join(packageDir, "test", "fixtures", "src-helper.ts"),
-              "export const helper = 1;\n"
-            );
-            yield* fs.writeFileString(
-              path.join(packageDir, "test", "Example.test.ts"),
-              `import { helper } from "./fixtures/src-helper.ts";\nvoid helper;\n`
-            );
+          yield* writePackage(packageDir, "@beep/example");
+          yield* fs.makeDirectory(path.join(packageDir, "test", "fixtures"), { recursive: true });
+          yield* fs.writeFileString(
+            path.join(packageDir, "test", "fixtures", "src-helper.ts"),
+            "export const helper = 1;\n"
+          );
+          yield* fs.writeFileString(
+            path.join(packageDir, "test", "Example.test.ts"),
+            `import { helper } from "./fixtures/src-helper.ts";\nvoid helper;\n`
+          );
 
-            yield* runLintCommand(["package-test-imports"]);
+          yield* runLintCommand(["package-test-imports"]);
 
-            const logLines = yield* TestConsole.logLines;
-            const errorLines = yield* TestConsole.errorLines;
-            expect(logLines).toEqual(["[check-package-test-imports] OK: package test imports use package aliases."]);
-            expect(errorLines).toEqual([]);
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
+          const logLines = yield* TestConsole.logLines;
+          const errorLines = yield* TestConsole.errorLines;
+          expect(logLines).toEqual(["[check-package-test-imports] OK: package test imports use package aliases."]);
+          expect(errorLines).toEqual([]);
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
 
-  it(
-    "allows source test-kit files under src internal test directories",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            const fs = yield* FileSystem.FileSystem;
-            const path = yield* Path.Path;
-            const packageDir = path.join("packages", "foundation", "modeling", "example");
+  it("allows source test-kit files under src internal test directories", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const packageDir = path.join("packages", "foundation", "modeling", "example");
 
-            yield* writePackage(packageDir, "@beep/example");
-            yield* fs.makeDirectory(path.join(packageDir, "src", "internal", "test"), { recursive: true });
-            yield* fs.writeFileString(
-              path.join(packageDir, "src", "internal", "helper.ts"),
-              "export const helper = 1;\n"
-            );
-            yield* fs.writeFileString(
-              path.join(packageDir, "src", "internal", "test", "Example.test-kit.ts"),
-              `import { helper } from "../helper.ts";\nvoid helper;\n`
-            );
+          yield* writePackage(packageDir, "@beep/example");
+          yield* fs.makeDirectory(path.join(packageDir, "src", "internal", "test"), { recursive: true });
+          yield* fs.writeFileString(
+            path.join(packageDir, "src", "internal", "helper.ts"),
+            "export const helper = 1;\n"
+          );
+          yield* fs.writeFileString(
+            path.join(packageDir, "src", "internal", "test", "Example.test-kit.ts"),
+            `import { helper } from "../helper.ts";\nvoid helper;\n`
+          );
 
-            yield* runLintCommand(["package-test-imports"]);
+          yield* runLintCommand(["package-test-imports"]);
 
-            const logLines = yield* TestConsole.logLines;
-            const errorLines = yield* TestConsole.errorLines;
-            expect(logLines).toEqual(["[check-package-test-imports] OK: package test imports use package aliases."]);
-            expect(errorLines).toEqual([]);
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
+          const logLines = yield* TestConsole.logLines;
+          const errorLines = yield* TestConsole.errorLines;
+          expect(logLines).toEqual(["[check-package-test-imports] OK: package test imports use package aliases."]);
+          expect(errorLines).toEqual([]);
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
 
-  it(
-    "allows internal package alias imports",
-    () =>
-      Effect.runPromise(
-        withTempWorkingDirectory(
-          Effect.gen(function* () {
-            const fs = yield* FileSystem.FileSystem;
-            const path = yield* Path.Path;
-            const packageDir = path.join("packages", "foundation", "modeling", "example");
+  it("allows internal package alias imports", () =>
+    Effect.runPromise(
+      withTempWorkingDirectory(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const packageDir = path.join("packages", "foundation", "modeling", "example");
 
-            yield* writePackage(packageDir, "@beep/example");
-            yield* fs.makeDirectory(path.join(packageDir, "test"), { recursive: true });
-            yield* fs.writeFileString(
-              path.join(packageDir, "test", "Example.test.ts"),
-              `import { Hidden } from "@beep/example/internal/Hidden";\nvoid Hidden;\n`
-            );
+          yield* writePackage(packageDir, "@beep/example");
+          yield* fs.makeDirectory(path.join(packageDir, "test"), { recursive: true });
+          yield* fs.writeFileString(
+            path.join(packageDir, "test", "Example.test.ts"),
+            `import { Hidden } from "@beep/example/internal/Hidden";\nvoid Hidden;\n`
+          );
 
-            yield* runLintCommand(["package-test-imports"]);
+          yield* runLintCommand(["package-test-imports"]);
 
-            const logLines = yield* TestConsole.logLines;
-            const errorLines = yield* TestConsole.errorLines;
-            expect(logLines).toEqual(["[check-package-test-imports] OK: package test imports use package aliases."]);
-            expect(errorLines).toEqual([]);
-          })
-        ).pipe(provideScopedLayer(testLayer))
-      ),
-    5_000
-  );
+          const logLines = yield* TestConsole.logLines;
+          const errorLines = yield* TestConsole.errorLines;
+          expect(logLines).toEqual(["[check-package-test-imports] OK: package test imports use package aliases."]);
+          expect(errorLines).toEqual([]);
+        })
+      ).pipe(provideScopedLayer(testLayer))
+    ));
 });
 
 const BASELINE_FILE = "baseline.jsonc";

--- a/standards/coverage.regression-baseline.jsonc
+++ b/standards/coverage.regression-baseline.jsonc
@@ -6013,12 +6013,12 @@
           "lines": 31.57,
           "statements": 28.57,
           "branches": 0,
-          "functions": 0,
+          "functions": 27.27,
           "uncovered": {
             "lines": 13,
             "statements": 15,
             "branches": 2,
-            "functions": 11
+            "functions": 8
           }
         },
         "packages/foundation/ui-system/editor/src/code-block-view.tsx": {
@@ -6061,12 +6061,12 @@
           "lines": 35.29,
           "statements": 30,
           "branches": 0,
-          "functions": 0,
+          "functions": 25,
           "uncovered": {
             "lines": 11,
             "statements": 14,
             "branches": 2,
-            "functions": 12
+            "functions": 9
           }
         },
         "packages/foundation/ui-system/editor/src/mermaid-view.tsx": {

--- a/standards/coverage.regression-baseline.jsonc
+++ b/standards/coverage.regression-baseline.jsonc
@@ -6013,12 +6013,12 @@
           "lines": 31.57,
           "statements": 28.57,
           "branches": 0,
-          "functions": 27.27,
+          "functions": 0,
           "uncovered": {
             "lines": 13,
             "statements": 15,
             "branches": 2,
-            "functions": 8
+            "functions": 11
           }
         },
         "packages/foundation/ui-system/editor/src/code-block-view.tsx": {
@@ -6061,12 +6061,12 @@
           "lines": 35.29,
           "statements": 30,
           "branches": 0,
-          "functions": 25,
+          "functions": 0,
           "uncovered": {
             "lines": 11,
             "statements": 14,
             "branches": 2,
-            "functions": 9
+            "functions": 12
           }
         },
         "packages/foundation/ui-system/editor/src/mermaid-view.tsx": {

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -193,7 +193,13 @@ const config: ViteUserConfig = {
     // only receive it as real argv. Granting it to forked test workers scopes
     // the flag to test execution; a job-wide node wrapper is off the table
     // because Next.js builds copy parent execArgv into worker NODE_OPTIONS.
-    execArgv: typeof globalThis.Float16Array === "undefined" ? ["--js-float16array"] : [],
+    // The predicate is version-based, not capability-based: vitest hands the
+    // pool an explicit execArgv (overriding fork inheritance), so a flagged
+    // main process with an unflagged worker list would strand the workers.
+    execArgv:
+      process.versions.bun === undefined && Number(process.versions.node.split(".")[0]) < 24
+        ? ["--js-float16array"]
+        : [],
     sequence: {
       concurrent: !vitestDoctestActive,
     },

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -188,6 +188,12 @@ const config: ViteUserConfig = {
       ...(vitestDoctestActive ? ["**/test/fixtures/**", "**/*.d.ts"] : []),
     ],
     setupFiles: [new URL("./vitest.setup.ts", import.meta.url).pathname],
+    // V8 gates Float16Array behind --js-float16array below Node 24 and rejects
+    // that flag inside NODE_OPTIONS, so the coverage lane's Node 22 runtime can
+    // only receive it as real argv. Granting it to forked test workers scopes
+    // the flag to test execution; a job-wide node wrapper is off the table
+    // because Next.js builds copy parent execArgv into worker NODE_OPTIONS.
+    execArgv: typeof globalThis.Float16Array === "undefined" ? ["--js-float16array"] : [],
     sequence: {
       concurrent: !vitestDoctestActive,
     },


### PR DESCRIPTION
## What

Replaces the coverage lane's job-wide node wrapper (from #1075) with a scoped grant: vitest's
top-level `execArgv` adds `--js-float16array` to forked test workers, and only when the
runtime lacks a native `Float16Array` (Node 22). The heavy.yml step now only verifies the
pinned runtime supports the flag.

## Why

The wrapper put a flag-injecting `node` shim on `GITHUB_PATH` for the whole coverage job.
Next.js builds copy parent `execArgv` into their page-data workers via `NODE_OPTIONS`, and
V8 rejects `--js-float16array` there — so any coverage run whose scope builds a Next app dies
with exit 9 (`Next.js build worker exited with code: 9`). PR #1060's post-merge coverage run
hit exactly this (full fallback → `@beep/todox` build), and main's own coverage lane is
exposed the same way.

## Proof

- Control: bare Node 22.22.3 has no `Float16Array`; with `--js-float16array` it does.
- `TypedArrays.test.ts` (the Float16Array contract, 9 tests) passes under plain Node 22.22.3
  with this config — workers self-arm the flag — on both this base and the #1060 branch, with
  and without `--coverage`.
- Bun and Node 24 resolve the guard to `[]` (native Float16Array): no behavior change.
- `heavy.yml` parses; no repo test references the removed wrapper step.

## Bootstrap note

Like #1075, this PR cannot self-validate its own Coverage Regression lane: `check.yml` invokes
`heavy.yml@main`, which still carries the wrapper, and this PR's changed files force the
coverage full fallback that builds `@beep/todox` under it. Expect that one lane red here; it
is the exact failure this PR removes. After merge, rerun #1060's coverage via a fresh push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1076"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791592847&installation_model_id=424656&pr_number=1076&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1076&signature=ea64ee817e7735f0fca92b98b5f51b1d795ec1cc71441c69d51ee58400edd4c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->