### PR TITLE
fix(repo-cli): judge pull-request coverage runs against the rows they raised

### DIFF
--- a/.changeset/coverage-raised-rows-hosted-reach.md
+++ b/.changeset/coverage-raised-rows-hosted-reach.md
@@ -1,0 +1,8 @@
+---
+"@beep/repo-cli": patch
+---
+
+Judge pull-request coverage runs against the baseline rows they raised, so a
+row a local regeneration lifted beyond what the hosted lane measures fails on
+the pull request with `row raised beyond hosted reach` instead of turning main
+red after the merge. Lowered and unchanged rows stay judged by the base floors.

--- a/goals/effect-vitest-canon/research/OPPORTUNITIES.md
+++ b/goals/effect-vitest-canon/research/OPPORTUNITIES.md
@@ -1593,3 +1593,21 @@ missing prerequisite without launching a scanner. Both failures are retained;
 the path was corrected and the fixed three-run cohort above followed. Stop
 dependent commands after an unsuccessful prerequisite rather than issuing
 them in the same orchestration batch.
+
+### Inventory not refreshed by the PR that added tests, 2026-09-11
+
+While publishing the coverage-ratchet hardening (`fix/coverage-raised-rows-own-floors`,
+PR #1091) the local Yeet cheap gate `lint:effect-vitest` went red with
+`[effect-vitest] 93 new finding(s)` and no per-finding listing. Attribution by
+content key (file, rule, symbol, evidence) against `HEAD:standards/effect-vitest.inventory.jsonc`
+showed 90 of 91 content-new findings in the cache test files that #1068 added
+(`packages/tooling/tool/cli/test/cache-*.test.ts`, `CacheQualification.policy.test.ts`)
+and one in the branch's own test file (an EV006 `expect(...).toEqual(O.some(...))`,
+fixed with `assertSome`). #1068 merged after the canon foundation (#1067) without
+refreshing the inventory, so every publish from main has failed this gate since,
+while the hosted lanes stay green because no hosted lane runs the linter. The
+inventory refresh was left out of #1091 to keep the diff focused; it needs its own
+`bun run beep lint effect-vitest --write` commit. What would have prevented it:
+the linter printing the new findings grouped by file (the count alone forced a
+hand attribution), and a hosted `lint:effect-vitest` lane or a main-push check so
+a stale inventory reds the PR that introduces it rather than every later publish.

--- a/packages/tooling/tool/cli/src/commands/Quality/internal/CoverageRegression.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/internal/CoverageRegression.ts
@@ -659,6 +659,11 @@ class CoverageRaisedRowFailure extends S.TaggedClass<CoverageRaisedRowFailure>($
     ...CoverageComparisonFailureFields,
     base: Percentage,
     proposed: Percentage,
+    // A row can be stricter by count alone (same percentage, fewer uncovered
+    // units), so the counts travel with the percentages for the diagnostic.
+    baseUncovered: NonNegativeInt,
+    proposedUncovered: NonNegativeInt,
+    actualUncovered: NonNegativeInt,
   },
   $I.annote("CoverageRaisedRowFailure", {
     description:
@@ -764,10 +769,22 @@ export class CoverageComparisonResult extends S.Class<CoverageComparisonResult>(
  * **Example** (Base-only comparison input)
  *
  * ```ts
- * import { CoverageComparisonBaselines, type CoverageRegressionBaseline } from "@beep/repo-cli/test/Quality"
+ * import { CoverageComparisonBaselines, CoverageRegressionBaseline } from "@beep/repo-cli/test/Quality"
+ * import { Percentage } from "@beep/schema/Percentage"
  * import * as O from "effect/Option"
  *
- * declare const baseline: CoverageRegressionBaseline
+ * const zero = Percentage.make(0)
+ * const baseline = CoverageRegressionBaseline.make({
+ *   schema_version: 2,
+ *   generated_at: "2026-09-11T00:00:00.000Z",
+ *   git_sha: "example",
+ *   command: "bun run coverage:baseline:write",
+ *   epsilon: 0.001,
+ *   minimum: { lines: zero, statements: zero, branches: zero, functions: zero },
+ *   exemptions: {},
+ *   follow_ups: {},
+ *   packages: {},
+ * })
  * const baselines = CoverageComparisonBaselines.make({ baseline, proposed: O.none() })
  * console.log(O.isNone(baselines.proposed)) // true
  * ```
@@ -2357,6 +2374,12 @@ const belowMinimumMetrics = (
  * its first push against the merged document while the pull request was judged
  * against the base rows. Lowered and unchanged rows stay governed by the base
  * comparison, so a floor-lowering fix proposes nothing this check can reject.
+ *
+ * @param metric - Metric being compared.
+ * @param base - Row from the base revision's document.
+ * @param proposed - Row from the pull request's own document.
+ * @param epsilon - Percentage-point tolerance for floating-point noise.
+ * @returns `true` when the proposed row is the stricter floor for the metric.
  */
 const rowRaised = (
   metric: CoverageMetricName,
@@ -2390,6 +2413,9 @@ const raisedFileRowJudgements = (
               base: base[metric],
               proposed: proposed[metric],
               actual: actual[metric],
+              baseUncovered: base.uncovered[metric],
+              proposedUncovered: proposed.uncovered[metric],
+              actualUncovered: actual.uncovered[metric],
             })
           )
         : O.none()
@@ -2417,6 +2443,45 @@ const raisedPackageRowJudgements = (
               base: base[metric],
               proposed: proposed[metric],
               actual: actual[metric],
+              baseUncovered: base.uncovered[metric],
+              proposedUncovered: proposed.uncovered[metric],
+              actualUncovered: actual.uncovered[metric],
+            })
+          )
+        : O.none()
+    )
+  );
+
+// A raised file row the run did not measure at all: main applies the vanished-
+// path rule to the merged document, so every raised metric with a positive
+// proposed percentage fails there. The base comparison only reports vanished
+// metrics whose base value is positive, so a row raised from zero would
+// otherwise slip through. Absent measurements read as zero, like that rule.
+const raisedVanishedFileRowJudgements = (
+  packageName: string,
+  packagePath: string,
+  filePath: string,
+  base: CoverageFileBaseline,
+  proposed: CoverageFileBaseline,
+  epsilon: number
+): ReadonlyArray<O.Option<CoverageComparisonFailure>> =>
+  pipe(
+    metricNames,
+    A.filter((metric) => rowRaised(metric, base, proposed, epsilon)),
+    A.map((metric) =>
+      proposed[metric] > ZERO_PERCENTAGE
+        ? O.some(
+            CoverageRaisedRowFailure.make({
+              packageName,
+              packagePath,
+              filePath: O.some(filePath),
+              metric,
+              base: base[metric],
+              proposed: proposed[metric],
+              actual: ZERO_PERCENTAGE,
+              baseUncovered: base.uncovered[metric],
+              proposedUncovered: proposed.uncovered[metric],
+              actualUncovered: NonNegativeInt.make(0),
             })
           )
         : O.none()
@@ -2424,9 +2489,10 @@ const raisedPackageRowJudgements = (
   );
 
 // Judge every row the branch raised above the base floors against the branch's
-// own value. Only rows with both a base row and a measurement are candidates:
+// own value. Only rows with a base row in a measured package are candidates:
 // new files already carry the branch row in `baseline`, so they are never
-// stricter than it, and unmeasured packages have nothing to judge.
+// stricter than it, and unmeasured packages have nothing to judge. A raised
+// file row missing from the package measurement is judged as vanished.
 const judgeRaisedRows = (
   baseline: CoverageRegressionBaseline,
   proposed: CoverageRegressionBaseline,
@@ -2445,17 +2511,29 @@ const judgeRaisedRows = (
               A.sort(coverageFileByPathOrder),
               A.flatMap(([filePath, proposedFile]) =>
                 pipe(
-                  O.all([R.get(basePackage.files, filePath), R.get(actual.baseline.files, filePath)]),
-                  O.map(([baseFile, actualFile]) =>
-                    raisedFileRowJudgements(
-                      packageName,
-                      proposedPackage.path,
-                      filePath,
-                      baseFile,
-                      proposedFile,
-                      actualFile,
-                      baseline.epsilon
-                    )
+                  R.get(basePackage.files, filePath),
+                  O.map((baseFile) =>
+                    O.match(R.get(actual.baseline.files, filePath), {
+                      onNone: () =>
+                        raisedVanishedFileRowJudgements(
+                          packageName,
+                          proposedPackage.path,
+                          filePath,
+                          baseFile,
+                          proposedFile,
+                          baseline.epsilon
+                        ),
+                      onSome: (actualFile) =>
+                        raisedFileRowJudgements(
+                          packageName,
+                          proposedPackage.path,
+                          filePath,
+                          baseFile,
+                          proposedFile,
+                          actualFile,
+                          baseline.epsilon
+                        ),
+                    })
                   ),
                   O.getOrElse(A.empty<O.Option<CoverageComparisonFailure>>)
                 )
@@ -2555,26 +2633,35 @@ export const compareCoverageRegressionSnapshotsForTesting: {
  * Pure comparison that also judges the rows a pull request raised against its
  * own proposed values, exposed for package-local tests.
  *
- * **Example** (Judge a raised row)
+ * **Example** (Judge a branch that proposes the base document unchanged)
  *
  * ```ts
  * import {
  *   CoverageComparisonBaselines,
- *   compareCoverageRegressionSnapshotsWithProposedForTesting,
- *   type CoverageRegressionBaseline,
- *   type CoverageSnapshotEntry
+ *   CoverageRegressionBaseline,
+ *   compareCoverageRegressionSnapshotsWithProposedForTesting
  * } from "@beep/repo-cli/test/Quality"
+ * import { Percentage } from "@beep/schema/Percentage"
  * import * as O from "effect/Option"
  *
- * declare const baseline: CoverageRegressionBaseline
- * declare const proposed: CoverageRegressionBaseline
- * declare const actuals: ReadonlyArray<CoverageSnapshotEntry>
+ * const zero = Percentage.make(0)
+ * const baseline = CoverageRegressionBaseline.make({
+ *   schema_version: 2,
+ *   generated_at: "2026-09-11T00:00:00.000Z",
+ *   git_sha: "example",
+ *   command: "bun run coverage:baseline:write",
+ *   epsilon: 0.001,
+ *   minimum: { lines: zero, statements: zero, branches: zero, functions: zero },
+ *   exemptions: {},
+ *   follow_ups: {},
+ *   packages: {},
+ * })
  * const result = compareCoverageRegressionSnapshotsWithProposedForTesting(
- *   CoverageComparisonBaselines.make({ baseline, proposed: O.some(proposed) }),
- *   actuals,
+ *   CoverageComparisonBaselines.make({ baseline, proposed: O.some(baseline) }),
+ *   [],
  *   false
  * )
- * console.log(result.raisedRowsJudged)
+ * console.log(result.raisedRowsJudged) // 0
  * ```
  *
  * @param baselines - Base floors plus the branch's own document.
@@ -2674,7 +2761,7 @@ const renderCoverageFailure = (failure: CoverageComparisonFailure): string =>
     Match.tag(
       "row-raised-beyond-reach",
       (raised) =>
-        `  - ${coverageDiagnosticFragment(raised.packageName)} (${coverageFailureLocation(raised)}) ${raised.metric}: row raised beyond hosted reach: this pull request raised the row from ${raised.base} to ${raised.proposed} but the lane measured ${raised.actual}`
+        `  - ${coverageDiagnosticFragment(raised.packageName)} (${coverageFailureLocation(raised)}) ${raised.metric}: row raised beyond hosted reach: this pull request raised the row from ${raised.base} (${raised.baseUncovered} uncovered) to ${raised.proposed} (${raised.proposedUncovered} uncovered) but the lane measured ${raised.actual} (${raised.actualUncovered} uncovered)`
     ),
     Match.exhaustive
   );

--- a/packages/tooling/tool/cli/src/commands/Quality/internal/CoverageRegression.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/internal/CoverageRegression.ts
@@ -606,8 +606,9 @@ export class CoverageBaselineWritePlan extends S.Class<CoverageBaselineWritePlan
 
 /**
  * One coverage comparison failure, distinguished by whether an existing
- * baseline dropped or a new file introduced uncovered units without a prior
- * file identity to compare.
+ * baseline dropped, a new file introduced uncovered units without a prior
+ * file identity to compare, or a pull request raised a row beyond what the
+ * lane measured.
  *
  * **Example** (Reporting one dropped metric)
  *
@@ -652,9 +653,22 @@ class CoverageNewUncoveredFileFailure extends S.TaggedClass<CoverageNewUncovered
   })
 ) {}
 
+class CoverageRaisedRowFailure extends S.TaggedClass<CoverageRaisedRowFailure>($I`CoverageRaisedRowFailure`)(
+  "row-raised-beyond-reach",
+  {
+    ...CoverageComparisonFailureFields,
+    base: Percentage,
+    proposed: Percentage,
+  },
+  $I.annote("CoverageRaisedRowFailure", {
+    description:
+      "A baseline row this pull request raised above the base revision's row and beyond what the lane measured.",
+  })
+) {}
+
 /**
- * Runtime schema for a tagged coverage regression caused by either a baseline
- * drop or a newly uncovered file.
+ * Runtime schema for a tagged coverage regression caused by a baseline drop,
+ * a newly uncovered file, or a row a pull request raised beyond reach.
  *
  * **Example** (Decode a baseline drop)
  *
@@ -679,10 +693,15 @@ class CoverageNewUncoveredFileFailure extends S.TaggedClass<CoverageNewUncovered
  * @category schemas
  * @since 0.0.0
  */
-export const CoverageComparisonFailure = S.Union([CoverageBaselineDropFailure, CoverageNewUncoveredFileFailure]).pipe(
+export const CoverageComparisonFailure = S.Union([
+  CoverageBaselineDropFailure,
+  CoverageNewUncoveredFileFailure,
+  CoverageRaisedRowFailure,
+]).pipe(
   S.toTaggedUnion("_tag"),
   $I.annoteSchema("CoverageComparisonFailure", {
-    description: "Tagged coverage regression reason for a baseline drop or newly uncovered file.",
+    description:
+      "Tagged coverage regression reason for a baseline drop, a newly uncovered file, or a row raised beyond reach.",
   })
 );
 
@@ -697,8 +716,10 @@ export type CoverageComparisonFailure = typeof CoverageComparisonFailure.Type;
 
 /**
  * Outcome of comparing current coverage against the committed baseline:
- * metric drops (failures), packages missing a current summary, and packages
- * new since the baseline was written.
+ * metric drops (failures), rows a pull request raised beyond what the run
+ * measured (raisedRowFailures, with the count of raised row metrics judged),
+ * packages missing a current summary, and packages new since the baseline
+ * was written.
  *
  * **Example** (Deciding whether a run regressed)
  *
@@ -715,6 +736,8 @@ export class CoverageComparisonResult extends S.Class<CoverageComparisonResult>(
   {
     comparedCount: S.Int,
     failures: S.Array(CoverageComparisonFailure),
+    raisedRowFailures: S.Array(CoverageComparisonFailure),
+    raisedRowsJudged: S.Int,
     minimumFailures: S.Array(CoverageComparisonFailure),
     missingActuals: S.Array(S.String),
     newPackages: S.Array(CoverageSnapshotEntry),
@@ -724,6 +747,46 @@ export class CoverageComparisonResult extends S.Class<CoverageComparisonResult>(
     description: "Outcome of comparing current coverage against the committed baseline.",
   })
 ) {}
+
+/**
+ * The documents one coverage comparison reads: the floors the measurement is
+ * judged against and, on a base-pinned pull-request run, the branch's own
+ * baseline so rows it raised can be judged against their proposed values.
+ *
+ * **Details**
+ *
+ * `baseline` is the base revision's document with the workspace's file
+ * identity (base floors for surviving files, branch rows for new files).
+ * `proposed` is the branch's committed document when `TURBO_SCM_BASE` pins a
+ * base, and `None` on main pushes and local runs, where the workspace
+ * document is the only floor and nothing is re-judged.
+ *
+ * **Example** (Base-only comparison input)
+ *
+ * ```ts
+ * import { CoverageComparisonBaselines, type CoverageRegressionBaseline } from "@beep/repo-cli/test/Quality"
+ * import * as O from "effect/Option"
+ *
+ * declare const baseline: CoverageRegressionBaseline
+ * const baselines = CoverageComparisonBaselines.make({ baseline, proposed: O.none() })
+ * console.log(O.isNone(baselines.proposed)) // true
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class CoverageComparisonBaselines extends S.Class<CoverageComparisonBaselines>($I`CoverageComparisonBaselines`)(
+  {
+    baseline: CoverageRegressionBaseline,
+    proposed: S.Option(CoverageRegressionBaseline),
+  },
+  $I.annote("CoverageComparisonBaselines", {
+    description: "Base-pinned comparison floors plus the branch's own baseline rows when a base is pinned.",
+  })
+) {}
+
+const baseOnlyComparison = (baseline: CoverageRegressionBaseline): CoverageComparisonBaselines =>
+  CoverageComparisonBaselines.make({ baseline, proposed: O.none() });
 
 const decodeVitestCoverageSummary = S.decodeUnknownEffect(S.fromJsonString(VitestCoverageSummary));
 
@@ -1635,13 +1698,13 @@ const readBaseline = Effect.fn("CoverageRegression.readBaseline")(function* (
 const readComparisonBaseline = Effect.fn("CoverageRegression.readComparisonBaseline")(function* (
   repoRoot: string
 ): Effect.fn.Return<
-  CoverageRegressionBaseline,
+  CoverageComparisonBaselines,
   CoverageRegressionError,
   FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
 > {
   const configuredBase = yield* configStringOption("TURBO_SCM_BASE");
   return yield* O.match(configuredBase, {
-    onNone: () => readBaseline(repoRoot),
+    onNone: () => readBaseline(repoRoot).pipe(Effect.map(baseOnlyComparison)),
     onSome: Effect.fn("CoverageRegression.readBaseComparisonBaseline")(function* (base) {
       const baseBaseline = yield* runGitRawOutput(
         repoRoot,
@@ -1654,7 +1717,7 @@ const readComparisonBaseline = Effect.fn("CoverageRegression.readComparisonBasel
         )
       );
       const workspaceBaseline = yield* readBaseline(repoRoot);
-      return CoverageRegressionBaseline.make({
+      const baseline = CoverageRegressionBaseline.make({
         ...baseBaseline,
         packages: R.map(baseBaseline.packages, (basePackage, packageName) =>
           pipe(
@@ -1676,12 +1739,17 @@ const readComparisonBaseline = Effect.fn("CoverageRegression.readComparisonBasel
           )
         ),
       });
+      // The branch's own document rides along: rows it raised above the base
+      // are judged against their proposed values, which is what main will
+      // apply on its first push after the merge.
+      return CoverageComparisonBaselines.make({ baseline, proposed: O.some(workspaceBaseline) });
     }),
   });
 });
 
 /**
- * Read the base-pinned baseline used by a coverage comparison.
+ * Read the base-pinned floors a coverage comparison judges against and, when a
+ * base is pinned, the branch's own baseline rows.
  *
  * **Example** (Build the comparison read)
  *
@@ -2072,6 +2140,11 @@ export const subtractPackageFromCoverageRegressionBaseline = Effect.fn(
 const actualByPackageName = (actuals: ReadonlyArray<CoverageSnapshotEntry>) =>
   R.fromEntries(A.map(actuals, (entry) => [entry.packageName, entry] as const));
 
+const packageEntryByNameOrder = Order.mapInput(
+  Order.String,
+  (entry: readonly [string, CoveragePackageBaseline]) => entry[0]
+);
+
 /**
  * Whether a metric's percentage drop reflects lost coverage rather than
  * deleted covered code.
@@ -2277,17 +2350,134 @@ const belowMinimumMetrics = (
     )
   );
 
-const compareCoverage = (
+/**
+ * Whether the pull request's row is a stricter floor than the base revision's
+ * for one metric: a higher percentage (beyond epsilon) or fewer uncovered
+ * units. Only such rows can turn main red after a merge, because main judges
+ * its first push against the merged document while the pull request was judged
+ * against the base rows. Lowered and unchanged rows stay governed by the base
+ * comparison, so a floor-lowering fix proposes nothing this check can reject.
+ */
+const rowRaised = (
+  metric: CoverageMetricName,
+  base: Pick<CoverageFileBaseline, CoverageMetricName | "uncovered">,
+  proposed: Pick<CoverageFileBaseline, CoverageMetricName | "uncovered">,
+  epsilon: number
+): boolean => proposed[metric] > base[metric] + epsilon || proposed.uncovered[metric] < base.uncovered[metric];
+
+// One entry per raised metric: `Some` when the measurement does not reach the
+// proposed row under the same drop rule main applies after the merge.
+const raisedFileRowJudgements = (
+  packageName: string,
+  packagePath: string,
+  filePath: string,
+  base: CoverageFileBaseline,
+  proposed: CoverageFileBaseline,
+  actual: CoverageFileBaseline,
+  epsilon: number
+): ReadonlyArray<O.Option<CoverageComparisonFailure>> =>
+  pipe(
+    metricNames,
+    A.filter((metric) => rowRaised(metric, base, proposed, epsilon)),
+    A.map((metric) =>
+      fileMetricRegressed(metric, proposed, actual, epsilon)
+        ? O.some(
+            CoverageRaisedRowFailure.make({
+              packageName,
+              packagePath,
+              filePath: O.some(filePath),
+              metric,
+              base: base[metric],
+              proposed: proposed[metric],
+              actual: actual[metric],
+            })
+          )
+        : O.none()
+    )
+  );
+
+const raisedPackageRowJudgements = (
+  packageName: string,
+  base: CoveragePackageBaseline,
+  proposed: CoveragePackageBaseline,
+  actual: CoveragePackageBaseline,
+  epsilon: number
+): ReadonlyArray<O.Option<CoverageComparisonFailure>> =>
+  pipe(
+    metricNames,
+    A.filter((metric) => rowRaised(metric, base, proposed, epsilon)),
+    A.map((metric) =>
+      metricRegressed(metric, proposed, actual, epsilon)
+        ? O.some(
+            CoverageRaisedRowFailure.make({
+              packageName,
+              packagePath: proposed.path,
+              filePath: O.none(),
+              metric,
+              base: base[metric],
+              proposed: proposed[metric],
+              actual: actual[metric],
+            })
+          )
+        : O.none()
+    )
+  );
+
+// Judge every row the branch raised above the base floors against the branch's
+// own value. Only rows with both a base row and a measurement are candidates:
+// new files already carry the branch row in `baseline`, so they are never
+// stricter than it, and unmeasured packages have nothing to judge.
+const judgeRaisedRows = (
   baseline: CoverageRegressionBaseline,
+  proposed: CoverageRegressionBaseline,
+  actualsByName: Record<string, CoverageSnapshotEntry>
+): ReadonlyArray<O.Option<CoverageComparisonFailure>> =>
+  pipe(
+    R.toEntries(proposed.packages),
+    A.sort(packageEntryByNameOrder),
+    A.flatMap(([packageName, proposedPackage]) =>
+      pipe(
+        O.all([R.get(baseline.packages, packageName), R.get(actualsByName, packageName)]),
+        O.map(([basePackage, actual]) =>
+          A.appendAll(
+            pipe(
+              R.toEntries(proposedPackage.files),
+              A.sort(coverageFileByPathOrder),
+              A.flatMap(([filePath, proposedFile]) =>
+                pipe(
+                  O.all([R.get(basePackage.files, filePath), R.get(actual.baseline.files, filePath)]),
+                  O.map(([baseFile, actualFile]) =>
+                    raisedFileRowJudgements(
+                      packageName,
+                      proposedPackage.path,
+                      filePath,
+                      baseFile,
+                      proposedFile,
+                      actualFile,
+                      baseline.epsilon
+                    )
+                  ),
+                  O.getOrElse(A.empty<O.Option<CoverageComparisonFailure>>)
+                )
+              )
+            ),
+            raisedPackageRowJudgements(packageName, basePackage, proposedPackage, actual.baseline, baseline.epsilon)
+          )
+        ),
+        O.getOrElse(A.empty<O.Option<CoverageComparisonFailure>>)
+      )
+    )
+  );
+
+const compareCoverage = (
+  baselines: CoverageComparisonBaselines,
   actuals: ReadonlyArray<CoverageSnapshotEntry>,
   scoped: boolean,
   expectedPackageNames: ReadonlyArray<string> = A.empty<string>()
 ): CoverageComparisonResult => {
+  const baseline = baselines.baseline;
   const actualsByName = actualByPackageName(actuals);
-  const baselineEntries = A.sort(
-    R.toEntries(baseline.packages),
-    Order.mapInput(Order.String, (entry: readonly [string, CoveragePackageBaseline]) => entry[0])
-  );
+  const baselineEntries = A.sort(R.toEntries(baseline.packages), packageEntryByNameOrder);
   const failures = pipe(
     baselineEntries,
     A.flatMap(([packageName, packageBaseline]) =>
@@ -2298,6 +2488,11 @@ const compareCoverage = (
         O.getOrElse(A.empty<CoverageComparisonFailure>)
       )
     )
+  );
+  const raisedRowJudgements = pipe(
+    baselines.proposed,
+    O.map((proposed) => judgeRaisedRows(baseline, proposed, actualsByName)),
+    O.getOrElse(A.empty<O.Option<CoverageComparisonFailure>>)
   );
   const minimumFailures = pipe(
     actuals,
@@ -2322,6 +2517,8 @@ const compareCoverage = (
   return {
     comparedCount: A.length(actuals) - A.length(newPackages),
     failures,
+    raisedRowFailures: A.getSomes(raisedRowJudgements),
+    raisedRowsJudged: A.length(raisedRowJudgements),
     minimumFailures,
     missingActuals,
     newPackages,
@@ -2345,7 +2542,66 @@ export const compareCoverageRegressionSnapshotsForTesting: {
     actuals: ReadonlyArray<CoverageSnapshotEntry>,
     scoped: boolean
   ): CoverageComparisonResult;
-} = dual(3, compareCoverage);
+} = dual(
+  3,
+  (
+    baseline: CoverageRegressionBaseline,
+    actuals: ReadonlyArray<CoverageSnapshotEntry>,
+    scoped: boolean
+  ): CoverageComparisonResult => compareCoverage(baseOnlyComparison(baseline), actuals, scoped)
+);
+
+/**
+ * Pure comparison that also judges the rows a pull request raised against its
+ * own proposed values, exposed for package-local tests.
+ *
+ * **Example** (Judge a raised row)
+ *
+ * ```ts
+ * import {
+ *   CoverageComparisonBaselines,
+ *   compareCoverageRegressionSnapshotsWithProposedForTesting,
+ *   type CoverageRegressionBaseline,
+ *   type CoverageSnapshotEntry
+ * } from "@beep/repo-cli/test/Quality"
+ * import * as O from "effect/Option"
+ *
+ * declare const baseline: CoverageRegressionBaseline
+ * declare const proposed: CoverageRegressionBaseline
+ * declare const actuals: ReadonlyArray<CoverageSnapshotEntry>
+ * const result = compareCoverageRegressionSnapshotsWithProposedForTesting(
+ *   CoverageComparisonBaselines.make({ baseline, proposed: O.some(proposed) }),
+ *   actuals,
+ *   false
+ * )
+ * console.log(result.raisedRowsJudged)
+ * ```
+ *
+ * @param baselines - Base floors plus the branch's own document.
+ * @param actuals - Coverage summaries produced by the run.
+ * @param scoped - Whether the run was intentionally filtered or affected-scoped.
+ * @returns Regression findings including raised rows the run did not reach.
+ * @category testing
+ * @since 0.0.0
+ */
+export const compareCoverageRegressionSnapshotsWithProposedForTesting: {
+  (
+    actuals: ReadonlyArray<CoverageSnapshotEntry>,
+    scoped: boolean
+  ): (baselines: CoverageComparisonBaselines) => CoverageComparisonResult;
+  (
+    baselines: CoverageComparisonBaselines,
+    actuals: ReadonlyArray<CoverageSnapshotEntry>,
+    scoped: boolean
+  ): CoverageComparisonResult;
+} = dual(
+  3,
+  (
+    baselines: CoverageComparisonBaselines,
+    actuals: ReadonlyArray<CoverageSnapshotEntry>,
+    scoped: boolean
+  ): CoverageComparisonResult => compareCoverage(baselines, actuals, scoped)
+);
 
 /**
  * Compare a scoped snapshot while requiring every explicitly selected package
@@ -2393,7 +2649,7 @@ export const compareCoverageRegressionSnapshotsForExpectedPackagesForTesting: {
     baseline: CoverageRegressionBaseline,
     actuals: ReadonlyArray<CoverageSnapshotEntry>,
     expectedPackageNames: ReadonlyArray<string>
-  ): CoverageComparisonResult => compareCoverage(baseline, actuals, true, expectedPackageNames)
+  ): CoverageComparisonResult => compareCoverage(baseOnlyComparison(baseline), actuals, true, expectedPackageNames)
 );
 
 const coverageFailureLocation = (failure: CoverageComparisonFailure): string =>
@@ -2414,6 +2670,11 @@ const renderCoverageFailure = (failure: CoverageComparisonFailure): string =>
       "new-uncovered-file",
       (newFile) =>
         `  - ${coverageDiagnosticFragment(newFile.packageName)} (${coverageFailureLocation(newFile)}) ${newFile.metric}: new file has ${newFile.uncovered} uncovered unit(s) at ${newFile.actual}% (no baseline file identity)`
+    ),
+    Match.tag(
+      "row-raised-beyond-reach",
+      (raised) =>
+        `  - ${coverageDiagnosticFragment(raised.packageName)} (${coverageFailureLocation(raised)}) ${raised.metric}: row raised beyond hosted reach: this pull request raised the row from ${raised.base} to ${raised.proposed} but the lane measured ${raised.actual}`
     ),
     Match.exhaustive
   );
@@ -2495,6 +2756,13 @@ const regressionLines = (
         ...renderCoverageFailuresForTesting(failures),
       ],
     }),
+    ...A.match(result.raisedRowFailures, {
+      onEmpty: A.empty<string>,
+      onNonEmpty: (failures) => [
+        "[coverage-ratchet] baseline row(s) raised beyond hosted reach (judged against this pull request's own rows, not the base floors):",
+        ...renderCoverageFailuresForTesting(failures),
+      ],
+    }),
     ...A.match(result.minimumFailures, {
       onEmpty: A.empty<string>,
       onNonEmpty: (failures) => [
@@ -2536,10 +2804,13 @@ const failurePackageNames = (failures: ReadonlyArray<CoverageComparisonFailure>)
  * Baseline regressions get the exact scoped regeneration command for the
  * regressed packages so an agent never reaches for the repo-wide writer, with
  * the two legitimate outcomes stated: restore the coverage, or accept the new
- * floors after review. Tier-minimum breaches get a restore-only hint: the
- * writer records floors, it cannot lift a package above the repository tier.
- * Missing summaries and disposition gaps get no command because they are
- * configuration problems, not floors.
+ * floors after review. Rows a pull request raised beyond what the lane
+ * measured get a lower-the-row hint and no writer command: a local
+ * regeneration is what mints such rows, so rerunning it cannot prove them.
+ * Tier-minimum breaches get a restore-only hint: the writer records floors,
+ * it cannot lift a package above the repository tier. Missing summaries and
+ * disposition gaps get no command because they are configuration problems,
+ * not floors.
  *
  * **Example** (Nothing regressed)
  *
@@ -2549,6 +2820,8 @@ const failurePackageNames = (failures: ReadonlyArray<CoverageComparisonFailure>)
  * const clean = CoverageComparisonResult.make({
  *   comparedCount: 0,
  *   failures: [],
+ *   raisedRowFailures: [],
+ *   raisedRowsJudged: 0,
  *   minimumFailures: [],
  *   missingActuals: [],
  *   newPackages: [],
@@ -2569,6 +2842,12 @@ export const renderCoverageRemediation = (result: CoverageComparisonResult): Rea
       "[coverage-ratchet] remediation: restore the lost coverage with tests, or, once a reviewer accepts the new floors, regenerate only the regressed rows:",
       `  ${sanitizeCoverageDiagnostic(coverageScopedBaselineWriteCommand(packageNames))}`,
       `  (the scoped run measures only those packages and merges their rows; never run ${coverageRegressionRegenerationCommand} for a per-package drop)`,
+    ],
+  }),
+  ...A.match(failurePackageNames(result.raisedRowFailures), {
+    onEmpty: A.empty<string>,
+    onNonEmpty: (packageNames) => [
+      `[coverage-ratchet] remediation: ${sanitizeCoverageDiagnostic(A.join(packageNames, ", "))} carry row(s) this pull request raised above what the hosted lane measures; set each named row in ${coverageRegressionBaselinePath} to the measured value or lower. A local regeneration minted these floors and cannot prove them; merged as-is they turn main red on its first push.`,
     ],
   }),
   ...A.match(failurePackageNames(result.minimumFailures), {
@@ -2598,9 +2877,10 @@ export const compareCoverageRegressionBaseline = Effect.fn("CoverageRegression.c
     CoverageRegressionError | QualityTaskFailed,
     FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
   > {
-    const baseline = yield* readComparisonBaseline(repoRoot);
+    const baselines = yield* readComparisonBaseline(repoRoot);
+    const baseline = baselines.baseline;
     const actuals = yield* collectCoverageSnapshot(repoRoot);
-    const result = compareCoverage(baseline, actuals, scoped, expectedPackageNames);
+    const result = compareCoverage(baselines, actuals, scoped, expectedPackageNames);
     const path = yield* Path.Path;
     const dispositionGaps = yield* workspaceCoverageDispositionGaps(repoRoot, path, baseline.exemptions);
 
@@ -2635,6 +2915,7 @@ export const compareCoverageRegressionBaseline = Effect.fn("CoverageRegression.c
         {
           present:
             A.isReadonlyArrayNonEmpty(result.failures) ||
+            A.isReadonlyArrayNonEmpty(result.raisedRowFailures) ||
             A.isReadonlyArrayNonEmpty(result.minimumFailures) ||
             A.isReadonlyArrayNonEmpty(result.missingActuals) ||
             A.isReadonlyArrayNonEmpty(dispositionGaps),
@@ -2642,7 +2923,18 @@ export const compareCoverageRegressionBaseline = Effect.fn("CoverageRegression.c
           error: QualityTaskFailed.new(1, "coverage:ratchet", "beep-cli coverage"),
         },
       ],
-      okLine: `[coverage-ratchet] ok: compared ${result.comparedCount} package(s) with epsilon ${baseline.epsilon}`,
+      okLine: A.join(
+        [
+          `[coverage-ratchet] ok: compared ${result.comparedCount} package(s) with epsilon ${baseline.epsilon}`,
+          ...O.match(baselines.proposed, {
+            onNone: A.empty<string>,
+            onSome: () => [
+              `${result.raisedRowsJudged} raised row metric(s) judged against this pull request's own rows`,
+            ],
+          }),
+        ],
+        "; "
+      ),
       tighten: O.none(),
     });
   }

--- a/packages/tooling/tool/cli/test/quality-tasks.test.ts
+++ b/packages/tooling/tool/cli/test/quality-tasks.test.ts
@@ -4682,7 +4682,7 @@ describe("quality task adapter", () => {
         );
         expect(A.map(result.raisedRowFailures, (failure) => failure.metric)).toEqual(allMetrics);
         expect(renderCoverageFailuresForTesting(result.raisedRowFailures)[0]).toBe(
-          `  - @beep/existing (${filePath}) branches: row raised beyond hosted reach: this pull request raised the row from 80 to 90 but the lane measured 85`
+          `  - @beep/existing (${filePath}) branches: row raised beyond hosted reach: this pull request raised the row from 80 (20 uncovered) to 90 (10 uncovered) but the lane measured 85 (15 uncovered)`
         );
         const remediation = A.join(renderCoverageRemediation(result), "\n");
         expect(remediation).toContain(
@@ -4726,6 +4726,31 @@ describe("quality task adapter", () => {
         // Against the proposed row (18 uncovered) main would fail on its first push.
         expect(result.raisedRowsJudged).toBe(4);
         expect(A.map(result.raisedRowFailures, (failure) => failure.metric)).toEqual(allMetrics);
+        // The counts name the stricter floor that actually failed, not just equal percentages.
+        expect(renderCoverageFailuresForTesting(result.raisedRowFailures)[0]).toBe(
+          `  - @beep/existing (${filePath}) branches: row raised beyond hosted reach: this pull request raised the row from 80 (20 uncovered) to 80 (18 uncovered) but the lane measured 79.5 (19 uncovered)`
+        );
+      });
+
+      it("fails raised rows whose file the lane did not measure", () => {
+        const vanished = compareCoverageRegressionSnapshotsWithProposedForTesting(
+          CoverageComparisonBaselines.make({
+            baseline: withRows({
+              "@beep/existing": packageRow(80, 20, { [filePath]: coverageFileBaseline(0, 5) }),
+            }),
+            proposed: proposing(packageRow(80, 20, { [filePath]: coverageFileBaseline(50, 2) })),
+          }),
+          [{ packageName: "@beep/existing", baseline: packageRow(80, 20, {}) }],
+          false
+        );
+
+        // The base row is 0%, so the vanished-path rule in the base comparison stays silent.
+        expect(vanished.failures).toEqual([]);
+        expect(vanished.raisedRowsJudged).toBe(4);
+        expect(A.map(vanished.raisedRowFailures, (failure) => failure.actual)).toEqual([0, 0, 0, 0]);
+        expect(renderCoverageFailuresForTesting(vanished.raisedRowFailures)[0]).toBe(
+          `  - @beep/existing (${filePath}) branches: row raised beyond hosted reach: this pull request raised the row from 0 (5 uncovered) to 50 (2 uncovered) but the lane measured 0 (0 uncovered)`
+        );
       });
 
       it("judges raised package totals with the package-level rule", () => {
@@ -4743,7 +4768,7 @@ describe("quality task adapter", () => {
           true,
         ]);
         expect(renderCoverageFailuresForTesting(result.raisedRowFailures)[0]).toBe(
-          "  - @beep/existing (packages/existing) branches: row raised beyond hosted reach: this pull request raised the row from 80 to 90 but the lane measured 85"
+          "  - @beep/existing (packages/existing) branches: row raised beyond hosted reach: this pull request raised the row from 80 (20 uncovered) to 90 (10 uncovered) but the lane measured 85 (15 uncovered)"
         );
       });
 

--- a/packages/tooling/tool/cli/test/quality-tasks.test.ts
+++ b/packages/tooling/tool/cli/test/quality-tasks.test.ts
@@ -4772,6 +4772,42 @@ describe("quality task adapter", () => {
         );
       });
 
+      it("passes a raised package total the lane reaches", () => {
+        const result = compare(
+          proposing(packageRow(90, 10, { [filePath]: coverageFileBaseline(80, 20) })),
+          packageRow(90, 10, { [filePath]: coverageFileBaseline(80, 20) })
+        );
+
+        expect(result.raisedRowsJudged).toBe(4);
+        expect(result.raisedRowFailures).toEqual([]);
+        expect(result.failures).toEqual([]);
+      });
+
+      it("does not fail a vanished file whose raised metric proposes zero percent", () => {
+        const newFile = "packages/existing/src/New.ts";
+        const zeroRaise = compareCoverageRegressionSnapshotsWithProposedForTesting(
+          CoverageComparisonBaselines.make({
+            baseline: withRows({
+              "@beep/existing": packageRow(80, 20, { [filePath]: coverageFileBaseline(0, 5) }),
+            }),
+            // Stricter by count only, still 0%: main's vanished-path rule needs a
+            // positive percentage, so nothing fails. The file unknown to the base
+            // document is not a candidate at all.
+            proposed: proposing(
+              packageRow(80, 20, {
+                [filePath]: coverageFileBaseline(0, 2),
+                [newFile]: coverageFileBaseline(50, 1),
+              })
+            ),
+          }),
+          [{ packageName: "@beep/existing", baseline: packageRow(80, 20, {}) }],
+          false
+        );
+
+        expect(zeroRaise.raisedRowsJudged).toBe(4);
+        expect(zeroRaise.raisedRowFailures).toEqual([]);
+      });
+
       it("judges nothing without a pinned base or without a measured package", () => {
         const actual = packageRow(85, 15, { [filePath]: coverageFileBaseline(85, 15) });
 

--- a/packages/tooling/tool/cli/test/quality-tasks.test.ts
+++ b/packages/tooling/tool/cli/test/quality-tasks.test.ts
@@ -144,7 +144,7 @@ import { NodeChildProcessSpawner } from "@effect/platform-node";
 import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
 import * as NodePath from "@effect/platform-node/NodePath";
 import { assert, describe, expect, it } from "@effect/vitest";
-import { assertNone } from "@effect/vitest/utils";
+import { assertNone, assertSome } from "@effect/vitest/utils";
 import {
   Cause,
   ConfigProvider,
@@ -4586,7 +4586,10 @@ describe("quality task adapter", () => {
             expect(selected.baseline.packages["@beep/a"]?.files["packages/a/src/Existing.ts"]?.lines).toBe(80);
             expect(selected.baseline.packages["@beep/a"]?.files["packages/a/src/New.ts"]?.lines).toBe(65);
             // The branch's own document rides along so rows it raised can be judged against it.
-            expect(O.map(selected.proposed, (proposed) => proposed.generated_at)).toEqual(O.some("branch-relaxation"));
+            assertSome(
+              O.map(selected.proposed, (proposed) => proposed.generated_at),
+              "branch-relaxation"
+            );
           })
         )
       ));

--- a/packages/tooling/tool/cli/test/quality-tasks.test.ts
+++ b/packages/tooling/tool/cli/test/quality-tasks.test.ts
@@ -28,6 +28,7 @@ import {
   baselineEntriesLostByReplacement,
   CoverageBaselineChangeSet,
   CoverageBaselineRowDelta,
+  CoverageComparisonBaselines,
   CoverageComparisonFailure,
   CoverageFileBaseline,
   CoveragePackageBaseline,
@@ -38,6 +39,7 @@ import {
   collectEffectTsgoDiagnosticLines,
   compareCoverageRegressionSnapshotsForExpectedPackagesForTesting,
   compareCoverageRegressionSnapshotsForTesting,
+  compareCoverageRegressionSnapshotsWithProposedForTesting,
   compareJSDocTotalsForTesting,
   compareKnipFindingsForTesting,
   coverageBaselineRowDelta,
@@ -4578,11 +4580,13 @@ describe("quality task adapter", () => {
                 ConfigProvider.fromUnknown({ TURBO_SCM_BASE: "HEAD" })
               )
             );
-            expect(selected.generated_at).toBe("base");
-            expect(selected.packages["@beep/a"]?.lines).toBe(80);
-            expect(selected.packages["@beep/a"]?.files["packages/a/src/Deleted.ts"]).toBeUndefined();
-            expect(selected.packages["@beep/a"]?.files["packages/a/src/Existing.ts"]?.lines).toBe(80);
-            expect(selected.packages["@beep/a"]?.files["packages/a/src/New.ts"]?.lines).toBe(65);
+            expect(selected.baseline.generated_at).toBe("base");
+            expect(selected.baseline.packages["@beep/a"]?.lines).toBe(80);
+            expect(selected.baseline.packages["@beep/a"]?.files["packages/a/src/Deleted.ts"]).toBeUndefined();
+            expect(selected.baseline.packages["@beep/a"]?.files["packages/a/src/Existing.ts"]?.lines).toBe(80);
+            expect(selected.baseline.packages["@beep/a"]?.files["packages/a/src/New.ts"]?.lines).toBe(65);
+            // The branch's own document rides along so rows it raised can be judged against it.
+            expect(O.map(selected.proposed, (proposed) => proposed.generated_at)).toEqual(O.some("branch-relaxation"));
           })
         )
       ));
@@ -4604,7 +4608,8 @@ describe("quality task adapter", () => {
             const selected = yield* readCoverageComparisonBaselineForTesting(repoRoot).pipe(
               Effect.provideService(ConfigProvider.ConfigProvider, ConfigProvider.fromUnknown({}))
             );
-            expect(selected.generated_at).toBe("workspace");
+            expect(selected.baseline.generated_at).toBe("workspace");
+            assertNone(selected.proposed);
           })
         )
       ));
@@ -4635,6 +4640,134 @@ describe("quality task adapter", () => {
           })
         )
       ));
+
+    describe("rows a pull request raised are judged against its own values", () => {
+      const filePath = "packages/existing/src/Index.ts";
+      const packageRow = (
+        metric: number,
+        uncovered: number,
+        files: Record<string, CoverageFileBaseline>
+      ): CoveragePackageBaseline =>
+        CoveragePackageBaseline.make({
+          ...coveragePackageBaseline("packages/existing", metric),
+          uncovered: coverageUncovered(uncovered),
+          files,
+        });
+      const baseFloors = withRows({
+        "@beep/existing": packageRow(80, 20, { [filePath]: coverageFileBaseline(80, 20) }),
+      });
+      const proposing = (row: CoveragePackageBaseline) => O.some(withRows({ "@beep/existing": row }));
+      const compare = (proposed: O.Option<CoverageRegressionBaseline>, actual: CoveragePackageBaseline) =>
+        compareCoverageRegressionSnapshotsWithProposedForTesting(
+          CoverageComparisonBaselines.make({ baseline: baseFloors, proposed }),
+          [{ packageName: "@beep/existing", baseline: actual }],
+          false
+        );
+      const allMetrics = ["branches", "functions", "lines", "statements"];
+
+      it("fails a raised file row the lane does not reach and names both numbers", () => {
+        const result = compare(
+          proposing(packageRow(80, 20, { [filePath]: coverageFileBaseline(90, 10) })),
+          packageRow(80, 20, { [filePath]: coverageFileBaseline(85, 15) })
+        );
+
+        // The base floor (80) is met, so the existing comparison stays green.
+        expect(result.failures).toEqual([]);
+        expect(result.raisedRowsJudged).toBe(4);
+        expect(A.map(result.raisedRowFailures, (failure) => failure._tag)).toEqual(
+          A.makeBy(4, () => "row-raised-beyond-reach")
+        );
+        expect(A.map(result.raisedRowFailures, (failure) => failure.metric)).toEqual(allMetrics);
+        expect(renderCoverageFailuresForTesting(result.raisedRowFailures)[0]).toBe(
+          `  - @beep/existing (${filePath}) branches: row raised beyond hosted reach: this pull request raised the row from 80 to 90 but the lane measured 85`
+        );
+        const remediation = A.join(renderCoverageRemediation(result), "\n");
+        expect(remediation).toContain(
+          "@beep/existing carry row(s) this pull request raised above what the hosted lane measures"
+        );
+        expect(remediation).not.toContain("--write-baseline");
+      });
+
+      it("passes a raised row the lane reaches", () => {
+        const result = compare(
+          proposing(packageRow(80, 20, { [filePath]: coverageFileBaseline(90, 10) })),
+          packageRow(80, 20, { [filePath]: coverageFileBaseline(90, 10) })
+        );
+
+        expect(result.raisedRowsJudged).toBe(4);
+        expect(result.raisedRowFailures).toEqual([]);
+        expect(result.failures).toEqual([]);
+        expect(renderCoverageRemediation(result)).toEqual([]);
+      });
+
+      it("leaves lowered rows to the base floors so a floor-lowering fix is judged by main alone", () => {
+        const result = compare(
+          proposing(packageRow(80, 20, { [filePath]: coverageFileBaseline(70, 30) })),
+          packageRow(80, 20, { [filePath]: coverageFileBaseline(75, 25) })
+        );
+
+        expect(result.raisedRowsJudged).toBe(0);
+        expect(result.raisedRowFailures).toEqual([]);
+        // The base floor still governs: 75 < 80 with more uncovered units is a drop.
+        expect(A.map(result.failures, (failure) => failure._tag)).toEqual(A.makeBy(4, () => "baseline-drop"));
+      });
+
+      it("treats fewer uncovered units at an equal percentage as a raised row", () => {
+        const result = compare(
+          proposing(packageRow(80, 20, { [filePath]: coverageFileBaseline(80, 18) })),
+          packageRow(80, 20, { [filePath]: coverageFileBaseline(79.5, 19) })
+        );
+
+        // Against the base floor 19 uncovered is not more than 20, so no drop is seen.
+        expect(result.failures).toEqual([]);
+        // Against the proposed row (18 uncovered) main would fail on its first push.
+        expect(result.raisedRowsJudged).toBe(4);
+        expect(A.map(result.raisedRowFailures, (failure) => failure.metric)).toEqual(allMetrics);
+      });
+
+      it("judges raised package totals with the package-level rule", () => {
+        const result = compare(
+          proposing(packageRow(90, 10, { [filePath]: coverageFileBaseline(80, 20) })),
+          packageRow(85, 15, { [filePath]: coverageFileBaseline(80, 20) })
+        );
+
+        expect(result.failures).toEqual([]);
+        expect(result.raisedRowsJudged).toBe(4);
+        expect(A.map(result.raisedRowFailures, (failure) => O.isNone(failure.filePath))).toEqual([
+          true,
+          true,
+          true,
+          true,
+        ]);
+        expect(renderCoverageFailuresForTesting(result.raisedRowFailures)[0]).toBe(
+          "  - @beep/existing (packages/existing) branches: row raised beyond hosted reach: this pull request raised the row from 80 to 90 but the lane measured 85"
+        );
+      });
+
+      it("judges nothing without a pinned base or without a measured package", () => {
+        const actual = packageRow(85, 15, { [filePath]: coverageFileBaseline(85, 15) });
+
+        const unpinned = compare(O.none(), actual);
+        expect(unpinned.raisedRowsJudged).toBe(0);
+        expect(unpinned.raisedRowFailures).toEqual([]);
+
+        const unmeasured = compareCoverageRegressionSnapshotsWithProposedForTesting(
+          CoverageComparisonBaselines.make({
+            baseline: baseFloors,
+            proposed: O.some(
+              withRows({
+                "@beep/existing": packageRow(90, 10, { [filePath]: coverageFileBaseline(90, 10) }),
+                "@beep/new": coveragePackageBaseline("packages/new", 90),
+              })
+            ),
+          }),
+          [],
+          true
+        );
+        expect(unmeasured.raisedRowsJudged).toBe(0);
+        expect(unmeasured.raisedRowFailures).toEqual([]);
+      });
+    });
 
     it("resolves an affected run from a dirty row-only baseline edit against the workspace", () =>
       Effect.runPromise(

--- a/standards/architecture/DECISIONS.md
+++ b/standards/architecture/DECISIONS.md
@@ -1783,6 +1783,49 @@ failing closed on handoff integrity, reusing the existing receipt vocabulary,
 and withholding publisher authority address those observed failure modes. Work
 packet: `explorations/grok-bot-automation/`.
 
+## 2026-09-11: Pull Requests Are Judged Against the Baseline Rows They Raise
+
+- **Status:** Active
+
+Decision:
+
+On a base-pinned coverage run (`TURBO_SCM_BASE` set, which is every
+pull-request run of the `Heavy / Coverage Regression` lane), the ratchet keeps
+judging the measurement against the base revision's rows and additionally
+judges every row the pull request raised against the pull request's own value.
+A row is raised, per metric, when the branch's
+`standards/coverage.regression-baseline.jsonc` carries a stricter floor than
+the base revision's document: a higher percentage (beyond epsilon) or fewer
+uncovered units. Package total rows and file rows are both covered. New files
+already use the branch row and are not re-judged; rows the pull request lowered
+or left unchanged are judged by the base floors alone. A raised row the lane
+does not reach fails with the distinct reason `row raised beyond hosted reach`,
+naming the row, the base value, the proposed value, and the measured value,
+under its own section, with a remediation that says to set the row to the
+measured value or lower. The scoped writer is not offered for that failure,
+because a local regeneration is what mints such rows. The ok line reports how
+many raised row metrics were judged. Runs without a pinned base (main pushes
+and local runs) behave as before.
+
+Rationale:
+
+PR #1068 regenerated the baseline locally and raised the
+`Lint/Lint.command.ts` and `Yeet/internal/Planner.ts` rows above what the
+hosted lane measures. The pull-request run was green because it compared the
+measurement against main's rows; main went red on the first push after the
+merge and every later pull request inherited that red until a floor-restoring
+PR landed. The lane had already measured both files on the pull request and
+produced the exact numbers main later failed on, so the verdict was available
+before the merge and simply not asked for. Judging only raised rows keeps the
+one legitimate direction open: a floor-lowering fix proposes nothing stricter
+than main and stays governed by the base comparison it was already subject to.
+The predicate reused for the raised-row verdict is the same drop rule main
+applies after the merge, so a pull-request pass on a raised row is a prediction
+that main stays green on that row.
+
+This extends the 2026-08-24 rule that the hosted lane is the authority for the
+floors: a raised row is now proven by the hosted lane before it can merge.
+
 ## Known Unknowns
 
 Areas the doctrine does not yet cover and which the authors expect to revise as the architecture is load-tested:


### PR DESCRIPTION
## fix(repo-cli): judge pull-request coverage runs against the rows they raised

On a base-pinned run the ratchet now also judges every baseline row the pull
request raised above the base revision against the pull request's own value,
failing with "row raised beyond hosted reach" when the lane does not reach it.
Lowered and unchanged rows stay judged by the base floors, so floor-lowering
fixes remain mergeable. Records the decision in DECISIONS.md.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/fix_coverage-raised-rows-own-floors-a71b4430fb10/verdict.json

---

<!-- yeet-provenance:start -->
## Provenance

- Workspace: <code>beep-effect3</code>
- Branch: <code>fix/coverage-raised-rows-own-floors</code>
- Agents (newest first):
  - `claude-code` (desktop) · `claude-fable-5-1` · <code>happy-yonath-326ada-ac</code> · monitored

Resume the publishing agent from any beep-effect checkout on the publishing workstation:

```sh
bun run beep yeet resume 1091
```

<!-- yeet-provenance
{
  "schemaVersion": 2,
  "pr": 1091,
  "branch": "fix/coverage-raised-rows-own-floors",
  "workspace": "beep-effect3",
  "agents": [
    {
      "harness": "claude-code",
      "entrypoint": "claude-desktop",
      "hostHarness": null,
      "model": "claude-fable-5-1",
      "label": "happy-yonath-326ada-ac",
      "workspace": null,
      "role": "monitored"
    }
  ]
}
-->
<!-- yeet-provenance:end -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1091"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791761570&installation_model_id=424656&pr_number=1091&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1091&signature=5fb3cdff4b1c9ea734e99e0ff7739327925422118aec90728cdf5c367d6787ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->