### PR TITLE
feat(repo-cli): nightly Graft meaning-tier refresh from an owner clone

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,6 +221,7 @@ memory layer; decision log 2026-09-08). Before grepping or opening source, run
 (exhaustive), `graft callers <symbol> [--depth N]` (edges), `graft skeleton
 <file>` (API surface), or `graft map` (orientation); the `graft` skill has the
 routing rules and caveats. Refresh with the exact `graft build` (structural,
-no key). Never run `graft init`, `uninstall`, `upgrade`, or `build --deep`
-from an agent: they rewrite tracked wiring or spend model quota.
+no key). Never run `graft init`, `uninstall`, `upgrade`, `build --deep`, `beep
+graft deep refresh`, or `beep graft deep install-timer` from an agent: they
+rewrite tracked wiring, spend model quota, or schedule a job that does.
 <!-- graft:end -->

--- a/docs/runbooks/graft-local-recovery.md
+++ b/docs/runbooks/graft-local-recovery.md
@@ -203,11 +203,11 @@ can assume a clean checkout on `main` and pin it without asking. Bootstrap it
 once against an existing clone's object store:
 
 ```sh
-git clone --reference $HOME/YeeBois/projects/beep-effect \
-  https://github.com/beep-effect/beep-effect.git $HOME/YeeBois/projects/beep-effect0
-cd $HOME/YeeBois/projects/beep-effect0 && bun install --frozen-lockfile && graft build
-mise trust $HOME/YeeBois/projects/beep-effect0/mise.toml
-bun run beep graft cache sync --from $HOME/YeeBois/projects/beep-effect --to $HOME/YeeBois/projects/beep-effect0
+git clone --reference "$HOME/YeeBois/projects/beep-effect" \
+  https://github.com/beep-effect/beep-effect.git "$HOME/YeeBois/projects/beep-effect0"
+cd "$HOME/YeeBois/projects/beep-effect0" && bun install --frozen-lockfile && graft build
+mise trust "$HOME/YeeBois/projects/beep-effect0/mise.toml"
+bun run beep graft cache sync --from "$HOME/YeeBois/projects/beep-effect" --to "$HOME/YeeBois/projects/beep-effect0"
 ```
 
 The HTTPS remote is load-bearing, not a preference. The systemd user manager
@@ -218,7 +218,7 @@ fetches with no credentials at all. Both `refresh` and `install-timer` read
 `https://`. An owner clone that already exists over SSH is re-pointed in place:
 
 ```sh
-git -C $HOME/YeeBois/projects/beep-effect0 remote set-url origin \
+git -C "$HOME/YeeBois/projects/beep-effect0" remote set-url origin \
   https://github.com/beep-effect/beep-effect.git
 ```
 
@@ -243,9 +243,9 @@ Copy an existing deep-build environment file rather than starting from an
 empty one, then set the model the nightly job should spend:
 
 ```sh
-install -m 600 $HOME/.cache/beep/graft-deep-grok.env $HOME/.config/beep-graft/env
-${EDITOR:-nano} $HOME/.config/beep-graft/env   # set GRAFT_MODEL=
-bun run beep graft deep install-timer --owner $HOME/YeeBois/projects/beep-effect0
+install -m 600 "$HOME/.cache/beep/graft-deep-grok.env" "$HOME/.config/beep-graft/env"
+${EDITOR:-nano} "$HOME/.config/beep-graft/env"   # set GRAFT_MODEL=
+bun run beep graft deep install-timer --owner "$HOME/YeeBois/projects/beep-effect0"
 ```
 
 The nightly job on this workstation runs `GRAFT_MODEL=claude-opus-5` through
@@ -302,8 +302,8 @@ Run it by hand the same way the timer does, which is also how to test a change
 to the schedule before trusting it overnight:
 
 ```sh
-bun run beep graft deep refresh --owner $HOME/YeeBois/projects/beep-effect0 --jobs 16
-bun run beep graft deep refresh --owner $HOME/YeeBois/projects/beep-effect0 --no-seed --no-rebuild
+bun run beep graft deep refresh --owner "$HOME/YeeBois/projects/beep-effect0" --jobs 16
+bun run beep graft deep refresh --owner "$HOME/YeeBois/projects/beep-effect0" --no-seed --no-rebuild
 ```
 
 `--model` overrides `GRAFT_MODEL` for the build; leaving it off keeps the

--- a/docs/runbooks/graft-local-recovery.md
+++ b/docs/runbooks/graft-local-recovery.md
@@ -224,10 +224,12 @@ git -C ~/YeeBois/projects/beep-effect0 remote set-url origin \
 
 The `mise trust` line is not optional either: the timer resolves `graft`
 through the mise node shim, and an untrusted config makes that shim refuse to
-run. `install-timer` checks it and refuses rather than installing a unit that
-will fail every night. The first seed is what saves the first night's full
-build: the refresh re-summarizes only changed files, so the owner starts from a
-meaning tier rather than from nothing.
+run. `install-timer` runs `mise trust --show` in the owner and fails closed on
+every answer but a clean one, so a mise that is missing, broken, or reporting an
+untrusted config refuses the install instead of leaving a unit that fails every
+night. The first seed is what saves the first night's full build: the refresh
+re-summarizes only changed files, so the owner starts from a meaning tier rather
+than from nothing.
 
 The provider keys live in `~/.config/beep-graft/env`, which systemd reads as
 the unit's `EnvironmentFile`. It holds the same keys as the deep-build

--- a/docs/runbooks/graft-local-recovery.md
+++ b/docs/runbooks/graft-local-recovery.md
@@ -190,6 +190,124 @@ runs, and a report with copied, removed, skipped, refused, and byte counts for
 writes. The command runs neither Git nor Graft. A dangling or unreadable
 sibling entry is skipped by `--siblings` rather than aborting discovery.
 
+## Refresh the meaning tier nightly (operator only)
+
+`beep graft deep refresh` is the scheduled form of the two sections above: it
+pins one owner clone to `origin/main`, rebuilds the meaning tier there, seeds
+the siblings, and runs a structural `graft build` in each seeded clone. It
+spends model quota, so it is an operator job like the build itself. Agents
+never run `refresh` or `install-timer`.
+
+The owner clone exists only for this job; nobody works in it, so the refresh
+can assume a clean checkout on `main` and pin it without asking. Bootstrap it
+once against an existing clone's object store:
+
+```sh
+git clone --reference ~/YeeBois/projects/beep-effect \
+  https://github.com/beep-effect/beep-effect.git ~/YeeBois/projects/beep-effect0
+cd ~/YeeBois/projects/beep-effect0 && bun install --frozen-lockfile && graft build
+mise trust ~/YeeBois/projects/beep-effect0/mise.toml
+bun run beep graft cache sync --from ~/YeeBois/projects/beep-effect --to ~/YeeBois/projects/beep-effect0
+```
+
+The HTTPS remote is load-bearing, not a preference. The systemd user manager
+carries no `SSH_AUTH_SOCK`, so a nightly `git fetch` over an SSH remote has no
+agent to answer for the key and fails; the repo is public, so an HTTPS remote
+fetches with no credentials at all. Both `refresh` and `install-timer` read
+`git remote get-url origin` in preflight and refuse anything that is not
+`https://`. An owner clone that already exists over SSH is re-pointed in place:
+
+```sh
+git -C ~/YeeBois/projects/beep-effect0 remote set-url origin \
+  https://github.com/beep-effect/beep-effect.git
+```
+
+The `mise trust` line is not optional either: the timer resolves `graft`
+through the mise node shim, and an untrusted config makes that shim refuse to
+run. `install-timer` checks it and refuses rather than installing a unit that
+will fail every night. The first seed is what saves the first night's full
+build: the refresh re-summarizes only changed files, so the owner starts from a
+meaning tier rather than from nothing.
+
+The provider keys live in `~/.config/beep-graft/env`, which systemd reads as
+the unit's `EnvironmentFile`. It holds the same keys as the deep-build
+environment files below (`GRAFT_PROVIDER`, `GRAFT_BASE_URL`, `GRAFT_API_KEY`,
+`GRAFT_MODEL`, `GRAFT_LLM_RETRIES`). Nothing reads or prints it except systemd;
+the CLI only checks that it exists, and the rendered unit references it without
+a leading `-`, so a missing file fails the unit loudly instead of starting a
+build with no key.
+
+Copy an existing deep-build environment file rather than starting from an
+empty one, then set the model the nightly job should spend:
+
+```sh
+install -m 600 ~/.cache/beep/graft-deep-grok.env ~/.config/beep-graft/env
+${EDITOR:-nano} ~/.config/beep-graft/env   # set GRAFT_MODEL=
+bun run beep graft deep install-timer --owner ~/YeeBois/projects/beep-effect0
+```
+
+The nightly job on this workstation runs `GRAFT_MODEL=claude-opus-5` through
+the local proxy; `grok-4.6` and `gpt-6-astra` remain valid values, and the
+effort suffixes in the build section below apply here too.
+
+That renders `beep-graft-deep-refresh.service` and
+`beep-graft-deep-refresh.timer` into `~/.config/systemd/user/`, reloads the
+user manager, and enables the timer for `*-*-* 02:30:00` with a ten-minute
+randomized delay. The service carries its own `PATH` (the mise shims, then
+`~/.local/bin` and `~/.bun/bin`) because a user unit otherwise starts with
+almost none, and `CI=true` so the repo CLI never waits on a prompt. Pass
+`--on-calendar` for a different schedule and `--uninstall` to disable and
+remove both units.
+
+Two `ExecStartPre` lines pull the owner clone and reinstall its dependencies
+before the CLI boots, so each night runs main's current `beep graft deep
+refresh` rather than whatever the clone held the day the timer was installed.
+That is also why the first scheduled run after this lands needs no manual pull:
+the unit updates the clone itself. The CLI repeats both steps once it starts;
+on an already-current clone they are no-ops.
+
+`TimeoutStartSec=8h` bounds the run above the sum of its own phase timeouts
+(a five-hour build plus fetch, install, and per-clone rebuilds).
+`KillMode=mixed` with `TimeoutStopSec=90` is what makes a stop legible:
+`systemctl --user stop` sends `SIGTERM` to the CLI alone, the runtime turns
+that into a fiber interrupt, and the run has time to write `outcome: failed`
+with an `interrupted` message and release its lock before systemd escalates.
+
+Read the last run back with:
+
+```sh
+bun run beep graft deep status            # human summary
+bun run beep graft deep status --json     # the schema-encoded status document
+```
+
+State lives under `~/.local/state/beep-graft`: `status.json` is rewritten
+atomically at every phase transition, `refresh.lock` fences concurrent runs,
+and `runs/<timestamp>.log` holds the captured output of every command that run
+executed, including the deep build. Because the status file is written on entry
+to each phase, `status` shows an in-flight run as `phase: build` with no
+outcome; a lock held by a live process refuses a second run and leaves the
+first run's status untouched.
+
+The outcome is the part worth reading. `ok` means the build finished at or
+above the coverage target and the seed applied with no refusals. `degraded`
+means the night is usable but imperfect: coverage below `--min-coverage`
+(0.95 by default), a seed the sync refused, or a sibling whose structural
+rebuild exited non-zero. `degraded` exits zero on purpose, so a 94% night does
+not page anyone. `failed` means a step refused or exited non-zero; the run
+exits non-zero and sends a critical desktop notification naming the failure.
+
+Run it by hand the same way the timer does, which is also how to test a change
+to the schedule before trusting it overnight:
+
+```sh
+bun run beep graft deep refresh --owner ~/YeeBois/projects/beep-effect0 --jobs 16
+bun run beep graft deep refresh --owner ~/YeeBois/projects/beep-effect0 --no-seed --no-rebuild
+```
+
+`--model` overrides `GRAFT_MODEL` for the build; leaving it off keeps the
+environment file in charge. `--no-seed` stops after the build, and
+`--no-rebuild` seeds without spending time on each clone's structural pass.
+
 ## Build the meaning tier (operator only)
 
 The meaning tier (`graft build --deep`) adds the concept map and the per-symbol

--- a/docs/runbooks/graft-local-recovery.md
+++ b/docs/runbooks/graft-local-recovery.md
@@ -203,11 +203,11 @@ can assume a clean checkout on `main` and pin it without asking. Bootstrap it
 once against an existing clone's object store:
 
 ```sh
-git clone --reference ~/YeeBois/projects/beep-effect \
-  https://github.com/beep-effect/beep-effect.git ~/YeeBois/projects/beep-effect0
-cd ~/YeeBois/projects/beep-effect0 && bun install --frozen-lockfile && graft build
-mise trust ~/YeeBois/projects/beep-effect0/mise.toml
-bun run beep graft cache sync --from ~/YeeBois/projects/beep-effect --to ~/YeeBois/projects/beep-effect0
+git clone --reference $HOME/YeeBois/projects/beep-effect \
+  https://github.com/beep-effect/beep-effect.git $HOME/YeeBois/projects/beep-effect0
+cd $HOME/YeeBois/projects/beep-effect0 && bun install --frozen-lockfile && graft build
+mise trust $HOME/YeeBois/projects/beep-effect0/mise.toml
+bun run beep graft cache sync --from $HOME/YeeBois/projects/beep-effect --to $HOME/YeeBois/projects/beep-effect0
 ```
 
 The HTTPS remote is load-bearing, not a preference. The systemd user manager
@@ -218,7 +218,7 @@ fetches with no credentials at all. Both `refresh` and `install-timer` read
 `https://`. An owner clone that already exists over SSH is re-pointed in place:
 
 ```sh
-git -C ~/YeeBois/projects/beep-effect0 remote set-url origin \
+git -C $HOME/YeeBois/projects/beep-effect0 remote set-url origin \
   https://github.com/beep-effect/beep-effect.git
 ```
 
@@ -231,7 +231,7 @@ night. The first seed is what saves the first night's full build: the refresh
 re-summarizes only changed files, so the owner starts from a meaning tier rather
 than from nothing.
 
-The provider keys live in `~/.config/beep-graft/env`, which systemd reads as
+The provider keys live in `$HOME/.config/beep-graft/env`, which systemd reads as
 the unit's `EnvironmentFile`. It holds the same keys as the deep-build
 environment files below (`GRAFT_PROVIDER`, `GRAFT_BASE_URL`, `GRAFT_API_KEY`,
 `GRAFT_MODEL`, `GRAFT_LLM_RETRIES`). Nothing reads or prints it except systemd;
@@ -243,9 +243,9 @@ Copy an existing deep-build environment file rather than starting from an
 empty one, then set the model the nightly job should spend:
 
 ```sh
-install -m 600 ~/.cache/beep/graft-deep-grok.env ~/.config/beep-graft/env
-${EDITOR:-nano} ~/.config/beep-graft/env   # set GRAFT_MODEL=
-bun run beep graft deep install-timer --owner ~/YeeBois/projects/beep-effect0
+install -m 600 $HOME/.cache/beep/graft-deep-grok.env $HOME/.config/beep-graft/env
+${EDITOR:-nano} $HOME/.config/beep-graft/env   # set GRAFT_MODEL=
+bun run beep graft deep install-timer --owner $HOME/YeeBois/projects/beep-effect0
 ```
 
 The nightly job on this workstation runs `GRAFT_MODEL=claude-opus-5` through
@@ -253,10 +253,10 @@ the local proxy; `grok-4.6` and `gpt-6-astra` remain valid values, and the
 effort suffixes in the build section below apply here too.
 
 That renders `beep-graft-deep-refresh.service` and
-`beep-graft-deep-refresh.timer` into `~/.config/systemd/user/`, reloads the
+`beep-graft-deep-refresh.timer` into `$HOME/.config/systemd/user/`, reloads the
 user manager, and enables the timer for `*-*-* 02:30:00` with a ten-minute
 randomized delay. The service carries its own `PATH` (the mise shims, then
-`~/.local/bin` and `~/.bun/bin`) because a user unit otherwise starts with
+`$HOME/.local/bin` and `$HOME/.bun/bin`) because a user unit otherwise starts with
 almost none, and `CI=true` so the repo CLI never waits on a prompt. Pass
 `--on-calendar` for a different schedule and `--uninstall` to disable and
 remove both units.
@@ -282,7 +282,7 @@ bun run beep graft deep status            # human summary
 bun run beep graft deep status --json     # the schema-encoded status document
 ```
 
-State lives under `~/.local/state/beep-graft`: `status.json` is rewritten
+State lives under `$HOME/.local/state/beep-graft`: `status.json` is rewritten
 atomically at every phase transition, `refresh.lock` fences concurrent runs,
 and `runs/<timestamp>.log` holds the captured output of every command that run
 executed, including the deep build. Because the status file is written on entry
@@ -302,8 +302,8 @@ Run it by hand the same way the timer does, which is also how to test a change
 to the schedule before trusting it overnight:
 
 ```sh
-bun run beep graft deep refresh --owner ~/YeeBois/projects/beep-effect0 --jobs 16
-bun run beep graft deep refresh --owner ~/YeeBois/projects/beep-effect0 --no-seed --no-rebuild
+bun run beep graft deep refresh --owner $HOME/YeeBois/projects/beep-effect0 --jobs 16
+bun run beep graft deep refresh --owner $HOME/YeeBois/projects/beep-effect0 --no-seed --no-rebuild
 ```
 
 `--model` overrides `GRAFT_MODEL` for the build; leaving it off keeps the

--- a/packages/tooling/tool/cli/src/commands/Graft/Graft.command.ts
+++ b/packages/tooling/tool/cli/src/commands/Graft/Graft.command.ts
@@ -4,15 +4,26 @@
  * @packageDocumentation
  * @since 0.0.0
  */
-import { Console, Effect } from "effect";
+import { Config, Console, Effect } from "effect";
 import * as A from "effect/Array";
+import * as Num from "effect/Number";
 import * as O from "effect/Option";
+import * as Path from "effect/Path";
 import * as S from "effect/Schema";
+import * as Str from "effect/String";
 import { Command, Flag } from "effect/unstable/cli";
 import { printCommandJson } from "../../internal/cli/Json.ts";
-import { GraftCacheIoError, GraftCacheTargetError } from "./Graft.errors.ts";
-import { GraftCacheSyncAction, GraftCacheSyncPlan, GraftCacheSyncReport } from "./Graft.schemas.ts";
+import { GraftCacheIoError, GraftCacheTargetError, GraftDeepPreflightError } from "./Graft.errors.ts";
+import {
+  GraftCacheSyncAction,
+  GraftCacheSyncPlan,
+  GraftCacheSyncReport,
+  GraftDeepRefreshOptions,
+  GraftDeepRefreshStatus,
+  GraftDeepTimerOptions,
+} from "./Graft.schemas.ts";
 import { GraftCacheSync, GraftCacheSyncLive } from "./Graft.service.ts";
+import { GraftDeepRefresh, GraftDeepRefreshLive, GraftDeepRefreshProgress } from "./GraftDeep.service.ts";
 
 const flags = {
   from: Flag.String("from").pipe(Flag.withDescription("Source clone containing graft/.cache/summaries.json")),
@@ -103,6 +114,209 @@ const cacheCommand = Command.make("cache", {}, () =>
   Console.log("Graft cache commands: sync --from <cloneDir> (--to <cloneDir>... | --siblings) [--dry-run] [--json]")
 ).pipe(Command.withDescription("Manage clone-local Graft meaning artifacts"), Command.withSubcommands([syncCommand]));
 
+const decodeRefreshOptions = S.decodeEffect(GraftDeepRefreshOptions);
+
+const deepFlags = {
+  owner: Flag.String("owner").pipe(Flag.withDescription("Owner clone the refresh pins to main and rebuilds in")),
+  model: Flag.String("model").pipe(
+    Flag.optional,
+    Flag.withDescription("GRAFT_MODEL for the deep build; omitted leaves the environment file in charge")
+  ),
+  jobs: Flag.Int("jobs").pipe(Flag.withDefault(16), Flag.withDescription("Crux-pass concurrency passed to graft -j")),
+  minCoverage: Flag.Finite("min-coverage").pipe(
+    Flag.withDefault(0.95),
+    Flag.withDescription("Symbol coverage below which the run reports degraded instead of ok")
+  ),
+  seed: Flag.Boolean("seed").pipe(
+    Flag.withDefault(true),
+    Flag.withDescription("Seed the rebuilt meaning tier into sibling clones; --no-seed skips it")
+  ),
+  rebuild: Flag.Boolean("rebuild").pipe(
+    Flag.withDefault(true),
+    Flag.withDescription("Run a structural graft build in every seeded clone; --no-rebuild skips it")
+  ),
+  rebuildConcurrency: Flag.Int("rebuild-concurrency").pipe(
+    Flag.withDefault(2),
+    Flag.withDescription("How many sibling rebuilds run at once")
+  ),
+  stateDir: Flag.String("state-dir").pipe(
+    Flag.optional,
+    Flag.withDescription("Status, lock, and run logs directory (default ~/.local/state/beep-graft)")
+  ),
+  json: Flag.Boolean("json").pipe(Flag.withDefault(false), Flag.withDescription("Print the schema-encoded status")),
+};
+
+const statusFlags = {
+  stateDir: deepFlags.stateDir,
+  json: deepFlags.json,
+};
+
+const timerFlags = {
+  owner: deepFlags.owner,
+  onCalendar: Flag.String("on-calendar").pipe(
+    Flag.withDefault("*-*-* 02:30:00"),
+    Flag.withDescription("systemd OnCalendar expression for the nightly refresh")
+  ),
+  envFile: Flag.String("env-file").pipe(
+    Flag.optional,
+    Flag.withDescription("EnvironmentFile with the Graft provider keys (default ~/.config/beep-graft/env)")
+  ),
+  uninstall: Flag.Boolean("uninstall").pipe(
+    Flag.withDefault(false),
+    Flag.withDescription("Disable and remove the refresh timer and service units")
+  ),
+};
+
+// Operators type `~/...` and relative paths; systemd and the lock file need
+// absolute ones, and no shell is involved to expand either.
+const resolveOperatorPath = (home: string, resolve: (input: string) => string, input: string): string =>
+  resolve(Str.startsWith("~/")(input) ? `${home}/${Str.slice(2)(input)}` : input);
+
+const renderStatus = (status: GraftDeepRefreshStatus): string =>
+  A.join(
+    [
+      `Graft deep refresh: ${status.phase}${O.getOrElse(
+        O.map(O.fromUndefinedOr(status.outcome), (outcome) => ` (${outcome})`),
+        () => ""
+      )}`,
+      `Owner: ${status.owner}${O.getOrElse(
+        O.map(O.fromUndefinedOr(status.head), (head) => ` at ${head}`),
+        () => ""
+      )}`,
+      `Model: ${status.model}; jobs: ${status.jobs}; started: ${status.startedAt}${O.getOrElse(
+        O.map(O.fromUndefinedOr(status.finishedAt), (finished) => `; finished: ${finished}`),
+        () => ""
+      )}`,
+      O.getOrElse(
+        O.map(
+          O.fromUndefinedOr(status.coverage),
+          (coverage) =>
+            `Coverage: ${coverage.covered}/${coverage.total} symbols (${coverage.total === 0 ? 0 : Num.round((coverage.covered / coverage.total) * 100, 1)}%); failed files: ${coverage.failedFiles}`
+        ),
+        () => "Coverage: not reported"
+      ),
+      O.getOrElse(
+        O.map(
+          O.fromUndefinedOr(status.seed),
+          (seed) =>
+            `Seeded: ${seed.copied} copied, ${seed.removed} removed, ${seed.skipped} skipped, ${seed.bytes} bytes`
+        ),
+        () => "Seeded: nothing applied"
+      ),
+      `Rebuilt: ${A.length(status.rebuilt)} clone(s), ${A.length(A.filter(status.rebuilt, (entry) => entry.exitCode !== 0))} failing`,
+      `Log: ${status.log}`,
+      ...A.map(
+        A.filter([O.getOrElse(O.fromUndefinedOr(status.message), () => "")], Str.isNonEmpty),
+        (message) => `Note: ${message}`
+      ),
+    ],
+    "\n"
+  );
+
+const deepRefreshCommand = Command.make(
+  "refresh",
+  deepFlags,
+  Effect.fn("GraftCommand.deepRefresh")(function* (options) {
+    const path = yield* Path.Path;
+    const home = yield* Effect.orDie(Config.String("HOME"));
+    const decoded = yield* decodeRefreshOptions({
+      owner: resolveOperatorPath(home, path.resolve, options.owner),
+      jobs: options.jobs,
+      minCoverage: options.minCoverage,
+      seed: options.seed,
+      rebuild: options.rebuild,
+      rebuildConcurrency: options.rebuildConcurrency,
+      stateDir: resolveOperatorPath(
+        home,
+        path.resolve,
+        O.getOrElse(options.stateDir, () => path.join(home, ".local", "state", "beep-graft"))
+      ),
+      ...O.getOrElse(
+        O.map(options.model, (model) => ({ model })),
+        () => ({})
+      ),
+    }).pipe(
+      Effect.mapError((cause) =>
+        GraftDeepPreflightError.make({ path: options.owner, message: "Invalid refresh options.", cause })
+      )
+    );
+    const refresh = yield* GraftDeepRefresh;
+    const status = yield* refresh
+      .run(decoded)
+      .pipe(
+        Effect.provideService(GraftDeepRefreshProgress, (phase) =>
+          options.json ? Effect.void : Console.log(`graft deep refresh: ${phase.phase}`)
+        )
+      );
+    yield* emit(options.json, status, GraftDeepRefreshStatus, renderStatus(status));
+  })
+).pipe(
+  Command.withDescription("Rebuild the meaning tier in the owner clone, then seed and rebuild the siblings"),
+  Command.provide(GraftDeepRefreshLive)
+);
+
+const deepStatusCommand = Command.make(
+  "status",
+  statusFlags,
+  Effect.fn("GraftCommand.deepStatus")(function* (options) {
+    const path = yield* Path.Path;
+    const home = yield* Effect.orDie(Config.String("HOME"));
+    const stateDir = resolveOperatorPath(
+      home,
+      path.resolve,
+      O.getOrElse(options.stateDir, () => path.join(home, ".local", "state", "beep-graft"))
+    );
+    const refresh = yield* GraftDeepRefresh;
+    const status = yield* refresh.readStatus(stateDir);
+    if (O.isNone(status)) {
+      return yield* Console.log(`No refresh recorded under ${stateDir}.`);
+    }
+    yield* emit(options.json, status.value, GraftDeepRefreshStatus, renderStatus(status.value));
+  })
+).pipe(
+  Command.withDescription("Render the most recent refresh status, including an in-flight run"),
+  Command.provide(GraftDeepRefreshLive)
+);
+
+const deepInstallTimerCommand = Command.make(
+  "install-timer",
+  timerFlags,
+  Effect.fn("GraftCommand.deepInstallTimer")(function* (options) {
+    const path = yield* Path.Path;
+    const home = yield* Effect.orDie(Config.String("HOME"));
+    const refresh = yield* GraftDeepRefresh;
+    const units = yield* refresh.installTimer(
+      GraftDeepTimerOptions.make({
+        owner: resolveOperatorPath(home, path.resolve, options.owner),
+        bunPath: process.execPath,
+        onCalendar: options.onCalendar,
+        envFile: resolveOperatorPath(
+          home,
+          path.resolve,
+          O.getOrElse(options.envFile, () => path.join(home, ".config", "beep-graft", "env"))
+        ),
+        uninstall: options.uninstall,
+      })
+    );
+    yield* Console.log(
+      A.join(
+        A.prepend(units, options.uninstall ? "graft deep install-timer: removed" : "graft deep install-timer: wrote"),
+        "\n"
+      )
+    );
+  })
+).pipe(
+  Command.withDescription("Install or remove the nightly refresh systemd user timer"),
+  Command.provide(GraftDeepRefreshLive)
+);
+
+const deepCommand = Command.make("deep", {}, () =>
+  Console.log("Graft deep commands: refresh --owner <cloneDir>, status, install-timer --owner <cloneDir>")
+).pipe(
+  Command.withDescription("Operator-only meaning-tier refresh; refresh spends model quota through graft build --deep"),
+  Command.withSubcommands([deepRefreshCommand, deepStatusCommand, deepInstallTimerCommand])
+);
+
 /**
  * Registers `beep graft cache sync` for local meaning-tier seeding.
  *
@@ -121,7 +335,9 @@ const cacheCommand = Command.make("cache", {}, () =>
  * @category cli-commands
  * @since 0.0.0
  */
-export const graftCommand = Command.make("graft", {}, () => Console.log("Graft commands: cache sync")).pipe(
+export const graftCommand = Command.make("graft", {}, () =>
+  Console.log("Graft commands: cache sync; deep refresh|status|install-timer")
+).pipe(
   Command.withDescription("Repo-owned operations on clone-local Graft caches"),
-  Command.withSubcommands([cacheCommand])
+  Command.withSubcommands([cacheCommand, deepCommand])
 );

--- a/packages/tooling/tool/cli/src/commands/Graft/Graft.command.ts
+++ b/packages/tooling/tool/cli/src/commands/Graft/Graft.command.ts
@@ -172,6 +172,13 @@ const timerFlags = {
 const resolveOperatorPath = (home: string, resolve: (input: string) => string, input: string): string =>
   resolve(Str.startsWith("~/")(input) ? `${home}/${Str.slice(2)(input)}` : input);
 
+const defaultStateDir = (home: string, path: Path.Path, configured: O.Option<string>): string =>
+  resolveOperatorPath(
+    home,
+    path.resolve,
+    O.getOrElse(configured, () => path.join(home, ".local", "state", "beep-graft"))
+  );
+
 const renderStatus = (status: GraftDeepRefreshStatus): string =>
   A.join(
     [
@@ -213,99 +220,187 @@ const renderStatus = (status: GraftDeepRefreshStatus): string =>
     "\n"
   );
 
-const deepRefreshCommand = Command.make(
-  "refresh",
-  deepFlags,
-  Effect.fn("GraftCommand.deepRefresh")(function* (options) {
-    const path = yield* Path.Path;
-    const home = yield* Effect.orDie(Config.String("HOME"));
-    const decoded = yield* decodeRefreshOptions({
-      owner: resolveOperatorPath(home, path.resolve, options.owner),
-      jobs: options.jobs,
-      minCoverage: options.minCoverage,
-      seed: options.seed,
-      rebuild: options.rebuild,
-      rebuildConcurrency: options.rebuildConcurrency,
-      stateDir: resolveOperatorPath(
-        home,
-        path.resolve,
-        O.getOrElse(options.stateDir, () => path.join(home, ".local", "state", "beep-graft"))
-      ),
-      ...O.getOrElse(
-        O.map(options.model, (model) => ({ model })),
-        () => ({})
-      ),
-    }).pipe(
-      Effect.mapError((cause) =>
-        GraftDeepPreflightError.make({ path: options.owner, message: "Invalid refresh options.", cause })
+/**
+ * Runs one nightly meaning-tier refresh and renders or encodes its status.
+ *
+ * **Details**
+ *
+ * Exported so the handler can be driven under a scripted subprocess runner:
+ * the command wiring only supplies flags and the live layer. `--json`
+ * suppresses the per-phase lines so the encoded document is the only output.
+ *
+ * **Example** (Build a refresh program without running it)
+ *
+ * ```ts import.meta.vitest name="Build a refresh program without running it"
+ * import { runDeepRefresh } from "@beep/repo-cli/commands/Graft"
+ * import * as Effect from "effect/Effect"
+ * import * as O from "effect/Option"
+ * const program = runDeepRefresh({
+ *   owner: "/clones/beep-effect0",
+ *   model: O.none(),
+ *   jobs: 16,
+ *   minCoverage: 0.95,
+ *   seed: true,
+ *   rebuild: true,
+ *   rebuildConcurrency: 2,
+ *   stateDir: O.some("/state/beep-graft"),
+ *   json: false,
+ * })
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @param options - Resolved `graft deep refresh` flags.
+ * @returns The rendered or encoded status of the finished run.
+ * @category cli-commands
+ * @since 0.0.0
+ */
+export const runDeepRefresh = Effect.fn("GraftCommand.runDeepRefresh")(function* (options: {
+  readonly owner: string;
+  readonly model: O.Option<string>;
+  readonly jobs: number;
+  readonly minCoverage: number;
+  readonly seed: boolean;
+  readonly rebuild: boolean;
+  readonly rebuildConcurrency: number;
+  readonly stateDir: O.Option<string>;
+  readonly json: boolean;
+}) {
+  const path = yield* Path.Path;
+  const home = yield* Effect.orDie(Config.String("HOME"));
+  const decoded = yield* decodeRefreshOptions({
+    owner: resolveOperatorPath(home, path.resolve, options.owner),
+    jobs: options.jobs,
+    minCoverage: options.minCoverage,
+    seed: options.seed,
+    rebuild: options.rebuild,
+    rebuildConcurrency: options.rebuildConcurrency,
+    stateDir: defaultStateDir(home, path, options.stateDir),
+    ...O.getOrElse(
+      O.map(options.model, (model) => ({ model })),
+      () => ({})
+    ),
+  }).pipe(
+    Effect.mapError((cause) =>
+      GraftDeepPreflightError.make({ path: options.owner, message: "Invalid refresh options.", cause })
+    )
+  );
+  const refresh = yield* GraftDeepRefresh;
+  const status = yield* refresh
+    .run(decoded)
+    .pipe(
+      Effect.provideService(GraftDeepRefreshProgress, (phase) =>
+        options.json ? Effect.void : Console.log(`graft deep refresh: ${phase.phase}`)
       )
     );
-    const refresh = yield* GraftDeepRefresh;
-    const status = yield* refresh
-      .run(decoded)
-      .pipe(
-        Effect.provideService(GraftDeepRefreshProgress, (phase) =>
-          options.json ? Effect.void : Console.log(`graft deep refresh: ${phase.phase}`)
-        )
-      );
-    yield* emit(options.json, status, GraftDeepRefreshStatus, renderStatus(status));
-  })
-).pipe(
+  yield* emit(options.json, status, GraftDeepRefreshStatus, renderStatus(status));
+});
+
+/**
+ * Renders the recorded refresh status, or says that none was recorded.
+ *
+ * **Details**
+ *
+ * An in-flight run is readable: its status carries a phase and no outcome.
+ *
+ * **Example** (Build a status program without running it)
+ *
+ * ```ts import.meta.vitest name="Build a status program without running it"
+ * import { runDeepStatus } from "@beep/repo-cli/commands/Graft"
+ * import * as Effect from "effect/Effect"
+ * import * as O from "effect/Option"
+ * const program = runDeepStatus({ stateDir: O.none(), json: true })
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @param options - Resolved `graft deep status` flags.
+ * @returns The rendered or encoded status, when one is recorded.
+ * @category cli-commands
+ * @since 0.0.0
+ */
+export const runDeepStatus = Effect.fn("GraftCommand.runDeepStatus")(function* (options: {
+  readonly stateDir: O.Option<string>;
+  readonly json: boolean;
+}) {
+  const path = yield* Path.Path;
+  const home = yield* Effect.orDie(Config.String("HOME"));
+  const stateDir = defaultStateDir(home, path, options.stateDir);
+  const refresh = yield* GraftDeepRefresh;
+  const status = yield* refresh.readStatus(stateDir);
+  if (O.isNone(status)) {
+    return yield* Console.log(`No refresh recorded under ${stateDir}.`);
+  }
+  yield* emit(options.json, status.value, GraftDeepRefreshStatus, renderStatus(status.value));
+});
+
+/**
+ * Installs or removes the nightly refresh systemd user timer.
+ *
+ * **Details**
+ *
+ * The installer stats the environment file and refuses a missing one; an
+ * uninstall reports only the unit files it actually removed.
+ *
+ * **Example** (Build an install program without running it)
+ *
+ * ```ts import.meta.vitest name="Build an install program without running it"
+ * import { runDeepInstallTimer } from "@beep/repo-cli/commands/Graft"
+ * import * as Effect from "effect/Effect"
+ * import * as O from "effect/Option"
+ * const program = runDeepInstallTimer({
+ *   owner: "/clones/beep-effect0",
+ *   onCalendar: "*-*-* 02:30:00",
+ *   envFile: O.none(),
+ *   uninstall: false,
+ * })
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @param options - Resolved `graft deep install-timer` flags.
+ * @returns Nothing; the written or removed unit paths are printed.
+ * @category cli-commands
+ * @since 0.0.0
+ */
+export const runDeepInstallTimer = Effect.fn("GraftCommand.runDeepInstallTimer")(function* (options: {
+  readonly owner: string;
+  readonly onCalendar: string;
+  readonly envFile: O.Option<string>;
+  readonly uninstall: boolean;
+}) {
+  const path = yield* Path.Path;
+  const home = yield* Effect.orDie(Config.String("HOME"));
+  const refresh = yield* GraftDeepRefresh;
+  const units = yield* refresh.installTimer(
+    GraftDeepTimerOptions.make({
+      owner: resolveOperatorPath(home, path.resolve, options.owner),
+      bunPath: process.execPath,
+      onCalendar: options.onCalendar,
+      envFile: resolveOperatorPath(
+        home,
+        path.resolve,
+        O.getOrElse(options.envFile, () => path.join(home, ".config", "beep-graft", "env"))
+      ),
+      uninstall: options.uninstall,
+    })
+  );
+  const headline = options.uninstall ? "graft deep install-timer: removed" : "graft deep install-timer: wrote";
+  yield* Console.log(
+    A.isReadonlyArrayNonEmpty(units)
+      ? A.join(A.prepend(units, headline), "\n")
+      : "graft deep install-timer: no unit files were installed"
+  );
+});
+
+const deepRefreshCommand = Command.make("refresh", deepFlags, runDeepRefresh).pipe(
   Command.withDescription("Rebuild the meaning tier in the owner clone, then seed and rebuild the siblings"),
   Command.provide(GraftDeepRefreshLive)
 );
 
-const deepStatusCommand = Command.make(
-  "status",
-  statusFlags,
-  Effect.fn("GraftCommand.deepStatus")(function* (options) {
-    const path = yield* Path.Path;
-    const home = yield* Effect.orDie(Config.String("HOME"));
-    const stateDir = resolveOperatorPath(
-      home,
-      path.resolve,
-      O.getOrElse(options.stateDir, () => path.join(home, ".local", "state", "beep-graft"))
-    );
-    const refresh = yield* GraftDeepRefresh;
-    const status = yield* refresh.readStatus(stateDir);
-    if (O.isNone(status)) {
-      return yield* Console.log(`No refresh recorded under ${stateDir}.`);
-    }
-    yield* emit(options.json, status.value, GraftDeepRefreshStatus, renderStatus(status.value));
-  })
-).pipe(
+const deepStatusCommand = Command.make("status", statusFlags, runDeepStatus).pipe(
   Command.withDescription("Render the most recent refresh status, including an in-flight run"),
   Command.provide(GraftDeepRefreshLive)
 );
 
-const deepInstallTimerCommand = Command.make(
-  "install-timer",
-  timerFlags,
-  Effect.fn("GraftCommand.deepInstallTimer")(function* (options) {
-    const path = yield* Path.Path;
-    const home = yield* Effect.orDie(Config.String("HOME"));
-    const refresh = yield* GraftDeepRefresh;
-    const units = yield* refresh.installTimer(
-      GraftDeepTimerOptions.make({
-        owner: resolveOperatorPath(home, path.resolve, options.owner),
-        bunPath: process.execPath,
-        onCalendar: options.onCalendar,
-        envFile: resolveOperatorPath(
-          home,
-          path.resolve,
-          O.getOrElse(options.envFile, () => path.join(home, ".config", "beep-graft", "env"))
-        ),
-        uninstall: options.uninstall,
-      })
-    );
-    yield* Console.log(
-      A.join(
-        A.prepend(units, options.uninstall ? "graft deep install-timer: removed" : "graft deep install-timer: wrote"),
-        "\n"
-      )
-    );
-  })
-).pipe(
+const deepInstallTimerCommand = Command.make("install-timer", timerFlags, runDeepInstallTimer).pipe(
   Command.withDescription("Install or remove the nightly refresh systemd user timer"),
   Command.provide(GraftDeepRefreshLive)
 );

--- a/packages/tooling/tool/cli/src/commands/Graft/Graft.errors.ts
+++ b/packages/tooling/tool/cli/src/commands/Graft/Graft.errors.ts
@@ -1,5 +1,5 @@
 /**
- * Typed failures for Graft cache validation and filesystem operations.
+ * Typed failures for Graft cache validation, filesystem, and refresh operations.
  *
  * @packageDocumentation
  * @since 0.0.0
@@ -7,6 +7,7 @@
 import { $RepoCliId } from "@beep/identity/packages";
 import { Defect } from "@beep/schema";
 import * as S from "effect/Schema";
+import { GraftDeepRefreshPhase } from "./Graft.schemas.ts";
 
 const $I = $RepoCliId.create("commands/Graft/Graft.errors");
 
@@ -85,5 +86,97 @@ export class GraftCacheIoError extends S.TaggedError<GraftCacheIoError>($I`Graft
   { path: S.String, message: S.String, cause: Defect({ includeStack: true }) },
   $I.annoteError<GraftCacheIoError>("GraftCacheIoError", {
     description: "Filesystem or schema encoding failure during cache sync.",
+  })
+) {}
+
+/**
+ * Refuses to start a refresh while another run holds the lock.
+ *
+ * **Details**
+ *
+ * A lock whose holder process is gone is replaced instead of reported, so this
+ * failure always names a process that was alive when the lock was inspected.
+ *
+ * **Example** (Name the run holding the lock)
+ *
+ * ```ts import.meta.vitest name="Name the run holding the lock"
+ * import { GraftDeepLockError } from "@beep/repo-cli/commands/Graft"
+ * console.log(GraftDeepLockError.make({ path: "/state/refresh.lock", holderPid: 4321 }).holderPid)
+ * // 4321
+ * ```
+ *
+ * @category errors
+ * @since 0.0.0
+ */
+export class GraftDeepLockError extends S.TaggedError<GraftDeepLockError>($I`GraftDeepLockError`)(
+  "GraftDeepLockError",
+  { path: S.String, holderPid: S.Int, cause: S.optionalKey(Defect({ includeStack: true })) },
+  $I.annoteError<GraftDeepLockError>("GraftDeepLockError", {
+    description: "Refresh lock is held by a live process.",
+  })
+) {}
+
+/**
+ * Rejects an owner clone or operator environment a refresh must not touch.
+ *
+ * **Details**
+ *
+ * Preflight refuses before any Git or Graft work, so a rejected run leaves the
+ * owner clone exactly as it found it.
+ *
+ * **Example** (Explain a dirty owner clone)
+ *
+ * ```ts import.meta.vitest name="Explain a dirty owner clone"
+ * import { GraftDeepPreflightError } from "@beep/repo-cli/commands/Graft"
+ * console.log(GraftDeepPreflightError.make({ path: "/clones/a", message: "Working tree is dirty." })._tag)
+ * // "GraftDeepPreflightError"
+ * ```
+ *
+ * @category errors
+ * @since 0.0.0
+ */
+export class GraftDeepPreflightError extends S.TaggedError<GraftDeepPreflightError>($I`GraftDeepPreflightError`)(
+  "GraftDeepPreflightError",
+  { path: S.String, message: S.String, cause: S.optionalKey(Defect({ includeStack: true })) },
+  $I.annoteError<GraftDeepPreflightError>("GraftDeepPreflightError", {
+    description: "Owner clone or operator environment is unfit for a refresh.",
+  })
+) {}
+
+/**
+ * Retains the phase, exit code, and log of a refresh step that failed.
+ *
+ * **Details**
+ *
+ * The log path is the run log the captured output was appended to, so the
+ * operator never has to reproduce the step to read what it printed.
+ *
+ * **Example** (Point at the failing phase and log)
+ *
+ * ```ts import.meta.vitest name="Point at the failing phase and log"
+ * import { GraftDeepStepError } from "@beep/repo-cli/commands/Graft"
+ * const error = GraftDeepStepError.make({
+ *   step: "build",
+ *   exitCode: 1,
+ *   log: "/state/beep-graft/runs/20260911T023000Z.log",
+ *   message: "graft build --deep exited with 1.",
+ * })
+ * console.log(error.step) // build
+ * ```
+ *
+ * @category errors
+ * @since 0.0.0
+ */
+export class GraftDeepStepError extends S.TaggedError<GraftDeepStepError>($I`GraftDeepStepError`)(
+  "GraftDeepStepError",
+  {
+    step: GraftDeepRefreshPhase,
+    exitCode: S.Int,
+    log: S.String,
+    message: S.String,
+    cause: S.optionalKey(Defect({ includeStack: true })),
+  },
+  $I.annoteError<GraftDeepStepError>("GraftDeepStepError", {
+    description: "A refresh step refused to spawn, timed out, or exited non-zero.",
   })
 ) {}

--- a/packages/tooling/tool/cli/src/commands/Graft/Graft.schemas.ts
+++ b/packages/tooling/tool/cli/src/commands/Graft/Graft.schemas.ts
@@ -1,12 +1,18 @@
 /**
- * Plans and receipts for copying clone-local Graft meaning artifacts.
+ * Plans, receipts, and refresh status for clone-local Graft meaning artifacts.
  *
  * @packageDocumentation
  * @since 0.0.0
  */
 import { $RepoCliId } from "@beep/identity/packages";
-import { LiteralKit, NonNegativeInt } from "@beep/schema";
+import { LiteralKit, NonNegativeInt, PosInt } from "@beep/schema";
+import { UnitInterval } from "@beep/schema/UnitInterval";
+import { pipe } from "effect";
+import * as A from "effect/Array";
+import * as O from "effect/Option";
+import * as Result from "effect/Result";
 import * as S from "effect/Schema";
+import * as Str from "effect/String";
 
 const $I = $RepoCliId.create("commands/Graft/Graft.schemas");
 
@@ -187,5 +193,357 @@ export class GraftCacheSyncReport extends S.Class<GraftCacheSyncReport>($I`Graft
   },
   $I.annote("GraftCacheSyncReport", {
     description: "Applied sync plan with copy, removal, skip, and refusal counts and exact bytes copied.",
+  })
+) {}
+
+/**
+ * Ordered stages of one nightly meaning-tier refresh.
+ *
+ * **Details**
+ *
+ * The status file records the stage a run reached, so an interrupted run is
+ * distinguishable from a finished one by its phase rather than by its outcome.
+ *
+ * **Example** (Inspect the refresh stages)
+ *
+ * ```ts import.meta.vitest name="Inspect the refresh stages"
+ * import { GraftDeepRefreshPhase } from "@beep/repo-cli/commands/Graft"
+ * console.log(GraftDeepRefreshPhase.Options)
+ * // ["preflight", "pull", "install", "build", "seed", "rebuild", "done"]
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const GraftDeepRefreshPhase = LiteralKit([
+  "preflight",
+  "pull",
+  "install",
+  "build",
+  "seed",
+  "rebuild",
+  "done",
+]).pipe(
+  $I.annoteSchema("GraftDeepRefreshPhase", {
+    description: "Ordered stages of a nightly Graft meaning-tier refresh run.",
+  })
+);
+
+/**
+ * A stage reached by a nightly meaning-tier refresh.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type GraftDeepRefreshPhase = typeof GraftDeepRefreshPhase.Type;
+
+/**
+ * Verdict a finished refresh run reports to its operator.
+ *
+ * **Details**
+ *
+ * Only `failed` is worth paging for: it means a step refused or exited
+ * non-zero. A `degraded` run still seeded the siblings, so the nightly timer
+ * exits zero on it.
+ *
+ * **Example** (Recognize a degraded verdict)
+ *
+ * ```ts import.meta.vitest name="Recognize a degraded verdict"
+ * import { GraftDeepRefreshOutcome } from "@beep/repo-cli/commands/Graft"
+ * console.log(GraftDeepRefreshOutcome.is.degraded("degraded")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const GraftDeepRefreshOutcome = LiteralKit(["ok", "degraded", "failed"]).pipe(
+  $I.annoteSchema("GraftDeepRefreshOutcome", {
+    description: "Verdict of a finished refresh: clean, usable but below target, or failed.",
+  })
+);
+
+/**
+ * A verdict reported by a finished refresh run.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type GraftDeepRefreshOutcome = typeof GraftDeepRefreshOutcome.Type;
+
+/**
+ * Symbol coverage and summary failures reported by a deep build.
+ *
+ * **Details**
+ *
+ * `covered` and `total` count symbols, not files. `failedFiles` counts the
+ * files whose summary request never completed, which stays zero when the
+ * build never printed that line.
+ *
+ * **Example** (Describe a 98% build)
+ *
+ * ```ts import.meta.vitest name="Describe a 98% build"
+ * import { GraftDeepCoverage } from "@beep/repo-cli/commands/Graft"
+ * import { NonNegativeInt } from "@beep/schema/Number"
+ * const coverage = GraftDeepCoverage.make({
+ *   covered: NonNegativeInt.make(38_520),
+ *   total: NonNegativeInt.make(39_115),
+ *   failedFiles: NonNegativeInt.make(1),
+ * })
+ * console.log(coverage.covered) // 38520
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class GraftDeepCoverage extends S.Class<GraftDeepCoverage>($I`GraftDeepCoverage`)(
+  { covered: NonNegativeInt, total: NonNegativeInt, failedFiles: NonNegativeInt },
+  $I.annote("GraftDeepCoverage", {
+    description: "Symbol coverage and failed-summary counts parsed from a deep build's output.",
+  })
+) {}
+
+// Graft prints its progress with carriage returns, so a coverage line can share
+// a physical line with the progress counter that preceded it. Both patterns are
+// global because only the last occurrence in a long log describes the finished
+// build.
+const DEEP_COVERAGE_LINE = /meaning coverage:\s*(\d+)\s*\/\s*(\d+)\s*symbols/gu;
+const DEEP_FAILED_FILES_LINE = /(\d+)\s*file\(s\)\s+failed to summarize/gu;
+
+const DeepCoverageCounts = S.Struct({
+  covered: S.FiniteFromString,
+  total: S.FiniteFromString,
+  failedFiles: S.FiniteFromString,
+}).pipe(S.decodeTo(GraftDeepCoverage));
+
+const decodeDeepCoverageCounts = S.decodeUnknownResult(DeepCoverageCounts);
+
+const lastDeepMatch = (pattern: RegExp, text: string): O.Option<RegExpMatchArray> =>
+  A.last(A.fromIterable(Str.matchAll(pattern)(text)));
+
+/**
+ * Reads the symbol coverage a deep build reported in its captured output.
+ *
+ * **Details**
+ *
+ * Carriage returns are normalized to newlines before matching, and the last
+ * coverage line wins. A missing `file(s) failed to summarize` line means no
+ * file failed, not unknown; a missing coverage line yields `O.none()`.
+ *
+ * **Example** (Read coverage out of build output)
+ *
+ * ```ts import.meta.vitest name="Read coverage out of build output"
+ * import { parseDeepCoverage } from "@beep/repo-cli/commands/Graft"
+ * import * as O from "effect/Option"
+ * const parsed = parseDeepCoverage("meaning coverage: 38520/39115 symbols (98%).\n")
+ * console.log(O.map(parsed, (coverage) => coverage.total)) // { _id: 'Option', _tag: 'Some', value: 39115 }
+ * ```
+ *
+ * @param text - Captured stdout and stderr of `graft build --deep`.
+ * @returns The parsed coverage when the build printed a coverage line.
+ * @category parsing
+ * @since 0.0.0
+ */
+export const parseDeepCoverage = (text: string): O.Option<GraftDeepCoverage> => {
+  const normalized = Str.replaceAll("\r", "\n")(text);
+  return pipe(
+    lastDeepMatch(DEEP_COVERAGE_LINE, normalized),
+    O.flatMap((coverage) =>
+      O.all({
+        covered: O.fromUndefinedOr(coverage[1]),
+        total: O.fromUndefinedOr(coverage[2]),
+        failedFiles: O.some(
+          pipe(
+            lastDeepMatch(DEEP_FAILED_FILES_LINE, normalized),
+            O.flatMap((failed) => O.fromUndefinedOr(failed[1])),
+            O.getOrElse(() => "0")
+          )
+        ),
+      })
+    ),
+    O.flatMap((counts) => Result.getSuccess(decodeDeepCoverageCounts(counts)))
+  );
+};
+
+/**
+ * Everything one refresh run needs, already resolved to absolute paths.
+ *
+ * **Details**
+ *
+ * An absent `model` leaves `GRAFT_MODEL` to the environment file the systemd
+ * unit loads, so the timer can change models without touching the unit.
+ *
+ * **Example** (Configure a nightly run)
+ *
+ * ```ts import.meta.vitest name="Configure a nightly run"
+ * import { GraftDeepRefreshOptions } from "@beep/repo-cli/commands/Graft"
+ * import { PosInt } from "@beep/schema/Int"
+ * import { UnitInterval } from "@beep/schema/UnitInterval"
+ * const options = GraftDeepRefreshOptions.make({
+ *   owner: "/clones/beep-effect0",
+ *   jobs: PosInt.make(16),
+ *   minCoverage: UnitInterval.make(0.95),
+ *   seed: true,
+ *   rebuild: true,
+ *   rebuildConcurrency: PosInt.make(2),
+ *   stateDir: "/state/beep-graft",
+ * })
+ * console.log(options.jobs) // 16
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class GraftDeepRefreshOptions extends S.Class<GraftDeepRefreshOptions>($I`GraftDeepRefreshOptions`)(
+  {
+    owner: S.String,
+    model: S.optional(S.String),
+    jobs: PosInt,
+    minCoverage: UnitInterval,
+    seed: S.Boolean,
+    rebuild: S.Boolean,
+    rebuildConcurrency: PosInt,
+    stateDir: S.String,
+  },
+  $I.annote("GraftDeepRefreshOptions", {
+    description: "Resolved inputs of one nightly meaning-tier refresh run.",
+  })
+) {}
+
+/**
+ * Result of the structural rebuild run in one seeded clone.
+ *
+ * **Details**
+ *
+ * A non-zero `exitCode` degrades the run instead of failing it: the seeded
+ * meaning tier is already in place and the clone's own rebuild can be retried.
+ *
+ * **Example** (Record a rebuilt clone)
+ *
+ * ```ts import.meta.vitest name="Record a rebuilt clone"
+ * import { GraftDeepSiblingRebuild } from "@beep/repo-cli/commands/Graft"
+ * import { NonNegativeInt } from "@beep/schema/Number"
+ * const rebuilt = GraftDeepSiblingRebuild.make({
+ *   root: "/clones/beep-effect2",
+ *   exitCode: 0,
+ *   seconds: NonNegativeInt.make(42),
+ * })
+ * console.log(rebuilt.exitCode) // 0
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class GraftDeepSiblingRebuild extends S.Class<GraftDeepSiblingRebuild>($I`GraftDeepSiblingRebuild`)(
+  { root: S.String, exitCode: S.Int, seconds: NonNegativeInt },
+  $I.annote("GraftDeepSiblingRebuild", {
+    description: "Exit status and wall time of one seeded clone's structural rebuild.",
+  })
+) {}
+
+/**
+ * The single file a human or a later run reads to learn what the last refresh did.
+ *
+ * **Details**
+ *
+ * It is rewritten at every phase transition, so an in-flight run is readable:
+ * such a status carries a `phase` and no `finishedAt` or `outcome`. `model`
+ * records `"(env default)"` when the run left the model to the environment.
+ *
+ * **Example** (Describe an in-flight run)
+ *
+ * ```ts import.meta.vitest name="Describe an in-flight run"
+ * import { GraftDeepRefreshStatus } from "@beep/repo-cli/commands/Graft"
+ * import { PosInt } from "@beep/schema/Int"
+ * const status = GraftDeepRefreshStatus.make({
+ *   schemaVersion: "beep-graft-deep-refresh/v1",
+ *   owner: "/clones/beep-effect0",
+ *   model: "(env default)",
+ *   jobs: PosInt.make(16),
+ *   startedAt: "2026-09-11T02:30:00.000Z",
+ *   phase: "build",
+ *   rebuilt: [],
+ *   log: "/state/beep-graft/runs/20260911T023000Z.log",
+ * })
+ * console.log(status.phase) // build
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class GraftDeepRefreshStatus extends S.Class<GraftDeepRefreshStatus>($I`GraftDeepRefreshStatus`)(
+  {
+    schemaVersion: S.Literal("beep-graft-deep-refresh/v1"),
+    owner: S.String,
+    head: S.optional(S.String),
+    model: S.String,
+    jobs: PosInt,
+    startedAt: S.String,
+    finishedAt: S.optional(S.String),
+    phase: GraftDeepRefreshPhase,
+    outcome: S.optional(GraftDeepRefreshOutcome),
+    coverage: S.optional(GraftDeepCoverage),
+    seed: S.optional(GraftCacheSyncReport),
+    rebuilt: S.Array(GraftDeepSiblingRebuild),
+    log: S.String,
+    message: S.optional(S.String),
+  },
+  $I.annote("GraftDeepRefreshStatus", {
+    description: "Phase, coverage, seed receipt, and rebuild results of the most recent refresh run.",
+  })
+) {}
+
+/**
+ * Contents of the refresh lock file that fences concurrent runs.
+ *
+ * **Details**
+ *
+ * The pid is what makes a lock releasable after a crash: a lock whose holder
+ * is gone is replaced rather than obeyed.
+ *
+ * **Example** (Describe a held lock)
+ *
+ * ```ts import.meta.vitest name="Describe a held lock"
+ * import { GraftDeepLock } from "@beep/repo-cli/commands/Graft"
+ * const lock = GraftDeepLock.make({ pid: 4321, startedAt: "2026-09-11T02:30:00.000Z" })
+ * console.log(lock.pid) // 4321
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class GraftDeepLock extends S.Class<GraftDeepLock>($I`GraftDeepLock`)(
+  { pid: S.Int, startedAt: S.String },
+  $I.annote("GraftDeepLock", { description: "Process id and start time of the run holding the refresh lock." })
+) {}
+
+/**
+ * Inputs for installing or removing the nightly refresh systemd user timer.
+ *
+ * **Details**
+ *
+ * `envFile` is only ever stat-ed by the installer; its contents reach the
+ * refresh through systemd's `EnvironmentFile`, never through this process.
+ *
+ * **Example** (Describe a nightly schedule)
+ *
+ * ```ts import.meta.vitest name="Describe a nightly schedule"
+ * import { GraftDeepTimerOptions } from "@beep/repo-cli/commands/Graft"
+ * const options = GraftDeepTimerOptions.make({
+ *   owner: "/clones/beep-effect0",
+ *   bunPath: "/usr/bin/bun",
+ *   onCalendar: "*-*-* 02:30:00",
+ *   envFile: "/home/op/.config/beep-graft/env",
+ *   uninstall: false,
+ * })
+ * console.log(options.onCalendar) // *-*-* 02:30:00
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class GraftDeepTimerOptions extends S.Class<GraftDeepTimerOptions>($I`GraftDeepTimerOptions`)(
+  { owner: S.String, bunPath: S.String, onCalendar: S.String, envFile: S.String, uninstall: S.Boolean },
+  $I.annote("GraftDeepTimerOptions", {
+    description: "Owner clone, Bun path, calendar expression, and environment file of the refresh timer.",
   })
 ) {}

--- a/packages/tooling/tool/cli/src/commands/Graft/Graft.schemas.ts
+++ b/packages/tooling/tool/cli/src/commands/Graft/Graft.schemas.ts
@@ -6,6 +6,7 @@
  */
 import { $RepoCliId } from "@beep/identity/packages";
 import { LiteralKit, NonNegativeInt, PosInt } from "@beep/schema";
+import { DurationUnit } from "@beep/schema/Duration";
 import { UnitInterval } from "@beep/schema/UnitInterval";
 import { pipe } from "effect";
 import * as A from "effect/Array";
@@ -545,5 +546,86 @@ export class GraftDeepTimerOptions extends S.Class<GraftDeepTimerOptions>($I`Gra
   { owner: S.String, bunPath: S.String, onCalendar: S.String, envFile: S.String, uninstall: S.Boolean },
   $I.annote("GraftDeepTimerOptions", {
     description: "Owner clone, Bun path, calendar expression, and environment file of the refresh timer.",
+  })
+) {}
+
+/**
+ * How a refresh step's output is captured.
+ *
+ * **Details**
+ *
+ * A step read for its value takes `stdout` alone: Git writes advisory warnings
+ * to stderr, and merging them would make `status --porcelain` look dirty or
+ * corrupt a parsed revision. A step whose output only reaches the run log takes
+ * `merge`, where a failure explains itself.
+ *
+ * **Example** (Recognize the parsed-output source)
+ *
+ * ```ts import.meta.vitest name="Recognize the parsed-output source"
+ * import { GraftDeepCaptureSource } from "@beep/repo-cli/commands/Graft"
+ * console.log(GraftDeepCaptureSource.is.stdout("stdout")) // true
+ * ```
+ *
+ * @category schemas
+ * @since 0.0.0
+ */
+export const GraftDeepCaptureSource = LiteralKit(["all", "merge", "stdout"]).pipe(
+  $I.annoteSchema("GraftDeepCaptureSource", {
+    description: "Which subprocess streams a refresh step captures.",
+  })
+);
+
+/**
+ * A capture strategy for one refresh step.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type GraftDeepCaptureSource = typeof GraftDeepCaptureSource.Type;
+
+// A duration the child-process runner accepts verbatim; constraining the field
+// to this shape is what keeps an unparseable bound out of a spawned step.
+const DurationExpression = S.TemplateLiteral([S.Finite, " ", DurationUnit]);
+
+/**
+ * One subprocess a refresh run needs, named by the phase that owns it.
+ *
+ * **Details**
+ *
+ * `timeout` is a Duration expression such as `"15 minutes"`. `log` is the run
+ * log a spawn failure is attributed to, and is absent for steps that run before
+ * a run log exists.
+ *
+ * **Example** (Describe a bounded probe)
+ *
+ * ```ts import.meta.vitest name="Describe a bounded probe"
+ * import { GraftDeepRunnerStep } from "@beep/repo-cli/commands/Graft"
+ * const step = GraftDeepRunnerStep.make({
+ *   command: "git",
+ *   args: ["status", "--porcelain"],
+ *   cwd: "/clones/beep-effect0",
+ *   phase: "preflight",
+ *   source: "stdout",
+ *   timeout: "2 minutes",
+ * })
+ * console.log(step.source) // stdout
+ * ```
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export class GraftDeepRunnerStep extends S.Class<GraftDeepRunnerStep>($I`GraftDeepRunnerStep`)(
+  {
+    command: S.String,
+    args: S.Array(S.String),
+    cwd: S.String,
+    env: S.optional(S.Record(S.String, S.String)),
+    log: S.optional(S.String),
+    phase: GraftDeepRefreshPhase,
+    source: S.optional(GraftDeepCaptureSource),
+    timeout: S.optional(DurationExpression),
+  },
+  $I.annote("GraftDeepRunnerStep", {
+    description: "Command, working directory, environment, and bound of one refresh subprocess.",
   })
 ) {}

--- a/packages/tooling/tool/cli/src/commands/Graft/GraftDeep.service.ts
+++ b/packages/tooling/tool/cli/src/commands/Graft/GraftDeep.service.ts
@@ -1,0 +1,1005 @@
+/**
+ * Nightly rebuild of the paid-for Graft meaning tier from one owner clone.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+import { $RepoCliId } from "@beep/identity/packages";
+import { NonNegativeInt } from "@beep/schema";
+import { Cause, Config, Effect, Exit, flow, Match, pipe } from "effect";
+import * as A from "effect/Array";
+import * as Context from "effect/Context";
+import * as DateTime from "effect/DateTime";
+import * as Dur from "effect/Duration";
+import * as Eq from "effect/Equal";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Num from "effect/Number";
+import * as O from "effect/Option";
+import * as Order from "effect/Order";
+import * as Path from "effect/Path";
+import * as Random from "effect/Random";
+import * as Result from "effect/Result";
+import * as Schedule from "effect/Schedule";
+import * as S from "effect/Schema";
+import * as Str from "effect/String";
+import { ChildProcessSpawner } from "effect/unstable/process";
+import { ensureZeroExit, formatCommandLine, OutputBound, runCaptured } from "../../internal/process/StepExec.ts";
+import { GraftCacheIoError, GraftDeepLockError, GraftDeepPreflightError, GraftDeepStepError } from "./Graft.errors.ts";
+import {
+  GraftCacheSyncAction,
+  GraftDeepLock,
+  GraftDeepRefreshOutcome,
+  GraftDeepRefreshStatus,
+  GraftDeepSiblingRebuild,
+  parseDeepCoverage,
+} from "./Graft.schemas.ts";
+import { GraftCacheSync, GraftCacheSyncLive } from "./Graft.service.ts";
+import type { CapturedStep, CaptureSource } from "../../internal/process/StepExec.ts";
+import type { GraftCacheSourceError, GraftCacheTargetError } from "./Graft.errors.ts";
+import type {
+  GraftCacheSyncReport,
+  GraftDeepCoverage,
+  GraftDeepRefreshOptions,
+  GraftDeepRefreshPhase,
+  GraftDeepTimerOptions,
+} from "./Graft.schemas.ts";
+
+const $I = $RepoCliId.create("commands/Graft/GraftDeep.service");
+
+const REFRESH_STATUS_VERSION = "beep-graft-deep-refresh/v1";
+const REFRESH_UNIT_BASE_NAME = "beep-graft-deep-refresh";
+const REFRESH_UNIT_DESCRIPTION = "beep graft deep refresh (nightly meaning-tier rebuild + sibling seed)";
+// A systemd user unit starts with a nearly empty PATH. The refresh spawns
+// `graft` (an npm global whose shebang resolves `node` through the mise shims)
+// and `bun`, so the unit carries the PATH those live on; %h is the home
+// directory systemd expands at load time.
+const REFRESH_UNIT_PATH = "%h/.local/share/mise/shims:%h/.local/bin:%h/.bun/bin:/usr/local/bin:/usr/bin:/bin";
+
+// The deep build prints a line per file for thousands of files; the shared
+// repo-run bound would drop the coverage summary that arrives at the very end.
+const deepOutputBound = OutputBound.make({
+  maxChars: 8 * 1024 * 1024,
+  truncatedNotice: `\n[beep-cli] graft deep output truncated after ${8 * 1024 * 1024} characters`,
+});
+
+// The shell convention for "killed by a timeout"; a sibling rebuild that never
+// reported an exit code is recorded under it rather than losing the run.
+const REBUILD_UNFINISHED_EXIT = 124;
+
+const isIntegerExit = S.is(S.Int);
+const exitCodeOf = (value: number): number => (isIntegerExit(value) ? value : 1);
+
+/**
+ * One subprocess a refresh run needs, named by the phase that owns it.
+ *
+ * @category models
+ * @since 0.0.0
+ */
+export interface GraftDeepRunnerStep {
+  readonly args: ReadonlyArray<string>;
+  readonly command: string;
+  readonly cwd: string;
+  readonly env?: Record<string, string | undefined> | undefined;
+  readonly log?: string | undefined;
+  readonly phase: GraftDeepRefreshPhase;
+  /**
+   * `"stdout"` for a step whose output is parsed, `"merge"` (the default) for a
+   * step whose output only reaches the run log.
+   */
+  readonly source?: CaptureSource | undefined;
+  readonly timeout?: Dur.Input | undefined;
+}
+
+/**
+ * The only seam through which a refresh reaches the operating system.
+ *
+ * **Details**
+ *
+ * Nonzero exit codes are returned in the captured result, matching the shared
+ * step executor; only a failure to spawn, a timeout, or a wedged pipe reaches
+ * the error channel.
+ *
+ * @category services
+ * @since 0.0.0
+ */
+export interface GraftDeepRunnerShape {
+  readonly isPidAlive: (pid: number) => Effect.Effect<boolean>;
+  readonly run: (step: GraftDeepRunnerStep) => Effect.Effect<CapturedStep, GraftDeepStepError>;
+}
+
+/**
+ * Service that runs the Git, Bun, Graft, and systemd commands a refresh needs.
+ *
+ * **Details**
+ *
+ * Keeping every subprocess behind one service is what lets the refresh be
+ * tested without a real clone, a real Graft install, or a model budget.
+ *
+ * **Example** (Describe a scripted step)
+ *
+ * ```ts import.meta.vitest name="Describe a scripted step"
+ * import { GraftDeepRunner } from "@beep/repo-cli/commands/Graft"
+ * import * as Effect from "effect/Effect"
+ * const program = GraftDeepRunner.use((runner) => runner.isPidAlive(1))
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @category services
+ * @since 0.0.0
+ */
+export class GraftDeepRunner extends Context.Service<GraftDeepRunner, GraftDeepRunnerShape>()($I`GraftDeepRunner`) {}
+
+const makeGraftDeepRunner = Effect.fnUntraced(function* () {
+  const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+  const run: GraftDeepRunnerShape["run"] = Effect.fn("GraftDeepRunner.run")(function* (step) {
+    return yield* runCaptured({
+      args: step.args,
+      bound: deepOutputBound,
+      command: step.command,
+      cwd: step.cwd,
+      extendEnv: true,
+      forceKillAfter: "30 seconds",
+      // A step that is read for its value takes stdout alone: git writes
+      // advisory warnings to stderr, and merging them would make
+      // `status --porcelain` look dirty or corrupt a parsed revision.
+      source: step.source ?? "merge",
+      tee: false,
+      trim: true,
+      ...(step.env === undefined ? {} : { env: step.env }),
+      ...(step.timeout === undefined ? {} : { timeout: step.timeout }),
+    }).pipe(
+      Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      Effect.mapError((cause) =>
+        GraftDeepStepError.make({
+          cause,
+          exitCode: 1,
+          log: step.log ?? "",
+          message: `${formatCommandLine(step.command, step.args)} could not run to completion in ${step.cwd}.`,
+          step: step.phase,
+        })
+      )
+    );
+  });
+  const isPidAlive: GraftDeepRunnerShape["isPidAlive"] = (pid) =>
+    Effect.sync(() => {
+      try {
+        process.kill(pid, 0);
+        return true;
+      } catch (error) {
+        // EPERM means the process exists and belongs to somebody else.
+        return Eq.equals(
+          O.getOrElse(O.fromUndefinedOr((error as { code?: string }).code), () => ""),
+          "EPERM"
+        );
+      }
+    });
+  return GraftDeepRunner.of({ isPidAlive, run });
+});
+
+/**
+ * Supplies the refresh runner over the platform child-process spawner.
+ *
+ * **Details**
+ *
+ * Building the layer spawns nothing; the spawner is captured so the service's
+ * methods carry no remaining requirement.
+ *
+ * **Example** (Provide the live runner)
+ *
+ * ```ts import.meta.vitest name="Provide the live runner"
+ * import { GraftDeepRunnerLive } from "@beep/repo-cli/commands/Graft"
+ * import * as Layer from "effect/Layer"
+ * console.log(Layer.isLayer(GraftDeepRunnerLive)) // true
+ * ```
+ *
+ * @category layers
+ * @since 0.0.0
+ */
+export const GraftDeepRunnerLive: Layer.Layer<GraftDeepRunner, never, ChildProcessSpawner.ChildProcessSpawner> =
+  Layer.effect(GraftDeepRunner, makeGraftDeepRunner());
+
+/**
+ * Sink that receives the status after every phase transition of a run.
+ *
+ * **Details**
+ *
+ * The default sink discards the status, so a library caller pays nothing. The
+ * CLI provides a printer that renders one line per completed phase while the
+ * run is still in flight.
+ *
+ * **Example** (Count phase transitions without printing)
+ *
+ * ```ts import.meta.vitest name="Count phase transitions without printing"
+ * import { GraftDeepRefreshProgress } from "@beep/repo-cli/commands/Graft"
+ * import * as Effect from "effect/Effect"
+ * const program = Effect.map(GraftDeepRefreshProgress, (sink) => typeof sink)
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @category services
+ * @since 0.0.0
+ */
+export const GraftDeepRefreshProgress: Context.Reference<(status: GraftDeepRefreshStatus) => Effect.Effect<void>> =
+  Context.Reference($I`GraftDeepRefreshProgress`, {
+    defaultValue: (): ((status: GraftDeepRefreshStatus) => Effect.Effect<void>) => () => Effect.void,
+  });
+
+/**
+ * Failures a refresh run can report to its caller.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type GraftDeepRefreshFailure =
+  | GraftDeepLockError
+  | GraftDeepPreflightError
+  | GraftDeepStepError
+  | GraftCacheSourceError
+  | GraftCacheTargetError
+  | GraftCacheIoError;
+
+/**
+ * Runs, reads back, and schedules the nightly meaning-tier refresh.
+ *
+ * **Details**
+ *
+ * Every method is safe to call concurrently with a running refresh: `run`
+ * fences itself with a lock file and `readStatus` only reads.
+ *
+ * @category services
+ * @since 0.0.0
+ */
+export interface GraftDeepRefreshShape {
+  readonly installTimer: (
+    options: GraftDeepTimerOptions
+  ) => Effect.Effect<ReadonlyArray<string>, GraftDeepPreflightError | GraftDeepStepError>;
+  readonly readStatus: (stateDir: string) => Effect.Effect<O.Option<GraftDeepRefreshStatus>, GraftCacheIoError>;
+  readonly run: (options: GraftDeepRefreshOptions) => Effect.Effect<GraftDeepRefreshStatus, GraftDeepRefreshFailure>;
+}
+
+/**
+ * Service that refreshes the meaning tier from an owner clone nobody works in.
+ *
+ * **Details**
+ *
+ * A run pins the owner clone to `origin/main` itself, rebuilds the meaning
+ * tier, seeds the siblings, and rebuilds each seeded clone structurally. Every
+ * phase transition is written to `<stateDir>/status.json` atomically, so an
+ * interrupted run is still readable.
+ *
+ * **Example** (Prepare a status read)
+ *
+ * ```ts import.meta.vitest name="Prepare a status read"
+ * import { GraftDeepRefresh } from "@beep/repo-cli/commands/Graft"
+ * import * as Effect from "effect/Effect"
+ * const program = GraftDeepRefresh.use((refresh) => refresh.readStatus("/state/beep-graft"))
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @category services
+ * @since 0.0.0
+ */
+export class GraftDeepRefresh extends Context.Service<GraftDeepRefresh, GraftDeepRefreshShape>()(
+  $I`GraftDeepRefresh`
+) {}
+
+/**
+ * Renders the systemd service and timer units for the nightly refresh.
+ *
+ * **Details**
+ *
+ * The service unit is returned first and the timer second. `EnvironmentFile`
+ * carries no leading dash on purpose: a missing environment file must fail the
+ * unit loudly instead of starting a build with no API key. The two
+ * `ExecStartPre` lines update the owner clone before the CLI boots, so each
+ * night runs main's current `beep graft deep refresh` rather than whatever the
+ * clone held when the timer was installed. `KillMode=mixed` with
+ * `TimeoutStopSec=90` sends `SIGTERM` to the CLI alone first, which `runMain`
+ * turns into a fiber interrupt, leaving time to record the interrupted run.
+ *
+ * **Example** (Render the timer calendar line)
+ *
+ * ```ts import.meta.vitest name="Render the timer calendar line"
+ * import { renderGraftDeepRefreshUnits } from "@beep/repo-cli/commands/Graft"
+ * import { GraftDeepTimerOptions } from "@beep/repo-cli/commands/Graft"
+ * import * as Str from "effect/String"
+ * const units = renderGraftDeepRefreshUnits(
+ *   GraftDeepTimerOptions.make({
+ *     owner: "/clones/beep-effect0",
+ *     bunPath: "/usr/bin/bun",
+ *     onCalendar: "*-*-* 02:30:00",
+ *     envFile: "/home/op/.config/beep-graft/env",
+ *     uninstall: false,
+ *   })
+ * )
+ * console.log(Str.includes("OnCalendar=*-*-* 02:30:00")(units[1]?.text ?? "")) // true
+ * ```
+ *
+ * @param options - Owner clone, Bun path, calendar expression, and environment file.
+ * @returns The service unit followed by the timer unit.
+ * @category formatting
+ * @since 0.0.0
+ */
+export const renderGraftDeepRefreshUnits = (
+  options: GraftDeepTimerOptions
+): ReadonlyArray<{ readonly fileName: string; readonly text: string }> => [
+  {
+    fileName: `${REFRESH_UNIT_BASE_NAME}.service`,
+    text: A.join(
+      [
+        "[Unit]",
+        `Description=${REFRESH_UNIT_DESCRIPTION}`,
+        "",
+        "[Service]",
+        "Type=oneshot",
+        `WorkingDirectory=${options.owner}`,
+        `Environment=PATH=${REFRESH_UNIT_PATH}`,
+        "Environment=CI=true",
+        `EnvironmentFile=${options.envFile}`,
+        `ExecStartPre=/usr/bin/git -C ${options.owner} pull --ff-only --quiet origin main`,
+        `ExecStartPre=${options.bunPath} install --frozen-lockfile`,
+        `ExecStart=${options.bunPath} run beep graft deep refresh --owner ${options.owner} --jobs 16`,
+        "TimeoutStartSec=8h",
+        "TimeoutStopSec=90",
+        "KillMode=mixed",
+        "Nice=10",
+        "Slice=background.slice",
+        "",
+      ],
+      "\n"
+    ),
+  },
+  {
+    fileName: `${REFRESH_UNIT_BASE_NAME}.timer`,
+    text: A.join(
+      [
+        "[Unit]",
+        `Description=Timer for ${REFRESH_UNIT_DESCRIPTION}`,
+        "",
+        "[Timer]",
+        `OnCalendar=${options.onCalendar}`,
+        "Persistent=true",
+        "RandomizedDelaySec=600",
+        "",
+        "[Install]",
+        "WantedBy=timers.target",
+        "",
+      ],
+      "\n"
+    ),
+  },
+];
+
+const statusCodec = S.fromJsonString(GraftDeepRefreshStatus);
+const decodeStatusJson = S.decodeUnknownEffect(statusCodec);
+const encodeStatusJson = S.encodeEffect(statusCodec);
+const lockCodec = S.fromJsonString(GraftDeepLock);
+const decodeLockJson = S.decodeUnknownEffect(lockCodec);
+const encodeLockJson = S.encodeEffect(lockCodec);
+
+const compactTimestamp = (iso: string): string => pipe(iso, Str.replaceAll(/[-:]/gu, ""), Str.replace(/\.\d+Z$/u, "Z"));
+
+const refreshFailureMessage = Match.type<GraftDeepRefreshFailure>().pipe(
+  Match.tag("GraftDeepLockError", (error) => `Refresh lock ${error.path} is held by live process ${error.holderPid}.`),
+  Match.tag(
+    "GraftDeepPreflightError",
+    "GraftCacheSourceError",
+    "GraftCacheTargetError",
+    "GraftCacheIoError",
+    (error) => error.message
+  ),
+  Match.tag("GraftDeepStepError", (error) => error.message),
+  Match.exhaustive
+);
+
+type StatusPatch = Partial<{
+  readonly coverage: GraftDeepCoverage;
+  readonly finishedAt: string;
+  readonly head: string;
+  readonly message: string;
+  readonly outcome: GraftDeepRefreshOutcome;
+  readonly phase: GraftDeepRefreshPhase;
+  readonly rebuilt: ReadonlyArray<GraftDeepSiblingRebuild>;
+  readonly seed: GraftCacheSyncReport;
+}>;
+
+const makeGraftDeepRefresh = Effect.fn("GraftDeepRefresh.make")(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const runner = yield* GraftDeepRunner;
+  const sync = yield* GraftCacheSync;
+
+  const ioError = (file: string) => (cause: unknown) =>
+    GraftCacheIoError.make({ path: file, message: `Graft deep refresh failed at ${file}.`, cause });
+
+  const statusPath = (stateDir: string) => path.join(stateDir, "status.json");
+
+  const readStatus: GraftDeepRefreshShape["readStatus"] = Effect.fn("GraftDeepRefresh.readStatus")(
+    function* (stateDir) {
+      const file = statusPath(path.resolve(stateDir));
+      if (!(yield* fs.exists(file).pipe(Effect.mapError(ioError(file))))) {
+        return O.none<GraftDeepRefreshStatus>();
+      }
+      const text = yield* fs.readFileString(file).pipe(Effect.mapError(ioError(file)));
+      return O.some(
+        yield* decodeStatusJson(text).pipe(
+          Effect.mapError((cause) =>
+            GraftCacheIoError.make({
+              path: file,
+              message: `Refresh status at ${file} is not a valid ${REFRESH_STATUS_VERSION} document.`,
+              cause,
+            })
+          )
+        )
+      );
+    }
+  );
+
+  // Temp-and-rename so a reader never observes a half-written status, matching
+  // how the cache sync replaces artifacts.
+  const writeStatus = Effect.fnUntraced(function* (stateDir: string, status: GraftDeepRefreshStatus) {
+    const file = statusPath(stateDir);
+    const encoded = yield* encodeStatusJson(status).pipe(Effect.mapError(ioError(file)));
+    const nonce = yield* Random.nextInt;
+    const temporary = path.join(stateDir, `.status-${nonce}.tmp`);
+    // Write beside the destination and rename, so `status` never observes a
+    // half-written document while a refresh is running.
+    yield* Effect.acquireUseRelease(
+      fs.writeFileString(temporary, `${encoded}\n`).pipe(Effect.mapError(ioError(temporary))),
+      () => fs.rename(temporary, file).pipe(Effect.mapError(ioError(file))),
+      () => Effect.ignore(fs.remove(temporary, { force: true }))
+    );
+  });
+
+  const acquireLock = Effect.fnUntraced(function* (stateDir: string, startedAt: string) {
+    const lockPath = path.join(stateDir, "refresh.lock");
+    const body = yield* encodeLockJson(GraftDeepLock.make({ pid: process.pid, startedAt })).pipe(
+      Effect.mapError(ioError(lockPath))
+    );
+    const claim = fs.writeFileString(lockPath, `${body}\n`, { flag: "wx" });
+    // Whoever holds the lock right now, not whoever held it when this run
+    // started looking: a lost steal race must never report the dead pid as
+    // live. The retry covers the microseconds between a winner renaming the
+    // stale lock aside and writing its own.
+    const holder = Effect.fnUntraced(function* () {
+      const existing = yield* fs.readFileString(lockPath).pipe(Effect.flatMap(decodeLockJson));
+      return existing.pid;
+    });
+    const holderNow = holder().pipe(
+      Effect.retry({ schedule: Schedule.spaced(Dur.millis(20)), times: 10 }),
+      Effect.mapError((cause) =>
+        GraftDeepPreflightError.make({
+          path: lockPath,
+          message: `Refresh lock ${lockPath} is unreadable; remove it once no refresh is running.`,
+          cause,
+        })
+      )
+    );
+    if (Result.isSuccess(yield* Effect.result(claim))) return lockPath;
+    const holderPid = yield* holderNow;
+    if (yield* runner.isPidAlive(holderPid)) {
+      return yield* GraftDeepLockError.make({ path: lockPath, holderPid });
+    }
+    // The holder is gone, so the lock is a crash leftover rather than a fence.
+    // Steal it by renaming it aside: renaming a missing source fails, so when
+    // several runs see the same dead pid exactly one of them wins, and a loser
+    // can never delete the winner's live lock.
+    const nonce = yield* Random.nextInt;
+    const aside = `${lockPath}.stale-${holderPid}-${nonce}`;
+    const stolen = yield* Effect.result(fs.rename(lockPath, aside));
+    if (Result.isFailure(stolen)) {
+      return yield* GraftDeepLockError.make({ path: lockPath, holderPid: yield* holderNow, cause: stolen.failure });
+    }
+    const reclaimed = yield* Effect.result(claim);
+    yield* Effect.ignore(fs.remove(aside, { force: true }));
+    if (Result.isFailure(reclaimed)) {
+      return yield* GraftDeepLockError.make({ path: lockPath, holderPid: yield* holderNow, cause: reclaimed.failure });
+    }
+    return lockPath;
+  });
+
+  const checkoutPreflight = Effect.fnUntraced(function* <E>(
+    owner: string,
+    appendLog: (text: string) => Effect.Effect<void, E>
+  ) {
+    const probe = Effect.fnUntraced(function* (args: ReadonlyArray<string>) {
+      const captured = yield* runner
+        .run({ args, command: "git", cwd: owner, phase: "preflight", source: "stdout", timeout: "2 minutes" })
+        .pipe(Effect.mapError((cause) => GraftDeepPreflightError.make({ path: owner, message: cause.message, cause })));
+      yield* appendLog(`$ ${formatCommandLine("git", args)}\n${captured.output}\n`);
+      if (!Eq.equals(exitCodeOf(captured.exitCode), 0)) {
+        return yield* GraftDeepPreflightError.make({
+          path: owner,
+          message: `${formatCommandLine("git", args)} exited with ${captured.exitCode} in ${owner}.`,
+        });
+      }
+      return captured.output;
+    });
+    const canonical = yield* fs
+      .realPath(owner)
+      .pipe(
+        Effect.mapError((cause) =>
+          GraftDeepPreflightError.make({ path: owner, message: `Owner clone ${owner} does not exist.`, cause })
+        )
+      );
+    const toplevel = yield* probe(["rev-parse", "--show-toplevel"]);
+    if (!Eq.equals(toplevel, canonical)) {
+      return yield* GraftDeepPreflightError.make({
+        path: owner,
+        message: `Owner ${owner} is not a Git work tree root; its toplevel is ${toplevel}.`,
+      });
+    }
+    const branch = yield* probe(["rev-parse", "--abbrev-ref", "HEAD"]);
+    if (!Eq.equals(branch, "main")) {
+      return yield* GraftDeepPreflightError.make({
+        path: owner,
+        message: `Owner ${owner} is on ${branch}; the refresh only runs from main.`,
+      });
+    }
+    const porcelain = yield* probe(["status", "--porcelain"]);
+    if (Str.isNonEmpty(porcelain)) {
+      return yield* GraftDeepPreflightError.make({
+        path: owner,
+        message: `Owner ${owner} has local changes; the refresh only runs from a clean checkout.`,
+      });
+    }
+    // The systemd user manager carries no SSH_AUTH_SOCK, so a nightly fetch
+    // over an SSH remote fails with no agent to ask. The repo is public, so an
+    // HTTPS remote fetches without credentials.
+    const remote = yield* probe(["remote", "get-url", "origin"]);
+    if (!Str.startsWith("https://")(remote)) {
+      return yield* GraftDeepPreflightError.make({
+        path: owner,
+        message: `Owner ${owner} fetches origin over ${remote}; the systemd user manager has no SSH agent. Run "git -C ${owner} remote set-url origin https://github.com/<org>/<repo>.git" and retry.`,
+      });
+    }
+    return canonical;
+  });
+
+  const run: GraftDeepRefreshShape["run"] = Effect.fn("GraftDeepRefresh.run")(function* (options) {
+    const owner = path.resolve(options.owner);
+    const stateDir = path.resolve(options.stateDir);
+    const startedAt = DateTime.formatIso(yield* DateTime.now);
+    const runsDir = path.join(stateDir, "runs");
+    const logPath = path.join(runsDir, `${compactTimestamp(startedAt)}.log`);
+
+    yield* fs.makeDirectory(runsDir, { recursive: true }).pipe(Effect.mapError(ioError(runsDir)));
+
+    const appendLog = Effect.fnUntraced(function* (text: string) {
+      yield* fs.writeFileString(logPath, text, { flag: "a" }).pipe(Effect.mapError(ioError(logPath)));
+    });
+
+    let status = GraftDeepRefreshStatus.make({
+      schemaVersion: REFRESH_STATUS_VERSION,
+      owner,
+      model: O.getOrElse(O.fromUndefinedOr(options.model), () => "(env default)"),
+      jobs: options.jobs,
+      startedAt,
+      phase: "preflight",
+      rebuilt: [],
+      log: logPath,
+    });
+    const commit = Effect.fnUntraced(function* (patch: StatusPatch) {
+      status = GraftDeepRefreshStatus.make({ ...status, ...patch });
+      yield* writeStatus(stateDir, status);
+      yield* (yield* GraftDeepRefreshProgress)(status);
+      return status;
+    });
+
+    const step = Effect.fnUntraced(function* (input: GraftDeepRunnerStep) {
+      const captured = yield* runner.run({ ...input, log: logPath });
+      yield* appendLog(`$ ${formatCommandLine(input.command, input.args)}\n${captured.output}\n`);
+      return captured;
+    });
+    const mustSucceed = Effect.fnUntraced(function* (input: GraftDeepRunnerStep) {
+      return yield* ensureZeroExit(yield* step(input), (exitCode) =>
+        GraftDeepStepError.make({
+          step: input.phase,
+          exitCode: exitCodeOf(exitCode),
+          log: logPath,
+          message: `${formatCommandLine(input.command, input.args)} exited with ${exitCode} in ${input.cwd}.`,
+        })
+      );
+    });
+
+    const refresh = Effect.fnUntraced(function* () {
+      yield* commit({ phase: "preflight" });
+      yield* checkoutPreflight(owner, appendLog);
+      const graftVersion = yield* runner
+        .run({ args: ["--version"], command: "graft", cwd: owner, phase: "preflight", timeout: "2 minutes" })
+        .pipe(
+          Effect.mapError((cause) =>
+            GraftDeepPreflightError.make({
+              path: owner,
+              message: `graft does not resolve on PATH for the refresh: ${cause.message}`,
+              cause,
+            })
+          )
+        );
+      if (!Eq.equals(exitCodeOf(graftVersion.exitCode), 0)) {
+        return yield* GraftDeepPreflightError.make({
+          path: owner,
+          message: `graft --version exited with ${graftVersion.exitCode}; the meaning tier cannot be rebuilt.`,
+        });
+      }
+      yield* appendLog(`$ graft --version\n${graftVersion.output}\n`);
+      const patchKit = path.join(owner, "scripts", "graft", "apply-dist-patches.sh");
+      const patches = yield* runner
+        .run({ args: ["--check"], command: patchKit, cwd: owner, phase: "preflight", timeout: "5 minutes" })
+        .pipe(
+          Effect.mapError((cause) => GraftDeepPreflightError.make({ path: patchKit, message: cause.message, cause }))
+        );
+      yield* appendLog(`$ ${formatCommandLine(patchKit, ["--check"])}\n${patches.output}\n`);
+      if (!Eq.equals(exitCodeOf(patches.exitCode), 0)) {
+        return yield* GraftDeepPreflightError.make({
+          path: patchKit,
+          message: `${patchKit} --check exited with ${patches.exitCode}; the installed Graft is missing repo patches.`,
+        });
+      }
+
+      yield* commit({ phase: "pull" });
+      const before = yield* mustSucceed({
+        args: ["rev-parse", "HEAD"],
+        command: "git",
+        cwd: owner,
+        phase: "pull",
+        source: "stdout",
+        timeout: "2 minutes",
+      });
+      yield* mustSucceed({
+        args: ["fetch", "--quiet", "origin"],
+        command: "git",
+        cwd: owner,
+        phase: "pull",
+        timeout: "15 minutes",
+      });
+      yield* mustSucceed({
+        args: ["merge", "--ff-only", "origin/main"],
+        command: "git",
+        cwd: owner,
+        phase: "pull",
+        timeout: "5 minutes",
+      });
+      const after = yield* mustSucceed({
+        args: ["rev-parse", "HEAD"],
+        command: "git",
+        cwd: owner,
+        phase: "pull",
+        source: "stdout",
+        timeout: "2 minutes",
+      });
+      const lockDiff = yield* step({
+        args: ["diff", "--quiet", before.output, after.output, "--", "bun.lock"],
+        command: "git",
+        cwd: owner,
+        phase: "pull",
+        timeout: "5 minutes",
+      });
+      yield* commit({ head: after.output, phase: "install" });
+      if (!Eq.equals(exitCodeOf(lockDiff.exitCode), 0)) {
+        yield* mustSucceed({
+          args: ["install", "--frozen-lockfile"],
+          command: "bun",
+          cwd: owner,
+          phase: "install",
+          timeout: "30 minutes",
+        });
+      }
+
+      yield* commit({ phase: "build" });
+      const cruxRetries = yield* Effect.orDie(Config.String("GRAFT_CRUX_EMPTY_RETRIES").pipe(Config.option));
+      const build = yield* mustSucceed({
+        args: ["build", "--deep", "-j", `${options.jobs}`, "--allow-partial"],
+        command: "graft",
+        cwd: owner,
+        env: {
+          ...pipe(
+            O.fromUndefinedOr(options.model),
+            O.map((model) => ({ GRAFT_MODEL: model })),
+            O.getOrElse(() => ({}))
+          ),
+          ...pipe(
+            cruxRetries,
+            O.map((retries) => ({ GRAFT_CRUX_EMPTY_RETRIES: retries })),
+            O.getOrElse(() => ({ GRAFT_CRUX_EMPTY_RETRIES: "2" }))
+          ),
+        },
+        phase: "build",
+        timeout: "5 hours",
+      });
+      const coverage = parseDeepCoverage(build.output);
+
+      yield* commit({
+        phase: "seed",
+        ...O.getOrElse(
+          O.map(coverage, (value) => ({ coverage: value })),
+          () => ({})
+        ),
+      });
+      let refusals = 0;
+      let seeded = O.none<GraftCacheSyncReport>();
+      if (options.seed) {
+        const plan = yield* sync.plan(owner, yield* sync.discoverSiblings(owner));
+        refusals = A.length(A.filter(plan.entries, (entry) => GraftCacheSyncAction.is.refuse(entry.action)));
+        // A refused destination fails closed in the sync service too; recording
+        // the refusal and moving on keeps the nightly job from paging.
+        seeded = Eq.equals(refusals, 0) ? O.some(yield* sync.apply(plan)) : O.none<GraftCacheSyncReport>();
+      }
+
+      yield* commit({
+        phase: "rebuild",
+        ...O.getOrElse(
+          O.map(seeded, (report) => ({ seed: report })),
+          () => ({})
+        ),
+      });
+      let rebuilt: ReadonlyArray<GraftDeepSiblingRebuild> = [];
+      if (options.rebuild && O.isSome(seeded)) {
+        const roots = A.sort(A.dedupe(A.map(seeded.value.plan.entries, (entry) => entry.target.root)), Order.String);
+        rebuilt = yield* Effect.forEach(
+          roots,
+          Effect.fnUntraced(function* (root) {
+            // A clone that times out or cannot spawn is recorded, not raised:
+            // failing here would interrupt the sibling rebuilds still running
+            // and throw away every result the night already earned.
+            const [elapsed, attempted] = yield* Effect.timed(
+              Effect.result(
+                step({ args: ["build"], command: "graft", cwd: root, phase: "rebuild", timeout: "15 minutes" })
+              )
+            );
+            return GraftDeepSiblingRebuild.make({
+              root,
+              exitCode: Result.isSuccess(attempted) ? exitCodeOf(attempted.success.exitCode) : REBUILD_UNFINISHED_EXIT,
+              seconds: NonNegativeInt.make(Num.round(Dur.toSeconds(elapsed), 0)),
+            });
+          }),
+          { concurrency: options.rebuildConcurrency }
+        );
+      }
+
+      const ratio = O.map(coverage, (value) => (Eq.equals(value.total, 0) ? 0 : value.covered / value.total));
+      const belowTarget = O.getOrElse(
+        O.map(ratio, (value) => value < options.minCoverage),
+        () => true
+      );
+      const rebuildFailures = A.length(A.filter(rebuilt, (entry) => !Eq.equals(entry.exitCode, 0)));
+      const degraded = belowTarget || refusals > 0 || rebuildFailures > 0;
+      // Absent coverage has two very different causes: a build that printed no
+      // coverage line, and a build whose line was cut off by the capture bound.
+      // The operator needs to know which before rerunning anything.
+      const coverageNote = O.match(ratio, {
+        onNone: () =>
+          build.truncated
+            ? "the build printed no readable coverage line because its output was truncated at the capture bound"
+            : "the build printed no coverage line",
+        onSome: (value) =>
+          value < options.minCoverage
+            ? `coverage is ${Num.round(value * 100, 1)}%, below the ${Num.round(options.minCoverage * 100, 1)}% target`
+            : "",
+      });
+      const notes = A.filter(
+        [
+          coverageNote,
+          refusals > 0 ? `${refusals} seed destination(s) were refused and nothing was seeded` : "",
+          rebuildFailures > 0 ? `${rebuildFailures} sibling rebuild(s) exited non-zero` : "",
+        ],
+        Str.isNonEmpty
+      );
+      return yield* commit({
+        finishedAt: DateTime.formatIso(yield* DateTime.now),
+        outcome: degraded ? GraftDeepRefreshOutcome.Enum.degraded : GraftDeepRefreshOutcome.Enum.ok,
+        phase: "done",
+        rebuilt,
+        ...(A.isReadonlyArrayNonEmpty(notes) ? { message: A.join(notes, "; ") } : {}),
+      });
+    });
+
+    // The run is already lost; a failing status write or a missing notifier
+    // must not replace the real cause.
+    const notifyFailure = Effect.fnUntraced(function* (message: string) {
+      yield* Effect.ignore(
+        runner.run({
+          args: ["--urgency=critical", "beep graft deep refresh failed", message],
+          command: "notify-send",
+          cwd: stateDir,
+          phase: status.phase,
+          timeout: "30 seconds",
+        })
+      );
+    });
+    const recordFailure = Effect.fnUntraced(function* (message: string) {
+      yield* Effect.ignore(
+        commit({
+          finishedAt: DateTime.formatIso(yield* DateTime.now),
+          message,
+          outcome: GraftDeepRefreshOutcome.Enum.failed,
+        })
+      );
+      yield* notifyFailure(message);
+    });
+
+    // `Effect.result` never sees an interruption, and systemd stops this unit
+    // with SIGTERM, which `runMain` turns into a fiber interrupt. Observing the
+    // exit instead is what keeps a stopped run from leaving status.json stuck
+    // mid-phase with no outcome. Finalizers run uninterruptibly, so the write
+    // and the notification complete, and both happen before the lock is
+    // released because the release is the outer acquire's finalizer.
+    const guarded = refresh().pipe(
+      Effect.onExit(
+        Effect.fnUntraced(function* (exit) {
+          if (Exit.isSuccess(exit)) return;
+          yield* recordFailure(
+            Cause.hasInterrupts(exit.cause)
+              ? `Refresh interrupted during ${status.phase}; the owner clone may hold a partial meaning tier.`
+              : O.getOrElse(O.map(Cause.findErrorOption(exit.cause), refreshFailureMessage), () =>
+                  Cause.pretty(exit.cause)
+                )
+          );
+        })
+      )
+    );
+
+    // A refused lock belongs to another run that owns status.json; recording
+    // this refusal there would erase the live run's progress, so an acquisition
+    // failure notifies without writing.
+    return yield* Effect.acquireUseRelease(
+      acquireLock(stateDir, startedAt).pipe(Effect.tapError(flow(refreshFailureMessage, notifyFailure))),
+      () => guarded,
+      (lockPath) => Effect.ignore(fs.remove(lockPath, { force: true }))
+    );
+  });
+
+  const runSystemctl = Effect.fnUntraced(function* (args: ReadonlyArray<string>, cwd: string) {
+    const captured = yield* runner.run({
+      args: ["--user", ...args],
+      command: "systemctl",
+      cwd,
+      phase: "preflight",
+      timeout: "2 minutes",
+    });
+    return yield* ensureZeroExit(captured, (exitCode) =>
+      GraftDeepStepError.make({
+        step: "preflight",
+        exitCode: exitCodeOf(exitCode),
+        log: "",
+        message: `systemctl --user ${A.join(args, " ")} exited with ${exitCode}: ${captured.output}`,
+      })
+    );
+  });
+
+  const installTimer: GraftDeepRefreshShape["installTimer"] = Effect.fn("GraftDeepRefresh.installTimer")(
+    function* (options) {
+      const home = yield* Config.String("HOME").pipe(
+        Effect.mapError((cause) =>
+          GraftDeepPreflightError.make({
+            path: options.owner,
+            message: "HOME is not set; cannot locate the systemd user unit directory.",
+            cause,
+          })
+        )
+      );
+      const unitDir = path.join(home, ".config", "systemd", "user");
+      const units = renderGraftDeepRefreshUnits(options);
+      const unitPaths = A.map(units, (unit) => path.join(unitDir, unit.fileName));
+      if (options.uninstall) {
+        yield* Effect.ignore(runSystemctl(["disable", "--now", `${REFRESH_UNIT_BASE_NAME}.timer`], home));
+        yield* Effect.forEach(unitPaths, (unit) => Effect.ignore(fs.remove(unit, { force: true })));
+        yield* runSystemctl(["daemon-reload"], home);
+        return unitPaths;
+      }
+      // Stat only: the environment file holds the proxy token and is never read
+      // by this process.
+      yield* fs.stat(options.envFile).pipe(
+        Effect.mapError((cause) =>
+          GraftDeepPreflightError.make({
+            path: options.envFile,
+            message: `Environment file ${options.envFile} does not exist; the unit would start without an API key.`,
+            cause,
+          })
+        )
+      );
+      yield* checkoutPreflight(options.owner, () => Effect.void);
+      // mise owns the node shim the graft launcher resolves; an untrusted
+      // config makes that shim refuse to run under the timer.
+      const trust = yield* Effect.result(
+        runner.run({
+          args: ["trust", "--show"],
+          command: "mise",
+          cwd: options.owner,
+          phase: "preflight",
+          source: "stdout",
+          timeout: "2 minutes",
+        })
+      );
+      if (
+        Result.isSuccess(trust) &&
+        Eq.equals(exitCodeOf(trust.success.exitCode), 0) &&
+        A.some(Str.split("\n")(trust.success.output), Str.includes(": untrusted"))
+      ) {
+        return yield* GraftDeepPreflightError.make({
+          path: options.owner,
+          message: `mise reports an untrusted config under ${options.owner}; run "mise trust" there before installing the timer.`,
+        });
+      }
+      yield* fs.makeDirectory(unitDir, { recursive: true }).pipe(
+        Effect.mapError((cause) =>
+          GraftDeepPreflightError.make({
+            path: unitDir,
+            message: `Failed creating the systemd user unit directory ${unitDir}.`,
+            cause,
+          })
+        )
+      );
+      yield* Effect.forEach(
+        A.zip(units, unitPaths),
+        Effect.fnUntraced(function* ([unit, unitPath]) {
+          yield* fs.writeFileString(unitPath, unit.text).pipe(
+            Effect.mapError((cause) =>
+              GraftDeepPreflightError.make({
+                path: unitPath,
+                message: `Failed writing ${unit.fileName}.`,
+                cause,
+              })
+            )
+          );
+        })
+      );
+      yield* runSystemctl(["daemon-reload"], home);
+      yield* runSystemctl(["enable", "--now", `${REFRESH_UNIT_BASE_NAME}.timer`], home);
+      return unitPaths;
+    }
+  );
+
+  return GraftDeepRefresh.of({ installTimer, readStatus, run });
+});
+
+/**
+ * Builds the refresh service over whatever runner and sync service are in context.
+ *
+ * **Details**
+ *
+ * Exposed separately from {@link GraftDeepRefreshLive} so a caller can supply
+ * a scripted runner and drive a whole run without Git, Bun, or Graft installed.
+ *
+ * **Example** (Compose the refresh service with a chosen runner)
+ *
+ * ```ts import.meta.vitest name="Compose the refresh service with a chosen runner"
+ * import { GraftDeepRefreshLayer, GraftDeepRunnerLive } from "@beep/repo-cli/commands/Graft"
+ * import * as Layer from "effect/Layer"
+ * console.log(Layer.isLayer(Layer.provide(GraftDeepRefreshLayer, GraftDeepRunnerLive))) // true
+ * ```
+ *
+ * @category layers
+ * @since 0.0.0
+ */
+export const GraftDeepRefreshLayer: Layer.Layer<
+  GraftDeepRefresh,
+  never,
+  FileSystem.FileSystem | Path.Path | GraftDeepRunner | GraftCacheSync
+> = Layer.effect(GraftDeepRefresh, makeGraftDeepRefresh());
+
+/**
+ * Supplies the refresh service over the live runner and the cache sync service.
+ *
+ * **Details**
+ *
+ * The layer captures the filesystem and path services, so only the platform
+ * child-process spawner remains a requirement of the composed layer.
+ *
+ * **Example** (Provide the refresh implementation)
+ *
+ * ```ts import.meta.vitest name="Provide the refresh implementation"
+ * import { GraftDeepRefreshLive } from "@beep/repo-cli/commands/Graft"
+ * import * as Layer from "effect/Layer"
+ * console.log(Layer.isLayer(GraftDeepRefreshLive)) // true
+ * ```
+ *
+ * @category layers
+ * @since 0.0.0
+ */
+export const GraftDeepRefreshLive: Layer.Layer<
+  GraftDeepRefresh,
+  never,
+  FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+> = GraftDeepRefreshLayer.pipe(Layer.provide(Layer.mergeAll(GraftDeepRunnerLive, GraftCacheSyncLive)));

--- a/packages/tooling/tool/cli/src/commands/Graft/GraftDeep.service.ts
+++ b/packages/tooling/tool/cli/src/commands/Graft/GraftDeep.service.ts
@@ -68,6 +68,161 @@ const deepOutputBound = OutputBound.make({
 // reported an exit code is recorded under it rather than losing the run.
 const REBUILD_UNFINISHED_EXIT = 124;
 
+type RefreshContext = {
+  readonly appendLog: (text: string) => Effect.Effect<void, GraftCacheIoError>;
+  readonly mustSucceed: (
+    input: GraftDeepRunnerStep
+  ) => Effect.Effect<CapturedStep, GraftDeepStepError | GraftCacheIoError>;
+  readonly options: GraftDeepRefreshOptions;
+  readonly owner: string;
+  readonly step: (input: GraftDeepRunnerStep) => Effect.Effect<CapturedStep, GraftDeepStepError | GraftCacheIoError>;
+};
+
+const revParseHeadStep = (owner: string) =>
+  GraftDeepRunnerStep.make({
+    args: ["rev-parse", "HEAD"],
+    command: "git",
+    cwd: owner,
+    phase: "pull",
+    source: "stdout",
+    timeout: "2 minutes",
+  });
+
+const fetchStep = (owner: string) =>
+  GraftDeepRunnerStep.make({
+    args: ["fetch", "--quiet", "origin"],
+    command: "git",
+    cwd: owner,
+    phase: "pull",
+    timeout: "15 minutes",
+  });
+
+const mergeStep = (owner: string) =>
+  GraftDeepRunnerStep.make({
+    args: ["merge", "--ff-only", "origin/main"],
+    command: "git",
+    cwd: owner,
+    phase: "pull",
+    timeout: "5 minutes",
+  });
+
+const lockDiffStep = (owner: string, before: string, after: string) =>
+  GraftDeepRunnerStep.make({
+    args: ["diff", "--quiet", before, after, "--", "bun.lock"],
+    command: "git",
+    cwd: owner,
+    phase: "pull",
+    timeout: "5 minutes",
+  });
+
+const bunInstallStep = (owner: string) =>
+  GraftDeepRunnerStep.make({
+    args: ["install", "--frozen-lockfile"],
+    command: "bun",
+    cwd: owner,
+    phase: "install",
+    timeout: "30 minutes",
+  });
+
+const deepBuildStep = (options: GraftDeepRefreshOptions, cruxRetries: O.Option<string>) =>
+  GraftDeepRunnerStep.make({
+    args: ["build", "--deep", "-j", `${options.jobs}`, "--allow-partial"],
+    command: "graft",
+    cwd: options.owner,
+    env: {
+      ...pipe(
+        O.fromUndefinedOr(options.model),
+        O.map((model) => ({ GRAFT_MODEL: model })),
+        O.getOrElse(() => ({}))
+      ),
+      ...pipe(
+        cruxRetries,
+        O.map((retries) => ({ GRAFT_CRUX_EMPTY_RETRIES: retries })),
+        O.getOrElse(() => ({ GRAFT_CRUX_EMPTY_RETRIES: "2" }))
+      ),
+    },
+    phase: "build",
+    timeout: "5 hours",
+  });
+
+const siblingBuildStep = (root: string) =>
+  GraftDeepRunnerStep.make({
+    args: ["build"],
+    command: "graft",
+    cwd: root,
+    phase: "rebuild",
+    timeout: "15 minutes",
+  });
+
+const coverageRatio = (coverage: O.Option<GraftDeepCoverage>): O.Option<number> =>
+  O.map(coverage, (value) => (Eq.equals(value.total, 0) ? 0 : value.covered / value.total));
+
+// Absent coverage has two very different causes: a build that printed no
+// coverage line, and a build whose line was cut off by the capture bound. The
+// operator needs to know which before rerunning anything.
+const coverageNote = (input: {
+  readonly minCoverage: number;
+  readonly ratio: O.Option<number>;
+  readonly truncated: boolean;
+}): string =>
+  O.match(input.ratio, {
+    onNone: () =>
+      input.truncated
+        ? "the build printed no readable coverage line because its output was truncated at the capture bound"
+        : "the build printed no coverage line",
+    onSome: (value) =>
+      value < input.minCoverage
+        ? `coverage is ${Num.round(value * 100, 1)}%, below the ${Num.round(input.minCoverage * 100, 1)}% target`
+        : "",
+  });
+
+const refusalNote = (refusals: number): string =>
+  refusals > 0 ? `${refusals} seed destination(s) were refused and nothing was seeded` : "";
+
+const rebuildNote = (failures: number): string =>
+  failures > 0 ? `${failures} sibling rebuild(s) exited non-zero` : "";
+
+/** Verdict and operator note for a run that reached its final phase. */
+const decideOutcome = (input: {
+  readonly coverage: O.Option<GraftDeepCoverage>;
+  readonly minCoverage: number;
+  readonly rebuilt: ReadonlyArray<GraftDeepSiblingRebuild>;
+  readonly refusals: number;
+  readonly truncated: boolean;
+}): { readonly message: O.Option<string>; readonly outcome: GraftDeepRefreshOutcome } => {
+  const ratio = coverageRatio(input.coverage);
+  const belowTarget = O.getOrElse(
+    O.map(ratio, (value) => value < input.minCoverage),
+    () => true
+  );
+  const failures = A.length(A.filter(input.rebuilt, (entry) => !Eq.equals(entry.exitCode, 0)));
+  const notes = A.filter(
+    [
+      coverageNote({ minCoverage: input.minCoverage, ratio, truncated: input.truncated }),
+      refusalNote(input.refusals),
+      rebuildNote(failures),
+    ],
+    Str.isNonEmpty
+  );
+  const degraded = belowTarget || input.refusals > 0 || failures > 0;
+  return {
+    message: A.isReadonlyArrayNonEmpty(notes) ? O.some(A.join(notes, "; ")) : O.none<string>(),
+    outcome: degraded ? GraftDeepRefreshOutcome.Enum.degraded : GraftDeepRefreshOutcome.Enum.ok,
+  };
+};
+
+// Only a seed that was actually applied has clones worth rebuilding.
+const rebuildTargets = (
+  options: GraftDeepRefreshOptions,
+  seeded: O.Option<GraftCacheSyncReport>
+): ReadonlyArray<string> =>
+  pipe(
+    seeded,
+    O.filter(() => options.rebuild),
+    O.map((report) => A.sort(A.dedupe(A.map(report.plan.entries, (entry) => entry.target.root)), Order.String)),
+    O.getOrElse((): ReadonlyArray<string> => [])
+  );
+
 const isIntegerExit = S.is(S.Int);
 const exitCodeOf = (value: number): number => (isIntegerExit(value) ? value : 1);
 
@@ -126,8 +281,10 @@ const makeGraftDeepRunner = Effect.fnUntraced(function* () {
       source: step.source ?? "merge",
       tee: false,
       trim: true,
-      ...(step.env === undefined ? {} : { env: step.env }),
-      ...(step.timeout === undefined ? {} : { timeout: step.timeout }),
+      // Both fields are declared `| undefined` by the runner, so an absent
+      // bound or environment is passed as the value rather than spread in.
+      env: step.env,
+      timeout: step.timeout,
     }).pipe(
       Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
       Effect.mapError((cause) =>
@@ -361,7 +518,7 @@ const lockCodec = S.fromJsonString(GraftDeepLock);
 const decodeLockJson = S.decodeUnknownEffect(lockCodec);
 const encodeLockJson = S.encodeEffect(lockCodec);
 
-const compactTimestamp = (iso: string): string => pipe(iso, Str.replaceAll(/[-:]/gu, ""), Str.replace(/\.\d+Z$/u, "Z"));
+const compactTimestamp: (iso: string) => string = flow(Str.replaceAll(/[-:]/gu, ""), Str.replace(/\.\d+Z$/u, "Z"));
 
 const refreshFailureMessage = Match.type<GraftDeepRefreshFailure>().pipe(
   Match.tag("GraftDeepLockError", (error) => `Refresh lock ${error.path} is held by live process ${error.holderPid}.`),
@@ -549,6 +706,112 @@ const makeGraftDeepRefresh = Effect.fn("GraftDeepRefresh.make")(function* () {
     return canonical;
   });
 
+  const assertGraftOnPath = Effect.fnUntraced(function* (ctx: RefreshContext) {
+    const captured = yield* runner
+      .run(
+        GraftDeepRunnerStep.make({
+          args: ["--version"],
+          command: "graft",
+          cwd: ctx.owner,
+          phase: "preflight",
+          timeout: "2 minutes",
+        })
+      )
+      .pipe(
+        Effect.mapError((cause) =>
+          GraftDeepPreflightError.make({
+            path: ctx.owner,
+            message: `graft does not resolve on PATH for the refresh: ${cause.message}`,
+            cause,
+          })
+        )
+      );
+    if (!Eq.equals(exitCodeOf(captured.exitCode), 0)) {
+      return yield* GraftDeepPreflightError.make({
+        path: ctx.owner,
+        message: `graft --version exited with ${captured.exitCode}; the meaning tier cannot be rebuilt.`,
+      });
+    }
+    yield* ctx.appendLog(`$ graft --version\n${captured.output}\n`);
+  });
+
+  const assertPatchKit = Effect.fnUntraced(function* (ctx: RefreshContext) {
+    const patchKit = path.join(ctx.owner, "scripts", "graft", "apply-dist-patches.sh");
+    const captured = yield* runner
+      .run(
+        GraftDeepRunnerStep.make({
+          args: ["--check"],
+          command: patchKit,
+          cwd: ctx.owner,
+          phase: "preflight",
+          timeout: "5 minutes",
+        })
+      )
+      .pipe(
+        Effect.mapError((cause) => GraftDeepPreflightError.make({ path: patchKit, message: cause.message, cause }))
+      );
+    yield* ctx.appendLog(`$ ${formatCommandLine(patchKit, ["--check"])}\n${captured.output}\n`);
+    if (!Eq.equals(exitCodeOf(captured.exitCode), 0)) {
+      return yield* GraftDeepPreflightError.make({
+        path: patchKit,
+        message: `${patchKit} --check exited with ${captured.exitCode}; the installed Graft is missing repo patches.`,
+      });
+    }
+  });
+
+  const preflightPhase = Effect.fnUntraced(function* (ctx: RefreshContext) {
+    yield* checkoutPreflight(ctx.owner, ctx.appendLog);
+    yield* assertGraftOnPath(ctx);
+    yield* assertPatchKit(ctx);
+  });
+
+  const pullPhase = Effect.fnUntraced(function* (ctx: RefreshContext) {
+    const before = yield* ctx.mustSucceed(revParseHeadStep(ctx.owner));
+    yield* ctx.mustSucceed(fetchStep(ctx.owner));
+    yield* ctx.mustSucceed(mergeStep(ctx.owner));
+    const after = yield* ctx.mustSucceed(revParseHeadStep(ctx.owner));
+    const lockDiff = yield* ctx.step(lockDiffStep(ctx.owner, before.output, after.output));
+    return { head: after.output, lockChanged: !Eq.equals(exitCodeOf(lockDiff.exitCode), 0) };
+  });
+
+  const installPhase = Effect.fnUntraced(function* (ctx: RefreshContext, lockChanged: boolean) {
+    if (!lockChanged) return;
+    yield* ctx.mustSucceed(bunInstallStep(ctx.owner));
+  });
+
+  const buildPhase = Effect.fnUntraced(function* (ctx: RefreshContext) {
+    const cruxRetries = yield* Effect.orDie(Config.String("GRAFT_CRUX_EMPTY_RETRIES").pipe(Config.option));
+    return yield* ctx.mustSucceed(deepBuildStep(ctx.options, cruxRetries));
+  });
+
+  const seedPhase = Effect.fnUntraced(function* (ctx: RefreshContext) {
+    if (!ctx.options.seed) return { refusals: 0, seeded: O.none<GraftCacheSyncReport>() };
+    const plan = yield* sync.plan(ctx.owner, yield* sync.discoverSiblings(ctx.owner));
+    const refusals = A.length(A.filter(plan.entries, (entry) => GraftCacheSyncAction.is.refuse(entry.action)));
+    // A refused destination fails closed in the sync service too; recording the
+    // refusal and moving on keeps the nightly job from paging.
+    const seeded = Eq.equals(refusals, 0) ? O.some(yield* sync.apply(plan)) : O.none<GraftCacheSyncReport>();
+    return { refusals, seeded };
+  });
+
+  // A clone that times out or cannot spawn is recorded, not raised: failing
+  // here would interrupt the sibling rebuilds still running and throw away
+  // every result the night already earned.
+  const rebuildClone = Effect.fnUntraced(function* (ctx: RefreshContext, root: string) {
+    const [elapsed, attempted] = yield* Effect.timed(Effect.result(ctx.step(siblingBuildStep(root))));
+    return GraftDeepSiblingRebuild.make({
+      root,
+      exitCode: Result.isSuccess(attempted) ? exitCodeOf(attempted.success.exitCode) : REBUILD_UNFINISHED_EXIT,
+      seconds: NonNegativeInt.make(Num.round(Dur.toSeconds(elapsed), 0)),
+    });
+  });
+
+  const rebuildPhase = Effect.fnUntraced(function* (ctx: RefreshContext, seeded: O.Option<GraftCacheSyncReport>) {
+    return yield* Effect.forEach(rebuildTargets(ctx.options, seeded), (root) => rebuildClone(ctx, root), {
+      concurrency: ctx.options.rebuildConcurrency,
+    });
+  });
+
   const run: GraftDeepRefreshShape["run"] = Effect.fn("GraftDeepRefresh.run")(function* (options) {
     const owner = path.resolve(options.owner);
     const stateDir = path.resolve(options.stateDir);
@@ -595,141 +858,19 @@ const makeGraftDeepRefresh = Effect.fn("GraftDeepRefresh.make")(function* () {
       );
     });
 
+    const ctx: RefreshContext = { appendLog, mustSucceed, options, owner, step };
     const refresh = Effect.fnUntraced(function* () {
       yield* commit({ phase: "preflight" });
-      yield* checkoutPreflight(owner, appendLog);
-      const graftVersion = yield* runner
-        .run(
-          GraftDeepRunnerStep.make({
-            args: ["--version"],
-            command: "graft",
-            cwd: owner,
-            phase: "preflight",
-            timeout: "2 minutes",
-          })
-        )
-        .pipe(
-          Effect.mapError((cause) =>
-            GraftDeepPreflightError.make({
-              path: owner,
-              message: `graft does not resolve on PATH for the refresh: ${cause.message}`,
-              cause,
-            })
-          )
-        );
-      if (!Eq.equals(exitCodeOf(graftVersion.exitCode), 0)) {
-        return yield* GraftDeepPreflightError.make({
-          path: owner,
-          message: `graft --version exited with ${graftVersion.exitCode}; the meaning tier cannot be rebuilt.`,
-        });
-      }
-      yield* appendLog(`$ graft --version\n${graftVersion.output}\n`);
-      const patchKit = path.join(owner, "scripts", "graft", "apply-dist-patches.sh");
-      const patches = yield* runner
-        .run(
-          GraftDeepRunnerStep.make({
-            args: ["--check"],
-            command: patchKit,
-            cwd: owner,
-            phase: "preflight",
-            timeout: "5 minutes",
-          })
-        )
-        .pipe(
-          Effect.mapError((cause) => GraftDeepPreflightError.make({ path: patchKit, message: cause.message, cause }))
-        );
-      yield* appendLog(`$ ${formatCommandLine(patchKit, ["--check"])}\n${patches.output}\n`);
-      if (!Eq.equals(exitCodeOf(patches.exitCode), 0)) {
-        return yield* GraftDeepPreflightError.make({
-          path: patchKit,
-          message: `${patchKit} --check exited with ${patches.exitCode}; the installed Graft is missing repo patches.`,
-        });
-      }
+      yield* preflightPhase(ctx);
 
       yield* commit({ phase: "pull" });
-      const before = yield* mustSucceed(
-        GraftDeepRunnerStep.make({
-          args: ["rev-parse", "HEAD"],
-          command: "git",
-          cwd: owner,
-          phase: "pull",
-          source: "stdout",
-          timeout: "2 minutes",
-        })
-      );
-      yield* mustSucceed(
-        GraftDeepRunnerStep.make({
-          args: ["fetch", "--quiet", "origin"],
-          command: "git",
-          cwd: owner,
-          phase: "pull",
-          timeout: "15 minutes",
-        })
-      );
-      yield* mustSucceed(
-        GraftDeepRunnerStep.make({
-          args: ["merge", "--ff-only", "origin/main"],
-          command: "git",
-          cwd: owner,
-          phase: "pull",
-          timeout: "5 minutes",
-        })
-      );
-      const after = yield* mustSucceed(
-        GraftDeepRunnerStep.make({
-          args: ["rev-parse", "HEAD"],
-          command: "git",
-          cwd: owner,
-          phase: "pull",
-          source: "stdout",
-          timeout: "2 minutes",
-        })
-      );
-      const lockDiff = yield* step(
-        GraftDeepRunnerStep.make({
-          args: ["diff", "--quiet", before.output, after.output, "--", "bun.lock"],
-          command: "git",
-          cwd: owner,
-          phase: "pull",
-          timeout: "5 minutes",
-        })
-      );
-      yield* commit({ head: after.output, phase: "install" });
-      if (!Eq.equals(exitCodeOf(lockDiff.exitCode), 0)) {
-        yield* mustSucceed(
-          GraftDeepRunnerStep.make({
-            args: ["install", "--frozen-lockfile"],
-            command: "bun",
-            cwd: owner,
-            phase: "install",
-            timeout: "30 minutes",
-          })
-        );
-      }
+      const pulled = yield* pullPhase(ctx);
+
+      yield* commit({ head: pulled.head, phase: "install" });
+      yield* installPhase(ctx, pulled.lockChanged);
 
       yield* commit({ phase: "build" });
-      const cruxRetries = yield* Effect.orDie(Config.String("GRAFT_CRUX_EMPTY_RETRIES").pipe(Config.option));
-      const build = yield* mustSucceed(
-        GraftDeepRunnerStep.make({
-          args: ["build", "--deep", "-j", `${options.jobs}`, "--allow-partial"],
-          command: "graft",
-          cwd: owner,
-          env: {
-            ...pipe(
-              O.fromUndefinedOr(options.model),
-              O.map((model) => ({ GRAFT_MODEL: model })),
-              O.getOrElse(() => ({}))
-            ),
-            ...pipe(
-              cruxRetries,
-              O.map((retries) => ({ GRAFT_CRUX_EMPTY_RETRIES: retries })),
-              O.getOrElse(() => ({ GRAFT_CRUX_EMPTY_RETRIES: "2" }))
-            ),
-          },
-          phase: "build",
-          timeout: "5 hours",
-        })
-      );
+      const build = yield* buildPhase(ctx);
       const coverage = parseDeepCoverage(build.output);
 
       yield* commit({
@@ -739,89 +880,33 @@ const makeGraftDeepRefresh = Effect.fn("GraftDeepRefresh.make")(function* () {
           () => ({})
         ),
       });
-      let refusals = 0;
-      let seeded = O.none<GraftCacheSyncReport>();
-      if (options.seed) {
-        const plan = yield* sync.plan(owner, yield* sync.discoverSiblings(owner));
-        refusals = A.length(A.filter(plan.entries, (entry) => GraftCacheSyncAction.is.refuse(entry.action)));
-        // A refused destination fails closed in the sync service too; recording
-        // the refusal and moving on keeps the nightly job from paging.
-        seeded = Eq.equals(refusals, 0) ? O.some(yield* sync.apply(plan)) : O.none<GraftCacheSyncReport>();
-      }
+      const seed = yield* seedPhase(ctx);
 
       yield* commit({
         phase: "rebuild",
         ...O.getOrElse(
-          O.map(seeded, (report) => ({ seed: report })),
+          O.map(seed.seeded, (report) => ({ seed: report })),
           () => ({})
         ),
       });
-      let rebuilt: ReadonlyArray<GraftDeepSiblingRebuild> = [];
-      if (options.rebuild && O.isSome(seeded)) {
-        const roots = A.sort(A.dedupe(A.map(seeded.value.plan.entries, (entry) => entry.target.root)), Order.String);
-        rebuilt = yield* Effect.forEach(
-          roots,
-          Effect.fnUntraced(function* (root) {
-            // A clone that times out or cannot spawn is recorded, not raised:
-            // failing here would interrupt the sibling rebuilds still running
-            // and throw away every result the night already earned.
-            const [elapsed, attempted] = yield* Effect.timed(
-              Effect.result(
-                step(
-                  GraftDeepRunnerStep.make({
-                    args: ["build"],
-                    command: "graft",
-                    cwd: root,
-                    phase: "rebuild",
-                    timeout: "15 minutes",
-                  })
-                )
-              )
-            );
-            return GraftDeepSiblingRebuild.make({
-              root,
-              exitCode: Result.isSuccess(attempted) ? exitCodeOf(attempted.success.exitCode) : REBUILD_UNFINISHED_EXIT,
-              seconds: NonNegativeInt.make(Num.round(Dur.toSeconds(elapsed), 0)),
-            });
-          }),
-          { concurrency: options.rebuildConcurrency }
-        );
-      }
+      const rebuilt = yield* rebuildPhase(ctx, seed.seeded);
 
-      const ratio = O.map(coverage, (value) => (Eq.equals(value.total, 0) ? 0 : value.covered / value.total));
-      const belowTarget = O.getOrElse(
-        O.map(ratio, (value) => value < options.minCoverage),
-        () => true
-      );
-      const rebuildFailures = A.length(A.filter(rebuilt, (entry) => !Eq.equals(entry.exitCode, 0)));
-      const degraded = belowTarget || refusals > 0 || rebuildFailures > 0;
-      // Absent coverage has two very different causes: a build that printed no
-      // coverage line, and a build whose line was cut off by the capture bound.
-      // The operator needs to know which before rerunning anything.
-      const coverageNote = O.match(ratio, {
-        onNone: () =>
-          build.truncated
-            ? "the build printed no readable coverage line because its output was truncated at the capture bound"
-            : "the build printed no coverage line",
-        onSome: (value) =>
-          value < options.minCoverage
-            ? `coverage is ${Num.round(value * 100, 1)}%, below the ${Num.round(options.minCoverage * 100, 1)}% target`
-            : "",
+      const decided = decideOutcome({
+        coverage,
+        minCoverage: options.minCoverage,
+        rebuilt,
+        refusals: seed.refusals,
+        truncated: build.truncated,
       });
-      const notes = A.filter(
-        [
-          coverageNote,
-          refusals > 0 ? `${refusals} seed destination(s) were refused and nothing was seeded` : "",
-          rebuildFailures > 0 ? `${rebuildFailures} sibling rebuild(s) exited non-zero` : "",
-        ],
-        Str.isNonEmpty
-      );
       return yield* commit({
         finishedAt: DateTime.formatIso(yield* DateTime.now),
-        outcome: degraded ? GraftDeepRefreshOutcome.Enum.degraded : GraftDeepRefreshOutcome.Enum.ok,
+        outcome: decided.outcome,
         phase: "done",
         rebuilt,
-        ...(A.isReadonlyArrayNonEmpty(notes) ? { message: A.join(notes, "; ") } : {}),
+        ...O.getOrElse(
+          O.map(decided.message, (message) => ({ message })),
+          () => ({})
+        ),
       });
     });
 

--- a/packages/tooling/tool/cli/src/commands/Graft/GraftDeep.service.ts
+++ b/packages/tooling/tool/cli/src/commands/Graft/GraftDeep.service.ts
@@ -31,11 +31,12 @@ import {
   GraftDeepLock,
   GraftDeepRefreshOutcome,
   GraftDeepRefreshStatus,
+  GraftDeepRunnerStep,
   GraftDeepSiblingRebuild,
   parseDeepCoverage,
 } from "./Graft.schemas.ts";
 import { GraftCacheSync, GraftCacheSyncLive } from "./Graft.service.ts";
-import type { CapturedStep, CaptureSource } from "../../internal/process/StepExec.ts";
+import type { CapturedStep } from "../../internal/process/StepExec.ts";
 import type { GraftCacheSourceError, GraftCacheTargetError } from "./Graft.errors.ts";
 import type {
   GraftCacheSyncReport,
@@ -69,27 +70,6 @@ const REBUILD_UNFINISHED_EXIT = 124;
 
 const isIntegerExit = S.is(S.Int);
 const exitCodeOf = (value: number): number => (isIntegerExit(value) ? value : 1);
-
-/**
- * One subprocess a refresh run needs, named by the phase that owns it.
- *
- * @category models
- * @since 0.0.0
- */
-export interface GraftDeepRunnerStep {
-  readonly args: ReadonlyArray<string>;
-  readonly command: string;
-  readonly cwd: string;
-  readonly env?: Record<string, string | undefined> | undefined;
-  readonly log?: string | undefined;
-  readonly phase: GraftDeepRefreshPhase;
-  /**
-   * `"stdout"` for a step whose output is parsed, `"merge"` (the default) for a
-   * step whose output only reaches the run log.
-   */
-  readonly source?: CaptureSource | undefined;
-  readonly timeout?: Dur.Input | undefined;
-}
 
 /**
  * The only seam through which a refresh reaches the operating system.
@@ -253,7 +233,7 @@ export type GraftDeepRefreshFailure =
 export interface GraftDeepRefreshShape {
   readonly installTimer: (
     options: GraftDeepTimerOptions
-  ) => Effect.Effect<ReadonlyArray<string>, GraftDeepPreflightError | GraftDeepStepError>;
+  ) => Effect.Effect<ReadonlyArray<string>, GraftDeepPreflightError | GraftDeepStepError | GraftCacheIoError>;
   readonly readStatus: (stateDir: string) => Effect.Effect<O.Option<GraftDeepRefreshStatus>, GraftCacheIoError>;
   readonly run: (options: GraftDeepRefreshOptions) => Effect.Effect<GraftDeepRefreshStatus, GraftDeepRefreshFailure>;
 }
@@ -337,9 +317,12 @@ export const renderGraftDeepRefreshUnits = (
         `Environment=PATH=${REFRESH_UNIT_PATH}`,
         "Environment=CI=true",
         `EnvironmentFile=${options.envFile}`,
-        `ExecStartPre=/usr/bin/git -C ${options.owner} pull --ff-only --quiet origin main`,
-        `ExecStartPre=${options.bunPath} install --frozen-lockfile`,
-        `ExecStart=${options.bunPath} run beep graft deep refresh --owner ${options.owner} --jobs 16`,
+        // systemd splits Exec* lines on whitespace with no shell involved, so
+        // every path argument is quoted. WorkingDirectory and EnvironmentFile
+        // take whole lines and must stay unquoted.
+        `ExecStartPre=/usr/bin/git -C "${options.owner}" pull --ff-only --quiet origin main`,
+        `ExecStartPre="${options.bunPath}" install --frozen-lockfile`,
+        `ExecStart="${options.bunPath}" run beep graft deep refresh --owner "${options.owner}" --jobs 16`,
         "TimeoutStartSec=8h",
         "TimeoutStopSec=90",
         "KillMode=mixed",
@@ -505,7 +488,16 @@ const makeGraftDeepRefresh = Effect.fn("GraftDeepRefresh.make")(function* () {
   ) {
     const probe = Effect.fnUntraced(function* (args: ReadonlyArray<string>) {
       const captured = yield* runner
-        .run({ args, command: "git", cwd: owner, phase: "preflight", source: "stdout", timeout: "2 minutes" })
+        .run(
+          GraftDeepRunnerStep.make({
+            args,
+            command: "git",
+            cwd: owner,
+            phase: "preflight",
+            source: "stdout",
+            timeout: "2 minutes",
+          })
+        )
         .pipe(Effect.mapError((cause) => GraftDeepPreflightError.make({ path: owner, message: cause.message, cause })));
       yield* appendLog(`$ ${formatCommandLine("git", args)}\n${captured.output}\n`);
       if (!Eq.equals(exitCodeOf(captured.exitCode), 0)) {
@@ -588,7 +580,7 @@ const makeGraftDeepRefresh = Effect.fn("GraftDeepRefresh.make")(function* () {
     });
 
     const step = Effect.fnUntraced(function* (input: GraftDeepRunnerStep) {
-      const captured = yield* runner.run({ ...input, log: logPath });
+      const captured = yield* runner.run(GraftDeepRunnerStep.make({ ...input, log: logPath }));
       yield* appendLog(`$ ${formatCommandLine(input.command, input.args)}\n${captured.output}\n`);
       return captured;
     });
@@ -607,7 +599,15 @@ const makeGraftDeepRefresh = Effect.fn("GraftDeepRefresh.make")(function* () {
       yield* commit({ phase: "preflight" });
       yield* checkoutPreflight(owner, appendLog);
       const graftVersion = yield* runner
-        .run({ args: ["--version"], command: "graft", cwd: owner, phase: "preflight", timeout: "2 minutes" })
+        .run(
+          GraftDeepRunnerStep.make({
+            args: ["--version"],
+            command: "graft",
+            cwd: owner,
+            phase: "preflight",
+            timeout: "2 minutes",
+          })
+        )
         .pipe(
           Effect.mapError((cause) =>
             GraftDeepPreflightError.make({
@@ -626,7 +626,15 @@ const makeGraftDeepRefresh = Effect.fn("GraftDeepRefresh.make")(function* () {
       yield* appendLog(`$ graft --version\n${graftVersion.output}\n`);
       const patchKit = path.join(owner, "scripts", "graft", "apply-dist-patches.sh");
       const patches = yield* runner
-        .run({ args: ["--check"], command: patchKit, cwd: owner, phase: "preflight", timeout: "5 minutes" })
+        .run(
+          GraftDeepRunnerStep.make({
+            args: ["--check"],
+            command: patchKit,
+            cwd: owner,
+            phase: "preflight",
+            timeout: "5 minutes",
+          })
+        )
         .pipe(
           Effect.mapError((cause) => GraftDeepPreflightError.make({ path: patchKit, message: cause.message, cause }))
         );
@@ -639,75 +647,89 @@ const makeGraftDeepRefresh = Effect.fn("GraftDeepRefresh.make")(function* () {
       }
 
       yield* commit({ phase: "pull" });
-      const before = yield* mustSucceed({
-        args: ["rev-parse", "HEAD"],
-        command: "git",
-        cwd: owner,
-        phase: "pull",
-        source: "stdout",
-        timeout: "2 minutes",
-      });
-      yield* mustSucceed({
-        args: ["fetch", "--quiet", "origin"],
-        command: "git",
-        cwd: owner,
-        phase: "pull",
-        timeout: "15 minutes",
-      });
-      yield* mustSucceed({
-        args: ["merge", "--ff-only", "origin/main"],
-        command: "git",
-        cwd: owner,
-        phase: "pull",
-        timeout: "5 minutes",
-      });
-      const after = yield* mustSucceed({
-        args: ["rev-parse", "HEAD"],
-        command: "git",
-        cwd: owner,
-        phase: "pull",
-        source: "stdout",
-        timeout: "2 minutes",
-      });
-      const lockDiff = yield* step({
-        args: ["diff", "--quiet", before.output, after.output, "--", "bun.lock"],
-        command: "git",
-        cwd: owner,
-        phase: "pull",
-        timeout: "5 minutes",
-      });
+      const before = yield* mustSucceed(
+        GraftDeepRunnerStep.make({
+          args: ["rev-parse", "HEAD"],
+          command: "git",
+          cwd: owner,
+          phase: "pull",
+          source: "stdout",
+          timeout: "2 minutes",
+        })
+      );
+      yield* mustSucceed(
+        GraftDeepRunnerStep.make({
+          args: ["fetch", "--quiet", "origin"],
+          command: "git",
+          cwd: owner,
+          phase: "pull",
+          timeout: "15 minutes",
+        })
+      );
+      yield* mustSucceed(
+        GraftDeepRunnerStep.make({
+          args: ["merge", "--ff-only", "origin/main"],
+          command: "git",
+          cwd: owner,
+          phase: "pull",
+          timeout: "5 minutes",
+        })
+      );
+      const after = yield* mustSucceed(
+        GraftDeepRunnerStep.make({
+          args: ["rev-parse", "HEAD"],
+          command: "git",
+          cwd: owner,
+          phase: "pull",
+          source: "stdout",
+          timeout: "2 minutes",
+        })
+      );
+      const lockDiff = yield* step(
+        GraftDeepRunnerStep.make({
+          args: ["diff", "--quiet", before.output, after.output, "--", "bun.lock"],
+          command: "git",
+          cwd: owner,
+          phase: "pull",
+          timeout: "5 minutes",
+        })
+      );
       yield* commit({ head: after.output, phase: "install" });
       if (!Eq.equals(exitCodeOf(lockDiff.exitCode), 0)) {
-        yield* mustSucceed({
-          args: ["install", "--frozen-lockfile"],
-          command: "bun",
-          cwd: owner,
-          phase: "install",
-          timeout: "30 minutes",
-        });
+        yield* mustSucceed(
+          GraftDeepRunnerStep.make({
+            args: ["install", "--frozen-lockfile"],
+            command: "bun",
+            cwd: owner,
+            phase: "install",
+            timeout: "30 minutes",
+          })
+        );
       }
 
       yield* commit({ phase: "build" });
       const cruxRetries = yield* Effect.orDie(Config.String("GRAFT_CRUX_EMPTY_RETRIES").pipe(Config.option));
-      const build = yield* mustSucceed({
-        args: ["build", "--deep", "-j", `${options.jobs}`, "--allow-partial"],
-        command: "graft",
-        cwd: owner,
-        env: {
-          ...pipe(
-            O.fromUndefinedOr(options.model),
-            O.map((model) => ({ GRAFT_MODEL: model })),
-            O.getOrElse(() => ({}))
-          ),
-          ...pipe(
-            cruxRetries,
-            O.map((retries) => ({ GRAFT_CRUX_EMPTY_RETRIES: retries })),
-            O.getOrElse(() => ({ GRAFT_CRUX_EMPTY_RETRIES: "2" }))
-          ),
-        },
-        phase: "build",
-        timeout: "5 hours",
-      });
+      const build = yield* mustSucceed(
+        GraftDeepRunnerStep.make({
+          args: ["build", "--deep", "-j", `${options.jobs}`, "--allow-partial"],
+          command: "graft",
+          cwd: owner,
+          env: {
+            ...pipe(
+              O.fromUndefinedOr(options.model),
+              O.map((model) => ({ GRAFT_MODEL: model })),
+              O.getOrElse(() => ({}))
+            ),
+            ...pipe(
+              cruxRetries,
+              O.map((retries) => ({ GRAFT_CRUX_EMPTY_RETRIES: retries })),
+              O.getOrElse(() => ({ GRAFT_CRUX_EMPTY_RETRIES: "2" }))
+            ),
+          },
+          phase: "build",
+          timeout: "5 hours",
+        })
+      );
       const coverage = parseDeepCoverage(build.output);
 
       yield* commit({
@@ -745,7 +767,15 @@ const makeGraftDeepRefresh = Effect.fn("GraftDeepRefresh.make")(function* () {
             // and throw away every result the night already earned.
             const [elapsed, attempted] = yield* Effect.timed(
               Effect.result(
-                step({ args: ["build"], command: "graft", cwd: root, phase: "rebuild", timeout: "15 minutes" })
+                step(
+                  GraftDeepRunnerStep.make({
+                    args: ["build"],
+                    command: "graft",
+                    cwd: root,
+                    phase: "rebuild",
+                    timeout: "15 minutes",
+                  })
+                )
               )
             );
             return GraftDeepSiblingRebuild.make({
@@ -799,13 +829,15 @@ const makeGraftDeepRefresh = Effect.fn("GraftDeepRefresh.make")(function* () {
     // must not replace the real cause.
     const notifyFailure = Effect.fnUntraced(function* (message: string) {
       yield* Effect.ignore(
-        runner.run({
-          args: ["--urgency=critical", "beep graft deep refresh failed", message],
-          command: "notify-send",
-          cwd: stateDir,
-          phase: status.phase,
-          timeout: "30 seconds",
-        })
+        runner.run(
+          GraftDeepRunnerStep.make({
+            args: ["--urgency=critical", "beep graft deep refresh failed", message],
+            command: "notify-send",
+            cwd: stateDir,
+            phase: status.phase,
+            timeout: "30 seconds",
+          })
+        )
       );
     });
     const recordFailure = Effect.fnUntraced(function* (message: string) {
@@ -851,13 +883,15 @@ const makeGraftDeepRefresh = Effect.fn("GraftDeepRefresh.make")(function* () {
   });
 
   const runSystemctl = Effect.fnUntraced(function* (args: ReadonlyArray<string>, cwd: string) {
-    const captured = yield* runner.run({
-      args: ["--user", ...args],
-      command: "systemctl",
-      cwd,
-      phase: "preflight",
-      timeout: "2 minutes",
-    });
+    const captured = yield* runner.run(
+      GraftDeepRunnerStep.make({
+        args: ["--user", ...args],
+        command: "systemctl",
+        cwd,
+        phase: "preflight",
+        timeout: "2 minutes",
+      })
+    );
     return yield* ensureZeroExit(captured, (exitCode) =>
       GraftDeepStepError.make({
         step: "preflight",
@@ -883,10 +917,17 @@ const makeGraftDeepRefresh = Effect.fn("GraftDeepRefresh.make")(function* () {
       const units = renderGraftDeepRefreshUnits(options);
       const unitPaths = A.map(units, (unit) => path.join(unitDir, unit.fileName));
       if (options.uninstall) {
-        yield* Effect.ignore(runSystemctl(["disable", "--now", `${REFRESH_UNIT_BASE_NAME}.timer`], home));
-        yield* Effect.forEach(unitPaths, (unit) => Effect.ignore(fs.remove(unit, { force: true })));
+        // Nothing installed is nothing to undo, so an absent unit is skipped
+        // rather than disabled; a unit that is present and refuses to be
+        // disabled or deleted is reported, because the next daemon-reload
+        // would load it again and the operator would believe it was gone.
+        const present = yield* Effect.filter(unitPaths, (unit) => fs.exists(unit).pipe(Effect.mapError(ioError(unit))));
+        if (A.isReadonlyArrayNonEmpty(present)) {
+          yield* runSystemctl(["disable", "--now", `${REFRESH_UNIT_BASE_NAME}.timer`], home);
+        }
+        yield* Effect.forEach(present, (unit) => fs.remove(unit).pipe(Effect.mapError(ioError(unit))));
         yield* runSystemctl(["daemon-reload"], home);
-        return unitPaths;
+        return present;
       }
       // Stat only: the environment file holds the proxy token and is never read
       // by this process.
@@ -900,23 +941,36 @@ const makeGraftDeepRefresh = Effect.fn("GraftDeepRefresh.make")(function* () {
         )
       );
       yield* checkoutPreflight(options.owner, () => Effect.void);
-      // mise owns the node shim the graft launcher resolves; an untrusted
-      // config makes that shim refuse to run under the timer.
-      const trust = yield* Effect.result(
-        runner.run({
-          args: ["trust", "--show"],
-          command: "mise",
-          cwd: options.owner,
-          phase: "preflight",
-          source: "stdout",
-          timeout: "2 minutes",
-        })
-      );
-      if (
-        Result.isSuccess(trust) &&
-        Eq.equals(exitCodeOf(trust.success.exitCode), 0) &&
-        A.some(Str.split("\n")(trust.success.output), Str.includes(": untrusted"))
-      ) {
+      // mise owns the node shim the rendered unit resolves `graft` through, so
+      // a mise that cannot answer is refused rather than assumed fine: the
+      // alternative is a timer that fails silently every night.
+      const trust = yield* runner
+        .run(
+          GraftDeepRunnerStep.make({
+            args: ["trust", "--show"],
+            command: "mise",
+            cwd: options.owner,
+            phase: "preflight",
+            source: "stdout",
+            timeout: "2 minutes",
+          })
+        )
+        .pipe(
+          Effect.mapError((cause) =>
+            GraftDeepPreflightError.make({
+              path: options.owner,
+              message: `mise trust --show could not run in ${options.owner}; install mise and run "mise trust" there, because the rendered unit resolves node through the mise shims.`,
+              cause,
+            })
+          )
+        );
+      if (!Eq.equals(exitCodeOf(trust.exitCode), 0)) {
+        return yield* GraftDeepPreflightError.make({
+          path: options.owner,
+          message: `mise trust --show exited with ${trust.exitCode} in ${options.owner}; install mise and run "mise trust" there, because the rendered unit resolves node through the mise shims.`,
+        });
+      }
+      if (A.some(Str.split("\n")(trust.output), Str.includes(": untrusted"))) {
         return yield* GraftDeepPreflightError.make({
           path: options.owner,
           message: `mise reports an untrusted config under ${options.owner}; run "mise trust" there before installing the timer.`,

--- a/packages/tooling/tool/cli/src/commands/Graft/GraftDeep.service.ts
+++ b/packages/tooling/tool/cli/src/commands/Graft/GraftDeep.service.ts
@@ -182,7 +182,12 @@ const refusalNote = (refusals: number): string =>
 const rebuildNote = (failures: number): string =>
   failures > 0 ? `${failures} sibling rebuild(s) exited non-zero` : "";
 
-/** Verdict and operator note for a run that reached its final phase. */
+/**
+ * Verdict and operator note for a run that reached its final phase.
+ *
+ * @param input - Coverage, the target ratio, sibling rebuild results, seed refusals, and whether the build log was truncated.
+ * @returns The outcome literal plus an optional note explaining a degraded verdict.
+ */
 const decideOutcome = (input: {
   readonly coverage: O.Option<GraftDeepCoverage>;
   readonly minCoverage: number;

--- a/packages/tooling/tool/cli/src/commands/Graft/index.ts
+++ b/packages/tooling/tool/cli/src/commands/Graft/index.ts
@@ -1,5 +1,5 @@
 /**
- * Repo-owned command group for seeding Graft meaning artifacts.
+ * Repo-owned command group for seeding and refreshing Graft meaning artifacts.
  *
  * @packageDocumentation
  * @since 0.0.0
@@ -12,14 +12,14 @@
  */
 export { graftCommand } from "./Graft.command.ts";
 /**
- * Typed source, target, and I/O failures.
+ * Typed source, target, I/O, lock, preflight, and step failures.
  *
  * @category errors
  * @since 0.0.0
  */
 export * from "./Graft.errors.ts";
 /**
- * Artifact domains, sync plans, and copy receipts.
+ * Artifact domains, sync plans, copy receipts, and refresh status.
  *
  * @category schemas
  * @since 0.0.0
@@ -33,9 +33,36 @@ export * from "./Graft.schemas.ts";
  */
 export { GraftCacheSync, GraftCacheSyncLive } from "./Graft.service.ts";
 /**
+ * Nightly meaning-tier refresh service, subprocess runner, and unit rendering.
+ *
+ * @category services
+ * @since 0.0.0
+ */
+export {
+  GraftDeepRefresh,
+  GraftDeepRefreshLayer,
+  GraftDeepRefreshLive,
+  GraftDeepRefreshProgress,
+  GraftDeepRunner,
+  GraftDeepRunnerLive,
+  renderGraftDeepRefreshUnits,
+} from "./GraftDeep.service.ts";
+/**
  * Cache sync service contract.
  *
  * @category type-level
  * @since 0.0.0
  */
 export type { GraftCacheSyncShape } from "./Graft.service.ts";
+/**
+ * Refresh service, runner, and failure contracts.
+ *
+ * @category type-level
+ * @since 0.0.0
+ */
+export type {
+  GraftDeepRefreshFailure,
+  GraftDeepRefreshShape,
+  GraftDeepRunnerShape,
+  GraftDeepRunnerStep,
+} from "./GraftDeep.service.ts";

--- a/packages/tooling/tool/cli/src/commands/Graft/index.ts
+++ b/packages/tooling/tool/cli/src/commands/Graft/index.ts
@@ -5,12 +5,12 @@
  * @since 0.0.0
  */
 /**
- * Graft command group root.
+ * Graft command group root and its testable deep-refresh handlers.
  *
  * @category cli-commands
  * @since 0.0.0
  */
-export { graftCommand } from "./Graft.command.ts";
+export { graftCommand, runDeepInstallTimer, runDeepRefresh, runDeepStatus } from "./Graft.command.ts";
 /**
  * Typed source, target, I/O, lock, preflight, and step failures.
  *
@@ -64,5 +64,4 @@ export type {
   GraftDeepRefreshFailure,
   GraftDeepRefreshShape,
   GraftDeepRunnerShape,
-  GraftDeepRunnerStep,
 } from "./GraftDeep.service.ts";

--- a/packages/tooling/tool/cli/test/graft-deep-refresh.test.ts
+++ b/packages/tooling/tool/cli/test/graft-deep-refresh.test.ts
@@ -14,6 +14,9 @@ import {
   graftCommand,
   parseDeepCoverage,
   renderGraftDeepRefreshUnits,
+  runDeepInstallTimer,
+  runDeepRefresh,
+  runDeepStatus,
 } from "@beep/repo-cli/commands/Graft";
 import { CommandJsonOutput } from "@beep/repo-cli/test/Cli";
 import { CapturedStep, formatCommandLine } from "@beep/repo-cli/test/Process";
@@ -22,7 +25,8 @@ import { NonNegativeInt } from "@beep/schema/Number";
 import { UnitInterval } from "@beep/schema/UnitInterval";
 import { provideScopedLayer } from "@beep/test-utils";
 import { NodeServices } from "@effect/platform-node";
-import { expect, layer } from "@effect/vitest";
+import { expect, it, layer } from "@effect/vitest";
+import { assertNone, assertSome, assertSuccess } from "@effect/vitest/utils";
 import { ConfigProvider, Console, Effect, FileSystem, Layer, Path } from "effect";
 import * as A from "effect/Array";
 import * as Dur from "effect/Duration";
@@ -183,10 +187,56 @@ const refreshOptions = (input: {
     ),
   });
 
+const liveRunnerLayer = GraftDeepRunnerLive.pipe(Layer.provide(NodeServices.layer));
+const cruxRetriesLayer = ConfigProvider.layer(ConfigProvider.fromUnknown({ GRAFT_CRUX_EMPTY_RETRIES: "5" }));
+
+const withLiveRunner = () => provideScopedLayer(liveRunnerLayer);
+const withCruxRetries = () => provideScopedLayer(cruxRetriesLayer);
+
 const refreshWith = (runner: Layer.Layer<GraftDeepRunner>) =>
   provideScopedLayer(GraftDeepRefreshLayer.pipe(Layer.provide(Layer.mergeAll(runner, GraftCacheSyncLive))));
 
 const withHome = (home: string) => provideScopedLayer(ConfigProvider.layer(ConfigProvider.fromUnknown({ HOME: home })));
+
+// Both the command tree and the exported handlers write through Console and
+// the JSON reference; capturing them is how a handler's rendering is asserted.
+const captureOutput = Effect.fnUntraced(function* <A, E, R>(effect: Effect.Effect<A, E, R>) {
+  const current = yield* Console.Console;
+  let output: ReadonlyArray<unknown> = [];
+  const result = yield* Effect.result(
+    effect.pipe(
+      Effect.provideService(Console.Console, {
+        ...current,
+        log: (...values: ReadonlyArray<unknown>) => {
+          output = A.appendAll(output, values);
+        },
+      }),
+      Effect.provideService(CommandJsonOutput, (text) =>
+        Effect.sync(() => {
+          output = A.append(output, text);
+        })
+      )
+    )
+  );
+  return { result, output };
+});
+
+const refreshFlags = (input: {
+  readonly owner: string;
+  readonly stateDir: string;
+  readonly json?: boolean;
+  readonly model?: string;
+}) => ({
+  owner: input.owner,
+  model: O.fromUndefinedOr(input.model),
+  jobs: 16,
+  minCoverage: 0.95,
+  seed: true,
+  rebuild: true,
+  rebuildConcurrency: 2,
+  stateDir: O.some(input.stateDir),
+  json: input.json ?? false,
+});
 
 const runCommand = Effect.fn("GraftDeepRefreshTest.runCommand")(function* (args: ReadonlyArray<string>) {
   const current = yield* Console.Console;
@@ -212,25 +262,60 @@ const runCommand = Effect.fn("GraftDeepRefreshTest.runCommand")(function* (args:
 const commandLines = (calls: ReadonlyArray<GraftDeepRunnerStep>): ReadonlyArray<string> =>
   A.map(calls, (call) => formatCommandLine(call.command, call.args));
 
+const assertJsonRoundTrip = Effect.fn("GraftDeepRefreshTest.assertJsonRoundTrip")(function* <A, I>(
+  codec: S.Codec<A, I>,
+  value: A
+) {
+  const json = S.fromJsonString(codec);
+  const encoded = yield* S.encodeEffect(json)(value);
+  const decoded = yield* S.decodeEffect(json)(encoded);
+  // Re-encoding what came back reproduces the document byte for byte, so a
+  // dropped or renamed field fails here. Comparing the decoded instance
+  // directly would instead compare an explicitly undefined optional key
+  // against an absent one, which JSON cannot represent either way.
+  expect(yield* S.encodeEffect(json)(decoded)).toBe(encoded);
+});
+
+it.effect.prop(
+  "round-trips arbitrary refresh statuses and coverage counts without losing optional fields",
+  [GraftDeepRefreshStatus, GraftDeepCoverage],
+  ([status, coverage]) =>
+    Effect.map(
+      Effect.all([
+        assertJsonRoundTrip(GraftDeepRefreshStatus, status),
+        assertJsonRoundTrip(GraftDeepCoverage, coverage),
+      ]),
+      () => true
+    )
+);
+
 // The real clock, not the test clock: this suite drives filesystem work, a
 // bounded retry inside the lock steal, and an interrupt delivered by a timeout.
-layer(NodeServices.layer, { excludeTestServices: true })("Graft deep refresh", (it) => {
+layer(NodeServices.layer, { excludeTestServices: true, timeout: "30 seconds" })("Graft deep refresh", (it) => {
   it.effect(
     "parses coverage from both summary lines, carriage-return progress, and reports none without a coverage line",
     Effect.fn(function* () {
       const both = parseDeepCoverage(`${FULL_COVERAGE}1 file(s) failed to summarize.\n`);
-      expect(O.map(both, (coverage) => [coverage.covered, coverage.total, coverage.failedFiles])).toEqual(
-        O.some([38_520, 39_115, 1])
+      assertSome(
+        O.map(both, (coverage) => [coverage.covered, coverage.total, coverage.failedFiles]),
+        [38_520, 39_115, 1]
       );
       // A build that summarized every file never prints the failure line.
-      expect(O.map(parseDeepCoverage(FULL_COVERAGE), (coverage) => coverage.failedFiles)).toEqual(O.some(0));
-      const noisy = `crux 4137/4138\rcrux 4138/4138\r${FULL_COVERAGE}`;
-      expect(O.map(parseDeepCoverage(noisy), (coverage) => coverage.covered)).toEqual(O.some(38_520));
-      // The last coverage line describes the finished build.
-      expect(O.map(parseDeepCoverage(`${LOW_COVERAGE}${FULL_COVERAGE}`), (coverage) => coverage.covered)).toEqual(
-        O.some(38_520)
+      assertSome(
+        O.map(parseDeepCoverage(FULL_COVERAGE), (coverage) => coverage.failedFiles),
+        NonNegativeInt.make(0)
       );
-      expect(parseDeepCoverage("graft build --deep: nothing to do\n")).toEqual(O.none());
+      const noisy = `crux 4137/4138\rcrux 4138/4138\r${FULL_COVERAGE}`;
+      assertSome(
+        O.map(parseDeepCoverage(noisy), (coverage) => coverage.covered),
+        NonNegativeInt.make(38_520)
+      );
+      // The last coverage line describes the finished build.
+      assertSome(
+        O.map(parseDeepCoverage(`${LOW_COVERAGE}${FULL_COVERAGE}`), (coverage) => coverage.covered),
+        NonNegativeInt.make(38_520)
+      );
+      assertNone(parseDeepCoverage("graft build --deep: nothing to do\n"));
     })
   );
 
@@ -305,8 +390,9 @@ layer(NodeServices.layer, { excludeTestServices: true })("Graft deep refresh", (
       // Nothing but the operator notification ran: the fence is checked before
       // any Git command, and the live run's status file is left alone.
       expect(A.map(calls, (call) => call.command)).toEqual(["notify-send"]);
-      expect(A.last(A.flatMap(calls, (call) => A.fromIterable(call.args)))).toEqual(
-        O.some(`Refresh lock ${lockPath} is held by live process ${process.pid}.`)
+      assertSome(
+        A.last(A.flatMap(calls, (call) => A.fromIterable(call.args))),
+        `Refresh lock ${lockPath} is held by live process ${process.pid}.`
       );
       expect(yield* fs.exists(path.join(stateDir, "status.json"))).toBe(false);
     })
@@ -410,7 +496,7 @@ layer(NodeServices.layer, { excludeTestServices: true })("Graft deep refresh", (
         GraftDeepRefresh.use((refresh) => refresh.run(refreshOptions({ owner, stateDir }))).pipe(refreshWith(runner)),
         Dur.seconds(2)
       );
-      expect(interrupted).toEqual(O.none());
+      assertNone(interrupted);
       const recorded = yield* decodeStatusJson(yield* fs.readFileString(path.join(stateDir, "status.json")));
       expect(recorded.outcome).toBe("failed");
       expect(recorded.message).toEqual(expect.stringContaining("interrupted during build"));
@@ -475,8 +561,14 @@ layer(NodeServices.layer, { excludeTestServices: true })("Graft deep refresh", (
       expect(status.outcome).toBe("ok");
       expect(status.head).toBe(OWNER_HEAD_AFTER);
       expect(status.model).toBe("(env default)");
-      expect(O.map(O.fromUndefinedOr(status.coverage), (coverage) => coverage.covered)).toEqual(O.some(38_520));
-      expect(O.map(O.fromUndefinedOr(status.seed), (seed) => seed.copied)).toEqual(O.some(12));
+      assertSome(
+        O.map(O.fromUndefinedOr(status.coverage), (coverage) => coverage.covered),
+        NonNegativeInt.make(38_520)
+      );
+      assertSome(
+        O.map(O.fromUndefinedOr(status.seed), (seed) => seed.copied),
+        NonNegativeInt.make(12)
+      );
       expect(A.map(status.rebuilt, (entry) => entry.root)).toEqual(siblings);
       expect(A.every(status.rebuilt, (entry) => entry.exitCode === 0)).toBe(true);
       expect(status.message).toBeUndefined();
@@ -490,8 +582,14 @@ layer(NodeServices.layer, { excludeTestServices: true })("Graft deep refresh", (
       const build = A.findFirst(calls, (call) =>
         Str.startsWith("graft build --deep")(formatCommandLine(call.command, call.args))
       );
-      expect(O.map(build, (call) => call.env?.GRAFT_CRUX_EMPTY_RETRIES)).toEqual(O.some("2"));
-      expect(O.map(build, (call) => call.env?.GRAFT_MODEL)).toEqual(O.some(undefined));
+      assertSome(
+        O.map(build, (call) => call.env?.GRAFT_CRUX_EMPTY_RETRIES),
+        "2"
+      );
+      assertSome(
+        O.map(build, (call) => call.env?.GRAFT_MODEL),
+        undefined
+      );
       expect(A.filter(commandLines(calls), (line) => line === "graft build")).toHaveLength(2);
       // The lockfile diff spans the revisions the pull actually moved between.
       expect(commandLines(calls)).toContain(`git diff --quiet ${OWNER_HEAD} ${OWNER_HEAD_AFTER} -- bun.lock`);
@@ -533,7 +631,10 @@ layer(NodeServices.layer, { excludeTestServices: true })("Graft deep refresh", (
       const build = A.findFirst(calls, (call) =>
         Str.startsWith("graft build --deep")(formatCommandLine(call.command, call.args))
       );
-      expect(O.map(build, (call) => call.source)).toEqual(O.some(undefined));
+      assertSome(
+        O.map(build, (call) => call.source),
+        undefined
+      );
     }),
     30_000
   );
@@ -549,7 +650,10 @@ layer(NodeServices.layer, { excludeTestServices: true })("Graft deep refresh", (
       ).pipe(refreshWith(runner));
       expect(status.outcome).toBe("degraded");
       expect(status.message).toEqual(expect.stringContaining("below the 95% target"));
-      expect(O.map(O.fromUndefinedOr(status.seed), (seed) => seed.refused)).toEqual(O.some(0));
+      assertSome(
+        O.map(O.fromUndefinedOr(status.seed), (seed) => seed.refused),
+        NonNegativeInt.make(0)
+      );
       expect(yield* fs.exists(path.join(siblings[0] ?? "", "graft", "INDEX.md"))).toBe(true);
       // A degraded night is not a failure, so no operator notification fires.
       expect(A.some(commandLines(calls), Str.startsWith("notify-send"))).toBe(false);
@@ -616,9 +720,9 @@ layer(NodeServices.layer, { excludeTestServices: true })("Graft deep refresh", (
           "Environment=PATH=%h/.local/share/mise/shims:%h/.local/bin:%h/.bun/bin:/usr/local/bin:/usr/bin:/bin",
           "Environment=CI=true",
           `EnvironmentFile=${path.join(stateDir, "env")}`,
-          `ExecStartPre=/usr/bin/git -C ${owner} pull --ff-only --quiet origin main`,
-          "ExecStartPre=/usr/bin/bun install --frozen-lockfile",
-          `ExecStart=/usr/bin/bun run beep graft deep refresh --owner ${owner} --jobs 16`,
+          `ExecStartPre=/usr/bin/git -C "${owner}" pull --ff-only --quiet origin main`,
+          'ExecStartPre="/usr/bin/bun" install --frozen-lockfile',
+          `ExecStart="/usr/bin/bun" run beep graft deep refresh --owner "${owner}" --jobs 16`,
           "TimeoutStartSec=8h",
           "TimeoutStopSec=90",
           "KillMode=mixed",
@@ -670,6 +774,44 @@ layer(NodeServices.layer, { excludeTestServices: true })("Graft deep refresh", (
       expect(untrusted._tag).toBe("GraftDeepPreflightError");
       expect(untrusted.message).toEqual(expect.stringContaining("untrusted config"));
       expect(A.some(commandLines(untrustedCalls), Str.startsWith("systemctl"))).toBe(false);
+      // The unit resolves node through the mise shims, so a mise that exits
+      // non-zero or cannot run at all refuses the install rather than leaving
+      // a timer that fails every night.
+      const brokenMise = yield* Effect.flip(GraftDeepRefresh.use((refresh) => refresh.installTimer(options))).pipe(
+        refreshWith(
+          scriptedRunner({
+            alive: [],
+            calls: [],
+            replies: repliesFor(owner, FULL_COVERAGE, [["mise trust --show", reply(127, "command not found")]]),
+          })
+        )
+      );
+      expect(brokenMise._tag).toBe("GraftDeepPreflightError");
+      expect(brokenMise.message).toEqual(expect.stringContaining("exited with 127"));
+      const absentMise = yield* Effect.flip(GraftDeepRefresh.use((refresh) => refresh.installTimer(options))).pipe(
+        refreshWith(
+          scriptedRunner({
+            alive: [],
+            calls: [],
+            intercept: (step) =>
+              step.command === "mise"
+                ? O.some(
+                    Effect.fail(
+                      GraftDeepStepError.make({
+                        step: "preflight",
+                        exitCode: 1,
+                        log: "",
+                        message: "mise trust --show could not spawn.",
+                      })
+                    )
+                  )
+                : O.none(),
+            replies: happyReplies(owner, FULL_COVERAGE),
+          })
+        )
+      );
+      expect(absentMise._tag).toBe("GraftDeepPreflightError");
+      expect(absentMise.message).toEqual(expect.stringContaining("could not run"));
       // A unit that fetches over SSH would fail every night: the user manager
       // has no agent to answer for the key.
       const sshCalls: Array<GraftDeepRunnerStep> = [];
@@ -696,7 +838,7 @@ layer(NodeServices.layer, { excludeTestServices: true })("Graft deep refresh", (
       const { directory } = yield* fixture();
       const version = yield* GraftDeepRunner.use((runner) =>
         runner.run({ args: ["--version"], command: process.execPath, cwd: directory, phase: "build" })
-      ).pipe(provideScopedLayer(GraftDeepRunnerLive.pipe(Layer.provide(NodeServices.layer))));
+      ).pipe(withLiveRunner());
       expect(version.exitCode).toBe(0);
       expect(Str.isNonEmpty(version.output)).toBe(true);
       const missing = yield* Effect.flip(
@@ -709,7 +851,7 @@ layer(NodeServices.layer, { excludeTestServices: true })("Graft deep refresh", (
             phase: "build",
           })
         )
-      ).pipe(provideScopedLayer(GraftDeepRunnerLive.pipe(Layer.provide(NodeServices.layer))));
+      ).pipe(withLiveRunner());
       expect(missing._tag).toBe("GraftDeepStepError");
       expect(missing.step).toBe("build");
       expect(missing.log).toBe("/state/run.log");
@@ -722,7 +864,7 @@ layer(NodeServices.layer, { excludeTestServices: true })("Graft deep refresh", (
             yield* runner.isPidAlive(0x3ff_ffff),
           ];
         })
-      ).pipe(provideScopedLayer(GraftDeepRunnerLive.pipe(Layer.provide(NodeServices.layer))));
+      ).pipe(withLiveRunner());
       expect(liveness).toEqual([true, true, false]);
     }),
     30_000
@@ -734,14 +876,15 @@ layer(NodeServices.layer, { excludeTestServices: true })("Graft deep refresh", (
       const { fs, path, owner, stateDir } = yield* fixture();
       const calls: Array<GraftDeepRunnerStep> = [];
       const runner = scriptedRunner({ alive: [], calls, replies: happyReplies(owner, FULL_COVERAGE) });
-      expect(yield* GraftDeepRefresh.use((refresh) => refresh.readStatus(stateDir)).pipe(refreshWith(runner))).toEqual(
-        O.none()
-      );
+      assertNone(yield* GraftDeepRefresh.use((refresh) => refresh.readStatus(stateDir)).pipe(refreshWith(runner)));
       yield* GraftDeepRefresh.use((refresh) => refresh.run(refreshOptions({ owner, stateDir }))).pipe(
         refreshWith(runner)
       );
       const read = yield* GraftDeepRefresh.use((refresh) => refresh.readStatus(stateDir)).pipe(refreshWith(runner));
-      expect(O.map(read, (status) => status.outcome)).toEqual(O.some("ok"));
+      assertSome(
+        O.map(read, (status) => status.outcome),
+        "ok"
+      );
       yield* fs.writeFileString(path.join(stateDir, "status.json"), "{ not a status }\n");
       const corrupt = yield* Effect.flip(GraftDeepRefresh.use((refresh) => refresh.readStatus(stateDir))).pipe(
         refreshWith(runner)
@@ -771,17 +914,23 @@ layer(NodeServices.layer, { excludeTestServices: true })("Graft deep refresh", (
       const build = A.findFirst(calls, (call) =>
         Str.startsWith("graft build --deep")(formatCommandLine(call.command, call.args))
       );
-      expect(O.map(build, (call) => call.env?.GRAFT_MODEL)).toEqual(O.some("grok-4.6(low)"));
+      assertSome(
+        O.map(build, (call) => call.env?.GRAFT_MODEL),
+        "grok-4.6(low)"
+      );
       // An operator-set crux retry budget is forwarded rather than overwritten.
       const configuredCalls: Array<GraftDeepRunnerStep> = [];
       yield* GraftDeepRefresh.use((refresh) => refresh.run(refreshOptions({ owner, stateDir }))).pipe(
         refreshWith(scriptedRunner({ alive: [], calls: configuredCalls, replies: happyReplies(owner, FULL_COVERAGE) })),
-        provideScopedLayer(ConfigProvider.layer(ConfigProvider.fromUnknown({ GRAFT_CRUX_EMPTY_RETRIES: "5" })))
+        withCruxRetries()
       );
       const configuredBuild = A.findFirst(configuredCalls, (call) =>
         Str.startsWith("graft build --deep")(formatCommandLine(call.command, call.args))
       );
-      expect(O.map(configuredBuild, (call) => call.env?.GRAFT_CRUX_EMPTY_RETRIES)).toEqual(O.some("5"));
+      assertSome(
+        O.map(configuredBuild, (call) => call.env?.GRAFT_CRUX_EMPTY_RETRIES),
+        "5"
+      );
     }),
     30_000
   );
@@ -936,7 +1085,7 @@ layer(NodeServices.layer, { excludeTestServices: true })("Graft deep refresh", (
     Effect.fn(function* () {
       const { fs, path, owner, siblings, stateDir } = yield* fixture();
       const empty = yield* runCommand(["deep", "status", "--state-dir", stateDir]);
-      expect(Result.isSuccess(empty.result)).toBe(true);
+      assertSuccess(empty.result, undefined);
       expect(empty.output).toEqual([`No refresh recorded under ${stateDir}.`]);
       const calls: Array<GraftDeepRunnerStep> = [];
       const runner = scriptedRunner({ alive: [], calls, replies: happyReplies(owner, FULL_COVERAGE) });
@@ -944,13 +1093,13 @@ layer(NodeServices.layer, { excludeTestServices: true })("Graft deep refresh", (
         refreshWith(runner)
       );
       const rendered = yield* runCommand(["deep", "status", "--state-dir", stateDir]);
-      expect(Result.isSuccess(rendered.result)).toBe(true);
+      assertSuccess(rendered.result, undefined);
       expect(rendered.output[0]).toEqual(expect.stringContaining("Graft deep refresh: done (ok)"));
       expect(rendered.output[0]).toEqual(expect.stringContaining("Coverage: 38520/39115 symbols (98.5%)"));
       expect(rendered.output[0]).toEqual(expect.stringContaining("Seeded: 12 copied"));
       expect(rendered.output[0]).toEqual(expect.stringContaining(`Rebuilt: ${A.length(siblings)} clone(s), 0 failing`));
       const encoded = yield* runCommand(["deep", "status", "--state-dir", stateDir, "--json"]);
-      expect(Result.isSuccess(encoded.result)).toBe(true);
+      assertSuccess(encoded.result, undefined);
       const decoded = yield* decodeStatusJson(encoded.output[0]);
       expect(decoded.head).toBe(OWNER_HEAD_AFTER);
       // A degraded note is rendered for the operator when one is recorded.
@@ -962,10 +1111,9 @@ layer(NodeServices.layer, { excludeTestServices: true })("Graft deep refresh", (
       expect(noted.output[0]).toEqual(expect.stringContaining("Note: one sibling rebuild failed"));
       // Invalid option values are refused before the service ever starts.
       const invalid = yield* runCommand(["deep", "refresh", "--owner", owner, "--state-dir", stateDir, "--jobs", "0"]);
-      expect(O.map(Result.getFailure(invalid.result), (failure) => failure)).toEqual(
-        O.some(
-          expect.objectContaining({ _tag: "GraftDeepPreflightError", path: owner, message: "Invalid refresh options." })
-        )
+      assertSome(
+        O.map(Result.getFailure(invalid.result), (error) => error._tag),
+        "GraftDeepPreflightError"
       );
       // A status with no head, coverage, or seed receipt still renders.
       yield* fs.writeFileString(
@@ -996,12 +1144,237 @@ layer(NodeServices.layer, { excludeTestServices: true })("Graft deep refresh", (
         "--env-file",
         path.join(stateDir, "absent-env"),
       ]);
-      expect(Result.isFailure(timer.result)).toBe(true);
+      assertSome(
+        O.map(Result.getFailure(timer.result), (error) => error._tag),
+        "GraftDeepPreflightError"
+      );
       const group = yield* runCommand(["deep"]);
       expect(group.output[0]).toEqual(expect.stringContaining("Graft deep commands: refresh"));
       const root = yield* runCommand([]);
       expect(root.output[0]).toEqual(expect.stringContaining("deep refresh|status|install-timer"));
     }),
     30_000
+  );
+
+  it.effect(
+    "quotes every path argument systemd would otherwise split",
+    Effect.fn(function* () {
+      const spaced = GraftDeepTimerOptions.make({
+        owner: "/clones/beep effect0",
+        bunPath: "/opt/bun 1/bin/bun",
+        onCalendar: "*-*-* 02:30:00",
+        envFile: "/home/op/beep graft/env",
+        uninstall: false,
+      });
+      const service = renderGraftDeepRefreshUnits(spaced)[0]?.text ?? "";
+      expect(A.filter(Str.split("\n")(service), Str.startsWith("Exec"))).toEqual([
+        'ExecStartPre=/usr/bin/git -C "/clones/beep effect0" pull --ff-only --quiet origin main',
+        'ExecStartPre="/opt/bun 1/bin/bun" install --frozen-lockfile',
+        'ExecStart="/opt/bun 1/bin/bun" run beep graft deep refresh --owner "/clones/beep effect0" --jobs 16',
+      ]);
+      // systemd reads these two as whole lines, so quoting them would make the
+      // quotes part of the path.
+      expect(Str.includes("WorkingDirectory=/clones/beep effect0")(service)).toBe(true);
+      expect(Str.includes("EnvironmentFile=/home/op/beep graft/env")(service)).toBe(true);
+    })
+  );
+
+  it.effect(
+    "reports a failing uninstall instead of claiming units were removed",
+    Effect.fn(function* () {
+      const { fs, path, directory, owner, stateDir } = yield* fixture();
+      const home = path.join(directory, "home");
+      yield* fs.makeDirectory(stateDir, { recursive: true });
+      yield* fs.writeFileString(path.join(stateDir, "env"), "GRAFT_PROVIDER=openai\n");
+      const options = GraftDeepTimerOptions.make({
+        owner,
+        bunPath: "/usr/bin/bun",
+        onCalendar: "*-*-* 02:30:00",
+        envFile: path.join(stateDir, "env"),
+        uninstall: false,
+      });
+      const trusted = repliesFor(owner, FULL_COVERAGE, [["mise trust --show", reply(0, `${owner}: trusted`)]]);
+      const installed = yield* GraftDeepRefresh.use((refresh) => refresh.installTimer(options)).pipe(
+        refreshWith(scriptedRunner({ alive: [], calls: [], replies: trusted })),
+        withHome(home)
+      );
+      const failure = yield* Effect.flip(
+        GraftDeepRefresh.use((refresh) =>
+          refresh.installTimer(GraftDeepTimerOptions.make({ ...options, uninstall: true }))
+        )
+      ).pipe(
+        refreshWith(
+          scriptedRunner({
+            alive: [],
+            calls: [],
+            replies: A.appendAll(
+              [["systemctl --user disable", reply(1, "Failed to disable unit: Access denied")] as const],
+              trusted
+            ),
+          })
+        ),
+        withHome(home)
+      );
+      expect(failure._tag).toBe("GraftDeepStepError");
+      expect(failure.message).toEqual(expect.stringContaining("Access denied"));
+      // The units are still installed, so nothing may claim they were removed.
+      expect(yield* Effect.forEach(installed, (unit) => fs.exists(unit))).toEqual([true, true]);
+    }),
+    30_000
+  );
+
+  it.effect(
+    "drives the refresh, status, and install-timer handlers the command tree wires",
+    Effect.fn(function* () {
+      const { fs, path, directory, owner, siblings, stateDir } = yield* fixture();
+      const home = path.join(directory, "home");
+      const calls: Array<GraftDeepRunnerStep> = [];
+      const runner = scriptedRunner({ alive: [], calls, replies: happyReplies(owner, FULL_COVERAGE) });
+
+      // With no --state-dir the handler falls back under HOME.
+      const defaultDir = yield* captureOutput(
+        runDeepStatus({ stateDir: O.none(), json: false }).pipe(refreshWith(runner), withHome(home))
+      );
+      expect(defaultDir.output).toEqual([
+        `No refresh recorded under ${path.join(home, ".local", "state", "beep-graft")}.`,
+      ]);
+
+      // A `~/` path is expanded against HOME; no shell is involved to do it.
+      const tilde = yield* captureOutput(
+        runDeepStatus({ stateDir: O.some("~/nowhere-graft"), json: false }).pipe(refreshWith(runner), withHome(home))
+      );
+      expect(tilde.output).toEqual([`No refresh recorded under ${path.join(home, "nowhere-graft")}.`]);
+
+      // No run recorded yet.
+      const empty = yield* captureOutput(
+        runDeepStatus({ stateDir: O.some(stateDir), json: false }).pipe(refreshWith(runner))
+      );
+      expect(empty.output).toEqual([`No refresh recorded under ${stateDir}.`]);
+
+      // The human refresh prints one line per phase, then the summary.
+      const human = yield* captureOutput(runDeepRefresh(refreshFlags({ owner, stateDir })).pipe(refreshWith(runner)));
+      assertSuccess(human.result, undefined);
+      expect(A.take(human.output, 7)).toEqual([
+        "graft deep refresh: preflight",
+        "graft deep refresh: pull",
+        "graft deep refresh: install",
+        "graft deep refresh: build",
+        "graft deep refresh: seed",
+        "graft deep refresh: rebuild",
+        "graft deep refresh: done",
+      ]);
+      expect(human.output[7]).toEqual(expect.stringContaining("Graft deep refresh: done (ok)"));
+      expect(human.output[7]).toEqual(expect.stringContaining(`Rebuilt: ${A.length(siblings)} clone(s), 0 failing`));
+
+      // `--json` suppresses the phase lines and emits the encoded document.
+      const encoded = yield* captureOutput(
+        runDeepRefresh(refreshFlags({ owner, stateDir, json: true, model: "grok-4.6(low)" })).pipe(refreshWith(runner))
+      );
+      expect(encoded.output).toHaveLength(1);
+      expect((yield* decodeStatusJson(encoded.output[0])).model).toBe("grok-4.6(low)");
+
+      // Status renders and encodes the recorded run.
+      const rendered = yield* captureOutput(
+        runDeepStatus({ stateDir: O.some(stateDir), json: false }).pipe(refreshWith(runner))
+      );
+      expect(rendered.output[0]).toEqual(expect.stringContaining("Coverage: 38520/39115 symbols (98.5%)"));
+      const statusJson = yield* captureOutput(
+        runDeepStatus({ stateDir: O.some(stateDir), json: true }).pipe(refreshWith(runner))
+      );
+      expect((yield* decodeStatusJson(statusJson.output[0])).head).toBe(OWNER_HEAD_AFTER);
+
+      // A failing build surfaces its typed error through the handler.
+      const failed = yield* captureOutput(
+        runDeepRefresh(refreshFlags({ owner, stateDir })).pipe(
+          refreshWith(
+            scriptedRunner({
+              alive: [],
+              calls: [],
+              replies: repliesFor(owner, FULL_COVERAGE, [["graft build --deep", reply(1, "provider refused")]]),
+            })
+          )
+        )
+      );
+      assertSome(
+        O.map(Result.getFailure(failed.result), (error) => error._tag),
+        "GraftDeepStepError"
+      );
+
+      // So does a lock held by a live process.
+      yield* fs.writeFileString(
+        path.join(stateDir, "refresh.lock"),
+        yield* encodeLockJson(GraftDeepLock.make({ pid: process.pid, startedAt: "2026-09-11T02:30:00.000Z" }))
+      );
+      const locked = yield* captureOutput(
+        runDeepRefresh(refreshFlags({ owner, stateDir })).pipe(
+          refreshWith(scriptedRunner({ alive: [process.pid], calls: [], replies: happyReplies(owner, FULL_COVERAGE) }))
+        )
+      );
+      assertSome(
+        O.map(Result.getFailure(locked.result), (error) => error._tag),
+        "GraftDeepLockError"
+      );
+      yield* fs.remove(path.join(stateDir, "refresh.lock"));
+
+      // A status whose build summarized nothing renders without dividing by zero.
+      yield* fs.writeFileString(
+        path.join(stateDir, "status.json"),
+        yield* encodeStatusJson(
+          GraftDeepRefreshStatus.make({
+            schemaVersion: "beep-graft-deep-refresh/v1",
+            owner,
+            model: "(env default)",
+            jobs: PosInt.make(16),
+            startedAt: "2026-09-11T02:30:00.000Z",
+            phase: "done",
+            outcome: "degraded",
+            coverage: GraftDeepCoverage.make({
+              covered: NonNegativeInt.make(0),
+              total: NonNegativeInt.make(0),
+              failedFiles: NonNegativeInt.make(0),
+            }),
+            rebuilt: [],
+            log: path.join(stateDir, "runs", "20260911T023000Z.log"),
+          })
+        )
+      );
+      const zero = yield* captureOutput(
+        runDeepStatus({ stateDir: O.some(stateDir), json: false }).pipe(refreshWith(runner))
+      );
+      expect(zero.output[0]).toEqual(expect.stringContaining("Coverage: 0/0 symbols (0%)"));
+
+      // install-timer writes, then removes, then has nothing left to remove.
+      const timerRunner = scriptedRunner({
+        alive: [],
+        calls: [],
+        replies: repliesFor(owner, FULL_COVERAGE, [["mise trust --show", reply(0, `${owner}: trusted`)]]),
+      });
+      yield* fs.writeFileString(path.join(stateDir, "env"), "GRAFT_PROVIDER=openai\n");
+      const timerFlags = { owner, onCalendar: "*-*-* 02:30:00", envFile: O.some(path.join(stateDir, "env")) };
+      const wrote = yield* captureOutput(
+        runDeepInstallTimer({ ...timerFlags, uninstall: false }).pipe(refreshWith(timerRunner), withHome(home))
+      );
+      expect(wrote.output[0]).toEqual(expect.stringContaining("graft deep install-timer: wrote"));
+      const removed = yield* captureOutput(
+        runDeepInstallTimer({ ...timerFlags, uninstall: true }).pipe(refreshWith(timerRunner), withHome(home))
+      );
+      expect(removed.output[0]).toEqual(expect.stringContaining("graft deep install-timer: removed"));
+      const again = yield* captureOutput(
+        runDeepInstallTimer({ ...timerFlags, uninstall: true }).pipe(refreshWith(timerRunner), withHome(home))
+      );
+      expect(again.output).toEqual(["graft deep install-timer: no unit files were installed"]);
+      // A default environment file is resolved under HOME when none is given.
+      const defaulted = yield* captureOutput(
+        runDeepInstallTimer({ owner, onCalendar: "*-*-* 02:30:00", envFile: O.none(), uninstall: false }).pipe(
+          refreshWith(timerRunner),
+          withHome(home)
+        )
+      );
+      assertSome(
+        O.map(Result.getFailure(defaulted.result), (error) => error._tag),
+        "GraftDeepPreflightError"
+      );
+    }),
+    60_000
   );
 });

--- a/packages/tooling/tool/cli/test/graft-deep-refresh.test.ts
+++ b/packages/tooling/tool/cli/test/graft-deep-refresh.test.ts
@@ -1,0 +1,1007 @@
+import {
+  GraftCacheSyncLive,
+  GraftDeepCoverage,
+  GraftDeepLock,
+  GraftDeepRefresh,
+  GraftDeepRefreshLayer,
+  GraftDeepRefreshOptions,
+  GraftDeepRefreshProgress,
+  GraftDeepRefreshStatus,
+  GraftDeepRunner,
+  GraftDeepRunnerLive,
+  GraftDeepStepError,
+  GraftDeepTimerOptions,
+  graftCommand,
+  parseDeepCoverage,
+  renderGraftDeepRefreshUnits,
+} from "@beep/repo-cli/commands/Graft";
+import { CommandJsonOutput } from "@beep/repo-cli/test/Cli";
+import { CapturedStep, formatCommandLine } from "@beep/repo-cli/test/Process";
+import { PosInt } from "@beep/schema/Int";
+import { NonNegativeInt } from "@beep/schema/Number";
+import { UnitInterval } from "@beep/schema/UnitInterval";
+import { provideScopedLayer } from "@beep/test-utils";
+import { NodeServices } from "@effect/platform-node";
+import { expect, layer } from "@effect/vitest";
+import { ConfigProvider, Console, Effect, FileSystem, Layer, Path } from "effect";
+import * as A from "effect/Array";
+import * as Dur from "effect/Duration";
+import * as MutableHashMap from "effect/MutableHashMap";
+import * as O from "effect/Option";
+import * as Result from "effect/Result";
+import * as S from "effect/Schema";
+import * as Str from "effect/String";
+import { Command } from "effect/unstable/cli";
+import type { GraftDeepRunnerStep } from "@beep/repo-cli/commands/Graft";
+
+const artifacts = [
+  ".cache/summaries.json",
+  "INDEX.md",
+  "effects.md",
+  "services.md",
+  ".graph/wiring.json",
+  "manifest.json",
+];
+const contents = [
+  '{"summaries":{"file":"paid summary"}}\n',
+  "# Index\n",
+  "# Effects\n",
+  "# Services\n",
+  '{"crux":"paid crux"}\n',
+  '{"version":1,"model":"test-model","repoDigest":"test-digest","files":[{"path":"src/file.ts","hash":"0a1b2c3d"}],"nodes":[{"slug":"effects","name":"Effects","type":"system","sources":["src/file.ts"]}]}\n',
+];
+
+const OWNER_HEAD = "1111111111111111111111111111111111111111";
+const OWNER_HEAD_AFTER = "2222222222222222222222222222222222222222";
+const FULL_COVERAGE = "meaning coverage: 38520/39115 symbols (98%).\n";
+const LOW_COVERAGE = "meaning coverage: 900/1000 symbols (90%).\n";
+
+const decodeStatusJson = S.decodeUnknownEffect(S.fromJsonString(GraftDeepRefreshStatus));
+const encodeStatusJson = S.encodeEffect(S.fromJsonString(GraftDeepRefreshStatus));
+const encodeLockJson = S.encodeEffect(S.fromJsonString(GraftDeepLock));
+
+// A clone tree the real cache sync accepts: an owner with the paid meaning tier
+// and two sibling clones whose basenames share its digit-stripped prefix.
+const fixture = Effect.fn("GraftDeepRefreshTest.fixture")(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const directory = yield* fs.realPath(yield* fs.makeTempDirectoryScoped({ prefix: "graft-deep-refresh-test-" }));
+  const owner = path.join(directory, "beep-effect0");
+  const siblings = A.map(["beep-effect2", "beep-effect3"], (name) => path.join(directory, name));
+  const stateDir = path.join(directory, "state");
+  yield* fs.makeDirectory(path.join(owner, ".git"), { recursive: true });
+  yield* Effect.forEach(
+    siblings,
+    Effect.fn("GraftDeepRefreshTest.sibling")(function* (root) {
+      yield* fs.makeDirectory(root, { recursive: true });
+      yield* fs.writeFileString(path.join(root, ".git"), "gitdir: untouched\n");
+    })
+  );
+  yield* Effect.forEach(
+    artifacts,
+    Effect.fn("GraftDeepRefreshTest.seed")(function* (relative, index) {
+      const file = path.join(owner, "graft", relative);
+      yield* fs.makeDirectory(path.dirname(file), { recursive: true });
+      yield* fs.writeFileString(file, contents[index] ?? "");
+    })
+  );
+  return { fs, path, directory, owner, siblings, stateDir };
+});
+
+const reply = (exitCode: number, output: string): CapturedStep =>
+  CapturedStep.make({ exitCode, output, truncated: false });
+
+// Scripted answers are matched on the rendered command line by prefix, so a
+// step whose arguments vary (the `-j` of a deep build) still resolves.
+const scriptedRunner = (options: {
+  readonly alive: ReadonlyArray<number>;
+  readonly calls: Array<GraftDeepRunnerStep>;
+  readonly intercept?: (step: GraftDeepRunnerStep) => O.Option<Effect.Effect<CapturedStep, GraftDeepStepError>>;
+  readonly replies: ReadonlyArray<readonly [string, CapturedStep]>;
+  readonly sequences?: ReadonlyArray<readonly [string, ReadonlyArray<CapturedStep>]>;
+}): Layer.Layer<GraftDeepRunner> => {
+  const seen = MutableHashMap.empty<string, number>();
+  const sequenced = (line: string): O.Option<CapturedStep> =>
+    O.flatMap(
+      A.findFirst(options.sequences ?? HEAD_SEQUENCE, ([prefix]) => Str.startsWith(prefix)(line)),
+      ([prefix, answers]) => {
+        const index = O.getOrElse(MutableHashMap.get(seen, prefix), () => 0);
+        MutableHashMap.set(seen, prefix, index + 1);
+        return O.orElse(A.get(answers, index), () => A.last(answers));
+      }
+    );
+  return Layer.succeed(
+    GraftDeepRunner,
+    GraftDeepRunner.of({
+      isPidAlive: Effect.fn("GraftDeepRefreshTest.isPidAlive")(function* (pid) {
+        return A.contains(options.alive, pid);
+      }),
+      run: Effect.fn("GraftDeepRefreshTest.run")(function* (step) {
+        options.calls.push(step);
+        const intercepted = options.intercept?.(step) ?? O.none();
+        if (O.isSome(intercepted)) return yield* intercepted.value;
+        const line = formatCommandLine(step.command, step.args);
+        return O.getOrElse(
+          O.orElse(sequenced(line), () =>
+            O.map(
+              A.findFirst(options.replies, ([prefix]) => Str.startsWith(prefix)(line)),
+              ([, answer]) => answer
+            )
+          ),
+          () => reply(0, "")
+        );
+      }),
+    })
+  );
+};
+
+// `git rev-parse HEAD` runs twice per pull and must answer differently each
+// time; prefix matching alone cannot tell the two calls apart.
+const HEAD_SEQUENCE: ReadonlyArray<readonly [string, ReadonlyArray<CapturedStep>]> = [
+  ["git rev-parse HEAD", [reply(0, OWNER_HEAD), reply(0, OWNER_HEAD_AFTER)]],
+];
+
+// Overrides are consulted first, so a test replaces one answer by name.
+const repliesFor = (
+  owner: string,
+  buildOutput: string,
+  overrides: ReadonlyArray<readonly [string, CapturedStep]> = []
+): ReadonlyArray<readonly [string, CapturedStep]> => A.appendAll(overrides, happyReplies(owner, buildOutput));
+
+const happyReplies = (owner: string, buildOutput: string): ReadonlyArray<readonly [string, CapturedStep]> => [
+  ["git rev-parse --show-toplevel", reply(0, owner)],
+  ["git rev-parse --abbrev-ref HEAD", reply(0, "main")],
+  ["git status --porcelain", reply(0, "")],
+  ["git remote get-url origin", reply(0, "https://github.com/beep-effect/beep-effect.git")],
+  ["graft --version", reply(0, "0.16.0")],
+  ["git fetch", reply(0, "")],
+  ["git merge", reply(0, "")],
+  ["git diff --quiet", reply(0, "")],
+  ["graft build --deep", reply(0, buildOutput)],
+  ["graft build", reply(0, "structural rebuild complete")],
+];
+
+const refreshOptions = (input: {
+  readonly owner: string;
+  readonly stateDir: string;
+  readonly minCoverage?: number;
+  readonly model?: string;
+  readonly seed?: boolean;
+  readonly rebuild?: boolean;
+}): GraftDeepRefreshOptions =>
+  GraftDeepRefreshOptions.make({
+    owner: input.owner,
+    stateDir: input.stateDir,
+    jobs: PosInt.make(16),
+    minCoverage: UnitInterval.make(input.minCoverage ?? 0.95),
+    seed: input.seed ?? true,
+    rebuild: input.rebuild ?? true,
+    rebuildConcurrency: PosInt.make(2),
+    ...O.getOrElse(
+      O.map(O.fromUndefinedOr(input.model), (model) => ({ model })),
+      () => ({})
+    ),
+  });
+
+const refreshWith = (runner: Layer.Layer<GraftDeepRunner>) =>
+  provideScopedLayer(GraftDeepRefreshLayer.pipe(Layer.provide(Layer.mergeAll(runner, GraftCacheSyncLive))));
+
+const withHome = (home: string) => provideScopedLayer(ConfigProvider.layer(ConfigProvider.fromUnknown({ HOME: home })));
+
+const runCommand = Effect.fn("GraftDeepRefreshTest.runCommand")(function* (args: ReadonlyArray<string>) {
+  const current = yield* Console.Console;
+  let output: ReadonlyArray<unknown> = [];
+  const result = yield* Effect.result(
+    Command.runWith(graftCommand, { version: "test", renderErrors: false })(args).pipe(
+      Effect.provideService(Console.Console, {
+        ...current,
+        log: (...values: ReadonlyArray<unknown>) => {
+          output = A.appendAll(output, values);
+        },
+      }),
+      Effect.provideService(CommandJsonOutput, (text) =>
+        Effect.sync(() => {
+          output = A.append(output, text);
+        })
+      )
+    )
+  );
+  return { result, output };
+});
+
+const commandLines = (calls: ReadonlyArray<GraftDeepRunnerStep>): ReadonlyArray<string> =>
+  A.map(calls, (call) => formatCommandLine(call.command, call.args));
+
+// The real clock, not the test clock: this suite drives filesystem work, a
+// bounded retry inside the lock steal, and an interrupt delivered by a timeout.
+layer(NodeServices.layer, { excludeTestServices: true })("Graft deep refresh", (it) => {
+  it.effect(
+    "parses coverage from both summary lines, carriage-return progress, and reports none without a coverage line",
+    Effect.fn(function* () {
+      const both = parseDeepCoverage(`${FULL_COVERAGE}1 file(s) failed to summarize.\n`);
+      expect(O.map(both, (coverage) => [coverage.covered, coverage.total, coverage.failedFiles])).toEqual(
+        O.some([38_520, 39_115, 1])
+      );
+      // A build that summarized every file never prints the failure line.
+      expect(O.map(parseDeepCoverage(FULL_COVERAGE), (coverage) => coverage.failedFiles)).toEqual(O.some(0));
+      const noisy = `crux 4137/4138\rcrux 4138/4138\r${FULL_COVERAGE}`;
+      expect(O.map(parseDeepCoverage(noisy), (coverage) => coverage.covered)).toEqual(O.some(38_520));
+      // The last coverage line describes the finished build.
+      expect(O.map(parseDeepCoverage(`${LOW_COVERAGE}${FULL_COVERAGE}`), (coverage) => coverage.covered)).toEqual(
+        O.some(38_520)
+      );
+      expect(parseDeepCoverage("graft build --deep: nothing to do\n")).toEqual(O.none());
+    })
+  );
+
+  it.effect(
+    "round-trips a complete status document through the JSON codec",
+    Effect.fn(function* () {
+      const status = GraftDeepRefreshStatus.make({
+        schemaVersion: "beep-graft-deep-refresh/v1",
+        owner: "/clones/beep-effect0",
+        head: OWNER_HEAD_AFTER,
+        model: "grok-4.6(low)",
+        jobs: PosInt.make(16),
+        startedAt: "2026-09-11T02:30:00.000Z",
+        finishedAt: "2026-09-11T09:12:00.000Z",
+        phase: "done",
+        outcome: "degraded",
+        coverage: GraftDeepCoverage.make({
+          covered: NonNegativeInt.make(38_520),
+          total: NonNegativeInt.make(39_115),
+          failedFiles: NonNegativeInt.make(1),
+        }),
+        rebuilt: [],
+        log: "/state/beep-graft/runs/20260911T023000Z.log",
+        message: "coverage is 98.5%, below the 99% target",
+      });
+      expect(yield* decodeStatusJson(yield* encodeStatusJson(status))).toEqual(status);
+    })
+  );
+
+  it.effect(
+    "acquires the refresh lock, releases it on completion, and replaces a lock whose holder is gone",
+    Effect.fn(function* () {
+      const { fs, path, owner, stateDir } = yield* fixture();
+      const calls: Array<GraftDeepRunnerStep> = [];
+      const runner = scriptedRunner({ alive: [], calls, replies: happyReplies(owner, FULL_COVERAGE) });
+      const lockPath = path.join(stateDir, "refresh.lock");
+      yield* fs.makeDirectory(stateDir, { recursive: true });
+      yield* fs.writeFileString(
+        lockPath,
+        yield* encodeLockJson(GraftDeepLock.make({ pid: 424_242, startedAt: "2026-09-10T02:30:00.000Z" }))
+      );
+      const status = yield* GraftDeepRefresh.use((refresh) => refresh.run(refreshOptions({ owner, stateDir }))).pipe(
+        refreshWith(runner)
+      );
+      expect(status.outcome).toBe("ok");
+      // The stale lock was replaced, then removed when the run finished.
+      expect(yield* fs.exists(lockPath)).toBe(false);
+    })
+  );
+
+  it.effect(
+    "refuses to start while a live process holds the lock and leaves that lock untouched",
+    Effect.fn(function* () {
+      const { fs, path, owner, stateDir } = yield* fixture();
+      const calls: Array<GraftDeepRunnerStep> = [];
+      const runner = scriptedRunner({
+        alive: [process.pid],
+        calls,
+        replies: happyReplies(owner, FULL_COVERAGE),
+      });
+      const lockPath = path.join(stateDir, "refresh.lock");
+      yield* fs.makeDirectory(stateDir, { recursive: true });
+      const held = yield* encodeLockJson(
+        GraftDeepLock.make({ pid: process.pid, startedAt: "2026-09-11T02:30:00.000Z" })
+      );
+      yield* fs.writeFileString(lockPath, held);
+      const failure = yield* Effect.flip(
+        GraftDeepRefresh.use((refresh) => refresh.run(refreshOptions({ owner, stateDir })))
+      ).pipe(refreshWith(runner));
+      expect(failure._tag).toBe("GraftDeepLockError");
+      expect(yield* fs.readFileString(lockPath)).toBe(held);
+      // Nothing but the operator notification ran: the fence is checked before
+      // any Git command, and the live run's status file is left alone.
+      expect(A.map(calls, (call) => call.command)).toEqual(["notify-send"]);
+      expect(A.last(A.flatMap(calls, (call) => A.fromIterable(call.args)))).toEqual(
+        O.some(`Refresh lock ${lockPath} is held by live process ${process.pid}.`)
+      );
+      expect(yield* fs.exists(path.join(stateDir, "status.json"))).toBe(false);
+    })
+  );
+
+  it.effect(
+    "loses a stale-lock steal race without deleting the winner's lock and names the live holder",
+    Effect.fn(function* () {
+      const { fs, path, owner, stateDir } = yield* fixture();
+      const lockPath = path.join(stateDir, "refresh.lock");
+      const dead = 424_242;
+      yield* fs.makeDirectory(stateDir, { recursive: true });
+      yield* fs.writeFileString(
+        lockPath,
+        yield* encodeLockJson(GraftDeepLock.make({ pid: dead, startedAt: "2026-09-10T02:30:00.000Z" }))
+      );
+      const winner = yield* encodeLockJson(
+        GraftDeepLock.make({ pid: process.pid, startedAt: "2026-09-11T02:30:00.000Z" })
+      );
+      // Stand in for the racer that renamed the stale lock aside first and then
+      // claimed it: this run's rename finds nothing to move.
+      const racingFs = FileSystem.FileSystem.of({
+        ...fs,
+        rename: Effect.fn("GraftDeepRefreshTest.racingRename")(function* (from, to) {
+          if (from !== lockPath) return yield* fs.rename(from, to);
+          yield* fs.writeFileString(lockPath, winner);
+          return yield* fs.rename(path.join(stateDir, "never-existed"), to);
+        }),
+      });
+      const calls: Array<GraftDeepRunnerStep> = [];
+      const failure = yield* Effect.flip(
+        GraftDeepRefresh.use((refresh) => refresh.run(refreshOptions({ owner, stateDir })))
+      ).pipe(
+        refreshWith(scriptedRunner({ alive: [process.pid], calls, replies: happyReplies(owner, FULL_COVERAGE) })),
+        Effect.provideService(FileSystem.FileSystem, racingFs)
+      );
+      // The live winner is named, never the dead pid this run started from.
+      expect(failure).toEqual(expect.objectContaining({ _tag: "GraftDeepLockError", holderPid: process.pid }));
+      expect(yield* fs.readFileString(lockPath)).toBe(winner);
+      expect(yield* fs.exists(path.join(stateDir, "status.json"))).toBe(false);
+    }),
+    30_000
+  );
+
+  it.effect(
+    "records a sibling rebuild that never finished and degrades instead of losing the run",
+    Effect.fn(function* () {
+      const { owner, siblings, stateDir } = yield* fixture();
+      const stalled = siblings[1] ?? "";
+      const calls: Array<GraftDeepRunnerStep> = [];
+      const runner = scriptedRunner({
+        alive: [],
+        calls,
+        // A rebuild that hits its own timeout reaches the error channel; the
+        // run must degrade rather than interrupt the clones still rebuilding.
+        intercept: (step) =>
+          step.phase === "rebuild" && step.cwd === stalled
+            ? O.some(
+                Effect.fail(
+                  GraftDeepStepError.make({
+                    step: "rebuild",
+                    exitCode: 1,
+                    log: "",
+                    message: `graft build timed out in ${stalled}.`,
+                  })
+                )
+              )
+            : O.none(),
+        replies: happyReplies(owner, FULL_COVERAGE),
+      });
+      const status = yield* GraftDeepRefresh.use((refresh) => refresh.run(refreshOptions({ owner, stateDir }))).pipe(
+        refreshWith(runner)
+      );
+      expect(status.outcome).toBe("degraded");
+      expect(status.message).toEqual(expect.stringContaining("1 sibling rebuild(s) exited non-zero"));
+      expect(A.map(status.rebuilt, (entry) => [entry.root, entry.exitCode])).toEqual([
+        [siblings[0], 0],
+        [stalled, 124],
+      ]);
+    }),
+    30_000
+  );
+
+  it.effect(
+    "records an interrupted run as failed, notifies, and releases the lock",
+    Effect.fn(function* () {
+      const { fs, path, owner, stateDir } = yield* fixture();
+      const calls: Array<GraftDeepRunnerStep> = [];
+      const runner = scriptedRunner({
+        alive: [],
+        calls,
+        // systemd stops the unit with SIGTERM, which runMain turns into a fiber
+        // interrupt; a deep build parked mid-run is what that interrupts.
+        intercept: (step) =>
+          Str.startsWith("graft build --deep")(formatCommandLine(step.command, step.args))
+            ? O.some(Effect.never)
+            : O.none(),
+        replies: happyReplies(owner, FULL_COVERAGE),
+      });
+      const interrupted = yield* Effect.timeoutOption(
+        GraftDeepRefresh.use((refresh) => refresh.run(refreshOptions({ owner, stateDir }))).pipe(refreshWith(runner)),
+        Dur.seconds(2)
+      );
+      expect(interrupted).toEqual(O.none());
+      const recorded = yield* decodeStatusJson(yield* fs.readFileString(path.join(stateDir, "status.json")));
+      expect(recorded.outcome).toBe("failed");
+      expect(recorded.message).toEqual(expect.stringContaining("interrupted during build"));
+      expect(recorded.finishedAt).toBeDefined();
+      expect(A.some(commandLines(calls), Str.startsWith("notify-send"))).toBe(true);
+      // The finalizer ran inside the locked region, and the lock came off after.
+      expect(yield* fs.exists(path.join(stateDir, "refresh.lock"))).toBe(false);
+    }),
+    30_000
+  );
+
+  it.effect(
+    "refuses a dirty tree, a non-main branch, and a failing patch-kit check before touching Git history",
+    Effect.fn(function* () {
+      const { owner, stateDir } = yield* fixture();
+      const refuse = Effect.fn("GraftDeepRefreshTest.refuse")(function* (
+        replies: ReadonlyArray<readonly [string, CapturedStep]>
+      ) {
+        const calls: Array<GraftDeepRunnerStep> = [];
+        const runner = scriptedRunner({ alive: [], calls, replies });
+        const failure = yield* Effect.flip(
+          GraftDeepRefresh.use((refresh) => refresh.run(refreshOptions({ owner, stateDir })))
+        ).pipe(refreshWith(runner));
+        return { calls, failure };
+      });
+      const dirty = yield* refuse(
+        repliesFor(owner, FULL_COVERAGE, [["git status --porcelain", reply(0, " M AGENTS.md")]])
+      );
+      expect(dirty.failure._tag).toBe("GraftDeepPreflightError");
+      expect(A.some(commandLines(dirty.calls), Str.startsWith("git fetch"))).toBe(false);
+      const branched = yield* refuse(
+        repliesFor(owner, FULL_COVERAGE, [["git rev-parse --abbrev-ref HEAD", reply(0, "feat/graft-deep-refresh")]])
+      );
+      expect(branched.failure._tag).toBe("GraftDeepPreflightError");
+      const patched = yield* refuse(repliesFor(owner, FULL_COVERAGE, [["/", reply(1, "missing: ai/crux.js")]]));
+      expect(patched.failure._tag).toBe("GraftDeepPreflightError");
+      expect(A.some(commandLines(patched.calls), Str.includes("apply-dist-patches.sh"))).toBe(true);
+      // The notifier fires once per failed run.
+      expect(A.filter(commandLines(patched.calls), Str.startsWith("notify-send"))).toHaveLength(1);
+    })
+  );
+
+  it.effect(
+    "records every phase in status.json, seeds both siblings, rebuilds them, and reports ok",
+    Effect.fn(function* () {
+      const { fs, path, owner, siblings, stateDir } = yield* fixture();
+      const calls: Array<GraftDeepRunnerStep> = [];
+      const runner = scriptedRunner({ alive: [], calls, replies: happyReplies(owner, FULL_COVERAGE) });
+      let phases: ReadonlyArray<string> = [];
+      const statusFile = path.join(stateDir, "status.json");
+      // Reading the file back inside the sink proves the status was on disk
+      // before the phase was announced.
+      const recordPhase = Effect.fnUntraced(function* () {
+        const onDisk = yield* decodeStatusJson(yield* fs.readFileString(statusFile));
+        phases = A.append(phases, onDisk.phase);
+      });
+      const status = yield* GraftDeepRefresh.use((refresh) => refresh.run(refreshOptions({ owner, stateDir }))).pipe(
+        Effect.provideService(GraftDeepRefreshProgress, () => Effect.orDie(recordPhase())),
+        refreshWith(runner)
+      );
+      expect(phases).toEqual(["preflight", "pull", "install", "build", "seed", "rebuild", "done"]);
+      expect(status.outcome).toBe("ok");
+      expect(status.head).toBe(OWNER_HEAD_AFTER);
+      expect(status.model).toBe("(env default)");
+      expect(O.map(O.fromUndefinedOr(status.coverage), (coverage) => coverage.covered)).toEqual(O.some(38_520));
+      expect(O.map(O.fromUndefinedOr(status.seed), (seed) => seed.copied)).toEqual(O.some(12));
+      expect(A.map(status.rebuilt, (entry) => entry.root)).toEqual(siblings);
+      expect(A.every(status.rebuilt, (entry) => entry.exitCode === 0)).toBe(true);
+      expect(status.message).toBeUndefined();
+      // Both clones really received the paid artifacts.
+      expect(yield* fs.readFileString(path.join(siblings[0] ?? "", "graft", "manifest.json"))).toBe(contents[5]);
+      expect(yield* fs.readFileString(path.join(siblings[1] ?? "", "graft", ".cache", "summaries.json"))).toBe(
+        contents[0]
+      );
+      // The deep build carries the crux-retry default and one structural
+      // rebuild ran per seeded clone.
+      const build = A.findFirst(calls, (call) =>
+        Str.startsWith("graft build --deep")(formatCommandLine(call.command, call.args))
+      );
+      expect(O.map(build, (call) => call.env?.GRAFT_CRUX_EMPTY_RETRIES)).toEqual(O.some("2"));
+      expect(O.map(build, (call) => call.env?.GRAFT_MODEL)).toEqual(O.some(undefined));
+      expect(A.filter(commandLines(calls), (line) => line === "graft build")).toHaveLength(2);
+      // The lockfile diff spans the revisions the pull actually moved between.
+      expect(commandLines(calls)).toContain(`git diff --quiet ${OWNER_HEAD} ${OWNER_HEAD_AFTER} -- bun.lock`);
+      expect(A.some(commandLines(calls), Str.startsWith("notify-send"))).toBe(false);
+      // The run log kept the captured output of the deep build.
+      expect(Str.includes("meaning coverage")(yield* fs.readFileString(status.log))).toBe(true);
+    }),
+    30_000
+  );
+
+  it.effect(
+    "ignores git stderr noise on the value-bearing probes",
+    Effect.fn(function* () {
+      const { owner, stateDir } = yield* fixture();
+      const calls: Array<GraftDeepRunnerStep> = [];
+      // A --reference clone routinely warns about a broken origin/HEAD ref.
+      // Merged into stdout that warning reads as a dirty tree and as a corrupt
+      // revision, so every parsed probe must ask for stdout alone.
+      const runner = scriptedRunner({ alive: [], calls, replies: happyReplies(owner, FULL_COVERAGE) });
+      const status = yield* GraftDeepRefresh.use((refresh) => refresh.run(refreshOptions({ owner, stateDir }))).pipe(
+        refreshWith(runner)
+      );
+      expect(status.outcome).toBe("ok");
+      const parsed = A.filter(calls, (call) =>
+        A.contains(
+          [
+            "git rev-parse --show-toplevel",
+            "git rev-parse --abbrev-ref HEAD",
+            "git status --porcelain",
+            "git remote get-url origin",
+            "git rev-parse HEAD",
+          ],
+          formatCommandLine(call.command, call.args)
+        )
+      );
+      expect(A.length(parsed)).toBe(6);
+      expect(A.every(parsed, (call) => call.source === "stdout")).toBe(true);
+      // Log-only steps keep stderr, which is where a failing build explains itself.
+      const build = A.findFirst(calls, (call) =>
+        Str.startsWith("graft build --deep")(formatCommandLine(call.command, call.args))
+      );
+      expect(O.map(build, (call) => call.source)).toEqual(O.some(undefined));
+    }),
+    30_000
+  );
+
+  it.effect(
+    "reports degraded when coverage is below the target and still seeds the siblings",
+    Effect.fn(function* () {
+      const { fs, path, owner, siblings, stateDir } = yield* fixture();
+      const calls: Array<GraftDeepRunnerStep> = [];
+      const runner = scriptedRunner({ alive: [], calls, replies: happyReplies(owner, LOW_COVERAGE) });
+      const status = yield* GraftDeepRefresh.use((refresh) =>
+        refresh.run(refreshOptions({ owner, stateDir, minCoverage: 0.95 }))
+      ).pipe(refreshWith(runner));
+      expect(status.outcome).toBe("degraded");
+      expect(status.message).toEqual(expect.stringContaining("below the 95% target"));
+      expect(O.map(O.fromUndefinedOr(status.seed), (seed) => seed.refused)).toEqual(O.some(0));
+      expect(yield* fs.exists(path.join(siblings[0] ?? "", "graft", "INDEX.md"))).toBe(true);
+      // A degraded night is not a failure, so no operator notification fires.
+      expect(A.some(commandLines(calls), Str.startsWith("notify-send"))).toBe(false);
+    }),
+    30_000
+  );
+
+  it.effect(
+    "fails a non-zero deep build, records the failure in status.json, and notifies the operator",
+    Effect.fn(function* () {
+      const { fs, path, owner, siblings, stateDir } = yield* fixture();
+      const calls: Array<GraftDeepRunnerStep> = [];
+      const runner = scriptedRunner({
+        alive: [],
+        calls,
+        replies: repliesFor(owner, FULL_COVERAGE, [
+          ["graft build --deep", reply(1, "fatal: provider refused the request")],
+        ]),
+      });
+      const failure = yield* Effect.flip(
+        GraftDeepRefresh.use((refresh) => refresh.run(refreshOptions({ owner, stateDir })))
+      ).pipe(refreshWith(runner));
+      expect(failure._tag).toBe("GraftDeepStepError");
+      const recorded = yield* decodeStatusJson(yield* fs.readFileString(path.join(stateDir, "status.json")));
+      expect(recorded.outcome).toBe("failed");
+      expect(recorded.phase).toBe("build");
+      expect(recorded.message).toEqual(expect.stringContaining("exited with 1"));
+      const notifications = A.filter(calls, (call) => call.command === "notify-send");
+      expect(A.map(notifications, (call) => A.take(call.args, 2))).toEqual([
+        ["--urgency=critical", "beep graft deep refresh failed"],
+      ]);
+      // Nothing was seeded and no clone was rebuilt.
+      expect(yield* fs.exists(path.join(siblings[0] ?? "", "graft"))).toBe(false);
+      expect(A.filter(commandLines(calls), (line) => line === "graft build")).toHaveLength(0);
+      expect(yield* fs.exists(path.join(stateDir, "refresh.lock"))).toBe(false);
+    }),
+    30_000
+  );
+
+  it.effect(
+    "renders the systemd units verbatim and refuses to install without an environment file",
+    Effect.fn(function* () {
+      const { fs, path, owner, stateDir } = yield* fixture();
+      const options = GraftDeepTimerOptions.make({
+        owner,
+        bunPath: "/usr/bin/bun",
+        onCalendar: "*-*-* 02:30:00",
+        envFile: path.join(stateDir, "env"),
+        uninstall: false,
+      });
+      const units = renderGraftDeepRefreshUnits(options);
+      expect(A.map(units, (unit) => unit.fileName)).toEqual([
+        "beep-graft-deep-refresh.service",
+        "beep-graft-deep-refresh.timer",
+      ]);
+      expect(units[0]?.text).toBe(
+        [
+          "[Unit]",
+          "Description=beep graft deep refresh (nightly meaning-tier rebuild + sibling seed)",
+          "",
+          "[Service]",
+          "Type=oneshot",
+          `WorkingDirectory=${owner}`,
+          "Environment=PATH=%h/.local/share/mise/shims:%h/.local/bin:%h/.bun/bin:/usr/local/bin:/usr/bin:/bin",
+          "Environment=CI=true",
+          `EnvironmentFile=${path.join(stateDir, "env")}`,
+          `ExecStartPre=/usr/bin/git -C ${owner} pull --ff-only --quiet origin main`,
+          "ExecStartPre=/usr/bin/bun install --frozen-lockfile",
+          `ExecStart=/usr/bin/bun run beep graft deep refresh --owner ${owner} --jobs 16`,
+          "TimeoutStartSec=8h",
+          "TimeoutStopSec=90",
+          "KillMode=mixed",
+          "Nice=10",
+          "Slice=background.slice",
+          "",
+        ].join("\n")
+      );
+      expect(units[1]?.text).toBe(
+        [
+          "[Unit]",
+          "Description=Timer for beep graft deep refresh (nightly meaning-tier rebuild + sibling seed)",
+          "",
+          "[Timer]",
+          "OnCalendar=*-*-* 02:30:00",
+          "Persistent=true",
+          "RandomizedDelaySec=600",
+          "",
+          "[Install]",
+          "WantedBy=timers.target",
+          "",
+        ].join("\n")
+      );
+      const calls: Array<GraftDeepRunnerStep> = [];
+      const runner = scriptedRunner({ alive: [], calls, replies: happyReplies(owner, FULL_COVERAGE) });
+      const failure = yield* Effect.flip(GraftDeepRefresh.use((refresh) => refresh.installTimer(options))).pipe(
+        refreshWith(runner)
+      );
+      expect(failure).toEqual(
+        expect.objectContaining({ _tag: "GraftDeepPreflightError", path: path.join(stateDir, "env") })
+      );
+      // A missing environment file is refused before systemd is touched.
+      expect(A.some(commandLines(calls), Str.startsWith("systemctl"))).toBe(false);
+      // Once the file exists the installer refuses an untrusted mise config.
+      yield* fs.makeDirectory(stateDir, { recursive: true });
+      yield* fs.writeFileString(path.join(stateDir, "env"), "GRAFT_PROVIDER=openai\n");
+      const untrustedCalls: Array<GraftDeepRunnerStep> = [];
+      const untrusted = yield* Effect.flip(GraftDeepRefresh.use((refresh) => refresh.installTimer(options))).pipe(
+        refreshWith(
+          scriptedRunner({
+            alive: [],
+            calls: untrustedCalls,
+            replies: repliesFor(owner, FULL_COVERAGE, [
+              ["mise trust --show", reply(0, `${owner}/mise.toml: untrusted`)],
+            ]),
+          })
+        )
+      );
+      expect(untrusted._tag).toBe("GraftDeepPreflightError");
+      expect(untrusted.message).toEqual(expect.stringContaining("untrusted config"));
+      expect(A.some(commandLines(untrustedCalls), Str.startsWith("systemctl"))).toBe(false);
+      // A unit that fetches over SSH would fail every night: the user manager
+      // has no agent to answer for the key.
+      const sshCalls: Array<GraftDeepRunnerStep> = [];
+      const sshRemote = yield* Effect.flip(GraftDeepRefresh.use((refresh) => refresh.installTimer(options))).pipe(
+        refreshWith(
+          scriptedRunner({
+            alive: [],
+            calls: sshCalls,
+            replies: repliesFor(owner, FULL_COVERAGE, [
+              ["git remote get-url origin", reply(0, "git@github.com:beep-effect/beep-effect.git")],
+            ]),
+          })
+        )
+      );
+      expect(sshRemote._tag).toBe("GraftDeepPreflightError");
+      expect(sshRemote.message).toEqual(expect.stringContaining("no SSH agent"));
+      expect(A.some(commandLines(sshCalls), Str.startsWith("systemctl"))).toBe(false);
+    })
+  );
+
+  it.effect(
+    "captures real subprocess output, tags a command that cannot spawn, and probes process liveness",
+    Effect.fn(function* () {
+      const { directory } = yield* fixture();
+      const version = yield* GraftDeepRunner.use((runner) =>
+        runner.run({ args: ["--version"], command: process.execPath, cwd: directory, phase: "build" })
+      ).pipe(provideScopedLayer(GraftDeepRunnerLive.pipe(Layer.provide(NodeServices.layer))));
+      expect(version.exitCode).toBe(0);
+      expect(Str.isNonEmpty(version.output)).toBe(true);
+      const missing = yield* Effect.flip(
+        GraftDeepRunner.use((runner) =>
+          runner.run({
+            args: [],
+            command: "beep-graft-deep-refresh-missing-binary",
+            cwd: directory,
+            log: "/state/run.log",
+            phase: "build",
+          })
+        )
+      ).pipe(provideScopedLayer(GraftDeepRunnerLive.pipe(Layer.provide(NodeServices.layer))));
+      expect(missing._tag).toBe("GraftDeepStepError");
+      expect(missing.step).toBe("build");
+      expect(missing.log).toBe("/state/run.log");
+      const liveness = yield* GraftDeepRunner.use(
+        Effect.fn("GraftDeepRefreshTest.liveness")(function* (runner) {
+          // PID 1 always exists; a non-root prober sees it through EPERM.
+          return [
+            yield* runner.isPidAlive(process.pid),
+            yield* runner.isPidAlive(1),
+            yield* runner.isPidAlive(0x3ff_ffff),
+          ];
+        })
+      ).pipe(provideScopedLayer(GraftDeepRunnerLive.pipe(Layer.provide(NodeServices.layer))));
+      expect(liveness).toEqual([true, true, false]);
+    }),
+    30_000
+  );
+
+  it.effect(
+    "reads back a missing, a written, and an unreadable status document",
+    Effect.fn(function* () {
+      const { fs, path, owner, stateDir } = yield* fixture();
+      const calls: Array<GraftDeepRunnerStep> = [];
+      const runner = scriptedRunner({ alive: [], calls, replies: happyReplies(owner, FULL_COVERAGE) });
+      expect(yield* GraftDeepRefresh.use((refresh) => refresh.readStatus(stateDir)).pipe(refreshWith(runner))).toEqual(
+        O.none()
+      );
+      yield* GraftDeepRefresh.use((refresh) => refresh.run(refreshOptions({ owner, stateDir }))).pipe(
+        refreshWith(runner)
+      );
+      const read = yield* GraftDeepRefresh.use((refresh) => refresh.readStatus(stateDir)).pipe(refreshWith(runner));
+      expect(O.map(read, (status) => status.outcome)).toEqual(O.some("ok"));
+      yield* fs.writeFileString(path.join(stateDir, "status.json"), "{ not a status }\n");
+      const corrupt = yield* Effect.flip(GraftDeepRefresh.use((refresh) => refresh.readStatus(stateDir))).pipe(
+        refreshWith(runner)
+      );
+      expect(corrupt._tag).toBe("GraftCacheIoError");
+      expect(corrupt.path).toBe(path.join(stateDir, "status.json"));
+    }),
+    30_000
+  );
+
+  it.effect(
+    "passes the requested model and reinstalls dependencies only when bun.lock moved",
+    Effect.fn(function* () {
+      const { owner, stateDir } = yield* fixture();
+      const calls: Array<GraftDeepRunnerStep> = [];
+      const runner = scriptedRunner({
+        alive: [],
+        calls,
+        // `git diff --quiet` exits 1 when the lockfile changed across the pull.
+        replies: repliesFor(owner, FULL_COVERAGE, [["git diff --quiet", reply(1, "")]]),
+      });
+      const status = yield* GraftDeepRefresh.use((refresh) =>
+        refresh.run(refreshOptions({ owner, stateDir, model: "grok-4.6(low)" }))
+      ).pipe(refreshWith(runner));
+      expect(status.model).toBe("grok-4.6(low)");
+      expect(A.filter(commandLines(calls), Str.startsWith("bun install --frozen-lockfile"))).toHaveLength(1);
+      const build = A.findFirst(calls, (call) =>
+        Str.startsWith("graft build --deep")(formatCommandLine(call.command, call.args))
+      );
+      expect(O.map(build, (call) => call.env?.GRAFT_MODEL)).toEqual(O.some("grok-4.6(low)"));
+      // An operator-set crux retry budget is forwarded rather than overwritten.
+      const configuredCalls: Array<GraftDeepRunnerStep> = [];
+      yield* GraftDeepRefresh.use((refresh) => refresh.run(refreshOptions({ owner, stateDir }))).pipe(
+        refreshWith(scriptedRunner({ alive: [], calls: configuredCalls, replies: happyReplies(owner, FULL_COVERAGE) })),
+        provideScopedLayer(ConfigProvider.layer(ConfigProvider.fromUnknown({ GRAFT_CRUX_EMPTY_RETRIES: "5" })))
+      );
+      const configuredBuild = A.findFirst(configuredCalls, (call) =>
+        Str.startsWith("graft build --deep")(formatCommandLine(call.command, call.args))
+      );
+      expect(O.map(configuredBuild, (call) => call.env?.GRAFT_CRUX_EMPTY_RETRIES)).toEqual(O.some("5"));
+    }),
+    30_000
+  );
+
+  it.effect(
+    "refuses a missing owner, a nested work tree, a broken graft install, and an unreadable lock",
+    Effect.fn(function* () {
+      const { fs, path, directory, owner, stateDir } = yield* fixture();
+      const refuse = Effect.fn("GraftDeepRefreshTest.refuseWith")(function* (
+        replies: ReadonlyArray<readonly [string, CapturedStep]>,
+        root: string = owner
+      ) {
+        const calls: Array<GraftDeepRunnerStep> = [];
+        return yield* Effect.flip(
+          GraftDeepRefresh.use((refresh) => refresh.run(refreshOptions({ owner: root, stateDir })))
+        ).pipe(refreshWith(scriptedRunner({ alive: [], calls, replies })));
+      });
+      const absent = yield* refuse(happyReplies(owner, FULL_COVERAGE), path.join(directory, "beep-effect-absent"));
+      expect(absent._tag).toBe("GraftDeepPreflightError");
+      const nested = yield* refuse(
+        repliesFor(owner, FULL_COVERAGE, [["git rev-parse --show-toplevel", reply(0, directory)]])
+      );
+      expect(nested._tag).toBe("GraftDeepPreflightError");
+      const sshRemote = yield* refuse(
+        repliesFor(owner, FULL_COVERAGE, [
+          ["git remote get-url origin", reply(0, "git@github.com:beep-effect/beep-effect.git")],
+        ])
+      );
+      expect(sshRemote._tag).toBe("GraftDeepPreflightError");
+      expect(sshRemote.message).toEqual(expect.stringContaining("remote set-url origin https://"));
+      const brokenGraft = yield* refuse(
+        repliesFor(owner, FULL_COVERAGE, [["graft --version", reply(127, "command not found")]])
+      );
+      expect(brokenGraft._tag).toBe("GraftDeepPreflightError");
+      yield* fs.makeDirectory(stateDir, { recursive: true });
+      yield* fs.writeFileString(path.join(stateDir, "refresh.lock"), "half a lock\n");
+      const unreadable = yield* refuse(happyReplies(owner, FULL_COVERAGE));
+      expect(unreadable).toEqual(
+        expect.objectContaining({ _tag: "GraftDeepPreflightError", path: path.join(stateDir, "refresh.lock") })
+      );
+    }),
+    30_000
+  );
+
+  it.effect(
+    "reports degraded with unknown coverage when the build printed no coverage line",
+    Effect.fn(function* () {
+      const { owner, stateDir } = yield* fixture();
+      const calls: Array<GraftDeepRunnerStep> = [];
+      const runner = scriptedRunner({
+        alive: [],
+        calls,
+        replies: repliesFor(owner, FULL_COVERAGE, [["graft build --deep", reply(0, "nothing to do\n")]]),
+      });
+      const status = yield* GraftDeepRefresh.use((refresh) => refresh.run(refreshOptions({ owner, stateDir }))).pipe(
+        refreshWith(runner)
+      );
+      expect(status.outcome).toBe("degraded");
+      expect(status.coverage).toBeUndefined();
+      expect(status.message).toEqual(expect.stringContaining("the build printed no coverage line"));
+      // A build whose output overran the capture bound says so, because the
+      // remedy is different from a build that genuinely printed nothing.
+      const truncatedCalls: Array<GraftDeepRunnerStep> = [];
+      const truncated = yield* GraftDeepRefresh.use((refresh) => refresh.run(refreshOptions({ owner, stateDir }))).pipe(
+        refreshWith(
+          scriptedRunner({
+            alive: [],
+            calls: truncatedCalls,
+            replies: repliesFor(owner, FULL_COVERAGE, [
+              [
+                "graft build --deep",
+                CapturedStep.make({ exitCode: 0, output: "summarizing 5216/5216", truncated: true }),
+              ],
+            ]),
+          })
+        )
+      );
+      expect(truncated.message).toEqual(expect.stringContaining("truncated at the capture bound"));
+    }),
+    30_000
+  );
+
+  it.effect(
+    "writes both units under the operator home, enables the timer, and removes them on uninstall",
+    Effect.fn(function* () {
+      const { fs, path, directory, owner, stateDir } = yield* fixture();
+      const home = path.join(directory, "home");
+      const unitDir = path.join(home, ".config", "systemd", "user");
+      yield* fs.makeDirectory(stateDir, { recursive: true });
+      yield* fs.writeFileString(path.join(stateDir, "env"), "GRAFT_PROVIDER=openai\n");
+      const options = GraftDeepTimerOptions.make({
+        owner,
+        bunPath: "/usr/bin/bun",
+        onCalendar: "*-*-* 02:30:00",
+        envFile: path.join(stateDir, "env"),
+        uninstall: false,
+      });
+      const calls: Array<GraftDeepRunnerStep> = [];
+      const runner = scriptedRunner({
+        alive: [],
+        calls,
+        replies: repliesFor(owner, FULL_COVERAGE, [["mise trust --show", reply(0, `${owner}: trusted`)]]),
+      });
+      const written = yield* GraftDeepRefresh.use((refresh) => refresh.installTimer(options)).pipe(
+        refreshWith(runner),
+        withHome(home)
+      );
+      expect(written).toEqual([
+        path.join(unitDir, "beep-graft-deep-refresh.service"),
+        path.join(unitDir, "beep-graft-deep-refresh.timer"),
+      ]);
+      const units = renderGraftDeepRefreshUnits(options);
+      expect(yield* fs.readFileString(written[0] ?? "")).toBe(units[0]?.text);
+      expect(yield* fs.readFileString(written[1] ?? "")).toBe(units[1]?.text);
+      expect(A.filter(commandLines(calls), Str.startsWith("systemctl"))).toEqual([
+        "systemctl --user daemon-reload",
+        "systemctl --user enable --now beep-graft-deep-refresh.timer",
+      ]);
+      const removedCalls: Array<GraftDeepRunnerStep> = [];
+      const removed = yield* GraftDeepRefresh.use((refresh) =>
+        refresh.installTimer(GraftDeepTimerOptions.make({ ...options, uninstall: true }))
+      ).pipe(refreshWith(scriptedRunner({ alive: [], calls: removedCalls, replies: [] })), withHome(home));
+      expect(removed).toEqual(written);
+      expect(yield* fs.exists(written[0] ?? "")).toBe(false);
+      expect(yield* fs.exists(written[1] ?? "")).toBe(false);
+      expect(A.filter(commandLines(removedCalls), Str.startsWith("systemctl"))).toEqual([
+        "systemctl --user disable --now beep-graft-deep-refresh.timer",
+        "systemctl --user daemon-reload",
+      ]);
+      // A systemd reload that fails is a step failure, not a silent install.
+      const refused = yield* Effect.flip(GraftDeepRefresh.use((refresh) => refresh.installTimer(options))).pipe(
+        refreshWith(
+          scriptedRunner({
+            alive: [],
+            calls: [],
+            replies: repliesFor(owner, FULL_COVERAGE, [
+              ["mise trust --show", reply(0, `${owner}: trusted`)],
+              ["systemctl --user daemon-reload", reply(1, "Failed to connect to bus")],
+            ]),
+          })
+        ),
+        withHome(home)
+      );
+      expect(refused._tag).toBe("GraftDeepStepError");
+      expect(refused.message).toEqual(expect.stringContaining("Failed to connect to bus"));
+    }),
+    30_000
+  );
+
+  it.effect(
+    "renders, encodes, and refuses refresh status through the command surface",
+    Effect.fn(function* () {
+      const { fs, path, owner, siblings, stateDir } = yield* fixture();
+      const empty = yield* runCommand(["deep", "status", "--state-dir", stateDir]);
+      expect(Result.isSuccess(empty.result)).toBe(true);
+      expect(empty.output).toEqual([`No refresh recorded under ${stateDir}.`]);
+      const calls: Array<GraftDeepRunnerStep> = [];
+      const runner = scriptedRunner({ alive: [], calls, replies: happyReplies(owner, FULL_COVERAGE) });
+      yield* GraftDeepRefresh.use((refresh) => refresh.run(refreshOptions({ owner, stateDir }))).pipe(
+        refreshWith(runner)
+      );
+      const rendered = yield* runCommand(["deep", "status", "--state-dir", stateDir]);
+      expect(Result.isSuccess(rendered.result)).toBe(true);
+      expect(rendered.output[0]).toEqual(expect.stringContaining("Graft deep refresh: done (ok)"));
+      expect(rendered.output[0]).toEqual(expect.stringContaining("Coverage: 38520/39115 symbols (98.5%)"));
+      expect(rendered.output[0]).toEqual(expect.stringContaining("Seeded: 12 copied"));
+      expect(rendered.output[0]).toEqual(expect.stringContaining(`Rebuilt: ${A.length(siblings)} clone(s), 0 failing`));
+      const encoded = yield* runCommand(["deep", "status", "--state-dir", stateDir, "--json"]);
+      expect(Result.isSuccess(encoded.result)).toBe(true);
+      const decoded = yield* decodeStatusJson(encoded.output[0]);
+      expect(decoded.head).toBe(OWNER_HEAD_AFTER);
+      // A degraded note is rendered for the operator when one is recorded.
+      yield* fs.writeFileString(
+        path.join(stateDir, "status.json"),
+        yield* encodeStatusJson(GraftDeepRefreshStatus.make({ ...decoded, message: "one sibling rebuild failed" }))
+      );
+      const noted = yield* runCommand(["deep", "status", "--state-dir", stateDir]);
+      expect(noted.output[0]).toEqual(expect.stringContaining("Note: one sibling rebuild failed"));
+      // Invalid option values are refused before the service ever starts.
+      const invalid = yield* runCommand(["deep", "refresh", "--owner", owner, "--state-dir", stateDir, "--jobs", "0"]);
+      expect(O.map(Result.getFailure(invalid.result), (failure) => failure)).toEqual(
+        O.some(
+          expect.objectContaining({ _tag: "GraftDeepPreflightError", path: owner, message: "Invalid refresh options." })
+        )
+      );
+      // A status with no head, coverage, or seed receipt still renders.
+      yield* fs.writeFileString(
+        path.join(stateDir, "status.json"),
+        yield* encodeStatusJson(
+          GraftDeepRefreshStatus.make({
+            schemaVersion: "beep-graft-deep-refresh/v1",
+            owner,
+            model: "(env default)",
+            jobs: PosInt.make(16),
+            startedAt: "2026-09-11T02:30:00.000Z",
+            phase: "build",
+            rebuilt: [],
+            log: path.join(stateDir, "runs", "20260911T023000Z.log"),
+          })
+        )
+      );
+      const inFlight = yield* runCommand(["deep", "status", "--state-dir", stateDir]);
+      expect(inFlight.output[0]).toEqual(expect.stringContaining("Graft deep refresh: build"));
+      expect(inFlight.output[0]).toEqual(expect.stringContaining("Coverage: not reported"));
+      expect(inFlight.output[0]).toEqual(expect.stringContaining("Seeded: nothing applied"));
+      // install-timer refuses a missing environment file before spawning systemd.
+      const timer = yield* runCommand([
+        "deep",
+        "install-timer",
+        "--owner",
+        owner,
+        "--env-file",
+        path.join(stateDir, "absent-env"),
+      ]);
+      expect(Result.isFailure(timer.result)).toBe(true);
+      const group = yield* runCommand(["deep"]);
+      expect(group.output[0]).toEqual(expect.stringContaining("Graft deep commands: refresh"));
+      const root = yield* runCommand([]);
+      expect(root.output[0]).toEqual(expect.stringContaining("deep refresh|status|install-timer"));
+    }),
+    30_000
+  );
+});

--- a/scripts/graft/patches/0.18.0/ai-crux.patch
+++ b/scripts/graft/patches/0.18.0/ai-crux.patch
@@ -1,0 +1,48 @@
+--- a/ai/crux.js
++++ b/ai/crux.js
+@@ -79,8 +79,10 @@
+     return obj.symbols
+         .map((s) => s)
+         .filter((s) => typeof s.id === "string")
++        // Local patch (2026-09-09): grok echoes the whole target row ("id | kind | lines Lx-Ly")
++        // as the id; keep the verbatim id segment so entries match graph node ids.
+         .map((s) => ({
+-        id: s.id,
++        id: s.id.split(" | ")[0].trim(),
+         summary: typeof s.summary === "string" ? s.summary.trim() : "",
+         crux_start: num(s.crux_start),
+         crux_end: num(s.crux_end),
+@@ -117,7 +119,7 @@
+         this.lastMiss = null;
+         if (input.nodes.length === 0)
+             return [];
+-        const res = await this.model.create({
++        const request = {
+             temperature: 0,
+             maxTokens: 8192,
+             tools: [
+@@ -132,9 +134,21 @@
+                 { role: "system", content: SYSTEM_PROMPT },
+                 { role: "user", content: userContent(input) },
+             ],
+-        });
+-        const parsed = parseResults(argsFromResponse(res));
+-        this.lastMiss = classifyCruxMiss(res, parsed);
++        };
++        // Local patch (2026-09-09): grok-class models ignore the forced tool call on a
++        // share of crux requests and answer in prose; retry those before recording a miss.
++        const emptyRetries = Number(process.env.GRAFT_CRUX_EMPTY_RETRIES ?? 2);
++        const isEmpty = (r) => ((r && (r.size ?? r.length)) ?? 0) === 0;
++        let res = await this.model.create(request);
++        let parsed = parseResults(argsFromResponse(res));
++        let miss = classifyCruxMiss(res, parsed);
++        for (let attempt = 1; isEmpty(parsed) && miss && miss.kind !== "truncated" && attempt <= emptyRetries; attempt++) {
++            console.error(`  crux ${input.path ?? ""}: ${miss.kind}, retry ${attempt}/${emptyRetries}`);
++            res = await this.model.create(request);
++            parsed = parseResults(argsFromResponse(res));
++            miss = classifyCruxMiss(res, parsed);
++        }
++        this.lastMiss = miss;
+         return parsed;
+     }
+ }

--- a/scripts/graft/patches/0.18.0/ai-llm-openai.patch
+++ b/scripts/graft/patches/0.18.0/ai-llm-openai.patch
@@ -1,0 +1,18 @@
+--- a/ai/llm/openai.js
++++ b/ai/llm/openai.js
+@@ -1,3 +1,4 @@
++import { appendFileSync as __dumpAppend } from "node:fs";
+ /**
+  * OpenAI-compatible transport. Wraps the `openai` SDK pointed at any
+  * OpenAI-compatible endpoint (OpenAI, OpenRouter, Fireworks, a LiteLLM proxy,
+@@ -187,6 +188,10 @@
+         return this.client.chat.completions.create(attempt);
+     }
+     fromResponse(resp, format) {
++        // Local patch (2026-09-09): raw response dump for diagnosing empty-parsed cruxes.
++        if (process.env.GRAFT_DUMP_DIR) {
++            try { __dumpAppend(process.env.GRAFT_DUMP_DIR + "/responses.jsonl", JSON.stringify(resp) + "\n"); } catch {}
++        }
+         const choice = resp.choices[0];
+         const msg = choice?.message;
+         const rawCalls = (msg?.tool_calls ?? []).filter((c) => c.type === "function");

--- a/scripts/graft/patches/0.18.0/context-build.patch
+++ b/scripts/graft/patches/0.18.0/context-build.patch
@@ -1,0 +1,23 @@
+--- a/context/build.js
++++ b/context/build.js
+@@ -162,10 +162,20 @@
+         const cached = Array.isArray(nodes) && nodes.length > 0;
+         if (!cached) {
+             nodes = await opts.synthesizer.synthesize(batches[b]);
++            // Local patch (2026-09-09): an empty batch is usually the model ignoring
++            // tool_choice; retry a bounded number of times before accepting the hole.
++            const emptyRetries = Number(process.env.GRAFT_SYNTH_EMPTY_RETRIES ?? 2);
++            for (let attempt = 1; nodes.length === 0 && attempt <= emptyRetries; attempt++) {
++                console.error(`  synthesis batch ${b + 1}/${batches.length}: empty, retry ${attempt}/${emptyRetries}`);
++                nodes = await opts.synthesizer.synthesize(batches[b]);
++            }
+             if (nodes.length > 0)
+                 cache.synth[key] = nodes;
+             else
+                 delete cache.synth[key];
++            // Local patch (2026-09-09): checkpoint after every batch so a thrown
++            // provider error cannot discard hours of finished synthesis.
++            saveCache(outDir, cache);
+         }
+         const links = nodes.reduce((n, node) => n + node.links.length, 0);
+         console.error(`  synthesis batch ${b + 1}/${batches.length}: ${nodes.length} nodes, ${links} links${cached ? " (cached)" : ""}`);


### PR DESCRIPTION
## feat(repo-cli): nightly Graft meaning-tier refresh from an owner clone

Add `beep graft deep refresh|status|install-timer`. The refresh pins a
dedicated owner clone to origin/main, runs `graft build --deep` there,
seeds the sibling clones with the existing cache sync, rebuilds each
sibling's structural graph, and writes an atomic status document at every
phase. `install-timer` renders a self-updating systemd user unit (02:30
nightly) whose preflight refuses SSH remotes, untrusted mise configs, and a
missing environment file. Every subprocess is injectable, so the suite
drives the whole run with a scripted runner: lock steal race, interrupted
run, degraded coverage, slow sibling rebuild, and unit rendering.

Port the Graft dist patch kit to 0.18.0 (the three patched files are
byte-identical upstream) and document the owner-clone bootstrap, the env
file, and the outcome semantics in the recovery runbook.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

## Local proof

- fallow-advisory-feedback: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/feat_graft-deep-refresh-de6e2d99ff83/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1094"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791764624&installation_model_id=424656&pr_number=1094&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1094&signature=2592226aefc8629aab14f5603e27c52162b541a2238f9d41b5658eea7013da38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

---

<!-- yeet-provenance:start -->
## Provenance

- Workspace: <code>beep-effect6</code>
- Branch: <code>feat/graft-deep-refresh</code>
- Agents (newest first):
  - `unknown` (unknown) · `unknown` · monitored

Resume the publishing agent from any beep-effect checkout on the publishing workstation:

```sh
bun run beep yeet resume 1094
```

<!-- yeet-provenance
{
  "schemaVersion": 2,
  "pr": 1094,
  "branch": "feat/graft-deep-refresh",
  "workspace": "beep-effect6",
  "agents": [
    {
      "harness": "unknown",
      "entrypoint": "unknown",
      "hostHarness": null,
      "model": "unknown",
      "label": null,
      "workspace": null,
      "role": "monitored"
    }
  ]
}
-->
<!-- yeet-provenance:end -->
