### PR TITLE
chore(security): allowlist the beep-ci-ops auditor run record trees for gitleaks

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -56,13 +56,20 @@ paths = [
 [[rules]]
 id = "generic-api-key"
 
-[[allowlists]]
-description = "beep-ci-ops auditor run records (hypotheses, analyses, proposals, reviews, dockets, the archived dispositions index) quote validator config facts verbatim, e.g. (config_key_value, \"nonce=<uuid>\") and _tag=admission-<event>; the config_key_value predicate name trips the generic-api-key keyword prefilter on admission nonces that are already committed in the corpus pins. The records are digest-bound (review chain_sha256) and cannot be reworded; scoped to the run trees only."
+[[rules.allowlists]]
+description = "beep-ci-ops auditor run records (hypotheses, analyses, proposals, reviews, dockets, the archived dispositions index) quote validator config facts verbatim, e.g. (config_key_value, \"nonce=<uuid>\") and _tag=admission-<event>; the config_key_value predicate name trips this rule's keyword prefilter on admission nonces already committed in the corpus pins. The records are digest-bound (review chain_sha256) and cannot be reworded. Scoped to this rule, these trees, and lines carrying exactly those shapes; every other detector still scans them."
+condition = "AND"
+regexTarget = "line"
 paths = [
   '''^(?:/repo/)?explorations/beep-ci-operational-ontology/ontology/extraction/s4/beep-ci-ops/work/(?:hypotheses|foundational|alternative|proposals|sittings|review-audit|denotation-batches)/[^/]+$''',
   '''^(?:/repo/)?explorations/beep-ci-operational-ontology/ontology/extraction/s4/beep-ci-ops/work-run3/impl-report\.md$''',
   '''^(?:/repo/)?explorations/beep-ci-operational-ontology/ontology/extraction/s4/beep-ci-ops/runs/orun-[^/]+\.(?:index|manifest)\.yaml$''',
   '''^(?:/repo/)?explorations/beep-ci-operational-ontology/ontology/extraction/s4/archives/beep-ci-ops/orun-[^/]+\.(?:observations|work)/.*$''',
+]
+regexes = [
+  '''config_key_value''',
+  '''nonce=[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}''',
+  '''_tag=admission-[a-z-]+''',
 ]
 
 [[rules.allowlists]]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -57,9 +57,9 @@ paths = [
 id = "generic-api-key"
 
 [[rules.allowlists]]
-description = "beep-ci-ops auditor run records (hypotheses, analyses, proposals, reviews, dockets, the archived dispositions index) quote validator config facts verbatim, e.g. (config_key_value, \"nonce=<uuid>\") and _tag=admission-<event>; the config_key_value predicate name trips this rule's keyword prefilter on admission nonces already committed in the corpus pins. The records are digest-bound (review chain_sha256) and cannot be reworded. Scoped to this rule, these trees, and lines carrying exactly those shapes; every other detector still scans them."
+description = "beep-ci-ops auditor run records (hypotheses, analyses, proposals, reviews, dockets, the archived dispositions index) quote validator config facts verbatim; the config_key_value predicate name trips this rule's keyword prefilter on admission journal fields already committed in the corpus pins (nonce and attemptId UUIDs, _tag=admission-<event>, <event>AtMillis epoch stamps). The records are digest-bound (review chain_sha256) and cannot be reworded. Scoped to this rule and these trees, and only to findings whose matched secret is exactly one of those field shapes; any other secret on the same line still fires, and every other detector still scans the trees."
 condition = "AND"
-regexTarget = "line"
+regexTarget = "secret"
 paths = [
   '''^(?:/repo/)?explorations/beep-ci-operational-ontology/ontology/extraction/s4/beep-ci-ops/work/(?:hypotheses|foundational|alternative|proposals|sittings|review-audit|denotation-batches)/[^/]+$''',
   '''^(?:/repo/)?explorations/beep-ci-operational-ontology/ontology/extraction/s4/beep-ci-ops/work-run3/impl-report\.md$''',
@@ -67,9 +67,9 @@ paths = [
   '''^(?:/repo/)?explorations/beep-ci-operational-ontology/ontology/extraction/s4/archives/beep-ci-ops/orun-[^/]+\.(?:observations|work)/.*$''',
 ]
 regexes = [
-  '''config_key_value''',
-  '''nonce=[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}''',
-  '''_tag=admission-[a-z-]+''',
+  '''^(?:nonce|attemptId)=[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$''',
+  '''^_tag=admission-[a-z-]+$''',
+  '''^[A-Za-z]+AtMillis=[0-9]{13}$''',
 ]
 
 [[rules.allowlists]]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -56,6 +56,15 @@ paths = [
 [[rules]]
 id = "generic-api-key"
 
+[[allowlists]]
+description = "beep-ci-ops auditor run records (hypotheses, analyses, proposals, reviews, dockets, the archived dispositions index) quote validator config facts verbatim, e.g. (config_key_value, \"nonce=<uuid>\") and _tag=admission-<event>; the config_key_value predicate name trips the generic-api-key keyword prefilter on admission nonces that are already committed in the corpus pins. The records are digest-bound (review chain_sha256) and cannot be reworded; scoped to the run trees only."
+paths = [
+  '''^(?:/repo/)?explorations/beep-ci-operational-ontology/ontology/extraction/s4/beep-ci-ops/work/(?:hypotheses|foundational|alternative|proposals|sittings|review-audit|denotation-batches)/[^/]+$''',
+  '''^(?:/repo/)?explorations/beep-ci-operational-ontology/ontology/extraction/s4/beep-ci-ops/work-run3/impl-report\.md$''',
+  '''^(?:/repo/)?explorations/beep-ci-operational-ontology/ontology/extraction/s4/beep-ci-ops/runs/orun-[^/]+\.(?:index|manifest)\.yaml$''',
+  '''^(?:/repo/)?explorations/beep-ci-operational-ontology/ontology/extraction/s4/archives/beep-ci-ops/orun-[^/]+\.(?:observations|work)/.*$''',
+]
+
 [[rules.allowlists]]
 description = "Verified immutable Boolean-creep digest false positives; exact path and line only."
 condition = "AND"


### PR DESCRIPTION
The hosted Secret Scanning lane scans pull requests with the base branch's `.gitleaks.toml` (by design: a PR cannot broaden its own allowlist), so the run-3 closeout on #1078 is red on 27 `generic-api-key` findings that are all of one shape: auditor run records quote validator config facts verbatim, e.g. `(config_key_value, "nonce=<uuid>")` and `_tag=admission-<event>`. The `config_key_value` predicate name trips the keyword prefilter on admission nonces that are already committed in the corpus pins and passed the same scan there.

The records are digest-bound (every adversary review binds the full chain closure by `chain_sha256`), so they cannot be reworded without invalidating the run. This adds one path-scoped `[[allowlists]]` entry covering only the run record trees under `ontology/extraction/s4/beep-ci-ops/{work,work-run3,runs}` and the `archives/beep-ci-ops` shelters. No rule is disabled and no other path is affected.

Same hunk is already in #1078's closeout commit; merging this first lets #1078's Secret Scanning rerun green, and the later merge is a clean no-op on this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791623196&installation_model_id=424656&pr_number=1084&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1084&signature=e6de591c7c01512991424d141d788c2dff351d05bedcd89af6c3b620ccd299cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->