### PR TITLE
chore(coverage): record baseline rows for the Graft deep refresh service

### DIFF
--- a/standards/coverage.regression-baseline.jsonc
+++ b/standards/coverage.regression-baseline.jsonc
@@ -23823,6 +23823,18 @@
             "functions": 0
           }
         },
+        "packages/tooling/tool/cli/src/commands/Graft/GraftDeep.service.ts": {
+          "lines": 95.43,
+          "statements": 95.36,
+          "branches": 88.05,
+          "functions": 89.1,
+          "uncovered": {
+            "lines": 13,
+            "statements": 14,
+            "branches": 8,
+            "functions": 11
+          }
+        },
         "packages/tooling/tool/cli/src/commands/Graft/index.ts": {
           "lines": 100,
           "statements": 100,


### PR DESCRIPTION
## chore(coverage): record baseline rows for the Graft deep refresh service

The ratchet fails a new file that has any uncovered unit until it carries
baseline rows; these are the values the hosted coverage lane measured on
6dae44868f. The remaining uncovered units are error-mapping lambdas and
the HOME-missing branch.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
(cherry picked from commit 28636346e4e3190c3616776c4513719baba81060)

## Local proof

- fallow-advisory-feedback: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/feat_graft-deep-coverage-rows-86eb31a303fe/verdict.json

---

<!-- yeet-provenance:start -->
## Provenance

- Workspace: <code>beep-effect6</code>
- Branch: <code>feat/graft-deep-coverage-rows</code>
- Agents (newest first):
  - `unknown` (unknown) · `unknown` · created

Resume the publishing agent from any beep-effect checkout on the publishing workstation:

```sh
bun run beep yeet resume 1099
```

<!-- yeet-provenance
{
  "schemaVersion": 2,
  "pr": 1099,
  "branch": "feat/graft-deep-coverage-rows",
  "workspace": "beep-effect6",
  "agents": [
    {
      "harness": "unknown",
      "entrypoint": "unknown",
      "hostHarness": null,
      "model": "unknown",
      "label": null,
      "workspace": null,
      "role": "created"
    }
  ]
}
-->
<!-- yeet-provenance:end -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1099"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791775544&installation_model_id=424656&pr_number=1099&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1099&signature=cacb2e9dd48f235b4534fb9b81c86479f0ce049291033f3a0a9aba2c84d1503c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->