### PR TITLE
test(coverage): THROWAWAY post-merge proof A for #1104 — eligible lowering must go green

### DIFF
--- a/standards/coverage.regression-baseline.jsonc
+++ b/standards/coverage.regression-baseline.jsonc
@@ -6082,8 +6082,8 @@
           }
         },
         "packages/foundation/ui-system/editor/src/mermaid-node.tsx": {
-          "lines": 35.29,
-          "statements": 30,
+          "lines": 34.29,
+          "statements": 29,
           "branches": 0,
           "functions": 25,
           "uncovered": {


### PR DESCRIPTION
**THROWAWAY — do not merge. Close after the Coverage Regression lane completes.**

Post-merge half of the two-way proof for #1104 (the pre-merge attempt #1105 could not run because a branch stacked on the PR carried its own edit to a global coverage input).

This branch is main plus one edit to `standards/coverage.regression-baseline.jsonc`: the `@beep/editor` row for `src/mermaid-node.tsx` goes from lines 35.29 / statements 30 to 34.29 / 29. `@beep/editor` owns no changed file, is not a dependent of one, and the baseline document is the only changed path, so the comparator must judge the row at the lowered value.

Expected `Heavy / Coverage Regression`: **green**, ok line reporting `2 floor(s) lowered on packages it could not have moved`, the lowered-floors block naming both metrics, and a `tighten` advisory because the lane measures above the lowered floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791800270&installation_model_id=424656&pr_number=1113&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1113&signature=6cd426ef6e73da25b693cd14417e81acaf4e402674bba5753536014070612559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->