### PR TITLE
fix(repo-cli): keep the journal-lock reap adopter election exclusive

### DIFF
--- a/.changeset/admission-reap-adopter-election.md
+++ b/.changeset/admission-reap-adopter-election.md
@@ -1,0 +1,8 @@
+---
+"@beep/repo-cli": patch
+---
+
+Keep the journal-lock reap adopter election exclusive: a contender whose adopter
+listing predates the winner's claim rename could recreate the claim from the
+still-dead lock and adopt a second time. The election now re-checks after the
+claim link and drops a claim it recreated while a live adopter exists.

--- a/packages/tooling/tool/cli/src/internal/repo-run/AdmissionJournal.ts
+++ b/packages/tooling/tool/cli/src/internal/repo-run/AdmissionJournal.ts
@@ -1031,6 +1031,16 @@ const adoptJournalLockReapClaim = Effect.fnUntraced(function* (
     election._tag === "takeover"
       ? election.adopterPath
       : yield* fs.link(lockPath, claimPath).pipe(Effect.as(claimPath), Effect.orElseSucceed(constant(claimPath)));
+  // The winner's rename frees the deterministic claim name while the lock still
+  // holds the dead generation, so a contender whose adopter listing predates
+  // that rename can recreate the claim from the same lock and adopt a second
+  // time. Re-run the election once the claim exists: a live adopter that
+  // appeared meanwhile blocks this contender, which drops the claim it may
+  // have just recreated so no stale snapshot outlives the adoption.
+  if (election._tag === "unclaimed" && (yield* electReapAdopter(claimPath, nowMillis))._tag === "blocked") {
+    yield* fs.remove(claimPath, { force: true }).pipe(Effect.ignore);
+    return O.none();
+  }
   const claimedToken = yield* fs.readFileString(sourcePath).pipe(Effect.option);
   if (!O.exists(claimedToken, (token) => token === observedToken)) {
     return O.none();

--- a/packages/tooling/tool/cli/test/quality-scheduler.test.ts
+++ b/packages/tooling/tool/cli/test/quality-scheduler.test.ts
@@ -1926,6 +1926,137 @@ describe("quality-scheduler", () => {
       })
     ));
 
+  // The hosted ordering behind the "expected 2 to be 1" red on PR #1072: the
+  // follower's adopter listing completes before the leader renames its claim,
+  // but the follower's claim link runs after that rename freed the claim name.
+  // The follower recreates the claim from the still-dead lock and adopts a
+  // second time unless the election re-checks after the link.
+  it("keeps the adopter election exclusive when a contender links its claim after the winner's rename", () =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const gibRef = yield* Ref.make(50);
+        yield* withAdmissionTempRoot(gibRef, (tempRoot) =>
+          Effect.gen(function* () {
+            const fs = yield* FileSystem.FileSystem;
+            const path = yield* Path.Path;
+            const lockPath = path.join(tempRoot.root, "journal.lock");
+            const replacementSeedPath = path.join(tempRoot.root, "replacement-seed.lock");
+            const replacementToken = `${process.pid}:replacement-writer`;
+            yield* fs.makeDirectory(tempRoot.root, { recursive: true, mode: 0o700 });
+            expect(yield* acquireJournalFileLock(replacementSeedPath, replacementToken, 1)).toBe(true);
+            const replacementGeneration = yield* fs.readFileString(replacementSeedPath);
+            yield* releaseAdmissionJournalLockForTesting(replacementSeedPath, replacementToken);
+            yield* fs.writeFileString(lockPath, `${DEAD_PID}:abandoned-generation`);
+
+            const stageLinks = yield* Ref.make(0);
+            const bothContendersReady = yield* Deferred.make<void>();
+            const followerListed = yield* Deferred.make<void>();
+            const leaderAdopted = yield* Deferred.make<void>();
+            const followerLinked = yield* Deferred.make<void>();
+            const followerDone = yield* Deferred.make<void>();
+            const lockTombstones = yield* Ref.make(0);
+            const isClaimLink = (existingPath: string, newPath: string): boolean =>
+              Str.Equivalence(existingPath, lockPath) &&
+              Str.includes(".reap-")(newPath) &&
+              !Str.includes(".adopt-")(newPath);
+            const isTombstoneRename = (oldPath: string, newPath: string): boolean =>
+              Str.Equivalence(oldPath, lockPath) && Str.includes(".tombstone-")(newPath);
+            const rendezvousStageLink = Effect.fn("rendezvousStageLink")(function* (
+              existingPath: string,
+              newPath: string
+            ) {
+              if (Str.includes(".stage-")(existingPath) && Str.Equivalence(newPath, lockPath)) {
+                const count = yield* Ref.updateAndGet(stageLinks, (value) => value + 1);
+                if (count === 2) {
+                  yield* Deferred.succeed(bothContendersReady, undefined);
+                }
+                yield* Deferred.await(bothContendersReady);
+              }
+            });
+            const publishReplacementBeforeTombstone = Effect.fn("publishReplacementBeforeTombstone")(function* (
+              oldPath: string,
+              newPath: string
+            ) {
+              if (isTombstoneRename(oldPath, newPath)) {
+                yield* Ref.update(lockTombstones, (value) => value + 1);
+                yield* fs.remove(lockPath, { force: true });
+                yield* fs.writeFileString(lockPath, replacementGeneration);
+              }
+            });
+            const leaderFileSystem = FileSystem.FileSystem.of({
+              ...fs,
+              link: Effect.fn("leader.link")(function* (existingPath, newPath) {
+                yield* rendezvousStageLink(existingPath, newPath);
+                if (isClaimLink(existingPath, newPath)) {
+                  yield* Deferred.await(followerListed);
+                }
+                return yield* fs.link(existingPath, newPath);
+              }),
+              rename: Effect.fn("leader.rename")(function* (oldPath, newPath) {
+                if (isTombstoneRename(oldPath, newPath)) {
+                  yield* Deferred.await(followerLinked);
+                }
+                yield* publishReplacementBeforeTombstone(oldPath, newPath);
+                yield* fs.rename(oldPath, newPath);
+                if (Str.includes(".adopt-")(newPath)) {
+                  yield* Deferred.succeed(leaderAdopted, undefined);
+                }
+              }),
+              remove: Effect.fn("leader.remove")(function* (target, options) {
+                if (Str.includes(".adopt-")(target)) {
+                  yield* Deferred.await(followerDone);
+                }
+                return yield* fs.remove(target, options);
+              }),
+            });
+            const followerFileSystem = FileSystem.FileSystem.of({
+              ...fs,
+              readDirectory: Effect.fn("follower.readDirectory")(function* (directory, options) {
+                const entries = yield* fs.readDirectory(directory, options);
+                if (yield* Deferred.isDone(bothContendersReady)) {
+                  yield* Deferred.succeed(followerListed, undefined);
+                }
+                return entries;
+              }),
+              link: Effect.fn("follower.link")(function* (existingPath, newPath) {
+                yield* rendezvousStageLink(existingPath, newPath);
+                if (isClaimLink(existingPath, newPath)) {
+                  yield* Deferred.await(leaderAdopted);
+                }
+                yield* fs.link(existingPath, newPath);
+                if (isClaimLink(existingPath, newPath)) {
+                  yield* Deferred.succeed(followerLinked, undefined);
+                }
+              }),
+              rename: Effect.fn("follower.rename")(function* (oldPath, newPath) {
+                yield* publishReplacementBeforeTombstone(oldPath, newPath);
+                yield* fs.rename(oldPath, newPath);
+              }),
+            });
+
+            const acquired = yield* Effect.all(
+              [
+                acquireJournalFileLock(lockPath, `${process.pid}:leader`, 1).pipe(
+                  Effect.provideService(FileSystem.FileSystem, leaderFileSystem)
+                ),
+                acquireJournalFileLock(lockPath, `${process.pid}:follower`, 1).pipe(
+                  Effect.provideService(FileSystem.FileSystem, followerFileSystem),
+                  Effect.ensuring(Deferred.succeed(followerDone, undefined))
+                ),
+              ],
+              { concurrency: "unbounded" }
+            );
+
+            expect(acquired).toStrictEqual([false, false]);
+            expect(yield* Ref.get(lockTombstones)).toBe(1);
+            expect(yield* fs.readFileString(lockPath)).toBe(replacementGeneration);
+            expect(A.filter(yield* fs.readDirectory(tempRoot.root), Str.includes(".reap-"))).toStrictEqual([]);
+            yield* releaseAdmissionJournalLockForTesting(lockPath, replacementToken);
+          })
+        );
+      })
+    ));
+
   it("retains a displaced generation when a third writer wins and fences its stale publish", () =>
     Effect.runPromise(
       Effect.gen(function* () {


### PR DESCRIPTION
## fix(repo-cli): keep the journal-lock reap adopter election exclusive

Adoption is four filesystem steps: list adopters, hard-link the lock to a deterministic
claim name, read the claim, rename it to a unique adopter name. Exclusivity rested on that
rename, but the winner's rename frees the claim name while the lock still holds the dead
generation. A contender whose listing completed before that rename and whose link ran after
it recreated the claim from the same lock, read the same dead token, and adopted a second
time; both then took and restored the lock. Property Laws hit exactly this on PR #1072
("expected 2 to be 1" in the election test) because libuv can complete a slow readdir after
a rival's link, read, and rename. Re-run the election once the claim exists and drop a claim
recreated while a live adopter is present. A new test forces the hosted ordering with
per-contender filesystem hooks; it fails with the same assertion before the fix.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

## Why

Property Laws on PR #1072 failed the election test in `quality-scheduler.test.ts` ("elects one claim adopter and restores a replacement published before the reclaim rename") with `expected 2 to be 1`: two contenders both adopted the reclaim of a dead owner's journal lock. Memory had this pair of race tests filed as a coverage coin-flip on a branch arm; the assertion failure is the same race surfacing as a wrong outcome.

## The race

Adoption in `adoptJournalLockReapClaim` is four filesystem steps: list existing adopters, hard-link the lock to a deterministic claim name, read the claim, rename it to a unique adopter name. Exclusivity rests on that rename, because a deterministic name can only be renamed once. The gap: the winner's rename frees the claim name while the lock still holds the dead generation. A contender whose directory listing completed before the winner's rename, but whose link ran after it, recreates the claim from the same lock, reads the same dead token, and renames it successfully. Both then run the reap finish and each takes and restores the lock. Under libuv's threadpool a slow `readdir` completing after a rival's link, read, and rename is a legitimate ordering, which is why it only shows under hosted load. In production the content and inode fences in the finish bound the damage to a second adopter briefly taking and restoring a live writer's lock.

## What changed

- `AdmissionJournal.ts` (`adoptJournalLockReapClaim`): once the claim link exists in the unclaimed branch, the election runs again. A live adopter that appeared meanwhile blocks the contender, which removes the claim it may have just recreated so no stale snapshot outlives the adoption. The takeover branch keeps its existing fence, since it renames a deterministic old adopter name.
- `quality-scheduler.test.ts`: a new case reproduces the hosted ordering deterministically with per-contender filesystem services. The follower's claim link waits for the leader's claim-to-adopter rename; the leader's claim link waits for the follower's adopter listing; the leader's tombstone rename waits for the follower's link; the leader's adopter release waits for the follower to finish. It asserts one tombstone, both acquisitions refused, the restored replacement generation, and no leftover `.reap-` claims.
- `.changeset/admission-reap-adopter-election.md`: `@beep/repo-cli` patch.

## Proof

- Before the fix the new test fails in 21 ms with the same `expected 2 to be 1`; after it, 132/132 in the file pass.
- Determinism: 12 consecutive runs of the adopter tests on Bun, 0 failures; the same tests pass on Node.
- `bun run package-test-typecheck` (repo-cli) exit 0; `bunx turbo run check --filter=@beep/repo-cli --force` 33/33; `bun run docgen:local` exit 0; biome clean.
- `bun run coverage -- --filter=@beep/repo-cli` (Node ratchet): 3351 tests passed, `[coverage-ratchet] ok`, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/fix_admission-reap-adopter-election-417ab3f16bab/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1077"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791596510&installation_model_id=424656&pr_number=1077&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1077&signature=700248210afc0629aecc4f4d4f8fade1f09a0fc67a75721f2d91a1f06be746e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

---

<!-- yeet-provenance:start -->
## Provenance

- Workspace: <code>beep-effect3</code>
- Branch: <code>fix/admission-reap-adopter-election</code>
- Agents (newest first):
  - `claude-code` (desktop) · `claude-fable-5-1` · <code>happy-yonath-326ada-6a</code> · monitored

Resume the publishing agent from any beep-effect checkout on the publishing workstation:

```sh
bun run beep yeet resume 1077
```

<!-- yeet-provenance
{
  "schemaVersion": 2,
  "pr": 1077,
  "branch": "fix/admission-reap-adopter-election",
  "workspace": "beep-effect3",
  "agents": [
    {
      "harness": "claude-code",
      "entrypoint": "claude-desktop",
      "hostHarness": null,
      "model": "claude-fable-5-1",
      "label": "happy-yonath-326ada-6a",
      "workspace": null,
      "role": "monitored"
    }
  ]
}
-->
<!-- yeet-provenance:end -->

