### PR TITLE
fix(coverage): restore hosted-reachable floors for Lint.command.ts and Planner.ts

### DIFF
--- a/standards/coverage.regression-baseline.jsonc
+++ b/standards/coverage.regression-baseline.jsonc
@@ -24208,14 +24208,14 @@
           }
         },
         "packages/tooling/tool/cli/src/commands/Lint/Lint.command.ts": {
-          "lines": 74.5,
-          "statements": 73.38,
-          "branches": 58.62,
-          "functions": 68.65,
+          "lines": 73.92,
+          "statements": 72.89,
+          "branches": 56.02,
+          "functions": 68.18,
           "uncovered": {
-            "lines": 90,
-            "statements": 99,
-            "branches": 72,
+            "lines": 92,
+            "statements": 101,
+            "branches": 77,
             "functions": 21
           }
         },
@@ -26560,15 +26560,15 @@
           }
         },
         "packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts": {
-          "lines": 98.47,
-          "statements": 98.54,
+          "lines": 97.7,
+          "statements": 97.81,
           "branches": 100,
-          "functions": 97.43,
+          "functions": 96.15,
           "uncovered": {
-            "lines": 2,
-            "statements": 2,
+            "lines": 3,
+            "statements": 3,
             "branches": 0,
-            "functions": 2
+            "functions": 3
           }
         },
         "packages/tooling/tool/cli/src/commands/Yeet/internal/Porcelain.ts": {

--- a/standards/coverage.regression-baseline.jsonc
+++ b/standards/coverage.regression-baseline.jsonc
@@ -24211,7 +24211,7 @@
           "lines": 73.92,
           "statements": 72.89,
           "branches": 56.02,
-          "functions": 68.18,
+          "functions": 68.65,
           "uncovered": {
             "lines": 92,
             "statements": 101,


### PR DESCRIPTION
## Restore hosted-reachable coverage floors for two repo-cli files

`Heavy / Coverage Regression` has been red on `main` since #1068 merged (first red run 34538490915
on 662823dd96). The lane itself was healthy: 192 repo-cli test files passed and every shard was ok;
the verdict was the ratchet:

```
@beep/repo-cli (packages/tooling/tool/cli/src/commands/Lint/Lint.command.ts) branches: 56.02 < 58.62
@beep/repo-cli (packages/tooling/tool/cli/src/commands/Lint/Lint.command.ts) lines: 73.92 < 74.5
@beep/repo-cli (packages/tooling/tool/cli/src/commands/Lint/Lint.command.ts) statements: 72.89 < 73.38
@beep/repo-cli (packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts) functions: 96.15 < 97.43
@beep/repo-cli (packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts) lines: 97.7 < 98.47
@beep/repo-cli (packages/tooling/tool/cli/src/commands/Yeet/internal/Planner.ts) statements: 97.81 < 98.54
```

### Cause

#1068 regenerated `standards/coverage.regression-baseline.jsonc` locally and that regen raised the two
files' rows to what the local run measured (Lint.command.ts branches 53.94 → 58.62, Planner.ts
functions 84.61 → 97.43, and the other metrics alongside). The hosted lane measures these files lower
(Node 22 pin, hosted environment), and it did so identically on #1068's own pull-request run and on
`main`, so the numbers are stable. Pull requests are judged against `main`'s rows, so #1068's run was
green; after merge `main` was judged against the raised rows and could not reach them.

### Change

The six flagged metrics go back to the values the hosted lane measures: Lint.command.ts
lines 73.92 / statements 72.89 / branches 56.02 (functions stay 68.65: hosted measures 68.18 with the
same 21 uncovered functions, which the ratchet does not count as a regression), Planner.ts lines 97.7 /
statements 97.81 / functions 96.15 (branches stay 100). Uncovered counts are recomputed at those
percentages from the recorded totals. No other row moves. These floors are above the pre-#1068 rows,
so the ratchet keeps the gain the hosted lane can actually see.

### Proof

This pull request cannot prove itself: its run is judged against `main`'s current (raised) rows,
so `Heavy / Coverage Regression` stays red here by construction. The first `main` push after merge is
the proof; a comment with its link follows. Every other lane is expected green.

### Follow-up (separate)

The ratchet lets a pull request raise rows the hosted lane cannot reach and only fails after merge.
Judging a pull request that edits the baseline against its own raised rows as well would catch this
before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)