### PR TITLE
fix(utils): keep HostProcess off the browser eval path so professional-desktop mounts

### DIFF
--- a/.changeset/hostprocess-browser-eval.md
+++ b/.changeset/hostprocess-browser-eval.md
@@ -1,0 +1,5 @@
+---
+"@beep/utils": patch
+---
+
+Guard the HostProcess module-load platform/architecture reads through `globalThis.process` so browser bundles evaluate the `@beep/utils` barrel without throwing; the constants fall back to `"browser"` / `"unknown"` when no process global exists.

--- a/packages/foundation/modeling/utils/src/HostProcess.ts
+++ b/packages/foundation/modeling/utils/src/HostProcess.ts
@@ -19,7 +19,16 @@ import { Context } from "effect";
 const $I = $RepoUtilsId.create("HostProcess");
 
 /**
- * The host operating system platform, read once at module load.
+ * Host process handle read through `globalThis` (never a bare `process`
+ * identifier) so evaluating this module — and the `@beep/utils` barrel — is
+ * safe in browser bundles, where the global is absent. Mirrors the lazy
+ * `globalThis.process?.getBuiltinModule` idiom in `Path.ts` / `FileSystem.ts`.
+ */
+const hostProcess: { readonly platform?: string; readonly arch?: string } | undefined = globalThis.process;
+
+/**
+ * The host operating system platform, read once at module load; `"browser"`
+ * when no host process global exists (browser bundles).
  *
  * **When to use**
  *
@@ -37,10 +46,11 @@ const $I = $RepoUtilsId.create("HostProcess");
  * @category constants
  * @since 0.0.0
  */
-export const currentHostPlatform: string = process.platform;
+export const currentHostPlatform: string = hostProcess?.platform ?? "browser";
 
 /**
- * The host CPU architecture, read once at module load.
+ * The host CPU architecture, read once at module load; `"unknown"` when no
+ * host process global exists (browser bundles).
  *
  * **When to use**
  *
@@ -58,7 +68,7 @@ export const currentHostPlatform: string = process.platform;
  * @category constants
  * @since 0.0.0
  */
-export const currentHostArchitecture: string = process.arch;
+export const currentHostArchitecture: string = hostProcess?.arch ?? "unknown";
 
 /**
  * Reference for the host operating system platform.

--- a/packages/foundation/modeling/utils/test/HostProcess.test.ts
+++ b/packages/foundation/modeling/utils/test/HostProcess.test.ts
@@ -1,0 +1,66 @@
+import {
+  currentHostArchitecture,
+  currentHostPlatform,
+  HostProcessArchitecture,
+  HostProcessPlatform,
+} from "@beep/utils/HostProcess";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+import * as S from "effect/Schema";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+
+const decodeGuardOutput = S.decodeSync(S.fromJsonString(S.Struct({ platform: S.String, arch: S.String })));
+
+describe("HostProcess", () => {
+  it("reads the real host platform and architecture on a Node-compatible runtime", () => {
+    expect(currentHostPlatform.length).toBeGreaterThan(0);
+    expect(currentHostPlatform).not.toBe("browser");
+    expect(currentHostArchitecture.length).toBeGreaterThan(0);
+    expect(currentHostArchitecture).not.toBe("unknown");
+  });
+
+  it.effect(
+    "defaults the Effect references to the module constants",
+    Effect.fnUntraced(function* () {
+      expect(yield* HostProcessPlatform).toBe(currentHostPlatform);
+      expect(yield* HostProcessArchitecture).toBe(currentHostArchitecture);
+    })
+  );
+
+  it.effect(
+    "lets tests pin the platform and architecture via provideService",
+    Effect.fnUntraced(function* () {
+      const pinned = yield* Effect.all([HostProcessPlatform, HostProcessArchitecture]).pipe(
+        Effect.provideService(HostProcessPlatform, "win32"),
+        Effect.provideService(HostProcessArchitecture, "arm64")
+      );
+      expect(pinned).toEqual(["win32", "arm64"]);
+    })
+  );
+});
+
+it.layer(NodeServices.layer)("HostProcess browser-eval guard", (it) => {
+  // Regression guard for the professional-desktop blank shell: evaluating the
+  // `@beep/utils` barrel in an environment with no `process` global (a browser
+  // bundle) must not throw, and the host constants must take their fallbacks.
+  it.effect(
+    "evaluates the @beep/utils barrel without a process global",
+    Effect.fnUntraced(function* () {
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const script = [
+        "delete globalThis.process;",
+        'const mod = await import("@beep/utils");',
+        "console.log(JSON.stringify({ platform: mod.currentHostPlatform, arch: mod.currentHostArchitecture }));",
+      ].join("\n");
+      const command = ChildProcess.make("bun", ["-e", script], {
+        cwd: import.meta.dirname,
+        stdout: "pipe",
+        stderr: "inherit",
+      });
+      const output = yield* spawner.string(command);
+      expect(decodeGuardOutput(output.trim())).toEqual({ platform: "browser", arch: "unknown" });
+    }),
+    30_000
+  );
+});

--- a/standards/effect-vitest.inventory.jsonc
+++ b/standards/effect-vitest.inventory.jsonc
@@ -158811,6 +158811,27 @@
       "status": "open"
     },
     {
+      "id": "EV010:packages/foundation/modeling/utils/test/HostProcess.test.ts:7:@effect/platform-node/NodeServices@0#1",
+      "lens": "resource",
+      "ruleId": "EV010",
+      "package": "@beep/utils",
+      "file": "packages/foundation/modeling/utils/test/HostProcess.test.ts",
+      "line": 7,
+      "endLine": 7,
+      "symbol": "@effect/platform-node/NodeServices",
+      "occurrence": "v2:fb7d6bba929488197f859519d08aea3efcf9ac097f647f2bbff02362d70850d7",
+      "class": "platform-resource-provenance-review",
+      "evidence": "import * as NodeServices from \"@effect/platform-node/NodeServices\";",
+      "replacement": {
+        "primitive": "it.layer",
+        "sketch": "Review opaque platform resource provenance; filesystem use is unproven. Preserve the subject and identify actual services before selecting a filesystem layer. it.layer: Use for per-test-layer-provide candidates (EV002, candidate class per-test-layer-provide), resource-wrapper candidates (EV003, candidate class resource-wrapper), and platform-filesystem-candidate judgments (EV010, candidate class platform-filesystem-candidate)."
+      },
+      "severity": "info",
+      "confidence": 0.55,
+      "mechanization": "judgment",
+      "status": "open"
+    },
+    {
       "id": "EV010:packages/foundation/ui-system/brand/test/assets.test.ts:3:@effect/platform-bun/BunServices@0#1",
       "lens": "resource",
       "ruleId": "EV010",
@@ -169910,6 +169931,27 @@
       "occurrence": "v2:924c420b508082074308dcebab352520fd6c170cfe32f7cdd569bb4e41c903e7",
       "class": "resource-layer-without-hook-timeout",
       "evidence": "layer(UnknownTestLayer)",
+      "replacement": {
+        "primitive": "it.layer.option.timeout",
+        "sketch": "it.layer.option.timeout: Use for resource-layer-without-hook-timeout findings (EV014, candidate class resource-layer-without-hook-timeout). layer.option.timeout: Use for resource-layer-without-hook-timeout judgments (EV014, candidate class resource-layer-without-hook-timeout) at standalone layer(resource, { timeout }) acquisition when the resource needs an explicit hook budget. Diagnose slow or hung acquisition/release before selecting that budget."
+      },
+      "severity": "major",
+      "confidence": 0.55,
+      "mechanization": "judgment",
+      "status": "open"
+    },
+    {
+      "id": "EV014:packages/foundation/modeling/utils/test/HostProcess.test.ts:43:it.layer@0#1",
+      "lens": "resource",
+      "ruleId": "EV014",
+      "package": "@beep/utils",
+      "file": "packages/foundation/modeling/utils/test/HostProcess.test.ts",
+      "line": 43,
+      "endLine": 43,
+      "symbol": "it.layer",
+      "occurrence": "v2:ab37be405c19c932735a550c25f0dec5bb1a0e39cc39e730e7f73fcc2090d455",
+      "class": "resource-layer-without-hook-timeout",
+      "evidence": "it.layer(NodeServices.layer)",
       "replacement": {
         "primitive": "it.layer.option.timeout",
         "sketch": "it.layer.option.timeout: Use for resource-layer-without-hook-timeout findings (EV014, candidate class resource-layer-without-hook-timeout). layer.option.timeout: Use for resource-layer-without-hook-timeout judgments (EV014, candidate class resource-layer-without-hook-timeout) at standalone layer(resource, { timeout }) acquisition when the resource needs an explicit hook budget. Diagnose slow or hung acquisition/release before selecting that budget."


### PR DESCRIPTION
## fix(utils): keep HostProcess off the browser eval path so professional-desktop mounts

HostProcess.ts read process.platform and process.arch at module evaluation,
so any browser bundle pulling the @beep/utils barrel threw
"ReferenceError: process is not defined" and the professional-desktop shell
never mounted. Read the host process through globalThis (the same idiom
Path.ts and FileSystem.ts already use) with "browser"/"unknown" fallbacks,
keep the Context.Reference defaults lazy, and add a regression test that
imports the barrel in a subprocess with no process global.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/fix_hostprocess-browser-eval-ae9c411267c6/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791799946&installation_model_id=424656&pr_number=1109&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1109&signature=942d5a27db4fe8631e41a78ecb2b6404720c2fd0a3b7126904f9df3e171f98a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

---

<!-- yeet-provenance:start -->
## Provenance

- Workspace: <code>beep-effect21</code>
- Branch: <code>fix/hostprocess-browser-eval</code>
- Agents (newest first):
  - `claude-code` (desktop) · `claude-fable-5` · <code>beep-effect21-43</code> · created

Resume the publishing agent from any beep-effect checkout on the publishing workstation:

```sh
bun run beep yeet resume 1109
```

<!-- yeet-provenance
{
  "schemaVersion": 2,
  "pr": 1109,
  "branch": "fix/hostprocess-browser-eval",
  "workspace": "beep-effect21",
  "agents": [
    {
      "harness": "claude-code",
      "entrypoint": "claude-desktop",
      "hostHarness": null,
      "model": "claude-fable-5",
      "label": "beep-effect21-43",
      "workspace": null,
      "role": "created"
    }
  ]
}
-->
<!-- yeet-provenance:end -->
