### PR TITLE
fix(repo-cli): keep labs workspaces out of docgen discovery

### DIFF
--- a/packages/tooling/tool/cli/src/commands/Docgen/internal/Workspace.ts
+++ b/packages/tooling/tool/cli/src/commands/Docgen/internal/Workspace.ts
@@ -18,7 +18,7 @@ import { Effect, FileSystem, HashMap, MutableHashSet, Order, Path } from "effect
 import { dual } from "effect/Function";
 import * as P from "effect/Predicate";
 import * as S from "effect/Schema";
-import { LABS_PATH_IGNORE_GLOB } from "../../../internal/cli/Labs/index.ts";
+import { isLabsWorkspacePath, LABS_PATH_IGNORE_GLOB } from "../../../internal/cli/Labs/index.ts";
 import { byRelativePathAscending, DocgenConfigDocument, DocgenWorkspacePackage } from "../Docgen.schemas.ts";
 import type { NoSuchFileError } from "@beep/repo-utils";
 import type { DocgenPackageStatus, ResolveDocgenWorkspacePackageOptions } from "../Docgen.schemas.ts";
@@ -331,8 +331,15 @@ export const discoverDocgenWorkspacePackages: (
   const path = yield* Path.Path;
   const repoRoot = rootDir ?? (yield* findRepoRoot());
   const workspaceDirs = yield* resolveWorkspaceDirs(repoRoot);
-  const packages = yield* Effect.forEach(
+  // Labs are ceremony-exempt (goals/lab-apps-lifecycle D2): lab workspaces are
+  // never docgen participants, so a stray docgen.json below apps/labs must not
+  // turn one into a generation, aggregation, or local-plan target.
+  const docgenWorkspaceEntries = A.filter(
     HashMap.toEntries(workspaceDirs),
+    ([, absolutePath]) => !isLabsWorkspacePath(path.relative(repoRoot, absolutePath))
+  );
+  const packages = yield* Effect.forEach(
+    docgenWorkspaceEntries,
     Effect.fnUntraced(function* ([name, absolutePath]) {
       const relativePath = normalizeSlashes(path.relative(repoRoot, absolutePath));
       const hasDocgenConfig = yield* packageHasDocgenConfig(absolutePath);

--- a/packages/tooling/tool/cli/test/docgen.test.ts
+++ b/packages/tooling/tool/cli/test/docgen.test.ts
@@ -1762,6 +1762,63 @@ export const ProofFixture = 1;
       )
     ));
 
+  it("keeps ceremony-exempt labs workspaces out of docgen discovery and aggregation", () =>
+    Effect.runPromise(
+      withTempRepo(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const tmpDir = process.cwd();
+          yield* fs.writeFileString(
+            path.join(tmpDir, "package.json"),
+            encodeJson({
+              name: "@beep/test-root",
+              private: true,
+              workspaces: ["packages/foundation/*/*", "apps/labs/*"],
+            })
+          );
+
+          const packageDir = path.join(tmpDir, "packages", "foundation", "modeling", "schema");
+          const packageDocsModulesDir = path.join(packageDir, "docs", "modules");
+          yield* fs.makeDirectory(packageDocsModulesDir, { recursive: true });
+          yield* fs.writeFileString(
+            path.join(packageDir, "package.json"),
+            encodeJson({ name: "@beep/schema", version: "0.0.0" })
+          );
+          yield* fs.writeFileString(path.join(packageDir, "docgen.json"), encodeJson({ srcDir: "src" }));
+          yield* fs.writeFileString(
+            path.join(packageDocsModulesDir, "Schema.md"),
+            `---\nparent: Modules\ntitle: Schema\n---\n\ncontent\n`
+          );
+
+          // A stray docgen.json below the ceremony-exempt labs root must never
+          // turn a lab workspace into a docgen target (goals/lab-apps-lifecycle
+          // D2): the Heavy / Docgen lane failed on exactly this shape when
+          // apps/labs/api-docs carried one.
+          const labsAppDir = path.join(tmpDir, "apps", "labs", "api-docs");
+          const labsDocsModulesDir = path.join(labsAppDir, "docs", "modules");
+          yield* fs.makeDirectory(labsDocsModulesDir, { recursive: true });
+          yield* fs.writeFileString(
+            path.join(labsAppDir, "package.json"),
+            encodeJson({ name: "@beep/api-docs", version: "0.0.0" })
+          );
+          yield* fs.writeFileString(path.join(labsAppDir, "docgen.json"), encodeJson({ srcDir: "src" }));
+          yield* fs.writeFileString(
+            path.join(labsDocsModulesDir, "ApiDocs.md"),
+            `---\nparent: Modules\ntitle: ApiDocs\n---\n\ncontent\n`
+          );
+
+          const packages = yield* discoverDocgenWorkspacePackages(tmpDir);
+          const results = yield* aggregateGeneratedDocs();
+          const labsAggregateExists = yield* fs.exists(path.join(tmpDir, "docs", "generated", "labs", "api-docs"));
+
+          expect(A.map(packages, (pkg) => pkg.name)).toEqual(["@beep/schema"]);
+          expect(A.map(results, (result) => result.packageName)).toEqual(["@beep/schema"]);
+          expect(labsAggregateExists).toBe(false);
+        })
+      )
+    ));
+
   it("supports clean aggregation when stale docs paths conflict with nested package docs", () =>
     Effect.runPromise(
       withTempRepo(


### PR DESCRIPTION
## fix(repo-cli): keep labs workspaces out of docgen discovery

A stray docgen.json under apps/labs made discoverDocgenWorkspacePackages
select the lab workspace as a docgen target, failing the Heavy / Docgen
lane on PR #1080 even though the orphan scan correctly exempts labs
(goals/lab-apps-lifecycle D2). Filter labs workspace dirs out of the
shared docgen discovery with the canonical isLabsWorkspacePath guard and
add a regression test proving a labs workspace carrying docgen.json and
generated-looking docs is never discovered or aggregated.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/claude_mystifying-aryabhata-48cbd2-d8afdda04047/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1085"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791626598&installation_model_id=424656&pr_number=1085&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1085&signature=f6565a2df20c82e51aea9b2bac06e436f445b4ce620925a420c063cf88bcd9fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

---

<!-- yeet-provenance:start -->
## Provenance

- Workspace: <code>beep-effect5</code>
- Branch: <code>claude/mystifying-aryabhata-48cbd2</code>
- Agents (newest first):
  - `claude-code` (desktop) · `claude-fable-5` · <code>mystifying-aryabhata-48cbd2-1e</code> · monitored

Resume the publishing agent from any beep-effect checkout on the publishing workstation:

```sh
bun run beep yeet resume 1085
```

<!-- yeet-provenance
{
  "schemaVersion": 2,
  "pr": 1085,
  "branch": "claude/mystifying-aryabhata-48cbd2",
  "workspace": "beep-effect5",
  "agents": [
    {
      "harness": "claude-code",
      "entrypoint": "claude-desktop",
      "hostHarness": null,
      "model": "claude-fable-5",
      "label": "mystifying-aryabhata-48cbd2-1e",
      "workspace": null,
      "role": "monitored"
    }
  ]
}
-->
<!-- yeet-provenance:end -->
