### PR TITLE
test(repo-cli): align the live lint worker budget with the coverage testTimeout

### DIFF
--- a/packages/tooling/tool/cli/test/lint-workers.test.ts
+++ b/packages/tooling/tool/cli/test/lint-workers.test.ts
@@ -421,8 +421,10 @@ describe("thin lint workers", { concurrent: false }, () => {
 
 // These tests spawn the CLI (ts-morph, eslint) for real; under coverage instrumentation on a
 // two-worker hosted runner the laws worker took 40 s on main and 60 s on PR #1079, so an explicit
-// 60 s cap raced the runner instead of catching hangs. The CLI bounds its own children.
-const EXECUTED_WORKER_TIMEOUT_MILLIS = 180_000;
+// 60 s cap raced the runner instead of catching hangs. The budget equals the package config's
+// coverage and deep-sweep `testTimeout` (300 s) so no per-test cap sits below the lane's own;
+// a hang still fails here because the CLI bounds its children.
+const EXECUTED_WORKER_TIMEOUT_MILLIS = 300_000;
 
 describe("executed lint workers", { concurrent: false }, () => {
   it.effect(


### PR DESCRIPTION
Follow-up to #1079 (merged at 52d2b0f72c). Greptile's last P2 on that PR was fixed one commit after the merge: the live lint-worker tests spawn the CLI (ts-morph, eslint) for real, and any explicit per-test timeout below the package's coverage and deep-sweep `testTimeout` (300 s) clamps the lane's own budget. The budget now equals that 300 s; a genuine hang still fails there because the CLI bounds its children.

Test-only change, one file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1081"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791615210&installation_model_id=424656&pr_number=1081&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1081&signature=3eef06fe3c22e96dd79f5fe44cb260ad55aa486e12f2f492591c35b72f29b7cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

---

<!-- yeet-provenance:start -->
## Provenance

- Workspace: <code>beep-effect3</code>
- Branch: <code>fix/live-lint-worker-budget</code>
- Agents (newest first):
  - `claude-code` (desktop) · `claude-fable-5-1` · <code>beep-effect3-ec</code> · monitored

Resume the publishing agent from any beep-effect checkout on the publishing workstation:

```sh
bun run beep yeet resume 1081
```

<!-- yeet-provenance
{
  "schemaVersion": 2,
  "pr": 1081,
  "branch": "fix/live-lint-worker-budget",
  "workspace": "beep-effect3",
  "agents": [
    {
      "harness": "claude-code",
      "entrypoint": "claude-desktop",
      "hostHarness": null,
      "model": "claude-fable-5-1",
      "label": "beep-effect3-ec",
      "workspace": null,
      "role": "monitored"
    }
  ]
}
-->
<!-- yeet-provenance:end -->
