### PR TITLE
chore(explorations): verify the run-4 intake docket and restore its compressed duties

### DIFF
--- a/explorations/beep-ci-operational-ontology/README.md
+++ b/explorations/beep-ci-operational-ontology/README.md
@@ -28,21 +28,31 @@ Auditor run 3 is closed and projected; run-4 pre-work is in flight. What is open
    (158 families), and the kind-level denotation-grain sentence with its
    empty-candidate clause. Lane brief and report:
    [research/run4-lanes/](./research/run4-lanes/).
-2. **Run-4 intake docket drafted** as a pre-pin draft in
-   [research/auditor-run4-intake.md](./research/auditor-run4-intake.md) (this PR):
+2. **Run-4 intake docket merged in PR #1095** (`9292600368`) as a pre-pin draft in
+   [research/auditor-run4-intake.md](./research/auditor-run4-intake.md):
    the prior-run chain (`b9c140ccd31b`, 284 rows), Queue A (15 flagged TAXONOMY
    records), Queue B (rat-047..052), Queue C (all 138 unresolved rows exactly once:
    84 live in three buckets, 54 carried by the fifteen sitting-2 clusters), Queue D
-   (the eight withdrawals and today's organic eviction census), Queue E (CQ-019/020
+   (the eight withdrawals and a dated organic eviction census), Queue E (CQ-019/020
    leftovers), Queue F (S6 POLICY `corpus_tree`/`corpus_base`), and the engine
    follow-ups queued for a later pin (NDJSON configuration support, historical
    archive-path handling, index rows referencing more than one proposal per
-   observation). Every count is re-verified at the run-4 pin.
+   observation). The 2026-09-12 verification restored omitted evidence duties and
+   recorded a dated census; its corrections and the three routing decisions (J01
+   rebucketed to C(iii), J02 reworded as independent instrumentation requirements, J03
+   left to the run-4 sitting) landed with
+   [the verification report](./research/run4-lanes/run4-docket-verification-report.md).
+   Every count is re-verified at the run-4 pin.
 3. **Run 4 proper** waits on time-to-certainty C4 (the proof-ledger writer): the
    Ruling-17 issuance and custody flags (rat-047/048/051/052) cannot discharge before
    it. Choreography is run 3's: pin commit → evidence tag → frozen run in a detached
    worktree at the tag → seats → gate → sittings → one PR, with gate fixes pushed the
-   moment they appear.
+   moment they appear. C3.3, C3.4, C3.5, C3.6, C4a, C4 and C5 are all unchecked
+   in `goals/time-to-certainty/PLAN.md` at this verification.
+
+The provisional `ciops-prov:` namespace keeps open closure and exclusion from
+negation/ratified typing. Sitting 3 presented no separate namespace proposal;
+S8 IRI design remains deferred.
 
 Routing for token-heavy Codex work stays `gpt-6-astra` at `medium`
 ([decision update](./DECISIONS.md)); auditor seats keep the packet's 2026-08-27
@@ -181,6 +191,14 @@ graduation. Full plan with locked decisions: [`DECISIONS.md`](./DECISIONS.md).
 
 ## Trail
 
+- 2026-09-12: Verified the merged PR #1095 docket against the authority records.
+  All 138 unresolved IDs, the 54 carried-cluster assignments, 15 TAXONOMY flags,
+  six Queue B quote pairs and engine digests match. Restored complete index and
+  withdrawal evidence duties, removed unsupported carried-row retirement routes,
+  and dated the live census. The corrections landed with the report; the orchestrator
+  resolved its three routing findings (J01 rebucketed, J02 reworded, J03 deferred to
+  the run-4 sitting). C4 stays unchecked. See
+  [the verification report](./research/run4-lanes/run4-docket-verification-report.md).
 - 2026-09-11: Run-4 intake docket drafted (pre-pin) at `research/auditor-run4-intake.md`
   after PR #1092 merged as `e16e7a9297`: prior chain `b9c140ccd31b` recomputed, 138
   unresolved rows placed exactly once (84 live, 54 carried by sitting-2 cluster), 15

--- a/explorations/beep-ci-operational-ontology/ops/manifest.json
+++ b/explorations/beep-ci-operational-ontology/ops/manifest.json
@@ -6,8 +6,8 @@
     "status": "active",
     "stage": "research",
     "openQuestions": [
-      "Run-4 pre-work (run 3 COMPLETE 2026-09-10 as orun-2026-09-10T02:10:52Z at pin 1c7cd98289, PR #1078; S5 gate amendment + run-2/run-3 projection merged in PR #1089; do not rerun runs 1-3): (1) PR #1092 MERGED as e16e7a9297: auditor skill v15 (required per-seat `effort` on the run-manifest contract with a self-test family, the kind-level denotation-grain sentence with its empty-candidate clause); (2) the run-4 intake docket research/auditor-run4-intake.md is DRAFTED as a pre-pin draft, PR pending (84 unresolved + 54 carried rows with fresh evidence duties, TAXONOMY flags, eight withdrawals awaiting organic eviction evidence, the VerificationResultArtifact content-snapshot rival, CQ-019/CQ-020 leftovers, corpus_tree/corpus_base for S6 POLICY, engine follow-ups: NDJSON config support, historical archive-path handling, index rows referencing more than one proposal per observation); (3) run 4 proper only after time-to-certainty C4 (proof-ledger writer) so the Ruling-17 issuance/custody flags rat-047/048/051/052 can discharge; prior chain runs/orun-2026-09-10T02:10:52Z.index.yaml sha12 b9c140ccd31b; run-3 choreography (pin commit -> evidence tag -> frozen run in a detached worktree at the tag -> seats -> gate -> sittings -> one PR).",
-      "S8 IRI scheme: deferred per the standing pipeline (Ruling 15: emission v2 carries the SeatRequest nonce alongside positional node ids so identity criteria ratify semantically without IRI syntax); the ciops-prov: namespace re-proposal rides run 3 with the ordering cluster."
+      "Run-4 pre-work (run 3 COMPLETE 2026-09-10 as orun-2026-09-10T02:10:52Z at pin 1c7cd98289, PR #1078; S5 gate amendment + run-2/run-3 projection merged in PR #1089; do not rerun runs 1-3): (1) PR #1092 MERGED as e16e7a9297: auditor skill v15 (required per-seat `effort` on the run-manifest contract with a self-test family, the kind-level denotation-grain sentence with its empty-candidate clause); (2) the run-4 intake docket research/auditor-run4-intake.md merged in PR #1095 as 9292600368 and remains a pre-pin draft (84 unresolved + 54 carried rows with fresh evidence duties, TAXONOMY flags, eight withdrawals awaiting organic eviction evidence, the VerificationResultArtifact content-snapshot rival, CQ-019/CQ-020 leftovers, corpus_tree/corpus_base for S6 POLICY, engine follow-ups: NDJSON config support, historical archive-path handling, index rows referencing more than one proposal per observation); Verification on 2026-09-12 restored omitted evidence duties and recorded a dated live census; the corrections and the orchestrator's resolution of its three routing findings (J01 rebucketed, J02 reworded, J03 deferred to the run-4 sitting) landed with research/run4-lanes/run4-docket-verification-report.md. (3) run 4 proper only after time-to-certainty C4 (proof-ledger writer) so the Ruling-17 issuance/custody flags rat-047/048/051/052 can discharge; C3.3, C3.4, C3.5, C3.6, C4a, C4 and C5 are all unchecked in PLAN.md; prior chain runs/orun-2026-09-10T02:10:52Z.index.yaml sha12 b9c140ccd31b; run-3 choreography (pin commit -> evidence tag -> frozen run in a detached worktree at the tag -> seats -> gate -> sittings -> one PR).",
+      "S8 IRI scheme remains deferred under Ruling 15. The ciops-prov: namespace remains provisional with open closure and exclusion from negation/ratified typing; run-3 sitting 3 presented no separate namespace proposal, so joint ordering-cluster ratification did not decide namespace or IRI syntax."
     ],
     "sources": ["research/SOURCES.md"],
     "links": {
@@ -16,6 +16,6 @@
       "supersededBy": null
     },
     "created": "2026-08-27",
-    "updated": "2026-09-11"
+    "updated": "2026-09-12"
   }
 }

--- a/explorations/beep-ci-operational-ontology/research/auditor-run4-intake.md
+++ b/explorations/beep-ci-operational-ontology/research/auditor-run4-intake.md
@@ -69,8 +69,11 @@ decision; the duty is what run 4 must observe to lift it. Lifting a flag is a si
 sitting-1 Ruling-4 deferrals ride the cluster: token-charge repricing, rule-versus-application
 identity, demand continuity and episode unity. Routing: the Stage C capture (organic admission
 chains with repricing or resubmission), the emission-v2 fixture and Turtle sites for
-rule-versus-application identity, and the C4 proof facts for episode closure. The cluster lifts
-or re-flags together, as it ratified.
+rule-versus-application identity, and an observed attempt-membership and closure chain for
+episode unity (an instrumentation requirement; C4 is committed to issuance and custody
+provenance under Ruling 17 and is not asserted to supply it). Its initial ratification was joint
+(sitting-3 Ruling 1); whether its flags lift individually or only together is a run-4 sitting
+decision with no ruling yet.
 
 - **ScheduleProposal** (class, `rat-059`): with issuance-versus-content identity deferred to run 4 as flagged and its episode, governing-specification and request endpoint flags retained within the joint ordering cluster.
 - **SeatRequest** (class, `rat-061`): with demand-versus-description grain and handling/resubmission continuity deferred to run 4 as flagged.
@@ -98,6 +101,26 @@ copy/correction and issuance identity wait for C4 (Queue C(iii), Queue D).
 
 - **SeatGrant** (class, `rat-066`): with account-copy identity and effective authorization continuity deferred to run 4 as flagged.
 - **VerificationResultArtifact** (class, `rat-070`): with equal-content assessment, copy/correction and issuance identity deferred to run 4 as flagged.
+
+The reuse duties carried only through `later_ratifications` also remain explicit:
+
+`rat-067` (`otp:admb-seat-request:001`):
+
+> Accept otp:admb-seat-request:001 as the SeatRequest recorded-demand-account reuse under sitting-1
+> Ruling 2, with account-copy identity, effective queue participation and withdrawal/resubmission
+> continuity deferred to run 4 as flagged.
+
+`rat-068` (`otp:att-admission-allocation:001`):
+
+> Accept otp:att-admission-allocation:001 as the SeatGrant recorded-lease-value reuse under
+> sitting-1 Ruling 2, treating the two heartbeat reports as snapshots of one candidate subject, with
+> effective allocation continuity deferred to run 4 as flagged.
+
+`rat-069` (`otp:att-verification-attempt:001`):
+
+> Accept otp:att-verification-attempt:001 as the VerificationAttempt recorded-history reuse under
+> sitting-1 Ruling 2, with account-version identity and effective invocation continuity deferred to
+> run 4 as flagged.
 
 ### Queue B: flagged provenance items rat-047 through rat-052 (run 2)
 
@@ -178,13 +201,14 @@ The four buckets are disjoint and total 138: 84 live rows in C(i)–C(iii) and t
 run-2 rows in C(iv). Counts are observation rows, not proposals or terms. The id census is copied
 mechanically from `INDEX`; every `unresolved` id appears exactly once. Each bucket states what
 run 3 showed and what run 4 must add; the index-close lane writes that as fresh `needed_evidence`
-with the run-4 `since` date, never the run-3 text.
+with the run-4 `since` date, never the run-3 text. The verbatim requirements below preserve
+the prior obligations for review; they are not ready-made run-4 disposition text.
 
 | Bucket | Rows | Meaning |
 | --- | ---: | --- |
 | C(i) | 14 | Live corpus-addressable duties: the Stage C capture, a scripted checkout-cache experiment, a verdict consumer, or CQ work can decide them. |
-| C(ii) | 3 | Live decision-gated rows: a consuming decision or executable CQ must exist before evidence can be sought. |
-| C(iii) | 67 | Live identity-experiment rows: the journal-entry duplicate-payload trace, the allocation double-count trace, and the VerificationResultArtifact content-snapshot rival. |
+| C(ii) | 2 | Live decision-gated rows: a consuming decision or executable CQ must exist before evidence can be sought. |
+| C(iii) | 68 | Live identity-experiment rows: the journal-entry duplicate-payload trace, the allocation double-count trace, the VerificationResultArtifact content-snapshot rival, and the assessment-model selection experiment. |
 | C(iv) | 54 | Carried run-2 rows re-parked at run-3 sitting 2 (Rulings 2 and 3), grouped by the sitting's fifteen clusters. |
 | Total | 138 | Every unresolved observation id exactly once. |
 
@@ -192,56 +216,126 @@ with the run-4 `since` date, never the run-3 text.
 
 **ov-token-charge-removal** (3): three ov rows: the removed token charge needs the corresponding journal chain or a liveness/reaping event tying it to a particular active grant and instant (Stage C capture).
 
+Needed evidence retained from `INDEX` (3 rows):
+
+> Needed evidence is the corresponding journal chain or an observation-backed liveness/reaping event
+> tying the removed charge to a particular active grant and instant.
+
   - `po:sha256:519764a98f511e5f2137e8eb2d6b072d92d27b62a4417db97040359034bb3282`
   - `po:sha256:a3b740b147b88dd94b092bee660c397cabadbbed2f35ddd14b6347c6ccb2f3fe`
   - `po:sha256:f41f8934b51e0e14a0344efa0b46898ea051035f811e3cee5e8de69c1bf43e2a`
 
 **seat-grant-organic-chains** (1): the synthetic SeatGrant operational reading; organic lease-eviction/renewal/transfer chains joined to an independently identified holder (Stage C capture; mirrors Queue D).
 
+Needed evidence retained from `INDEX` (1 rows):
+
+> Synthetic operational SeatGrant allocation-relator reading; the recorded-value grain governs
+> SeatGrant reuse this run. Needed: organic lease-eviction/renewal/transfer chains in a fleet
+> capture showing effective allocation continuity, joined to an independently identified holder.
+
   - `so:sha256:27fc89410ea6dbdacff098a5500ba7a968df33a96e89d47c65b107e436fc301f`
 
-**recovery-durations** (2): detection-and-recovery with standalone and lane-rerun components; needs independent execution boundaries before a complete duration can be derived (C4 proof facts).
+**recovery-durations** (2): detection-and-recovery with standalone and lane-rerun components; needs independent execution boundaries before a complete duration can be derived (an instrumentation requirement; not asserted to come from C4).
+
+Needed evidence retained from `INDEX` (2 rows):
+
+> A detection-and-recovery process with standalone and lane-rerun components; this changes the
+> referent to the reported activity and requires independent execution boundaries before deriving a
+> complete duration. Retain the detection, attempt, task, lane, and each measurement target
+> together. CQ-007 cannot be answered by adding these durations to the whole attempt or to each
+> other without interval/overlap evidence. CQ-013 requires an independently supported signature
+> mapping, attributed delay, and lane cost comparisons; this one label and two measurements do not
+> settle them.
 
   - `so:sha256:37968f126c464470a069ac2051cb358a0a29720dd49df7256625cb4d17bfa2c6`
   - `so:sha256:928e7ce7acb4292bbd03703746cd347b6fd0aeeb2c144ee33188512f3ff91939`
 
-**assertion-boundary** (2): the assertion's emission/recording boundary versus the attempt boundary and record retention; needs the missing starts and admission joins (Stage C capture plus C4).
+**assertion-boundary** (2): the assertion's emission/recording boundary versus the attempt boundary and record retention; needs the missing starts and admission joins (Stage C capture plus independent attempt-start instrumentation; not asserted to come from C4).
+
+Needed evidence retained from `INDEX` (2 rows):
+
+> The assertion has an emission/recording boundary and persists as information afterwards. The
+> modeled attempt's boundary, actual work's termination, and record retention are different
+> intervals or instants. Missing starts and admission boundaries prevent elapsed work or queue
+> duration from being computed from these notices alone. Preserve each notice's modeled attempt,
+> terminal reason, and recording instant together, and retain the synthetic qualification on
+> evidence use. CQ-007 and CQ-012 require known boundaries and complete time decomposition; neither
+> recorded notice warrants adding admitted execution time or treating unmeasured waiting time as
+> zero.
 
   - `so:sha256:650d8047f7efde8b68d19380b2c6229f038cc3c6c0290f1045d4feaca7b71a98`
   - `so:sha256:68c2cc4f0ebf9f6acb48375aa66da02ca62db1610e969434dc8e714502ef2d1f`
 
 **checkout-cache-binding** (2): the same-cache accessibility/transfer experiment at task-input-hash and epoch grain with two checkout identities and separate probe times (a scripted run-4 capture, `run4-checkout-cache-binding-identity-consumer`).
 
+Needed evidence retained from `INDEX` (2 rows):
+
+> run4-checkout-cache-binding-identity-consumer: Preserve a same-cache accessibility/transfer
+> experiment at task-input-hash and epoch grain, with the two checkout identities and separate probe
+> times, positive access and bounded local absence, and a binding-change or correction trace. Supply
+> an observed consumer and a Must/Should executable CQ that must address the binding information
+> object's identity rather than the existing qualified checkout/cache relation. If direct relations
+> suffice, keep the class withdrawn. Common Git administration, directory-entry counts and
+> environment flags do not establish common cache access or a skip authorization.
+
   - `so:sha256:a90c39610e4a49911ace23bfa329876914961182bc6fbf2b9e8049b49ad3e3b9`
   - `so:sha256:f4532e29f3f1752921effc1f49c1712e5662464ce09f553e1f81130927db3e6b`
 
 **comparison-operand-binding** (2): an explicit comparison-operand binding and an observed validity decision that depends on the result (yeet verdict consumer).
+
+Needed evidence retained from `INDEX` (2 rows):
+
+> Needed evidence is an explicit comparison-operand binding and an observed validity decision that
+> depends on the result.
 
   - `so:sha256:d8cf8154d2e1435f81698ec0c8d67ea4bce53283ef275029392ce1a2d2f2f03f`
   - `so:sha256:f353b053a061870ff15017fd51401ea9165d54f608052fa1ea8daea981cf5d73`
 
 **wall-time-evidence-class** (2): a Must/Should CQ requiring a separately identified wall-time evidence class plus an observed consumer (CQ work, not capture).
 
+Needed evidence retained from `INDEX` (2 rows):
+
+> A Must/Should CQ whose executable query requires a separately identified wall-time evidence class
+> (rather than the execution-bound actualWallMs/usedCostEstimate calibration tuples CQ-025 already
+> consumes), plus an observed consumer that selects or rejects a verdict on that class.
+
   - `so:sha256:ebe4cdcf6e9eec35f3ac468a4e21b559e27b550b221042d8266b1bb55b3d3b30`
   - `so:sha256:f025dca6b8335e444986f450f43d7970deb3f4209456efce8a23a5e1c065d446`
 
-#### C(ii): decision-gated rows (3 rows)
+#### C(ii): decision-gated rows (2 rows)
 
 **governing-specification-comparison** (1): a concrete decision consuming the comparison record or a demonstrated dependency under an existing question.
+
+Needed evidence retained from `INDEX` (1 rows):
+
+> Needed evidence is a concrete decision consuming this comparison record, or a demonstrated
+> dependency making it necessary to identify the governing specification under an existing question.
 
   - `po:sha256:2cc77ae5391bd35d736242a9fff5ee6d2e64ee35cc18a420060b5a541f947ca6`
 
 **deferred-tail** (1): a decision that requires identifying requests omitted from the prescribed sequence.
 
+Needed evidence retained from `INDEX` (1 rows):
+
+> Needed evidence is a concrete decision that requires identifying requests omitted from the
+> prescribed sequence, or an observed mapping that makes this assertion necessary for an existing
+> decision.
+
   - `po:sha256:f60ddfb04ede510a8ffe6a04a36eac20caeb92175e59245f6b436897c83907b8`
 
-**assessment-model-selection** (1): two assessments of one explicitly identified PR/head changing a single component (proof-ledger issuance, C4).
-
-  - `so:sha256:34866c142b067589cef10ea45947b1e31d1f7ae8e7518b45d705f5df5a3d31ee`
-
-#### C(iii): identity-experiment rows (67 rows)
+#### C(iii): identity-experiment rows (68 rows)
 
 **journal-entry-duplicate-payload** (25): 25 admission-journal rows whose identity question needs a trace with two entries of identical semantic payload, independently distinguished emission occurrences, revision links and an observed consumer treatment; this is the AdmissionJournalEntry withdrawal's named evidence (Queue D).
+
+Needed evidence retained from `INDEX` (25 rows):
+
+> A journal append/copy/replay/correction trace containing two entries with identical semantic event
+> payloads, with independently distinguished emission occurrences and any revision links, plus an
+> observed consumer treatment of those entries as one repeated assertion or two separately
+> accountable assertions. This would discriminate content-object identity from assertion-token
+> identity and establish whether correction preserves an entry or produces a new one. The trace must
+> distinguish asserted event time from record creation time; another file hash or capture label
+> would not resolve the grain.
 
   - `so:sha256:01fe79ebf1f0cc28550c21c941e0c4ff963cbbbcff28cffe712d9b026288d99a`
   - `so:sha256:0385cf6e12920c8a96c520a7238b522f923a7c0116cd603fbeff793a7d0e6058`
@@ -270,6 +364,16 @@ with the run-4 `since` date, never the run-3 text.
   - `so:sha256:f1e3e6b059c258e89fc802148a2976a93bd0ade9c8e5568b6052d81945140f7a`
 
 **allocation-double-count** (28): 28 lease/accounting rows that need a time-aligned lease-store and admission-accounting trace showing one allocation counted in two decisions for the same independently identified beneficiary (Stage C capture plus the capacity contract of the carried cluster).
+
+Needed evidence retained from `INDEX` (28 rows):
+
+> A time-aligned lease-store and admission-accounting trace between a matched admission and release
+> or eviction, showing the same allocation counted in at least two separate decisions for the same
+> independently identified beneficiary, requested work, and capacity pool. Include a heartbeat or
+> lease update and termination followed by reacquisition, so continuity versus a new grant can be
+> observed, together with a captured conferral/termination rule stating whether authorization or
+> only charged occupancy persists. This would discriminate a continuing authorization relator from
+> an allocation mode, an event-derived holding situation, and a journal-only account.
 
   - `so:sha256:0415a4f1590540c534d5ccc9027d36acddbfa4ffdd84445bda5155dac85ac5c6`
   - `so:sha256:05a0dfbb8f434d75b8be6d1bd7d396925b594cb0e9ceb6b72bda31e76e9685d3`
@@ -302,6 +406,13 @@ with the run-4 `since` date, never the run-3 text.
 
 **result-artifact-content-snapshot** (14): 14 verdict rows carrying the VerificationResultArtifact content-snapshot rival: two independent equal-content assessments of one attempt whose consumers treat them as distinct or as one, plus issuance/correction provenance (C4).
 
+Needed evidence retained from `INDEX` (14 rows):
+
+> Content-snapshot identity for VerificationResultArtifact is the rival of the accepted
+> assessment-origin grain (otp:att-attempt-verdict:001). Needed: two independent equal-content
+> assessments of one attempt whose consumers treat them as distinct or as one result, plus the
+> issuance/correction provenance the proof-ledger writer will carry (time-to-certainty C4).
+
   - `so:sha256:05bdfd88fe028976d02147ad0bfa51ad66828d2ceae653806a6a947e8374aeda`
   - `so:sha256:1008941903be9f39b5f8ee44d50647d0b02ea0a1988e1712481a22f35e6a0465`
   - `so:sha256:18fe73166f5b7932c1ef8a529b9e26f0975324ad5451673374ff5b24bbfeb91c`
@@ -317,6 +428,20 @@ with the run-4 `since` date, never the run-3 text.
   - `so:sha256:f19da17d5b8f8ff5107a9b96cf4ff9256ebf03da52491e0370413f941f085e5d`
   - `so:sha256:faeff009ed066ab59b310901f7f127fa174f0b0e2859613529a9ac69673c3230`
 
+**assessment-model-selection** (1): an identity experiment over verdict records: two assessments of one explicitly identified PR/head changing a single component, with the consumer's criteria preserved (no decision prerequisite and no C4 dependence asserted; rebucketed from C(ii) on verification finding J01).
+
+Needed evidence retained from `INDEX` (1 rows):
+
+> To select among the remaining models, observe two assessments of the same explicitly identified
+> PR/head with their operational assessment instants and review/check states preserved, changing a
+> single component between them. Include the observed consumer's criteria and its distinction
+> between checksGreen and requiredChecksGreen, the connection to the CQ-006/CQ-017 obligations, and
+> whether it treats the second assessment as an update to one document or a distinct snapshot. A
+> retained copy after removal of the original record would additionally discriminate the
+> specific-bearer dependence claim.
+
+  - `so:sha256:34866c142b067589cef10ea45947b1e31d1f7ae8e7518b45d705f5df5a3d31ee`
+
 #### C(iv): carried run-2 rows by sitting-2 cluster (54 rows)
 
 Clusters follow `ONT/work/sittings/carried-clusters.yaml` (ids and order). Every row keeps
@@ -325,22 +450,79 @@ cluster's posture is the fresh evidence run 4 must add.
 
 **checkout-binding** (0): Run 3 retired the fleet-checkout-identity row (sitting-2 Ruling 1); no unresolved rows remain here.
 
-**grant-resource-contention** (2): Lease snapshots share nonce, grant instant and charge but differ in heartbeat instant; run 3 supplies organic release/eviction reports and synthetic termination joins. Run 4 must add an organic contention episode: two requests competing for the same capacity with the losing side's wait and the winner's effective holding, joined through the Stage C capture.
+**grant-resource-contention** (2): Run 3 supplies admission histories and synthetic termination joins, but the fleet manifests exclude lock files and proof-locks directories. Run 4 must add the actual contended-resource or proof-lock ownership join, acquisition/release boundaries and waiting/winning/losing outcome, with the rule linking FleetContestedPath to contention; admission authorization does not establish proof-lock ownership.
+
+Needed evidence retained from `INDEX` (2 rows):
+
+> Run 3 now captures root/nonce-scoped enqueue, admission, withdrawal, release and eviction reports,
+> including synthetic attempt-termination joins. The run3-fleet and run3b-fleet manifests exclude
+> lock files and proof-locks directories, and dh:att-overlap-diagnostic:001 still establishes only a
+> logged overlapping path. To decide C2/C3, obtain the run-2 sitting-2 Ruling-3 join for the actual
+> contended resource or proof-lock path: grant/lease and lock ownership identifiers, acquisition and
+> release boundaries, and a waiting/winning/losing outcome in one provenance chain. Identify the
+> rule linking FleetContestedPath to that contention and distinguish admission authorization from
+> proof-lock ownership. Admission counts, a common origin key and worktree overlap cannot supply
+> that missing relation.
 
   - `so:sha256:b42503da37767cc741db6196fbf13e019bdc59f71166ad4d95318966ca7ae123`
   - `po:sha256:5fa0d40013f2f1bace37c166a14058909069e91de0f63b823bd0921c40f68278`
 
-**admission-lifecycles** (5): Run 3 supplies same-root/nonce enqueue-admit-release chains and explicitly synthetic withdrawal and eviction boundaries. Run 4 must add organic withdrawal, lease-eviction and ticket-eviction chains from the Stage C capture (the canonical root today holds 2 lease evictions, 1 ticket eviction and 20 withdrawals in 442 v3 rows), each with the causal continuity the pure lifecycle duty names.
+**admission-lifecycles** (5): Run 3 supplies same-root/nonce enqueue-admit-release chains and explicitly synthetic withdrawal and eviction boundaries. Run 4 must retain the causal/carrier continuity, separate lifecycle CQ and independent memory-rider duties quoted below. Queue D records the dated live journal census; row incidence alone discharges none of these duties.
+
+Needed evidence retained from `INDEX` (1 rows):
+
+> Run 3 supplies an organic same-root/nonce enqueue-admit-release history, plus synthetic withdrawal
+> and eviction reports with two attempt-termination joins. The pure lifecycle duty still needs
+> authoritative causal continuity from one request's submission through grant and
+> release/cancellation, and a Must/Should CQ requiring a lifecycle distinct from its request, grant
+> and boundary reports. The memory rider remains independently parked under Ruling 6: the release
+> now carries memoryPeakBytes, but the resource-using occurrence/process boundary, sampling method
+> and interval, metric/unit, measurement provenance and its relationship to peakRssKb are still
+> missing. Different capture-scoped ownerRef values and an administrative termination notice cannot
+> decide either missing identity.
 
   - `so:sha256:c627961a8fcde9dca01027cbf052494763b5e6895805c1c0c50d8bf51ba3a7bb`
+
+Needed evidence retained from `INDEX` (1 rows):
+
+> Run 3 now provides a same-root/nonce organic enqueue-admit-release chain and explicit synthetic
+> withdrawal, grant-eviction and ticket-eviction boundaries. Synthetic attempt-terminated records
+> match the two eviction attemptIds. What remains is authoritative causal-continuity evidence
+> connecting one submitted request to its grant and release/cancellation, together with a
+> Must/Should decision CQ requiring that composite lifecycle separately from SeatRequest, SeatGrant
+> and their boundary reports. The terminal-only synthetic eviction chains lack their own retained
+> starts, and recordedAt is a reconciliation time rather than proof of actual execution cessation.
+
   - `so:sha256:d94bf0420d3457158959e6188c50d5949dc4fae4a48d07e7077f8c81df36fcb6`
+
+Needed evidence retained from `INDEX` (3 rows):
+
+> Run 3 adds two live lease snapshots with the same nonce, grant instant and charge but different
+> heartbeat instants, organic release/eviction reports, and explicitly synthetic
+> eviction-to-attempt-termination joins. It still lacks one provenance chain that binds a grant's
+> creation, complete heartbeat-rewrite history, release/eviction, actual ledger decrement and
+> carrier lineage. Capture-scoped ownerRef values cannot prove cross-capture owner continuity; a
+> terminal lastHeartbeatAtMillis is not a rewrite history, and the synthetic evicted lease has no
+> retained admission start. A Must/Should CQ must also require this lifecycle separately from
+> SeatGrant. Keep both the provenance and separate-warrant duties open.
+
   - `po:sha256:3aadb9c8ae061d71b2e8386d9b8af518d49df5a66abaa0bb0391783833a6eef4`
   - `po:sha256:51fa8a9b8fcef0856134c3599ef68eabe588532203230c5b0ac8c892da47c95a`
   - `po:sha256:56d67898f9daaa0ff3c1fb34ff05745d9a1f94cf2703726f7721d1f586f89e5f`
 
 **failure-signature-occurrences** (0): Retired at sitting 2 (Ruling 1): the three failure-signature rows were re-identified against the captured failureKind/failedStepId tuples; signature identity stays open on the run-3 verdict chain, not on these rows. No unresolved rows remain here.
 
-**cache-plan-resolution** (1): The verdict-corpus search is complete within its captured fields: rider_evidence=absent with zero structured occurrences. Run 4 either observes a resolver-result-to-execution join in a new capture or retires the rider as unobservable at this corpus grain; a copied park is rejected.
+**cache-plan-resolution** (1): The verdict-corpus search is complete within its captured fields: rider_evidence=absent with zero structured occurrences. The promoted rider remains unresolved under sitting-2 Ruling 2; run 4 must obtain the governed resolver-result-to-execution join quoted below.
+
+Needed evidence retained from `INDEX` (1 rows):
+
+> Run 3's verdict-corpus search is now complete within its captured fields: run3-fleet/MANIFEST.yaml
+> reports pa-cache-plan-resolution rider_evidence=absent with zero structured occurrences. Its
+> source_facts name the resolver domain and the resolver-to-command-arguments site, but the verdict
+> schema has no cache-plan field. Obtain an observed governed resolver result with its applicable
+> domain/version, joined to a particular Turbo execution and the cache posture actually applied.
+> Checkout cache topology, cacheStatus and enablement flags do not supply that execution join. This
+> promoted Ruling-6 rider remains open; the docket authorizes no new capture or runtime change.
 
   - `po:sha256:30be9d42308395a759ea42b1706c47b14bf2d995ff5d90eb85161cef24e27b61`
 
@@ -348,38 +530,159 @@ cluster's posture is the fresh evidence run 4 must add.
 
 **assessment-and-selector-governance** (9): Run 3 records verdict comparisons, greptileScore, proofTier and classified failure tuples, but no governing contract for freshness, review-score meaning, attribution or proof-tier selection. Run 4 must cite the authoritative contract (scale authority and version, selector scheme lineage, attribution conditions) or park each row with that contract named as the missing decision-maker.
 
+Needed evidence retained from `INDEX` (3 rows):
+
+> Run 3 adds verdict comparison values and timestamped checkout branch/head bindings;
+> dh:ver-git-comparison-context:001 still has no observed validity decision consuming those
+> comparisons. Under Ruling 6, obtain a versioned branch-freshness contract binding each assessment
+> to its branch and base operands, defining merge-base, behind-count and overlap meanings, and
+> showing assessment provenance, recomputation and the decision that changes with the result. A
+> recorded zero or a matching path is insufficient to establish equal trees or evidence validity.
+
   - `so:sha256:0a7f99ebe45f22164f484b539becf4d1d57384861db25b0c065fc67cca2574a7`
   - `so:sha256:a4fa5b4f6b8142d813d5867e01c92a245a9a7ee7d64b8841a3e27a068c88e764`
   - `so:sha256:c1e2fd7731b1efe855f70c75df8e7dd0bd99853668c551eca8fb80593a621d06`
+
+Needed evidence retained from `INDEX` (2 rows):
+
+> Run 3 now records greptileScore=5/5 in a verdict with proofTier=full, but a score spelling does
+> not supply its governed meaning. Under Ruling 6, obtain the scale authority and version, the exact
+> reviewed subject, score-production and revision provenance, and an observed assurance or closeout
+> decision governed by that score. Retain the distinction between a stored readiness assertion and a
+> current eligibility decision.
+
   - `so:sha256:12f0a017acb17063246f77ebb5c128271f9df67ea7bc1666268052f2d58873d1`
   - `so:sha256:258d88bf5d120ca46af4e7964a5c3a5674c5c4984b67c0f84fe8f706e979c3f6`
+
+Needed evidence retained from `INDEX` (1 rows):
+
+> Run 3 adds classified failure tuples and component results, which supply concrete reports but not
+> introduced/inherited/unrelated/environment attribution rules. Under Ruling 6, obtain necessary
+> conditions for every attribution member, overlap or precedence rules, and an assessment record
+> binding the change, baseline, environment, assessment provenance and revision history. failureKind
+> and failedStepId classify a report; they cannot by themselves assign responsibility or baseline
+> causation.
+
   - `po:sha256:a0460c0e2b60f310cb30b9c03ea0aa2e487e02aadaa0450c56bb04cff6b5c8c9`
+
+Needed evidence retained from `INDEX` (3 rows):
+
+> Run 3 adds proofTier=full in verdict and lease/request contexts, while result status and attained
+> assurance remain separate. Under Ruling 6, obtain planner authority and version/revision lineage
+> deciding a shared selector scheme versus copied domains or plan-borne classifications, together
+> with a Must/Should CQ whose decision consumes that selector. Repeated strings and the captured
+> priority domain cannot establish the proof-tier governance or its mapping to assurance tiers.
+
   - `po:sha256:8b0e7ebacbadd3d0a21df787d0070763c9151c438e5ad68ef69454c6bea0aca1`
   - `po:sha256:8d123d2b803018949aa079849fafabb4d38fbde7e7f77a5515d448cdc0a9f195`
   - `po:sha256:922212cafdb03daef5fb111352d661cfda30e1e9f3d3e8c3e6f45a19c6a82a50`
 
-**execution-boundaries-and-elapsed-scope** (2): Run 3 has attempts with startedAt/endedAt/elapsedMs and component statuses. Run 4 must obtain a passed-step execution record with its own boundary and the measured-extent authority (what an elapsed interval covers), which the proof-ledger writer (C4) is expected to carry.
+**execution-boundaries-and-elapsed-scope** (2): Run 3 has attempts with startedAt/endedAt/elapsedMs and component statuses. Run 4 must obtain a passed-step execution record with its own boundary and the measured-extent authority (what an elapsed interval covers), which no current writer supplies; C4 is committed to issuance and custody provenance (Ruling 17), not to these execution facts.
+
+Needed evidence retained from `INDEX` (1 rows):
+
+> Run 3 now has verdicts with a parent attemptId, passed component statuses and component durations,
+> and a separate failed attempt whose planned components are explicitly not-run. Under Ruling 6,
+> obtain a passed-step execution record preserving the authoritative parent-attempt join, each
+> repeated execution's identity and its own actual start/end boundaries. Whole-attempt bounds and a
+> repeated lane label do not supply the missing component occurrence boundaries; the passed-step
+> instrumentation was excluded from the v3 scope.
 
   - `so:sha256:3a8b51a1acc8602b1a583147d6d5e7e253481237fbf5806c9b13833698bc9090`
+
+Needed evidence retained from `INDEX` (1 rows):
+
+> Run 3 now supplies an identified attempt with startedAt, endedAt and elapsedMs, so the
+> missing-record part of the run-2 request has changed. Under Ruling 6, retain the measured-extent
+> question: establish authoritatively whether each value covers the entire attempt/command or a
+> particular WorkUnit occurrence, preserving target, interval and provenance.
+> fa:ver-wall-time-evidence:001 still asks for nested occurrence bindings, clock/precision
+> conventions and the explanation of a one-millisecond discrepancy. Parent-attempt timestamps cannot
+> be copied to each nested execution, and an assertion-content proposal does not settle what was
+> measured.
+
   - `po:sha256:2092736911a0c68e96ae8d9638b00ec4b6992b4da0677f325e4fd420fb41b2a7`
 
 **memory-measurement** (1): memoryPeakBytes now joins a release report through root and nonce. Run 4 must add the resource-using occurrence and process boundary, sampling method and interval; the Stage C capture rides the same admission histories.
 
+Needed evidence retained from `INDEX` (1 rows):
+
+> Run 3 now joins memoryPeakBytes=9904820224 to a particular admission release report through its
+> root and nonce. Under Ruling 6, obtain the measurement's resource-using occurrence and process
+> boundary, sampling method and interval, metric, unit and measurement provenance. Supply an
+> authoritative comparison with peakRssKb that decides whether the two fields measure one family. A
+> release-attached quantity, token charge or owner surrogate does not establish the measured process
+> or sampling semantics.
+
   - `so:sha256:78cf821b0771a1c60ef1f80746484a8da1df72bcf2b1eaa9ebed337144e5a245`
 
-**duration-and-comparison-issuance** (2): ExecutionDurationAssertion was withdrawn (Queue D). Run 4 must supply a Must/Should CQ whose executable query needs a separate wall-time evidence class plus an observed consumer, or keep the concession and retire the individuals.
+**duration-and-comparison-issuance** (2): ExecutionDurationAssertion was withdrawn (Queue D). The two carried rows retain separate duration-individual, equal-content carrier and diagnostic-comparison requirements under sitting-2 Ruling 2. Issuance remains open to run 4 under Ruling 17; the full duties follow.
+
+Needed evidence retained from `INDEX` (1 rows):
+
+> Run 3 adds attempt-scoped elapsedMs, nested durationMs and otp:ver-wall-time-evidence:001, whose
+> assertion-content, quality, token and scoped-literal models remain alternatives. Under Ruling 6,
+> the separate RecordedWallDurationMeasurement still needs a Must/Should executable CQ that must
+> traverse that individual instead of qualified values on an episode or execution. The carrier
+> alternative also needs authoritative issuance, custody, copy and correction lineage and a decision
+> CQ that distinguishes equal-content carrier tokens. Ruling 17 keeps the issuance duty open to run
+> 4: the fleet manifests observe zero proof ledgers, so captured verdicts cannot replace the missing
+> writer-issued provenance.
 
   - `so:sha256:2a207d4986630e8590f790457dabe07ffeecdb9b2bfa79cf254c6bce508a2998`
+
+Needed evidence retained from `INDEX` (1 rows):
+
+> Run 3 adds bounded attempt durations and a recovery diagnostic with distinct standaloneDurationMs
+> and laneRerunDurationMs inside a successful attempt. Under Ruling 6, retain both duration
+> concessions: a Must/Should CQ requiring a RecordedWallDurationMeasurement individual rather than
+> qualified episode/execution values, and an authoritative issuance/custody/copy/correction chain
+> plus a CQ distinguishing carrier tokens from equal content. The comparison concession additionally
+> needs identities for both compared executions, their measurement assertions, the comparison's
+> issuance, and a Must/Should decision CQ consuming a distinct comparison record. Ruling 17 keeps
+> issuance open to run 4 because zero proof ledgers were captured. Diagnostic timing alone supplies
+> neither the paired execution identities nor a separately warranted comparison.
+
   - `so:sha256:91988c625516a3fa1516b592a7dc4c6b197b56249390fde1fc1e116867ae1af3`
 
-**qa-and-conformance-evidence** (4): Run 3 has the admission projection fixture, the property-suite contract and the S7 replay result, none of which is a record/extract/judge QA run or an issued conformance package. Run 4 must join a beep-qa session (record, extract, judge) to an in-scope decision, or park with that chain named.
+**qa-and-conformance-evidence** (4): Run 3 has the admission projection fixture, the property-suite contract and the S7 replay result. The QA-stage chain and the three conformance/suite/replay-result chains remain distinct duties; the full requirements, including their issuance obligations, follow.
+
+Needed evidence retained from `INDEX` (1 rows):
+
+> Run 3 adds an admission projection fixture, property-suite contract and S7 replay result. Those
+> are not a record/extract/judge QA run. Under Ruling 6, obtain one provenance-bearing chain joining
+> all three QA stages to the in-scope Yeet or CI lane, its frozen tree and cache epoch, and the
+> assurance obligation that consumes the evidence. The captured replay's input digest and pass
+> assertion do not supply those QA-stage or assurance joins.
 
   - `po:sha256:3bf3cf7f37f4e3e046efb12751c4b9650dd3a2a16a0c99a1ec17563fa551048a`
+
+Needed evidence retained from `INDEX` (3 rows):
+
+> Run 3 adds emission-v2 contract and property-suite quotations and the bounded S7 differential
+> replay report of 41 matched admissions, but no independently issued conformance package. Under
+> Ruling 6, obtain all three remaining chains: a package manifest with independent authority/version
+> joining suite, implementation build, frozen inputs, replay execution, complete results,
+> limitations, issuance and custody; a separately governed/versioned suite specification, distinct
+> from its test-file carrier, and its Must/Should CQ; and identified replay execution/environment
+> plus result issuance, custody, retention/correction lineage and a Must/Should CQ for a separate
+> replay-result artifact. Ruling 17's zero-ledger census leaves issuance open to run 4; the passing
+> replay assertion is not that missing lineage.
+
   - `po:sha256:059c20e6b0972ff269acf52884fea9e75f4fc5144fac7728dbac333221866181`
   - `po:sha256:06dd8aab73f74fd680b9cf55a760da82d4a3420f91fc8ea9d8bdb27c4c000d57`
   - `po:sha256:2338c92205c5fc08e5e18d149e7aabca98b83589cf5984e6b83fa81b2401a98c`
 
 **workspace-package-identity** (7): Checkout bindings identify checkouts, not packages. Run 4 must obtain an authoritative package-continuity contract (workspace manifest identity across renames and moves) before any package-identity row can leave unresolved.
+
+Needed evidence retained from `INDEX` (7 rows):
+
+> Run 3 now has 107 checkout bindings with origin, branch/head, Git-directory and cache facts, plus
+> fleet attempt context. These identify checkout observations, not package continuity. Under Ruling
+> 6, obtain an authoritative package-identity policy and observed lineage deciding rename, move,
+> version change, fork and delete/recreate cases, including whether the candidate is a role or
+> immutable-content object. No new package identity policy was admitted with the binding corpus, and
+> a checkout token or package spelling cannot settle those cases.
 
   - `po:sha256:08a398bab03363136254e3e9c3ed49ebb16ffd18fb94b434111d4446cdf50d69`
   - `po:sha256:1189ec1eca4fb79695201186157334124e71372bbe906bb6119996f42b9fe842`
@@ -391,20 +694,68 @@ cluster's posture is the fresh evidence run 4 must add.
 
 **dependency-and-selection-contracts** (9): Step positions 0/1 describe an admission order, not a package graph; stored diff/head/tier context is not a governed affected-task selection run. Run 4 must obtain the package-report ordering contract, the docgen selection artifact with a dirty-tree pin, and the normative affected-task selection contract.
 
+Needed evidence retained from `INDEX` (6 rows):
+
+> Run 3 adds checkout bindings and an admission-order fixture whose step positions are 0 and 1;
+> those positions do not describe a package graph. Under Ruling 6, obtain the package-report
+> contract defining its numeric positions, ordering algorithm and dependency-edge semantics,
+> identify the producing graph/version, and show the operational verification decision consuming
+> that report. No new TS or package-graph observation was admitted with the journal/inventory
+> capture.
+
   - `po:sha256:5a59d414027abf00522737e1d86c7976c6837e7dcf88eb47112cc39709b2be1d`
   - `po:sha256:62ae30cfc28b391c7bf4a87534abeba849a8ca2ebd5f8ebe72cb5af81dcc50eb`
   - `po:sha256:64463ef1e1f2b77cb50713f8194bb055d35d02288f465e6902e337f9fc5f5edf`
   - `po:sha256:6e598d379ffd2f0565176b337833e4eedf0293941fa87936078ee572e63748a9`
   - `po:sha256:89165acdfec28c3a8692c411aead416ca1fd5f13333c0ea5c748e92aeab0cb98`
   - `po:sha256:90fa083c4887641658c0239762b509fd6c9bacc6f14cf29ee392ce08714572ff`
+
+Needed evidence retained from `INDEX` (1 rows):
+
+> Run 3 adds checkout branch/head snapshots and verdict applicability fields; it supplies no docgen
+> selection result with a dirty-tree pin. Under Ruling 6, retain both concessions: an observed
+> selection artifact binding base, head, dirty snapshot and selected members, a contract choosing
+> selected extension versus selection rule and a Must/Should specialization CQ; and an independently
+> versioned selection-rule authority, an observed pinned extension showing its application, a
+> rule-versus-result contract and a CQ requiring the specification. Checkout paths and stored diff
+> fingerprints do not supply those selected members or governance.
+
   - `po:sha256:795d76d79fdc3ad235d204aee98c96f70dcdb10704c927558f31012749553995`
+
+Needed evidence retained from `INDEX` (2 rows):
+
+> Run 3 adds stored diff/head/tier context and a deterministic admission-order contract, but neither
+> is a governed affected-task selection run. Under Ruling 6, obtain the normative selection contract
+> explaining how task inputs alter membership and whether failures open or close the selection, an
+> observed selected set under that contract, and the operational verification decision that trusts
+> it. The current applicability hypotheses still lack an observed accept/reject consumer.
+
   - `po:sha256:9cbd50f3655b7ae7102a1be9bfcfe939528b3eaebd0dc33257408365f9402062`
   - `po:sha256:a1f8202d5ff295e75dd7ad3f50f9454dad4bc2d53677e5936a6a0812250c5e43`
 
 **capacity-computation-and-snapshot** (7): Run 3 quotes the projection inequality and records requested/granted weightTokens but no pre-grant capacity stamp (Ruling 9). Run 4 must obtain the authoritative capacity computation and a Must/Should executable CQ traversing an AdmissionSnapshot, its capture act and instant.
 
+Needed evidence retained from `INDEX` (2 rows):
+
+> Run 3 now records requested/granted weightTokens and quotes the projection inequality
+> activeTokenTotal + weightTokens <= capacityMaxTokens. Ruling 9 deliberately omitted capacity
+> stamps. Under Ruling 6, obtain the authoritative capacity computation defining unit conversion,
+> reserve subtraction and hard-floor treatment, and a provenance-preserving join from its computed
+> value to capacityAtAdmissionTokens on an observed admission decision. A policy token charge and
+> reconstructed ledger total cannot stand for measured remaining capacity.
+
   - `po:sha256:3c757a7975b27b8597ccf8c6d886eb72ad2b8b51aaba8eb59cf21cc9a1a7a3c6`
   - `po:sha256:518aee86882c8b9092469203add3bc23c72acfed1d7139f136a96e8763f0c8c7`
+
+Needed evidence retained from `INDEX` (5 rows):
+
+> Run 3 now includes timestamped inventory and queue/lease reports, but Ruling 9 supplied no
+> pre-grant capacity stamps. Under Ruling 6, obtain a Must/Should executable CQ that traverses an
+> AdmissionSnapshot, its capture act and instant, machine and policy scope, and an authoritative
+> correlation to the immediately pre-grant decision that materializes capacityAtAdmissionTokens. A
+> later lease snapshot, a checkout inventory instant and the projection's capacity inequality do not
+> establish that missing pre-grant state.
+
   - `po:sha256:6b31f817391e66aab8fc9796fed0c0bbdbd8285c9e86438e9172d1ce6bbaef61`
   - `po:sha256:8a555d65d66a8d7f44336fdb4ce8816f5a033a6ce448e311dc29615bfd8f41f2`
   - `po:sha256:8af3333c97798f24aeecfa40f40faefcf152f96fffb6717f647eabf0f5250a92`
@@ -413,9 +764,39 @@ cluster's posture is the fresh evidence run 4 must add.
 
 **origin-and-heartbeat-policy** (5): blockedOnOriginAtMillis=0 and lastHeartbeatAtMillis are captured; their governed meaning is not. Run 4 must obtain the deployed threshold/policy source for origin blocking and heartbeat suspicion, and read the zero against it.
 
+Needed evidence retained from `INDEX` (1 rows):
+
+> Run 3 now captures a ticket's blockedOnOriginAtMillis=0 and separately records queue, withdrawal
+> and eviction boundaries. dh:att-origin-block-marker:001 leaves the zero's meaning unresolved.
+> Under Ruling 6, obtain the deployed threshold rule, its unit and both true/false consequences,
+> decide grace versus staleness versus retry semantics, and observe a specifically origin-blocked
+> case governed by that rule. A terminal eviction or zero marker does not establish a grace-window
+> application.
+
   - `po:sha256:79df3741e52f870a9c5d7ac0f3c76fc333a1341bf8f15c7a7720f2b6982e88b3`
+
+Needed evidence retained from `INDEX` (2 rows):
+
+> Run 3 adds live heartbeat observations and explicit lease eviction reports with
+> lastHeartbeatAtMillis, plus a synthetic termination join. The Stage B heartbeat census checks four
+> organic rows, reports one legacy row without heartbeat and finds no ordering violations; this
+> bounds observations, not owner death. Under Ruling 6, obtain the deployed suspicion threshold and
+> unit, the identified suspected holder, an observed stale-heartbeat case, its operational
+> consequence, and the authority rule separating suspicion from permission to terminate. An eviction
+> reason or last-seen heartbeat is not proof that suspicion alone authorized termination.
+
   - `po:sha256:cb78d031658bfe80535beb490352c2086b2b8f629e3819df4fba336fbeb37598`
   - `po:sha256:cb9064130b643be08d25e627bcfc5264739ac1397a236d353835b473c2df5734`
+
+Needed evidence retained from `INDEX` (2 rows):
+
+> Run 3 now supplies a persisted ticket observation containing blockedOnOriginAtMillis=0 with
+> enqueue and heartbeat context, and the current null analysis refuses to read zero as either an
+> epoch instant or evidence of no contention. Under Ruling 6, obtain a semantically interpreted
+> origin-block onset/time and unit, the same ticket's observed originBusy wait, the
+> starvation-policy decision using it, and issuance/revision provenance across the relevant ticket
+> transitions. The observed zero and unrelated terminal chains do not establish those joins.
+
   - `po:sha256:e362227f9f3d78e8fcb933ddf9f5523b1ef97776a2546ad12c7f702c33fc1cdd`
   - `po:sha256:edf38d10efe0552b7de770a0cc24a9596cc4b5141b693889e987465f4174b4bb`
 
@@ -428,32 +809,113 @@ Withdrawals are deferrals with named evidence, not rejections (sitting-3 Ruling 
 | Withdrawn proposal | Term | Named run-4 evidence |
 | --- | --- | --- |
 | `otp:admb-journal-entry:001` | AdmissionJournalEntry | An observed decision consumer independently addressing admission-assertion identity and a Must/Should executable CQ whose required answer needs the entry individual (`run4-admission-journal-entry-identity-consumer`); the C(iii) duplicate-payload trace is its evidence. |
-| `otp:bind-checkout-cache-binding:001` | CheckoutCacheBindingRecord | The same-cache accessibility/transfer experiment at task-input-hash and epoch grain, two checkout identities, separate probe times, positive access and bounded local absence, and a binding change (C(i) `checkout-cache-binding`). |
-| `otp:bind-grant-termination:001` | AdmissionGrantTermination | An organic lease's admission and effective holding before and after release or eviction, correlated by admission chain and attempt binding, with claim acknowledgement and the matching attempt-termination write. |
-| `otp:bind-request-termination:001` | AdmissionRequestTermination | An organically queued request followed from enqueue through withdrawal or ticket eviction, with before/after effective membership, claim acknowledgement and matching attempt termination. |
+| `otp:bind-checkout-cache-binding:001` | CheckoutCacheBindingRecord | The same-cache accessibility/transfer experiment at task-input-hash and epoch grain, two checkout identities, separate probe times, positive access and bounded local absence, and a binding-change or correction trace, plus the binding-identity consumer and executable CQ (C(i) `checkout-cache-binding`). |
+| `otp:bind-grant-termination:001` | AdmissionGrantTermination | An organic lease's admission and effective holding before and after release or eviction, correlated by admission chain and attempt binding, with claim acknowledgement and the matching attempt-termination write where applicable; the full receipt also requires a decision consumer and separate termination-identity CQ. |
+| `otp:bind-request-termination:001` | AdmissionRequestTermination | An organically queued request followed from enqueue through withdrawal or ticket eviction, with before/after effective membership, claim acknowledgement and matching attempt termination where applicable; the full receipt also requires a consumer and separate queue-exit identity CQ. |
 | `otp:ver-wall-time-evidence:001` | ExecutionDurationAssertion | A Must/Should CQ whose executable query requires a separately identified wall-time evidence class plus an observed consumer selecting or rejecting a verdict on it (C(i) `wall-time-evidence-class`). |
 | `otp:bind-admission-grant:001` | SeatGrant (synthetic operational reading) | Organic lease-eviction/renewal/transfer chains in a fleet capture showing effective allocation continuity, joined to an independently identified holder. |
 | `otp:bind-admission-request:001` | SeatRequest (synthetic operational reading) | An organic withdrawal/resubmission chain with an independently tracked demand referent and both ticket records. |
 | `otp:ver-attempt-verdict:001` | VerificationResultArtifact (content-snapshot rival) | Two independent equal-content assessments of one attempt whose consumers treat them as distinct or as one, plus the issuance/correction provenance the proof-ledger writer will carry (C4). |
 
-**Organic eviction census (2026-09-11, counts only, no capture).** The admission histories that
-`CORPUS/etl_run3b_fleet_corpus.py` enumerates through `admission_sources()` (the canonical
-runtime root, the system temp root and the session temp root) hold today: canonical root 3
-journal files, 202 `yeet-admission-journal/v1` rows and 442 `v3` rows with 220
-`admission-enqueued`, 200 `admission-admitted`, 199 `admission-released`, 20
-`admission-withdrawn`, 2 `admission-lease-evicted` and 1 `admission-ticket-evicted`; session
-temp root 2 rows (one admitted, one released); system temp root absent. These are organic writer
-rows, distinct from the labeled `run3b-synthetic` fixture output. Whether they are new relative
-to the `run3b-fleet` capture (which reported 5 lease and 2 ticket evictions across its retained
-chains) is decided by the **Stage C capture at the run-4 pin**: a new `run4-fleet` pin produced
-by the run3b ETL mechanics under Rulings 10, 19 and 22 (synthetic labels retained; refreshed
-pins carry `corpus_tree`/`corpus_base`; residue scans zero), not by editing any existing pin.
+The table is a routing summary. The complete receipt duties govern re-opening each proposal:
+
+`otp:admb-journal-entry:001`: `run4-admission-journal-entry-identity-consumer` in `ONT/work/sittings/ratification-docket.md`.
+
+> An observed decision consumer independently addressing admission-assertion identity and a
+> Must/Should executable CQ whose required answer is lost when generic qualified assertions replace
+> the class; append/copy/replay/correction cases must distinguish content from emission tokens. An
+> operational event reading additionally needs an effective-transition join.
+
+`otp:bind-checkout-cache-binding:001`: `run4-checkout-cache-binding-identity-consumer` in `ONT/work/sittings/withdrawals-bind-ver-r1.yaml`.
+
+> Preserve a same-cache accessibility/transfer experiment at task-input-hash and epoch grain, with
+> the two checkout identities and separate probe times, positive access and bounded local absence,
+> and a binding-change or correction trace. Supply an observed consumer and a Must/Should executable
+> CQ that must address the binding information object's identity rather than the existing qualified
+> checkout/cache relation. If direct relations suffice, keep the class withdrawn. Common Git
+> administration, directory-entry counts and environment flags do not establish common cache access
+> or a skip authorization.
+
+`otp:bind-grant-termination:001`: `run4-organic-grant-eviction-boundary-and-consumer` in `ONT/work/sittings/withdrawals-bind-ver-r1.yaml`.
+
+> Capture an organic lease's admission and effective holding before and after release or eviction,
+> correlated by its admission chain and attempt binding, with claim acknowledgement and the matching
+> attempt-termination write where applicable. Distinguish ending active capacity from later
+> stale-record cleanup; retain a duplicated terminal report as a control. Include an observed
+> decision consumer and a Must/Should executable CQ that must distinguish termination occurrences
+> independently of qualified standing/end values. Synthetic coverage remains writer evidence, not
+> organic incidence; do not invent an admission, charge or origin for the injected dead lease by
+> copying contender A's chain.
+
+`otp:bind-request-termination:001`: `run4-organic-request-eviction-boundary-and-consumer` in `ONT/work/sittings/withdrawals-bind-ver-r1.yaml`.
+
+> Follow an organically queued request from enqueue through withdrawal or ticket eviction, with
+> before/after effective membership, claim acknowledgement and the matching attempt termination
+> where applicable. Distinguish stale-ticket cleanup from the actual queue exit, duplicate reports
+> from distinct exits, and a later resubmission from the ended participation. Supply a consumer and
+> a Must/Should executable CQ requiring the exit occurrence's identity rather than pending
+> membership and qualified end values. Keep the synthetic dead ticket's missing historical enqueue
+> and full wait unknown; do not infer destruction of an enduring demand or successful work execution
+> from a terminal write.
+
+`otp:ver-wall-time-evidence:001`: `run4-duration-assertion-correction-consumer` in `ONT/work/sittings/withdrawals-bind-ver-r1.yaml`.
+
+> Observe repeated measurements or corrections for the same identified execution interval, keeping
+> occurrence, scope, unit, precision/clock convention, both claims and the actual immutable
+> used-estimate binding. Supply a consumer and a Must/Should executable CQ whose complete answer
+> requires independent assertion identity or correction lineage that qualified execution literals
+> cannot preserve. Missing durations are unknown, not zero; repeated lane labels and
+> whole-attempt/component values do not define an additive partition.
+
+`otp:ver-wall-time-evidence:001`: `final withdrawal requirement` in `ONT/work/sittings/withdrawals-ver-r2.yaml`.
+
+> A Must/Should CQ whose executable query requires a separately identified wall-time evidence class
+> (rather than the execution-bound actualWallMs/usedCostEstimate calibration tuples CQ-025 already
+> consumes), plus an observed consumer that selects or rejects a verdict on that class.
+
+`otp:bind-admission-grant:001`: `final withdrawal requirement` in `ONT/work/sittings/withdrawals-sitting-3.yaml`.
+
+> Synthetic operational SeatGrant allocation-relator reading; the recorded-value grain governs
+> SeatGrant reuse this run. Needed: organic lease-eviction/renewal/transfer chains in a fleet
+> capture showing effective allocation continuity, joined to an independently identified holder.
+
+`otp:bind-admission-request:001`: `final withdrawal requirement` in `ONT/work/sittings/withdrawals-sitting-3.yaml`.
+
+> Synthetic SeatRequest reuse with category unresolved; the recorded-value grain governs SeatRequest
+> reuse this run. Needed: an organic withdrawal/resubmission chain with an independently tracked
+> demand referent and both ticket records.
+
+`otp:ver-attempt-verdict:001`: `final withdrawal requirement` in `ONT/work/sittings/withdrawals-sitting-3.yaml`.
+
+> Content-snapshot identity for VerificationResultArtifact is the rival of the accepted
+> assessment-origin grain (otp:att-attempt-verdict:001). Needed: two independent equal-content
+> assessments of one attempt whose consumers treat them as distinct or as one result, plus the
+> issuance/correction provenance the proof-ledger writer will carry (time-to-certainty C4).
+
+**Organic eviction census (2026-09-12 at 10:08:27 UTC, counts only, no capture).**
+`CORPUS/etl_run3b_fleet_corpus.py` enumerates the canonical runtime, system temp and session
+temp roots through `admission_sources()`; `capture()` reads one `journal.ndjson` per present
+root. At this read, the canonical root has one ETL journal with 623 rows: 200
+`yeet-admission-journal/v1` rows (all `admission-admitted`) and 423 `v3` rows (212
+`admission-enqueued`, 195 `admission-released`, 12 `admission-withdrawn`, 4
+`admission-lease-evicted`, 0 `admission-ticket-evicted`). The session temp root has one ETL
+journal with 2 v1 rows (one admitted, one released); the system temp root is absent. All
+observed rows parse. These are bounded retained-window counts, not a complete event history;
+zero retained ticket evictions does not establish that none occurred. The earlier 2026-09-11
+census is historical; the current journal bytes do not reproduce it. These organic writer
+rows remain distinct from labeled `run3b-synthetic` output. Whether retained chains are new
+relative to `run3b-fleet` (5 lease and 2 ticket evictions in its manifest) is decided by the
+**Stage C capture at the run-4 pin**: a new `run4-fleet` pin produced by the run3b ETL mechanics
+under Rulings 10, 19 and 22 (synthetic labels retained; refreshed pins carry
+`corpus_tree`/`corpus_base`; residue scans zero), not by editing any existing pin.
 
 ### Queue E: CQ-019 / CQ-020 leftovers (Ruling 16, sitting-3 Ruling 4)
 
 1. Object-valued `hasScope` and `Scope` stay **PARKED with the no-punning record**; the run-3
-   fixtures exercise only the literal `hasScopeTag` (ratified, rat-064). They ratify only if a
-   run-4 emission exercises arm 2 with an object-valued scope individual.
+   fixtures exercise only the literal `hasScopeTag` (ratified, rat-064). Re-opening requires an
+   authorized run-4 emission exercising arm 2 with an independently identified object-valued
+   Scope and its provenance/identity, followed by analysis, proposal and review
+   (`ONT/work/sittings/ratification-docket.md`, Queue D).
 2. `schedulesWorkUnit` remains CQ-019 arm 3's historical carrier, unratified and unrewritten.
 3. The CQ-020 amendment is applied and its ordering rows are discharged; no CQ, seed or fixture
    edit is owed to run 4. Queue placement changes nothing in `ontology/docs/competency-questions.yaml`.
@@ -473,6 +935,10 @@ not edit POLICY.yaml.
   Stage C capture and verbatim emission/prose observations; no compiler-derived TS
   SourceObservations are needed.
 - **S8 IRI scheme stays deferred (Ruling 15).** Nonce literals carry identity evidence.
+  `ciops-prov:` remains the provisional emission namespace with open closure and exclusion
+  from negation/ratified typing. No separate namespace proposal was presented at sitting 3;
+  the joint cluster ruling did not ratify absent proposals or decide S8 IRI syntax
+  (`ONT/work/sittings/ratification-docket.md`, "Intake spellings and the actual proposal set").
 - **Seats follow the run-3 launch entry** unless the run-4 launch entry amends it: Codex seats
   `gpt-6-astra` at `max` (the packet's 2026-08-27 delegated-lane directive governs seats; the
   root routing note's `medium` governs ordinary token-heavy work), the adversary in an

--- a/explorations/beep-ci-operational-ontology/research/run4-lanes/run4-docket-verification-brief.md
+++ b/explorations/beep-ci-operational-ontology/research/run4-lanes/run4-docket-verification-brief.md
@@ -1,0 +1,90 @@
+# Run-4 intake docket verification brief (one adversarial lane)
+
+You are a Codex verification lane in the checkout `beep-effect8-worktrees/run4-docket-verify`
+(branch `chore/ciops-run4-docket-verify` off main, which carries PR #1095). Do not run `git add`,
+`git commit`, `git stash`, `git checkout --`, or `git switch`; leave the tree dirty and list every
+touched path in your report. The orchestrator stages by name and commits. Paths are relative to
+`explorations/beep-ci-operational-ontology/` unless they start with `.claude/`, `goals/`, or
+`research/scripts`. Use Bun 1.4.2 from the session PATH. Set `UV_CACHE_DIR` to the operator-provided
+cache in the shell environment, then use `uv run --offline --python 3.12 --with pyyaml python`.
+
+## Why
+
+`research/auditor-run4-intake.md` was authored by the orchestrator, not a lane, and its first
+review found three real defects (a reversed rat-067/rat-068 binding, three Queue B evidence quotes
+truncated by a clipped read, and a C4 fallback contradicting the gate), all fixed in
+`30781ba7ef`. Run 4 will consume this docket at its pin. Your job is to try to break it: every
+factual claim in it must be checked against the record it cites, and anything that would send a
+run-4 seat or the pin lane to the wrong ratification, term, row, cluster, quote, count, digest or
+ruling is a blocking finding.
+
+## Records of authority (read these, not the docket's paraphrase of them)
+
+- `ontology/extraction/s4/beep-ci-ops/runs/orun-2026-09-10T02:10:52Z.index.yaml` (rows, outcomes,
+  `needed_evidence`, `carried_from_prior`, `since`) and its sha256[:12].
+- `ontology/extraction/s4/beep-ci-ops/work/sittings/carried-clusters.yaml` (cluster ids/names and
+  the `rows` mapping of prior observation ids to clusters), `carried-rows-docket.md`,
+  `ratification-docket.md` (per-proposal decisions and the journal-entry duty),
+  `withdrawals-bind-ver-r1.yaml`, `withdrawals-ver-r2.yaml`, `withdrawals-sitting-3.yaml`,
+  `sitting-{1,2,3}-decisions-entry.md`.
+- Ratifications: live `ontology/extraction/s4/beep-ci-ops/governance/ratifications/rat-053..070.yaml`
+  (`proposal_ref`, `verbatim_decision`), archived run-2
+  `ontology/extraction/s4/archives/beep-ci-ops/orun-2026-09-03T02:46:18Z.governance/ratifications/rat-032..052.yaml`,
+  and the run-2 `…orun-2026-09-03T02:46:18Z.work/sittings/ratification-docket.yaml` (`evidence_quote`).
+- `ontology/extraction/s5/TAXONOMY.yaml` (`ratification`, `flags` per record) and
+  `ontology/extraction/s5/DISPOSITIONS.yaml` (`later_ratifications`), `ontology/extraction/s6/PREDICATES.yaml`.
+- `DECISIONS.md` entries: run-3 corpora design grill (2026-09-03), Stage B grill (2026-09-08),
+  residue rulings (2026-09-09), run-3 launch (2026-09-09), run-3 sittings 1–3 (2026-09-10), S5
+  gate amendment (2026-09-10). Every "Ruling N" the docket cites must exist and say what the
+  docket says it says.
+- `research/auditor-run3-intake.md` (format template and the carried facts the docket re-states),
+  `ontology/extraction/s4/beep-ci-ops/work-run3/impl-report.md`,
+  `research/run3-lanes/handoff-2026-09-10.md`.
+- `.claude/skills/ontology-foundational-auditor/` (v15: `scripts/validate_artifacts.py`,
+  `REVIEW-HISTORY.md`, `prompts/denotation.md`, `SKILL.md`) and `.claude/skills/_shared/`
+  (the framed contracts digest, computed exactly as `check_manifest` does).
+- `goals/time-to-certainty/PLAN.md` (C-track checkboxes).
+- `ontology/extraction/s4/beep-ci-ops/corpus/etl_run3b_fleet_corpus.py` (`admission_sources()`),
+  and the run3b/run3 corpus manifests for the counts the docket quotes.
+
+## What to verify (every item, with evidence)
+
+1. **Prior-run chain.** Recompute the index digest; recount rows by outcome and by
+   live/carried; confirm the 84 + 54 split and the 216/68 populations.
+2. **Queue C totality and placement.** Re-run an independent totality check (every `unresolved`
+   id exactly once, no strays). Then for EVERY row: is its bucket (C(i)–C(iii) by evidence text;
+   C(iv) by the sitting-2 cluster mapping) consistent with the index's `needed_evidence` and the
+   `carried-clusters.yaml` membership? Is each bucket's "what run 3 showed / what run 4 must add"
+   posture faithful to the sitting-2 rulings and the index text, or does it invent, drop, or
+   contradict a duty? Are the three "no unresolved rows remain" clusters really empty?
+3. **Queue A.** Every TAXONOMY record with `flags` is listed once with the right `ratification`
+   id and the flag text verbatim; the rat-053..070 → proposal → term bindings in the prose match
+   `proposal_ref`; the `later_ratifications` claims match DISPOSITIONS.yaml.
+4. **Queue B.** The six `verbatim_decision` and `evidence_quote` texts are complete and verbatim;
+   the routing (C4-gated vs contract/governance duty) matches sitting-3 Ruling 3 and Ruling 17;
+   nothing the run-3 docket carried as a duty has been dropped.
+5. **Queue D.** The eight withdrawals, their receipt files and named evidence match the receipts;
+   the organic eviction census can be reproduced from `admission_sources()` roots (counts only);
+   the run3b-fleet comparison numbers match its manifest.
+6. **Queues E/F, non-triggers, engine deltas.** Rulings cited exist and are paraphrased
+   correctly; digests quoted match the working tree; the follow-up list matches the impl report
+   and the #1092 review record; "Not in scope" mirrors the run-3 docket.
+7. **Gate section and session surface.** The C4 checkbox state matches PLAN.md; the README's Next
+   Open Question, Trail entry and `ops/manifest.json` open question agree with the docket and
+   with each other (no stale "PR pending" wording now that #1095 is merged).
+8. **Format.** Section order and voice follow the run-3 docket; markdown lists render (blank line
+   before every id list); no host paths, user names, hostnames or numeric user ids anywhere.
+
+## Output
+
+- Apply a correction directly in `research/auditor-run4-intake.md` (and README/manifest if item 7
+  finds drift) ONLY when the record you quote makes the fix unambiguous; keep every id list
+  mechanically derived (never hand-edit an id). Anything judgmental (a posture you would word
+  differently, a routing you would argue with) goes in the report as a finding, not an edit.
+- Write `research/run4-lanes/run4-docket-verification-report.md`: a findings table (id, severity
+  BLOCKING / MINOR / CONFIRMED-OK, docket line, the record and quote that decides it, the fix
+  applied or proposed), the reproduced digest/census/totality outputs verbatim, the checks you
+  ran per item above with their verdict lines, blockers, and a final `### Files` list. If you
+  edited the docket, re-run the totality check and paste it.
+- Proofs on touched files: `typos`, residue scan, and `bun run beep explore atlas --check` only if
+  README/manifest changed (run `--write` first; the atlas is a git-ignored local projection).

--- a/explorations/beep-ci-operational-ontology/research/run4-lanes/run4-docket-verification-report.md
+++ b/explorations/beep-ci-operational-ontology/research/run4-lanes/run4-docket-verification-report.md
@@ -1,0 +1,689 @@
+# Run-4 docket verification report
+
+Verified 2026-09-12 in the requested checkout at HEAD
+`a97b397dc6cfe2455e3f438f2d9f46c617bfd2cb`. The incoming docket was byte-identical
+to PR #1095 head `30781ba7ef18634935f993a13db3e73854094b51`. GitHub reports that
+PR merged at 2026-09-12T02:44:51Z; its local squash `9292600368` and skill-v15
+squash `e16e7a9297` are ancestors of this HEAD.
+
+The eight requested checks are complete. The incoming ID census, final ratification
+bindings, Queue B quotes and engine digests pass. The prose omitted binding evidence
+duties and introduced two carried-row retirement alternatives; record-decided
+corrections are applied directly. Three judgment-dependent routing/governance findings
+(J01–J03) remain BLOCKING and unedited. A green mechanical check does not clear them.
+C4 is still unchecked, independently prohibiting run-4 launch.
+
+Only the docket, packet README, packet manifest and this report are authored changes.
+The incoming untracked brief remains untouched. No staging, commits, stashes,
+checkout restoration, branch switching, seat launch, corpus capture, pin/tag creation,
+ratification, flag lifting or prior-record mutation was performed.
+
+All record paths below are packet-relative unless prefixed `.claude/` or `goals/`.
+`ONT` = `ontology/extraction/s4/beep-ci-ops`; `ARCH` =
+`ontology/extraction/s4/archives/beep-ci-ops`; `INDEX` =
+`ONT/runs/orun-2026-09-10T02:10:52Z.index.yaml`. Docket locations show original line
+→ corrected line where possible. Source INDEX line numbers point to the full row.
+Quotes are exact record excerpts; YAML folding and Markdown wrapping are normalized.
+
+## Findings
+
+BLOCKING in an applied row describes the incoming defect. J01–J03 are unresolved.
+
+| ID | Severity | Docket line | Record and deciding quote | Fix applied or proposed |
+| --- | --- | --- | --- | --- |
+| V01 | CONFIRMED-OK | 35 → 35 | `INDEX` bytes and run-3 implementation report, population table: "84/198", "54 carried parks". Working-tree bytes equal both HEAD and the draft base. | Digest and all census claims verified; no edit. |
+| V02 | CONFIRMED-OK | 175 → 195 | `INDEX` and `carried-clusters.yaml.rows`; sitting-2 Ruling 1: "14 rows, 3 clusters". | 138/138 unique IDs; 54/54 carried placements; three empty clusters verified. IDs remain mechanically derived. |
+| V03 | CONFIRMED-OK | 62 → 62 | `TAXONOMY.yaml.terms[*].flags/ratification`, live rat-053..070 `proposal_ref`, and S5 gate amendment Rulings 1/3. | All 15 flag clauses match exactly. All 18 final bindings verified, including rat-067 → admb-seat-request → SeatRequest and rat-068 → att-admission-allocation → SeatGrant. Draft rat numbers in the sitting docket are not final authority. |
+| F01 | BLOCKING | 89 → 89 | rat-069: "with account-version identity and effective invocation continuity deferred to run 4 as flagged." Rat-067 also retains "account-copy identity, effective queue participation"; DISPOSITIONS carries the full decisions. | Applied: added complete rat-067/068/069 decisions so the prose no longer loses duties visible only through later_ratifications. The 15 TAXONOMY-entry census is unchanged. |
+| V04 | CONFIRMED-OK | 102 → 122 | Archived rat-047..052 verbatim_decision and run-2 ratification-docket.yaml evidence_quote; sitting-3 Ruling 3: "no run-2 flag is discharged" and "separate contract and governance duties". | All 12 full strings match the authority and the run-3 intake, including the former clipped quotes. Four C4 parks and two contract/governance duties retained. |
+| F02 | BLOCKING | 203 → 235, 208 → 250, 213 → 266 | `INDEX:528`: "CQ-013 requires an independently supported signature mapping, attributed delay, and lane cost comparisons"; `INDEX:692`: "retain the synthetic qualification"; `INDEX:948`: "Supply an observed consumer and a Must/Should executable CQ". | Applied: restored full live requirements, including interval/overlap and measurement-target boundaries, synthetic notice limits, positive access/bounded absence, binding correction and the separate class warrant. Source-specific C4 routing remains J02. |
+| F03 | BLOCKING | 234 → 313, 238 → 323 | `INDEX:212`: "or an observed mapping that makes this assertion necessary for an existing decision"; `INDEX:482`: "checksGreen and requiredChecksGreen", "CQ-006/CQ-017", "A retained copy after removal of the original record". | Applied: retained both alternatives and the complete two-assessment experiment. Bucket/routing judgment remains J01. |
+| F04 | BLOCKING | 244 → 339, 272 → 377 | `INDEX:227`: "distinguish asserted event time from record creation time"; `INDEX:245`: "requested work, and capacity pool", "termination followed by reacquisition", "a captured conferral/termination rule". | Applied: restored full requirements for all 25 journal and 28 allocation rows. Two counted decisions do not by themselves establish duplicate charging or continuing authorization. |
+| F05 | BLOCKING | 328 → 450 | `INDEX:1241`: "actual contended resource or proof-lock path", "grant/lease and lock ownership identifiers", "distinguish admission authorization from proof-lock ownership". Sitting-2 Ruling 2 includes "proof-lock paths". | Applied: replaced the admission-capacity-only summary and retained the full resource/lock join. The run3b generator excludes proof locks, so another admission sweep alone cannot discharge this duty. |
+| F06 | BLOCKING | 333 → 467 | `INDEX:1265`: "a Must/Should CQ requiring a lifecycle distinct from its request, grant and boundary reports" and "memory rider remains independently parked". Lease duty also requires "complete heartbeat-rewrite history" and "actual ledger decrement and carrier lineage". | Applied: restored all three distinct requirements across five rows and removed the undated live-count shorthand. Organic terminal incidence is insufficient. |
+| F07 | BLOCKING | 343 → 512 | `INDEX:1354`: "This promoted Ruling-6 rider remains open"; sitting-2 Ruling 2: "stay unresolved with NEW needed_evidence". | Applied: removed the invented retire-as-unobservable alternative. Restored applicable domain/version and the particular Turbo execution/applied cache-posture join. |
+| F08 | BLOCKING | 349 → 528 | `INDEX:1447`: "versioned branch-freshness contract", "recomputation and the decision that changes with the result". Other rows require score subject/revision provenance, attribution overlap/precedence and a selector decision CQ. | Applied: restored all four distinct requirements across nine rows. A contract name alone does not discharge the observed-case and decision duties. |
+| F09 | BLOCKING | 361 → 577 | `INDEX:1531`: "authoritative parent-attempt join, each repeated execution's identity and its own actual start/end boundaries". The second row retains measured extent, clock/precision and the one-millisecond discrepancy. | Applied: restored both full requirements. Whether C4 supplies the missing facts remains J02. |
+| F10 | BLOCKING | 366 → 603 | `INDEX:1552`: "metric, unit and measurement provenance" and "an authoritative comparison with peakRssKb". | Applied: restored the measurement-family comparison and provenance requirement, in addition to process/sampling boundaries. |
+| F11 | BLOCKING | 370 → 616 | `INDEX:1562`: "authoritative issuance, custody, copy and correction lineage"; the second row adds both execution identities, measurement assertions, comparison issuance and a distinct-comparison CQ. Sitting-2 Ruling 2 keeps these rows unresolved. | Applied: removed the invented retire-individuals alternative and restored both complete requirements, including carrier and comparison duties. The later class withdrawal did not retire these carried observations. |
+| F12 | BLOCKING | 375 → 645 | `INDEX:1586`: "joining all three QA stages to the in-scope Yeet or CI lane, its frozen tree and cache epoch". The other three rows say "obtain all three remaining chains" for conformance package, governed suite and replay-result identity/issuance. | Applied: separated the QA chain from the three conformance/suite/replay chains. One beep-qa session cannot discharge every row in this cluster. |
+| F13 | BLOCKING | 382 → 673 | `INDEX:1634`: "observed lineage deciding rename, move, version change, fork and delete/recreate cases" and "role or immutable-content object". | Applied: restored all continuity cases and the observed-lineage/grain requirement across seven rows. |
+| F14 | BLOCKING | 392 → 692 | `INDEX:1704`: "numeric positions, ordering algorithm and dependency-edge semantics" and "operational verification decision". The docgen row keeps both extension-versus-rule concessions; affected-task rows require the observed selected set and fail-open/closed contract. | Applied: restored all three distinct requirements across nine rows, including dirty snapshot, selected members, governed specification and consumer decisions. |
+| F15 | BLOCKING | 404 → 733 | `INDEX:1787`: "unit conversion, reserve subtraction and hard-floor treatment" and "capacityAtAdmissionTokens on an observed admission decision". Snapshot rows require machine/policy scope and the immediately pre-grant correlation. | Applied: restored both complete requirements across seven rows. Ruling 9 omitted capacity stamps; a later lease or the projection inequality is insufficient. |
+| F16 | BLOCKING | 414 → 762 | `INDEX:1857`: "unit and both true/false consequences" and a governed origin-blocked case. Other rows require suspicion-versus-termination authority and the same ticket's originBusy/starvation-policy use plus issuance/revision. | Applied: restored all three requirements across five rows. Reading zero against a threshold alone loses the observed-case and authority duties. |
+| F17 | BLOCKING | 422 → 800 | Withdrawal r1 receipt: "a Must/Should executable CQ that must distinguish termination occurrences independently" and "rather than pending membership and qualified end values". Journal-entry duty: "An operational event reading additionally needs an effective-transition join." | Applied: retained every full receipt duty, including binding-class warrants, terminal duplicates/cleanup controls, resubmission distinctions and conditional attempt termination. Eight withdrawals are 1 journal + 3 bind + 1 duration + 3 sitting-3 concessions, with r2 superseding only the duration file-retention decision. |
+| F18 | BLOCKING | 439 → 892 | ETL admission_sources() at lines 916–923 supplies roots; capture() at lines 1329–1346 reads one journal.ndjson per root. The bounded current read below finds canonical=1 ETL journal, 623 rows, 4 lease/0 ticket evictions; run3b-fleet manifest remains 5/2. | Applied: replaced the unreproducible current-tense census with a timestamped counts-only read and explicit schema/tag separation. The old dated sample is historical, not disproved as a past observation. No pin or raw history was written. |
+| F19 | MINOR | 452 → 909 | Ratification docket Queue D: "authorized run-4 emission" with "an independently identified Scope and its provenance/identity, followed by the required analysis, proposal and review". | Applied: made all recorded reopening prerequisites explicit; no automatic ratification or CQ edit. S6 hasScopeTag is ratified; hasScope and schedulesWorkUnit remain seed-only. |
+| F20 | MINOR | 475 → 934 | Ratification docket, Intake spellings: "remains the provisional emission namespace with open closure and exclusion from negation/ratified typing" and "No separate namespace OTP is present." | Applied: restored the omitted namespace carry-forward and corrected the manifest's stale rides-run-3 wording. S8 remains deferred. |
+| F21 | MINOR | README:31; manifest:9–10; Trail (before edits) | GitHub PR #1095: merged=true, head=30781ba7ef18634935f993a13db3e73854094b51; local squash 9292600368 is an ancestor of HEAD. explorations/AGENTS.md requires current manifest, Next Open Question and Trail. | Applied: recorded merged #1095, dated verification, remaining routing blockers, all seven unchecked gate boxes and the report link across the session surface. |
+| J01 | BLOCKING | 238 → 323 | `INDEX:482`: "To select among the remaining models, observe two assessments" with preserved instants/states and an observed consumer. It does not name a new consuming decision as prerequisite or proof-ledger issuance. | NOT EDITED: evidence text fits an identity experiment, while C(ii) is defined as requiring a decision/CQ before seeking evidence. Proposed: move this source-derived singleton to C(iii), or obtain authority for C(ii); recompute bucket counts and remove/justify its C4-specific source claim. The overall C4 launch gate remains intact. |
+| J02 | BLOCKING | 203 → 235, 208 → 250, 361 → 577; Queue A:72 | `INDEX:528` requires independent execution boundaries and CQ-013 facts; `INDEX:692` requires modeled-attempt/start/admission boundaries; `INDEX:1531` says passed-step instrumentation was excluded. Ruling 17 commits to issuance/custody, not these execution or episode facts. | NOT EDITED: C4 proof facts / expected-to-carry routing is an unproved producer contract. Proposed: cite the C4 schema/writer contract that supplies each required fact, or keep these as independent instrumentation/identity requirements. Applies to six rows and the Queue A episode-closure forecast; do not infer discharge from C4 completion. |
+| J03 | BLOCKING | 72–73 → 72–73 | Sitting-3 Ruling 1: the thirteen proposals "are adopted as drafted" with four deferrals "retained as flags for run 4". Ratification docket requires joint ratification of the initial cluster; it does not decide future all-or-nothing flag lifting. | NOT EDITED: "The cluster lifts or re-flags together, as it ratified" extends the recorded sitting procedure. Proposed: retain joint initial ratification as history and present future flag-lifting granularity to the steward, or cite an explicit existing ruling. This lane does not choose that governance rule. |
+| V05 | CONFIRMED-OK | 461 → 920 | POLICY.yaml:5 still has corpus_commit; the 2026-09-09 capture-provenance receipt says "S6 POLICY should adopt this capture/current-tree convention"; run-4 authoring brief Queue F authorizes docketing the later change. | No POLICY edit. The pin lane must regenerate and verify any authorized later provenance change; Ruling 22 is the refresh/security precedent, not a blanket permission to refresh ratified pins. Ruling 23 preserves capture history on repairs. |
+| V06 | CONFIRMED-OK | 499 → 962 | check_manifest:1154–1168 uses relative path + newline + byte length + newline + bytes over 21 files. REVIEW-HISTORY v15: "158 families". PR #1092 review reply queues index grammar beside NDJSON and archive-path follow-ups. | All quoted digests match; four other prompts equal the run-3 manifest. Current Python 3.12 self-test passes 158 families. Denotation and seat effort are already v15; the three other follow-ups remain queued. |
+| V07 | CONFIRMED-OK | 25 → 25 | PLAN.md lines 100, 102, 104, 108, 111, 121, 124: every named checkbox is [ ]. Run-4 authoring brief: "Run 4 proper is gated" on C4. | Hard gate preserved. Verification can finish, but a pin lane must stop before creating a pin/tag/manifest/seat while C4 is unchecked. The older handoff's projection blocker is superseded by S5 amendment and current projection records. |
+| V08 | CONFIRMED-OK | 531 → 994 | Run-3 intake Not in scope and run-4 authoring brief: no scheduler/runtime work, captures, reruns, CQ/seed/contract changes, ratification/waivers or lane publication. | Section order follows run 3 after the explicit gate. All 38 generated ID lists have a preceding blank line. No prohibited Git command, seat launch, authority-record edit, capture or pin operation occurred. |
+
+## Checks by brief item
+
+| Item | Checks and authority coverage | Verdict |
+| --- | --- | --- |
+| 1. Prior-run chain | SHA-256 over exact bytes; HEAD/base equality; all outcomes and carried markers; live archive and prior unresolved set equality; since dates and gate denominator. | PASS: 284 = 216 + 68; unresolved 138 = 84 + 54; b9c140ccd31b; historical 84/198, no waiver. |
+| 2. Queue C | Independent set/multiplicity check; 138 individual source-row joins; all 38 distinct evidence texts read; all 15 cluster IDs/order/counts checked; 68 carried outcomes/evidence/reasons/since values equal the adopted companion YAML; three retirement clusters verified empty. Full requirements are now preserved. | MECHANICAL PASS; substantive record-decided omissions fixed; J01/J02 remain BLOCKING. |
+| 3. Queue A | All 39 rat-032..070 files parsed; each resolves to the proposal digest it ratifies. All 18 live term/proposal bindings, all 15 flagged TAXONOMY rows and complete additive DISPOSITIONS lists checked. | PASS on binding/flag census; missing later-ratification duties restored; J03 remains BLOCKING. |
+| 4. Queue B | Six full decisions and six full evidence_quote values compared to both archival authority and run-3 intake; all six sitting-3 routes and separate-term prerequisites reviewed. | PASS: 6/6 complete quote pairs, 4 C4 parks + 2 contract/governance duties; no prior duty dropped. |
+| 5. Queue D | Eight unique withdrawals joined to journal-entry docket, bind/ver r1, ver r2 and sitting-3 receipts; retained historical duration duty distinguished from final withdrawal requirement. Count-only read uses exactly admission_sources roots and capture's journal filename; manifest 5/2 comparison checked. | PASS after restoring full duties and dated census; no inference of new chains or organic completeness. |
+| 6. E/F, non-triggers, engine | All 23 numbered corpora/Stage-B/residue rulings read in their dated sections; launch/sittings/S5 amendment read; all three sitting entries equal DECISIONS verbatim. Reviewed run-3 intake, implementation report and handoff; checked current S5/S6, POLICY, v15 validator/history/prompt/skill and the framed 21-file contract closure; read all five #1092 review threads plus status comment. | PASS after Scope prerequisites and provisional namespace carry-forward were made explicit; J02/J03 isolate unsupported extensions. |
+| 7. Gate/session | Exact seven PLAN checkbox states; merged #1095 read from GitHub and local ancestry; README Next Open Question, dated Trail and manifest reconciled; atlas write then check. | PASS for session consistency; C4 launch gate remains CLOSED. |
+| 8. Format | Run-3 section order and evidence-preserving voice; blank lines before every generated ID list; scoped typos, residue and diff-whitespace checks. | PASS, with proof receipts below. |
+
+Ruling citations resolve by dated section, not by number alone: corpora design
+Rulings 1–16 are at DECISIONS:819–960; Stage B Rulings 17–21 at 962–1034;
+residue Rulings 22–23 at 1036–1081; launch at 1083–1111; sittings 1–3 at
+1113–1236; S5 amendment at 1238–1271. In particular, Ruling 7 is the TS
+non-trigger, 9 omits capacity stamps, 10/19 require synthetic labels, 15 defers
+S8, 16 preserves legacy scope/work-unit spellings, 17 defers writer issuance,
+22 permits residue repair/refresh before ratification, and 23 forbids refreshing
+ratified captures. No Ruling N citation was silently resolved to another sitting.
+
+The run-3 handoff and implementation report retain their historical S5 projection
+block. S5 gate amendment Rulings 1–4, TAXONOMY's 52 terms, DISPOSITIONS' accepted
+FailureSignature/VerificationAttempt/dependsOnTransitive rows and S6's ratified
+dependsOnTransitive/hasScopeTag entries supersede that blocker. hasScope and
+schedulesWorkUnit remain seed-only. No historical report was rewritten.
+
+The #1092 review authority is the [resolved index-grammar reply](https://github.com/beep-effect/beep-effect/pull/1092#discussion_r3994232718)
+and [status comment](https://github.com/beep-effect/beep-effect/pull/1092#issuecomment-5642188498):
+the extra per-observation proposal pointers/coverage rule are a later versioned
+amendment with their own self-test families. The other four review threads cover
+the session surface, null-record coverage, stale v13 bytecode wording and the final
+contract-compatible null-record clause; none schedules those completed repairs
+again. [PR #1095](https://github.com/beep-effect/beep-effect/pull/1095) supplies the
+merged status. These were read-only requests; no comment or review was sent.
+
+## Reproduced outputs
+
+All Python ran through `uv run --offline --python 3.12 --with pyyaml python`,
+using the supplied UV_CACHE_DIR. Bun on PATH reported `1.4.2`. The checks are
+local verification, not a new ontology run or a run-4 launch gate execution.
+
+### Original totality and census
+
+```text
+INDEX sha256[:12]=b9c140ccd31b
+INDEX live: total=216 proposed=37 mapped=77 unresolved=84 irrelevant=18
+INDEX carried: total=68 proposed=0 mapped=0 unresolved=54 irrelevant=14
+INDEX all: total=284 proposed=37 mapped=77 unresolved=138 irrelevant=32
+TOTALITY listed=138 unique=138 unresolved=138 missing=0 strays=0 duplicates=0
+PLACEMENT C(i): rows=14 live=14 carried=0
+PLACEMENT C(ii): rows=3 live=3 carried=0
+PLACEMENT C(iii): rows=67 live=67 carried=0
+PLACEMENT C(iv): rows=54 live=0 carried=54
+CLUSTER checkout-binding: unresolved=0 membership=PASS
+CLUSTER grant-resource-contention: unresolved=2 membership=PASS
+CLUSTER admission-lifecycles: unresolved=5 membership=PASS
+CLUSTER failure-signature-occurrences: unresolved=0 membership=PASS
+CLUSTER cache-plan-resolution: unresolved=1 membership=PASS
+CLUSTER ordering-cluster: unresolved=0 membership=PASS
+CLUSTER assessment-and-selector-governance: unresolved=9 membership=PASS
+CLUSTER execution-boundaries-and-elapsed-scope: unresolved=2 membership=PASS
+CLUSTER memory-measurement: unresolved=1 membership=PASS
+CLUSTER duration-and-comparison-issuance: unresolved=2 membership=PASS
+CLUSTER qa-and-conformance-evidence: unresolved=4 membership=PASS
+CLUSTER workspace-package-identity: unresolved=7 membership=PASS
+CLUSTER dependency-and-selection-contracts: unresolved=9 membership=PASS
+CLUSTER capacity-computation-and-snapshot: unresolved=7 membership=PASS
+CLUSTER origin-and-heartbeat-policy: unresolved=5 membership=PASS
+CARRIED AUTHORITY: 68/68 rows match sitting-2 outcome, carry marker, evidence/reason and since
+CHAIN: 216 live IDs equal archive; 68 carried IDs equal run-2 unresolved; since=2026-09-10 for 138/138
+QUEUE A: 15/15 flags complete and verbatim; term/kind/ratification=PASS
+```
+
+### Corrected docket: totality, digests, bindings and manifests
+
+```text
+INDEX sha256[:12]=b9c140ccd31b
+INDEX live: total=216 proposed=37 mapped=77 unresolved=84 irrelevant=18
+INDEX carried: total=68 proposed=0 mapped=0 unresolved=54 irrelevant=14
+INDEX all: total=284 proposed=37 mapped=77 unresolved=138 irrelevant=32
+TOTALITY listed=138 unique=138 unresolved=138 missing=0 strays=0 duplicates=0
+PLACEMENT C(i): rows=14 live=14 carried=0
+PLACEMENT C(ii): rows=3 live=3 carried=0
+PLACEMENT C(iii): rows=67 live=67 carried=0
+PLACEMENT C(iv): rows=54 live=0 carried=54
+CLUSTER checkout-binding: unresolved=0 membership=PASS
+CLUSTER grant-resource-contention: unresolved=2 membership=PASS
+CLUSTER admission-lifecycles: unresolved=5 membership=PASS
+CLUSTER failure-signature-occurrences: unresolved=0 membership=PASS
+CLUSTER cache-plan-resolution: unresolved=1 membership=PASS
+CLUSTER ordering-cluster: unresolved=0 membership=PASS
+CLUSTER assessment-and-selector-governance: unresolved=9 membership=PASS
+CLUSTER execution-boundaries-and-elapsed-scope: unresolved=2 membership=PASS
+CLUSTER memory-measurement: unresolved=1 membership=PASS
+CLUSTER duration-and-comparison-issuance: unresolved=2 membership=PASS
+CLUSTER qa-and-conformance-evidence: unresolved=4 membership=PASS
+CLUSTER workspace-package-identity: unresolved=7 membership=PASS
+CLUSTER dependency-and-selection-contracts: unresolved=9 membership=PASS
+CLUSTER capacity-computation-and-snapshot: unresolved=7 membership=PASS
+CLUSTER origin-and-heartbeat-policy: unresolved=5 membership=PASS
+CARRIED AUTHORITY: 68/68 rows match sitting-2 outcome, carry marker, evidence/reason and since
+CHAIN: 216 live IDs equal archive; 68 carried IDs equal run-2 unresolved; since=2026-09-10 for 138/138
+QUEUE A: 15/15 flags complete and verbatim; term/kind/ratification=PASS
+RAT rat-053: otp:ov-admission-token-charge:001 | Accept otp:ov-admission-token-charge:001 as the admissionChargeTokens recorded-value property reuse within the joint ordering cluster, with repricing, assertion replacement, request/grant continuity and pre-admission capacity evidence deferred to run 4 as flagged.
+RAT rat-054: otp:ov-current-proposal-selection:001 | Accept otp:ov-current-proposal-selection:001 as hasCurrentProposal in a versioned, time-indexed projection context, with the episode identity flag retained and any operational selection-situation identity deferred, only with joint ordering-cluster ratification.
+RAT rat-055: otp:ov-origin-ordering-key:001 | Accept otp:ov-origin-ordering-key:001 as the hasOriginKey scalar-property reuse supporting ScheduleProposal and AdmissionProjectionSpecification, with repository-origin identity and normalization deferred to run 4 as flagged, within the joint ordering cluster.
+RAT rat-056: otp:ov-projection-specification:001 | Accept otp:ov-projection-specification:001 as the AdmissionProjectionSpecification repeatable-rule proposal within the joint ordering cluster, with rule-versus-application identity explicitly deferred to run 4 as flagged and no equation of rules with input-bound contexts.
+RAT rat-057: otp:ov-proposal-specification-binding:001 | Accept otp:ov-proposal-specification-binding:001 as the contextual hasProjectionSpecification object property, with AdmissionProjectionSpecification's rule-versus-application identity flag retained, only with joint ordering-cluster ratification.
+RAT rat-058: otp:ov-proposal-step-membership:001 | Accept otp:ov-proposal-step-membership:001 as the contextual hasStep object property for fixed prescription components, retaining the component-versus-tuple choice as flagged and ratifying it only with the complete ordering cluster.
+RAT rat-059: otp:ov-schedule-proposal:001 | Accept otp:ov-schedule-proposal:001 as the ScheduleProposal fixed-prescription-content reuse, with issuance-versus-content identity deferred to run 4 as flagged and its episode, governing-specification and request endpoint flags retained within the joint ordering cluster.
+RAT rat-060: otp:ov-schedule-step:001 | Accept otp:ov-schedule-step:001 as the ScheduleStep immutable prescription-component class, with tuple-versus-component and editable-instruction continuity retained as flags, only with joint ratification of its proposal, membership, position, request and scope relations.
+RAT rat-061: otp:ov-seat-request:001 | Accept otp:ov-seat-request:001 as the SeatRequest reuse within the joint ordering cluster, preserving the request/grant and request/specification distinctions, with demand-versus-description grain and handling/resubmission continuity deferred to run 4 as flagged.
+RAT rat-062: otp:ov-step-position:001 | Accept otp:ov-step-position:001 as the stepIndex zero-based integer property at contextual recorded-value grain, with the quality, precedence and reified-assignment alternatives retained as flags, only with joint ordering-cluster ratification.
+RAT rat-063: otp:ov-step-request-assignment:001 | Accept otp:ov-step-request-assignment:001 as the contextual schedulesSeatRequest object property, preserving the distinction from WorkUnitSpecification and carrying SeatRequest's continuity flag, only with joint ordering-cluster ratification.
+RAT rat-064: otp:ov-step-scope-tag:001 | Accept otp:ov-step-scope-tag:001 as the hasScopeTag controlled string annotation on a contextual step, with annotation/classification identity retained as flagged and object-valued hasScope/Scope still parked, only with joint ordering-cluster ratification.
+RAT rat-065: otp:ov-verification-episode:001 | Accept otp:ov-verification-episode:001 as the VerificationEpisode occurrence-context proposal within the joint ordering cluster, with process/event category, unity, attempt membership and closure identity explicitly deferred to run 4 as flagged.
+RAT rat-066: otp:admb-seat-grant:001 | Accept otp:admb-seat-grant:001 as the SeatGrant recorded-account reuse under sitting-1 Ruling 2, preserving its nonce-chain associations, with account-copy identity and effective authorization continuity deferred to run 4 as flagged.
+RAT rat-067: otp:admb-seat-request:001 | Accept otp:admb-seat-request:001 as the SeatRequest recorded-demand-account reuse under sitting-1 Ruling 2, with account-copy identity, effective queue participation and withdrawal/resubmission continuity deferred to run 4 as flagged.
+RAT rat-068: otp:att-admission-allocation:001 | Accept otp:att-admission-allocation:001 as the SeatGrant recorded-lease-value reuse under sitting-1 Ruling 2, treating the two heartbeat reports as snapshots of one candidate subject, with effective allocation continuity deferred to run 4 as flagged.
+RAT rat-069: otp:att-verification-attempt:001 | Accept otp:att-verification-attempt:001 as the VerificationAttempt recorded-history reuse under sitting-1 Ruling 2, with account-version identity and effective invocation continuity deferred to run 4 as flagged.
+RAT rat-070: otp:att-attempt-verdict:001 | Accept otp:att-attempt-verdict:001 as the assessment-origin VerificationResultArtifact reuse supporting the recorded VerificationAttempt account, with equal-content assessment, copy/correction and issuance identity deferred to run 4 as flagged.
+LATER SeatGrant original=rat-002 later=rat-066,rat-068
+LATER SeatRequest original=rat-007 later=rat-034,rat-061,rat-067
+LATER VerificationAttempt original=rat-033 later=rat-069
+QUEUE B rat-047: decision=VERBATIM evidence=VERBATIM lengths=104/202
+QUEUE B rat-048: decision=VERBATIM evidence=VERBATIM lengths=110/383
+QUEUE B rat-049: decision=VERBATIM evidence=VERBATIM lengths=105/368
+QUEUE B rat-050: decision=VERBATIM evidence=VERBATIM lengths=77/220
+QUEUE B rat-051: decision=VERBATIM evidence=VERBATIM lengths=112/397
+QUEUE B rat-052: decision=VERBATIM evidence=VERBATIM lengths=103/210
+QUEUE B: 6/6 complete decisions and evidence quotes; 4 C4 + 2 contract/governance duties
+DIGEST contracts=dcc8da4cc7f9 files=21
+DIGEST scripts/validate_artifacts.py=fdbcefc9fd70
+DIGEST SKILL.md=a12de4055976
+DIGEST scripts/run_adapter_sandbox.sh=ecb6dcab421b
+DIGEST prompts/alternative-model.md=4563e5726438
+DIGEST prompts/denotation.md=ddec132ee905
+DIGEST prompts/ontoclean-adversary.md=9dbfb7fc9d4c
+DIGEST prompts/synthesis.md=117d82b29904
+DIGEST prompts/ufo-analysis.md=3d94feb0629c
+DIGEST prior prompts unchanged=4/4
+SITTINGS: 3/3 decision entries occur verbatim in DECISIONS.md
+CORPUS run3-fleet totals={"bytes_emitted": 19054995, "events": 7975, "files_emitted": 1927, "payload_bytes": 16243246, "payload_files": 1926}
+CORPUS run3-checkout-identity totals={"bytes_emitted": 894958, "events": 108, "files_emitted": 217, "payload_bytes": 694899, "payload_files": 216}
+CORPUS run3b-fleet totals={"bytes_emitted": 15980568, "events": 7382, "files_emitted": 741, "payload_bytes": 14643914, "payload_files": 740}
+CORPUS run3b-fleet chain_counts={"in-flight": 3, "lease-evicted": 5, "pre-v3": 112, "ticket-evicted": 2, "unclassified": 0, "win": 21, "withdrawn": 23}
+CORPUS run3b-synthetic totals={"bytes_emitted": 43001, "events": 10, "files_emitted": 9, "payload_bytes": 6953, "payload_files": 8}
+CORPUS run3b-synthetic chain_counts={"in-flight": 0, "lease-evicted": 1, "pre-v3": 0, "ticket-evicted": 1, "unclassified": 0, "win": 1, "withdrawn": 1}
+GATE PLAN.md:100: - [ ] C3.3 `lint:laws` package task (sub-second laws plus package-test-imports); `beep:policy`
+GATE PLAN.md:102: - [ ] C3.4 `doctest` package task; mode branch in `vitest.shared.ts`; the root doctest config
+GATE PLAN.md:104: - [ ] C3.5 Turbo root tasks for the graph-wide sublanes (knip, fallow, oxlint, circular,
+GATE PLAN.md:108: - [ ] C3.6 economics re-run over the migrated lanes; the ledger report shows per-lane hashes.
+GATE PLAN.md:111: - [ ] C4a retire both legacy proof stores with receipts, never migrate them: (1) `YeetLaneProofState`
+GATE PLAN.md:121: - [ ] C4 shadow mode with a disagreement report; enforcement between pre-push and merged preview
+GATE PLAN.md:124: - [ ] C5 must-fail fixtures: changed package, epoch change, cross-profile reuse.
+MECHANICAL CHECKS: PASS
+```
+
+### Additional authority and fidelity checks
+
+```text
+INDEX BYTES: working tree = HEAD = e16e7a9297
+HISTORY: #1095 and #1092 merge commits are ancestors of HEAD; original docket = 30781ba7ef bytes
+EVIDENCE: 38/38 distinct index requirements retained verbatim modulo Markdown wrapping; all 138 rows covered
+WITHDRAWALS: 8/8 unique proposals; 9/9 receipt duties retained (duration r1 history plus final r2 requirement)
+RATIFICATIONS: 39/39 archived/live accept records resolve to byte-bound proposals; 18/18 run-3 terms match decision text
+FLAGS: 15/15 TAXONOMY flag clauses are exact accepting-decision suffixes
+LATER RATIFICATIONS: original joins preserved; full additive lists and reuse-grain justifications match
+QUEUE B CARRY-FORWARD: 12/12 complete quotes equal the run-3 docket; no prior evidence duty dropped
+SESSION: README, Trail and manifest agree on merged #1095, verification report, unresolved routing and closed C4 gate
+FORMAT: 38/38 observation-ID list starts have a preceding blank line
+FORMAT: run-3 section order retained; additional hard gate is before prior-run chain
+ADDITIONAL MECHANICAL CHECKS: PASS
+```
+
+### Count-only admission read
+
+```text
+CENSUS observed_at=2026-09-12T10:08:27.200553+00:00
+CENSUS {"by_version": {"yeet-admission-journal/v1": {"admission-admitted": 200}, "yeet-admission-journal/v3": {"admission-enqueued": 212, "admission-lease-evicted": 4, "admission-released": 195, "admission-withdrawn": 12}}, "etl_journal_files": 1, "parse_errors": 0, "root": "canonical", "rows": 623, "status": "present", "tags": {"admission-admitted": 200, "admission-enqueued": 212, "admission-lease-evicted": 4, "admission-released": 195, "admission-withdrawn": 12}, "versions": {"yeet-admission-journal/v1": 200, "yeet-admission-journal/v3": 423}}
+CENSUS {"by_version": {}, "etl_journal_files": 0, "parse_errors": 0, "root": "system-tmp", "rows": 0, "status": "absent", "tags": {}, "versions": {}}
+CENSUS {"by_version": {"yeet-admission-journal/v1": {"admission-admitted": 1, "admission-released": 1}}, "etl_journal_files": 1, "parse_errors": 0, "root": "session-tmp", "rows": 2, "status": "present", "tags": {"admission-admitted": 1, "admission-released": 1}, "versions": {"yeet-admission-journal/v1": 2}}
+CENSUS scope=one read per named ETL journal; counts only; no capture; no chain novelty or completeness inference
+```
+
+The census executes only the source-extracted admission_sources function with its
+standard-library dependencies, then reads journal.ndjson once per named root.
+The ETL capture function is never called. File size/mtime are checked before and
+after each read; raw row values, process identities and paths are neither printed
+nor retained. Only allowlisted schema/tag counters leave the reader. The earlier
+exploratory read had 622 canonical rows; one enqueue arrived before the reported
+623-row sample. The timestamp is therefore part of the claim. The journal's
+retained window cannot reproduce the earlier dated 644-row sample or establish
+whether any retained chain is new relative to run3b-fleet.
+
+### Engine self-test
+
+```text
+SELF-TEST PASS (158 rule families fire: canonical ids, nested closure, object grammar, mixed-unrep, discriminator, searched-true, warrant-XOR, parents grammar, id grammars incl. rat digits, crash-hardening, rat content binding + staleness + freshness, review edge-target/chain/history/continuity/revision_log incl. landed-rule join + duplicate rounds, chain cross-wire + verdict join, carried authentication + live-carried bypass, row-evidence join, since-exact, digest-fresh IRI, identifier pad + negation context + provider agreement incl. boolean-vs-unresolved, boolean pin_waived, ufo_category required, addressed-list shape, #-boundary, config pairing, vacuity-boolean, text exact-type sweep, container shapes, prior-FAIL coverage population, tri-state crash hardening, duplicate-key loader, syntax-aware pairing stripper, glued openers, mid-line bare keys, blank-line continuation, identity precedence, lexical component symlinks, run-id parser, closed shared run-id grammar + rotation parity, exact-hex digest locks, cross-line separator refusal, ini/properties quoted-payload, toml/BOM/form-feed comment boundaries, join quarantine, orphan review/rejection authority, predecessor-local row validation, symlink-loop fail-closed, bounded run-id fractions, CR line-break normalization, half-quote arm refusal, table-filter quarantine, predecessor date/grammar/reason/carried meters, control-escaped authority rendering, unexaminable-path fail-closed, referent-mapping guard, review revision-requests channel, ledger-rationale binding, revision-log digest union, closure-read fail-closed, runs-shelter poison guard, seat-effort provenance)
+```
+
+Exit 0. The self-test's duplicate-key and tab-padded run-id refusal messages on
+stderr are expected negative fixtures; they are not failures of the docket.
+
+### Touched-file proofs
+
+Commands: `typos` over the four authored paths listed under Files; an independent
+count-only residue scan over those same files; `git diff --check`;
+`bun run beep explore atlas --write` followed by `bun run beep explore atlas --check`.
+The residue scan checks host-path syntax, the local account and hostname, and
+numeric user identifiers without printing matched private values. The tree check
+also verifies that the staged set is empty and no authority path changed.
+
+```text
+RESIDUE PASS files=4 host_paths=0 account_names=0 host_names=0 numeric_user_ids=0
+TYPOS PASS files=4 exit=0 output=empty
+DIFF WHITESPACE PASS exit=0 output=empty
+TREE PASS tracked_changes=3 new_report=1 staged_paths=0 protected_authority_changes=0
+REPORT PASS row_matrix=138 unique=138 evidence_catalog=38 no_placeholders
+```
+
+```text
+$ bun run packages/tooling/tool/cli/src/bin.ts -- explore atlas --write
+[explore:atlas] wrote explorations/ATLAS.md and README status projections.
+$ bun run packages/tooling/tool/cli/src/bin.ts -- explore atlas --check
+[explore:atlas] OK: D3 Atlas and README projections are current.
+```
+
+Both atlas commands exited 0. The report's embedded reproduction snippet was
+executed successfully against the final docket: 138 listed, 138 unique, zero missing,
+zero strays, all 15 clusters PASS, contracts dcc8da4cc7f9 over 21 files.
+
+
+## Every unresolved row
+
+This table is generated from the authoritative INDEX and checked docket membership.
+Each full ID occurs once here. The source-line join authenticates its outcome,
+carried marker, since and complete needed_evidence. Requirement keys identify exact
+evidence texts, rather than paraphrases; the following catalog gives their source
+and corrected-docket quote locations. C(iv) membership is independently joined
+through carried-clusters.yaml.rows; live bucket placement is checked against the
+evidence text, with J01 explicitly disputed. J02 concerns producer routing rather
+than row membership.
+
+| Observation ID | Bucket / group | INDEX line | Requirement | Placement verdict |
+| --- | --- | ---: | --- | --- |
+| `po:sha256:519764a98f511e5f2137e8eb2d6b072d92d27b62a4417db97040359034bb3282` | C(i) / ov-token-charge-removal | L85 | E01 | PASS |
+| `po:sha256:a3b740b147b88dd94b092bee660c397cabadbbed2f35ddd14b6347c6ccb2f3fe` | C(i) / ov-token-charge-removal | L145 | E01 | PASS |
+| `po:sha256:f41f8934b51e0e14a0344efa0b46898ea051035f811e3cee5e8de69c1bf43e2a` | C(i) / ov-token-charge-removal | L204 | E01 | PASS |
+| `so:sha256:27fc89410ea6dbdacff098a5500ba7a968df33a96e89d47c65b107e436fc301f` | C(i) / seat-grant-organic-chains | L440 | E02 | PASS |
+| `so:sha256:37968f126c464470a069ac2051cb358a0a29720dd49df7256625cb4d17bfa2c6` | C(i) / recovery-durations | L528 | E03 | PASS |
+| `so:sha256:928e7ce7acb4292bbd03703746cd347b6fd0aeeb2c144ee33188512f3ff91939` | C(i) / recovery-durations | L881 | E03 | PASS |
+| `so:sha256:650d8047f7efde8b68d19380b2c6229f038cc3c6c0290f1045d4feaca7b71a98` | C(i) / assertion-boundary | L692 | E04 | PASS |
+| `so:sha256:68c2cc4f0ebf9f6acb48375aa66da02ca62db1610e969434dc8e714502ef2d1f` | C(i) / assertion-boundary | L724 | E04 | PASS |
+| `so:sha256:a90c39610e4a49911ace23bfa329876914961182bc6fbf2b9e8049b49ad3e3b9` | C(i) / checkout-cache-binding | L948 | E05 | PASS |
+| `so:sha256:f4532e29f3f1752921effc1f49c1712e5662464ce09f553e1f81130927db3e6b` | C(i) / checkout-cache-binding | L1210 | E05 | PASS |
+| `so:sha256:d8cf8154d2e1435f81698ec0c8d67ea4bce53283ef275029392ce1a2d2f2f03f` | C(i) / comparison-operand-binding | L1115 | E06 | PASS |
+| `so:sha256:f353b053a061870ff15017fd51401ea9165d54f608052fa1ea8daea981cf5d73` | C(i) / comparison-operand-binding | L1199 | E06 | PASS |
+| `so:sha256:ebe4cdcf6e9eec35f3ac468a4e21b559e27b550b221042d8266b1bb55b3d3b30` | C(i) / wall-time-evidence-class | L1168 | E07 | PASS |
+| `so:sha256:f025dca6b8335e444986f450f43d7970deb3f4209456efce8a23a5e1c065d446` | C(i) / wall-time-evidence-class | L1174 | E07 | PASS |
+| `po:sha256:2cc77ae5391bd35d736242a9fff5ee6d2e64ee35cc18a420060b5a541f947ca6` | C(ii) / governing-specification-comparison | L47 | E08 | PASS |
+| `po:sha256:f60ddfb04ede510a8ffe6a04a36eac20caeb92175e59245f6b436897c83907b8` | C(ii) / deferred-tail | L212 | E09 | PASS |
+| `so:sha256:34866c142b067589cef10ea45947b1e31d1f7ae8e7518b45d705f5df5a3d31ee` | C(ii) / assessment-model-selection | L482 | E10 | J01: bucket disputed |
+| `so:sha256:01fe79ebf1f0cc28550c21c941e0c4ff963cbbbcff28cffe712d9b026288d99a` | C(iii) / journal-entry-duplicate-payload | L227 | E11 | PASS |
+| `so:sha256:0385cf6e12920c8a96c520a7238b522f923a7c0116cd603fbeff793a7d0e6058` | C(iii) / journal-entry-duplicate-payload | L236 | E11 | PASS |
+| `so:sha256:05fa73f187683c8b5cfb25a3958ed5b6f3d344d1b984cb1ce1cdffe5a9b2674a` | C(iii) / journal-entry-duplicate-payload | L272 | E11 | PASS |
+| `so:sha256:0775b5fd356eaea7604537054326c7e97598c5f81504c0d815558297ebf0f50e` | C(iii) / journal-entry-duplicate-payload | L281 | E11 | PASS |
+| `so:sha256:08149709f365cd0031ec1a4a17e6f76e957b70a4507b8c15e077e41ec998abce` | C(iii) / journal-entry-duplicate-payload | L290 | E11 | PASS |
+| `so:sha256:10f2cebc7b17c5f7b15bd051ed0f0363d355c3e4cb2f927dd2b2852461ad2610` | C(iii) / journal-entry-duplicate-payload | L364 | E11 | PASS |
+| `so:sha256:146d2b385ef6e3fb892821dbd2df82091184f2dca48f8cd9b9eaa5d01019d942` | C(iii) / journal-entry-duplicate-payload | L383 | E11 | PASS |
+| `so:sha256:3b7f2e1876cc9602c8f4b911bdfec4bf8eb8b9a8355cec317b4e81bc900d2059` | C(iii) / journal-entry-duplicate-payload | L543 | E11 | PASS |
+| `so:sha256:4a98ae2d71bc800fd8718d37ccc93288cf66cc48dbffa2eddc2a0c7c3297a7d6` | C(iii) / journal-entry-duplicate-payload | L593 | E11 | PASS |
+| `so:sha256:522ce0efbf2933dac38a6f574c2ff640dadb305b695e06028dad7a5c0f25d91c` | C(iii) / journal-entry-duplicate-payload | L625 | E11 | PASS |
+| `so:sha256:65609cedeaf3e99b51031c38b99ab7bc16ea0ef59fa66bea1d446ef3f7bd3333` | C(iii) / journal-entry-duplicate-payload | L702 | E11 | PASS |
+| `so:sha256:6cf1d332ce7ea225c24cf5aea2e2192ab91ec06838463289be284bae7677e60c` | C(iii) / journal-entry-duplicate-payload | L747 | E11 | PASS |
+| `so:sha256:7627bd8803b5da11524904bb2c7b2fdcd7c320ba034444204852ded9c164cfff` | C(iii) / journal-entry-duplicate-payload | L778 | E11 | PASS |
+| `so:sha256:7e4e7d3c3f97a3907222c12d770c3f618aa1502dc1fd391f0738fd93f874dbbb` | C(iii) / journal-entry-duplicate-payload | L826 | E11 | PASS |
+| `so:sha256:91d2cd56cb62e64ab02890e9792e172bcd9350420a034a74fda5d8c35367bb4a` | C(iii) / journal-entry-duplicate-payload | L872 | E11 | PASS |
+| `so:sha256:a3d906985080a7bb34c6364829dd3add8d8d0a7235a3b00d027d9e9685e7eb19` | C(iii) / journal-entry-duplicate-payload | L929 | E11 | PASS |
+| `so:sha256:b16055eff4bab382b33f0a5629c273a35a659e407651035b9532fb833f1a722c` | C(iii) / journal-entry-duplicate-payload | L1010 | E11 | PASS |
+| `so:sha256:b303cb0ce5ff71bf3353ee50bced00e443bbba7d77e4f3e5cf7e6e8476d054aa` | C(iii) / journal-entry-duplicate-payload | L1026 | E11 | PASS |
+| `so:sha256:b4093c2df6b7863d8c90b35246c348aecbbc5201cc8a3968132345e8e29c038e` | C(iii) / journal-entry-duplicate-payload | L1035 | E11 | PASS |
+| `so:sha256:c19aff86102184c4aafeecb71520216ed5ccf721d1d16cce9a382bdd170d1967` | C(iii) / journal-entry-duplicate-payload | L1053 | E11 | PASS |
+| `so:sha256:c1e15b1c4eaa7eb7c6aa06fd4e88909368ddeac9931936b7d68c2bf857b1bcfa` | C(iii) / journal-entry-duplicate-payload | L1062 | E11 | PASS |
+| `so:sha256:cf8f163c919cdad854f3e9aabddf18a7c7589844a69389646492c47ac1f7d8e8` | C(iii) / journal-entry-duplicate-payload | L1093 | E11 | PASS |
+| `so:sha256:dae7bbf3b41b449e027e7be2793340e99e86ffbfbc9e3781a15b2c412919fba3` | C(iii) / journal-entry-duplicate-payload | L1130 | E11 | PASS |
+| `so:sha256:e7ddc88d39dcd0ebbfa2a08af2a670b1921da6c0a721d6b64a2a41b179fd1964` | C(iii) / journal-entry-duplicate-payload | L1159 | E11 | PASS |
+| `so:sha256:f1e3e6b059c258e89fc802148a2976a93bd0ade9c8e5568b6052d81945140f7a` | C(iii) / journal-entry-duplicate-payload | L1187 | E11 | PASS |
+| `so:sha256:0415a4f1590540c534d5ccc9027d36acddbfa4ffdd84445bda5155dac85ac5c6` | C(iii) / allocation-double-count | L245 | E12 | PASS |
+| `so:sha256:05a0dfbb8f434d75b8be6d1bd7d396925b594cb0e9ceb6b72bda31e76e9685d3` | C(iii) / allocation-double-count | L255 | E12 | PASS |
+| `so:sha256:0ac1b790ab6965774fb94a2741caa3d2254ad662e54f761a5ae8744e19e6b7af` | C(iii) / allocation-double-count | L299 | E12 | PASS |
+| `so:sha256:0dcfbaeaa65aeeec90c1e9590be8a33c1ffe9438f29ebbe7d8617d09a5e45b08` | C(iii) / allocation-double-count | L327 | E12 | PASS |
+| `so:sha256:0e50d84bdb1fbc2d463bced37bfe314caf8e1b5a8cc58dd5359978650ab1f53c` | C(iii) / allocation-double-count | L337 | E12 | PASS |
+| `so:sha256:0e797a3deeedd27cfa75082643ce788d6c73e073bf87a640fe50ce3896a43e2b` | C(iii) / allocation-double-count | L347 | E12 | PASS |
+| `so:sha256:126709ea74fec8cb4b03c021d7cf121aac566b19bea91c4ac8a452f33d01a94e` | C(iii) / allocation-double-count | L373 | E12 | PASS |
+| `so:sha256:155a7c875acf08bae8c3073be1e54bebd65f2b8d5192697d7687da967e781ae6` | C(iii) / allocation-double-count | L392 | E12 | PASS |
+| `so:sha256:232151f9f2afc0f8662cbd2c75d368bae594686ce7f0bdbac3e9f7238d6fd062` | C(iii) / allocation-double-count | L420 | E12 | PASS |
+| `so:sha256:27ba4f5468b662c17e401817a599ad4e45c2091d51423b279d8de9fbe97880b7` | C(iii) / allocation-double-count | L430 | E12 | PASS |
+| `so:sha256:2e58e1311fcc9f696bc06624bab0b4e23b6597ee1919f68e1516882ab067b53a` | C(iii) / allocation-double-count | L455 | E12 | PASS |
+| `so:sha256:4bb535144f06b1e9abc6a8c75f0dcc3fc7d030f9b64214adfd1bed92ca384b08` | C(iii) / allocation-double-count | L602 | E12 | PASS |
+| `so:sha256:5130545f45659ac9d904152da47d3e52ab06961250b57d626f3d8afc4993fe42` | C(iii) / allocation-double-count | L615 | E12 | PASS |
+| `so:sha256:563cd0ce4e6678eca1af8e3cf2ff8cc59e08e587eb8853bb6f4b76e3a634dc67` | C(iii) / allocation-double-count | L647 | E12 | PASS |
+| `so:sha256:6108f04e939048617511e050bbb2421593e88c3658829deaead9b406fcb811d9` | C(iii) / allocation-double-count | L666 | E12 | PASS |
+| `so:sha256:636db00ceac88a2c4857664e7f2fb863833b68fe94f1e28a111e3451d3dfcbb1` | C(iii) / allocation-double-count | L676 | E12 | PASS |
+| `so:sha256:675134527a157d157274937b2f8ad90b036d30b77340d61f1e202483d9ac828e` | C(iii) / allocation-double-count | L714 | E12 | PASS |
+| `so:sha256:6abcdc65b395bfc82d08b2c5e49d3c9553e97a46bd942343457e68e8da0a85e7` | C(iii) / allocation-double-count | L734 | E12 | PASS |
+| `so:sha256:7b8493be70e8285a866f898e5691df4cb02c5d51fd808635f508854d1ec5622c` | C(iii) / allocation-double-count | L807 | E12 | PASS |
+| `so:sha256:7f98fb05e2fa6d6b3b08618e7f5af09ecdefc3ff88752bbf437aff900e73036a` | C(iii) / allocation-double-count | L841 | E12 | PASS |
+| `so:sha256:94cda97bb49a7661b4b7bd7ed0cd0f5b8594223ad33ddbf9d9637e464ee5c902` | C(iii) / allocation-double-count | L897 | E12 | PASS |
+| `so:sha256:997fca9994bcb3a70f034acd490a212d79ae083f17c0a18972bdbc8a924a5346` | C(iii) / allocation-double-count | L910 | E12 | PASS |
+| `so:sha256:a4ff1bbe07b6d10ed237650df3bfbe94c9a94240167ba58443ebf37227476301` | C(iii) / allocation-double-count | L938 | E12 | PASS |
+| `so:sha256:ad5ef0f6bca50e85da674990519818fb3d4a14a1650ccb135b89f2f10d875248` | C(iii) / allocation-double-count | L977 | E12 | PASS |
+| `so:sha256:b0aa81e61691ffc2b4ef587508eae988e450f03407eefbfc524fb38a82c20cdc` | C(iii) / allocation-double-count | L1000 | E12 | PASS |
+| `so:sha256:cfb413d38b8e8e1903d6e83b8d2977c5fd102003636ca8403eaa958dc1791b6f` | C(iii) / allocation-double-count | L1102 | E12 | PASS |
+| `so:sha256:d90be1aaa963b3e017130d2add821e59f623ac0540f9563cd9dd1d607cae8ce9` | C(iii) / allocation-double-count | L1120 | E12 | PASS |
+| `so:sha256:e1936767a2458fe5eb08ac5e2ba0887e7ac51f70d06111cead6e54b854e39c17` | C(iii) / allocation-double-count | L1142 | E12 | PASS |
+| `so:sha256:05bdfd88fe028976d02147ad0bfa51ad66828d2ceae653806a6a947e8374aeda` | C(iii) / result-artifact-content-snapshot | L265 | E13 | PASS |
+| `so:sha256:1008941903be9f39b5f8ee44d50647d0b02ea0a1988e1712481a22f35e6a0465` | C(iii) / result-artifact-content-snapshot | L357 | E13 | PASS |
+| `so:sha256:18fe73166f5b7932c1ef8a529b9e26f0975324ad5451673374ff5b24bbfeb91c` | C(iii) / result-artifact-content-snapshot | L402 | E13 | PASS |
+| `so:sha256:34ba8416b74877505a8a69b9947fcebfab0c62e4f3bbd30218232b857e4539bf` | C(iii) / result-artifact-content-snapshot | L500 | E13 | PASS |
+| `so:sha256:74b8c4733f1c2049ac998444c4905ba5e016d2f0cd6cf310dc5e6fa7cd414af2` | C(iii) / result-artifact-content-snapshot | L765 | E13 | PASS |
+| `so:sha256:7947484312042fc0ac6c5bd485427b9cc3a28829e3745b39031f6400a9c1a9c8` | C(iii) / result-artifact-content-snapshot | L790 | E13 | PASS |
+| `so:sha256:7a639ef29784753fbf47a4860c76a214d945a67c34fe1675915e57253dd3d628` | C(iii) / result-artifact-content-snapshot | L797 | E13 | PASS |
+| `so:sha256:9078a6ab88adf6e8ae99c1baafab237dd8c100a21fa8425143ca76a0f5bb6fcc` | C(iii) / result-artifact-content-snapshot | L865 | E13 | PASS |
+| `so:sha256:929aa987fb5e550c58968f28fd06947d1bfd2b788815a77376329f06d9ca765a` | C(iii) / result-artifact-content-snapshot | L890 | E13 | PASS |
+| `so:sha256:a9a0813fdb533325632faeda662b8fa72b08b1e4868c9cfdf66c29939927dac9` | C(iii) / result-artifact-content-snapshot | L958 | E13 | PASS |
+| `so:sha256:b24d12302a876d81148174d1247fd84e7d304fababe40bf31e84e37093734224` | C(iii) / result-artifact-content-snapshot | L1019 | E13 | PASS |
+| `so:sha256:e4e14fa1e17afc043cbd2edc24b341d044e7d0aed068e15549d6cd38a7f560d1` | C(iii) / result-artifact-content-snapshot | L1152 | E13 | PASS |
+| `so:sha256:f19da17d5b8f8ff5107a9b96cf4ff9256ebf03da52491e0370413f941f085e5d` | C(iii) / result-artifact-content-snapshot | L1180 | E13 | PASS |
+| `so:sha256:faeff009ed066ab59b310901f7f127fa174f0b0e2859613529a9ac69673c3230` | C(iii) / result-artifact-content-snapshot | L1226 | E13 | PASS |
+| `so:sha256:b42503da37767cc741db6196fbf13e019bdc59f71166ad4d95318966ca7ae123` | C(iv) / grant-resource-contention | L1241 | E14 | PASS |
+| `po:sha256:5fa0d40013f2f1bace37c166a14058909069e91de0f63b823bd0921c40f68278` | C(iv) / grant-resource-contention | L1253 | E14 | PASS |
+| `so:sha256:c627961a8fcde9dca01027cbf052494763b5e6895805c1c0c50d8bf51ba3a7bb` | C(iv) / admission-lifecycles | L1265 | E15 | PASS |
+| `so:sha256:d94bf0420d3457158959e6188c50d5949dc4fae4a48d07e7077f8c81df36fcb6` | C(iv) / admission-lifecycles | L1277 | E16 | PASS |
+| `po:sha256:3aadb9c8ae061d71b2e8386d9b8af518d49df5a66abaa0bb0391783833a6eef4` | C(iv) / admission-lifecycles | L1288 | E17 | PASS |
+| `po:sha256:51fa8a9b8fcef0856134c3599ef68eabe588532203230c5b0ac8c892da47c95a` | C(iv) / admission-lifecycles | L1299 | E17 | PASS |
+| `po:sha256:56d67898f9daaa0ff3c1fb34ff05745d9a1f94cf2703726f7721d1f586f89e5f` | C(iv) / admission-lifecycles | L1310 | E17 | PASS |
+| `po:sha256:30be9d42308395a759ea42b1706c47b14bf2d995ff5d90eb85161cef24e27b61` | C(iv) / cache-plan-resolution | L1354 | E18 | PASS |
+| `so:sha256:0a7f99ebe45f22164f484b539becf4d1d57384861db25b0c065fc67cca2574a7` | C(iv) / assessment-and-selector-governance | L1447 | E19 | PASS |
+| `so:sha256:a4fa5b4f6b8142d813d5867e01c92a245a9a7ee7d64b8841a3e27a068c88e764` | C(iv) / assessment-and-selector-governance | L1457 | E19 | PASS |
+| `so:sha256:c1e2fd7731b1efe855f70c75df8e7dd0bd99853668c551eca8fb80593a621d06` | C(iv) / assessment-and-selector-governance | L1467 | E19 | PASS |
+| `so:sha256:12f0a017acb17063246f77ebb5c128271f9df67ea7bc1666268052f2d58873d1` | C(iv) / assessment-and-selector-governance | L1477 | E20 | PASS |
+| `so:sha256:258d88bf5d120ca46af4e7964a5c3a5674c5c4984b67c0f84fe8f706e979c3f6` | C(iv) / assessment-and-selector-governance | L1486 | E20 | PASS |
+| `po:sha256:a0460c0e2b60f310cb30b9c03ea0aa2e487e02aadaa0450c56bb04cff6b5c8c9` | C(iv) / assessment-and-selector-governance | L1495 | E21 | PASS |
+| `po:sha256:8b0e7ebacbadd3d0a21df787d0070763c9151c438e5ad68ef69454c6bea0aca1` | C(iv) / assessment-and-selector-governance | L1504 | E22 | PASS |
+| `po:sha256:8d123d2b803018949aa079849fafabb4d38fbde7e7f77a5515d448cdc0a9f195` | C(iv) / assessment-and-selector-governance | L1513 | E22 | PASS |
+| `po:sha256:922212cafdb03daef5fb111352d661cfda30e1e9f3d3e8c3e6f45a19c6a82a50` | C(iv) / assessment-and-selector-governance | L1522 | E22 | PASS |
+| `so:sha256:3a8b51a1acc8602b1a583147d6d5e7e253481237fbf5806c9b13833698bc9090` | C(iv) / execution-boundaries-and-elapsed-scope | L1531 | E23 | PASS |
+| `po:sha256:2092736911a0c68e96ae8d9638b00ec4b6992b4da0677f325e4fd420fb41b2a7` | C(iv) / execution-boundaries-and-elapsed-scope | L1541 | E24 | PASS |
+| `so:sha256:78cf821b0771a1c60ef1f80746484a8da1df72bcf2b1eaa9ebed337144e5a245` | C(iv) / memory-measurement | L1552 | E25 | PASS |
+| `so:sha256:2a207d4986630e8590f790457dabe07ffeecdb9b2bfa79cf254c6bce508a2998` | C(iv) / duration-and-comparison-issuance | L1562 | E26 | PASS |
+| `so:sha256:91988c625516a3fa1516b592a7dc4c6b197b56249390fde1fc1e116867ae1af3` | C(iv) / duration-and-comparison-issuance | L1573 | E27 | PASS |
+| `po:sha256:3bf3cf7f37f4e3e046efb12751c4b9650dd3a2a16a0c99a1ec17563fa551048a` | C(iv) / qa-and-conformance-evidence | L1586 | E28 | PASS |
+| `po:sha256:059c20e6b0972ff269acf52884fea9e75f4fc5144fac7728dbac333221866181` | C(iv) / qa-and-conformance-evidence | L1595 | E29 | PASS |
+| `po:sha256:06dd8aab73f74fd680b9cf55a760da82d4a3420f91fc8ea9d8bdb27c4c000d57` | C(iv) / qa-and-conformance-evidence | L1608 | E29 | PASS |
+| `po:sha256:2338c92205c5fc08e5e18d149e7aabca98b83589cf5984e6b83fa81b2401a98c` | C(iv) / qa-and-conformance-evidence | L1621 | E29 | PASS |
+| `po:sha256:08a398bab03363136254e3e9c3ed49ebb16ffd18fb94b434111d4446cdf50d69` | C(iv) / workspace-package-identity | L1634 | E30 | PASS |
+| `po:sha256:1189ec1eca4fb79695201186157334124e71372bbe906bb6119996f42b9fe842` | C(iv) / workspace-package-identity | L1644 | E30 | PASS |
+| `po:sha256:13b29fc0bebcac4b0914db214f136add0fa739ac50af65649c800b7013ccb67a` | C(iv) / workspace-package-identity | L1654 | E30 | PASS |
+| `po:sha256:1c941c2e1e41a932dfd00e48631a9dd6217c6e51fe9c681369139a8c0402ea84` | C(iv) / workspace-package-identity | L1664 | E30 | PASS |
+| `po:sha256:28e700021c9b4ba707087650a4e39ceed6540863e4d99b02af241b2b0fdbcaf8` | C(iv) / workspace-package-identity | L1674 | E30 | PASS |
+| `po:sha256:2f816bb5f468d1cc4a06de84c4a9bb8e4c9393a070c41e364f53d951cbf172e1` | C(iv) / workspace-package-identity | L1684 | E30 | PASS |
+| `po:sha256:51a827390306ccb0cf37e23d646c653fd4291f3ed346ae04e097e678a5097781` | C(iv) / workspace-package-identity | L1694 | E30 | PASS |
+| `po:sha256:5a59d414027abf00522737e1d86c7976c6837e7dcf88eb47112cc39709b2be1d` | C(iv) / dependency-and-selection-contracts | L1704 | E31 | PASS |
+| `po:sha256:62ae30cfc28b391c7bf4a87534abeba849a8ca2ebd5f8ebe72cb5af81dcc50eb` | C(iv) / dependency-and-selection-contracts | L1713 | E31 | PASS |
+| `po:sha256:64463ef1e1f2b77cb50713f8194bb055d35d02288f465e6902e337f9fc5f5edf` | C(iv) / dependency-and-selection-contracts | L1722 | E31 | PASS |
+| `po:sha256:6e598d379ffd2f0565176b337833e4eedf0293941fa87936078ee572e63748a9` | C(iv) / dependency-and-selection-contracts | L1731 | E31 | PASS |
+| `po:sha256:89165acdfec28c3a8692c411aead416ca1fd5f13333c0ea5c748e92aeab0cb98` | C(iv) / dependency-and-selection-contracts | L1740 | E31 | PASS |
+| `po:sha256:90fa083c4887641658c0239762b509fd6c9bacc6f14cf29ee392ce08714572ff` | C(iv) / dependency-and-selection-contracts | L1749 | E31 | PASS |
+| `po:sha256:795d76d79fdc3ad235d204aee98c96f70dcdb10704c927558f31012749553995` | C(iv) / dependency-and-selection-contracts | L1758 | E32 | PASS |
+| `po:sha256:9cbd50f3655b7ae7102a1be9bfcfe939528b3eaebd0dc33257408365f9402062` | C(iv) / dependency-and-selection-contracts | L1769 | E33 | PASS |
+| `po:sha256:a1f8202d5ff295e75dd7ad3f50f9454dad4bc2d53677e5936a6a0812250c5e43` | C(iv) / dependency-and-selection-contracts | L1778 | E33 | PASS |
+| `po:sha256:3c757a7975b27b8597ccf8c6d886eb72ad2b8b51aaba8eb59cf21cc9a1a7a3c6` | C(iv) / capacity-computation-and-snapshot | L1787 | E34 | PASS |
+| `po:sha256:518aee86882c8b9092469203add3bc23c72acfed1d7139f136a96e8763f0c8c7` | C(iv) / capacity-computation-and-snapshot | L1797 | E34 | PASS |
+| `po:sha256:6b31f817391e66aab8fc9796fed0c0bbdbd8285c9e86438e9172d1ce6bbaef61` | C(iv) / capacity-computation-and-snapshot | L1807 | E35 | PASS |
+| `po:sha256:8a555d65d66a8d7f44336fdb4ce8816f5a033a6ce448e311dc29615bfd8f41f2` | C(iv) / capacity-computation-and-snapshot | L1817 | E35 | PASS |
+| `po:sha256:8af3333c97798f24aeecfa40f40faefcf152f96fffb6717f647eabf0f5250a92` | C(iv) / capacity-computation-and-snapshot | L1827 | E35 | PASS |
+| `po:sha256:95037a7104c1dbd21fc02aeeeb45733f744c10ba07ea4c5db2a94db62d88e95a` | C(iv) / capacity-computation-and-snapshot | L1837 | E35 | PASS |
+| `po:sha256:95b57e4f4029739dacb78d5caa9b43939b1820fc17d3785a9ff32181d7d0e0b6` | C(iv) / capacity-computation-and-snapshot | L1847 | E35 | PASS |
+| `po:sha256:79df3741e52f870a9c5d7ac0f3c76fc333a1341bf8f15c7a7720f2b6982e88b3` | C(iv) / origin-and-heartbeat-policy | L1857 | E36 | PASS |
+| `po:sha256:cb78d031658bfe80535beb490352c2086b2b8f629e3819df4fba336fbeb37598` | C(iv) / origin-and-heartbeat-policy | L1866 | E37 | PASS |
+| `po:sha256:cb9064130b643be08d25e627bcfc5264739ac1397a236d353835b473c2df5734` | C(iv) / origin-and-heartbeat-policy | L1877 | E37 | PASS |
+| `po:sha256:e362227f9f3d78e8fcb933ddf9f5523b1ef97776a2546ad12c7f702c33fc1cdd` | C(iv) / origin-and-heartbeat-policy | L1888 | E38 | PASS |
+| `po:sha256:edf38d10efe0552b7de770a0cc24a9596cc4b5141b693889e987465f4174b4bb` | C(iv) / origin-and-heartbeat-policy | L1898 | E38 | PASS |
+
+### Evidence catalog
+
+Each quote is the complete `needed_evidence` value shared by the indicated rows.
+
+**E01: ov-token-charge-removal (3 rows)**. `INDEX:85`; corrected docket:218.
+
+> Needed evidence is the corresponding journal chain or an observation-backed liveness/reaping event tying the removed charge to a particular active grant and instant.
+
+**E02: seat-grant-organic-chains (1 rows)**. `INDEX:440`; corrected docket:229.
+
+> Synthetic operational SeatGrant allocation-relator reading; the recorded-value grain governs SeatGrant reuse this run. Needed: organic lease-eviction/renewal/transfer chains in a fleet capture showing effective allocation continuity, joined to an independently identified holder.
+
+**E03: recovery-durations (2 rows)**. `INDEX:528`; corrected docket:239.
+
+> A detection-and-recovery process with standalone and lane-rerun components; this changes the referent to the reported activity and requires independent execution boundaries before deriving a complete duration. Retain the detection, attempt, task, lane, and each measurement target together. CQ-007 cannot be answered by adding these durations to the whole attempt or to each other without interval/overlap evidence. CQ-013 requires an independently supported signature mapping, attributed delay, and lane cost comparisons; this one label and two measurements do not settle them.
+
+**E04: assertion-boundary (2 rows)**. `INDEX:692`; corrected docket:254.
+
+> The assertion has an emission/recording boundary and persists as information afterwards. The modeled attempt's boundary, actual work's termination, and record retention are different intervals or instants. Missing starts and admission boundaries prevent elapsed work or queue duration from being computed from these notices alone. Preserve each notice's modeled attempt, terminal reason, and recording instant together, and retain the synthetic qualification on evidence use. CQ-007 and CQ-012 require known boundaries and complete time decomposition; neither recorded notice warrants adding admitted execution time or treating unmeasured waiting time as zero.
+
+**E05: checkout-cache-binding (2 rows)**. `INDEX:948`; corrected docket:270.
+
+> run4-checkout-cache-binding-identity-consumer: Preserve a same-cache accessibility/transfer experiment at task-input-hash and epoch grain, with the two checkout identities and separate probe times, positive access and bounded local absence, and a binding-change or correction trace. Supply an observed consumer and a Must/Should executable CQ that must address the binding information object's identity rather than the existing qualified checkout/cache relation. If direct relations suffice, keep the class withdrawn. Common Git administration, directory-entry counts and environment flags do not establish common cache access or a skip authorization.
+
+**E06: comparison-operand-binding (2 rows)**. `INDEX:1115`; corrected docket:285.
+
+> Needed evidence is an explicit comparison-operand binding and an observed validity decision that depends on the result.
+
+**E07: wall-time-evidence-class (2 rows)**. `INDEX:1168`; corrected docket:295.
+
+> A Must/Should CQ whose executable query requires a separately identified wall-time evidence class (rather than the execution-bound actualWallMs/usedCostEstimate calibration tuples CQ-025 already consumes), plus an observed consumer that selects or rejects a verdict on that class.
+
+**E08: governing-specification-comparison (1 rows)**. `INDEX:47`; corrected docket:308.
+
+> Needed evidence is a concrete decision consuming this comparison record, or a demonstrated dependency making it necessary to identify the governing specification under an existing question.
+
+**E09: deferred-tail (1 rows)**. `INDEX:212`; corrected docket:317.
+
+> Needed evidence is a concrete decision that requires identifying requests omitted from the prescribed sequence, or an observed mapping that makes this assertion necessary for an existing decision.
+
+**E10: assessment-model-selection (1 rows)**. `INDEX:482`; corrected docket:327.
+
+> To select among the remaining models, observe two assessments of the same explicitly identified PR/head with their operational assessment instants and review/check states preserved, changing a single component between them. Include the observed consumer's criteria and its distinction between checksGreen and requiredChecksGreen, the connection to the CQ-006/CQ-017 obligations, and whether it treats the second assessment as an update to one document or a distinct snapshot. A retained copy after removal of the original record would additionally discriminate the specific-bearer dependence claim.
+
+**E11: journal-entry-duplicate-payload (25 rows)**. `INDEX:227`; corrected docket:343.
+
+> A journal append/copy/replay/correction trace containing two entries with identical semantic event payloads, with independently distinguished emission occurrences and any revision links, plus an observed consumer treatment of those entries as one repeated assertion or two separately accountable assertions. This would discriminate content-object identity from assertion-token identity and establish whether correction preserves an entry or produces a new one. The trace must distinguish asserted event time from record creation time; another file hash or capture label would not resolve the grain.
+
+**E12: allocation-double-count (28 rows)**. `INDEX:245`; corrected docket:381.
+
+> A time-aligned lease-store and admission-accounting trace between a matched admission and release or eviction, showing the same allocation counted in at least two separate decisions for the same independently identified beneficiary, requested work, and capacity pool. Include a heartbeat or lease update and termination followed by reacquisition, so continuity versus a new grant can be observed, together with a captured conferral/termination rule stating whether authorization or only charged occupancy persists. This would discriminate a continuing authorization relator from an allocation mode, an event-derived holding situation, and a journal-only account.
+
+**E13: result-artifact-content-snapshot (14 rows)**. `INDEX:265`; corrected docket:422.
+
+> Content-snapshot identity for VerificationResultArtifact is the rival of the accepted assessment-origin grain (otp:att-attempt-verdict:001). Needed: two independent equal-content assessments of one attempt whose consumers treat them as distinct or as one result, plus the issuance/correction provenance the proof-ledger writer will carry (time-to-certainty C4).
+
+**E14: grant-resource-contention (2 rows)**. `INDEX:1241`; corrected docket:454.
+
+> Run 3 now captures root/nonce-scoped enqueue, admission, withdrawal, release and eviction reports, including synthetic attempt-termination joins. The run3-fleet and run3b-fleet manifests exclude lock files and proof-locks directories, and dh:att-overlap-diagnostic:001 still establishes only a logged overlapping path. To decide C2/C3, obtain the run-2 sitting-2 Ruling-3 join for the actual contended resource or proof-lock path: grant/lease and lock ownership identifiers, acquisition and release boundaries, and a waiting/winning/losing outcome in one provenance chain. Identify the rule linking FleetContestedPath to that contention and distinguish admission authorization from proof-lock ownership. Admission counts, a common origin key and worktree overlap cannot supply that missing relation.
+
+**E15: admission-lifecycles (1 rows)**. `INDEX:1265`; corrected docket:471.
+
+> Run 3 supplies an organic same-root/nonce enqueue-admit-release history, plus synthetic withdrawal and eviction reports with two attempt-termination joins. The pure lifecycle duty still needs authoritative causal continuity from one request's submission through grant and release/cancellation, and a Must/Should CQ requiring a lifecycle distinct from its request, grant and boundary reports. The memory rider remains independently parked under Ruling 6: the release now carries memoryPeakBytes, but the resource-using occurrence/process boundary, sampling method and interval, metric/unit, measurement provenance and its relationship to peakRssKb are still missing. Different capture-scoped ownerRef values and an administrative termination notice cannot decide either missing identity.
+
+**E16: admission-lifecycles (1 rows)**. `INDEX:1277`; corrected docket:485.
+
+> Run 3 now provides a same-root/nonce organic enqueue-admit-release chain and explicit synthetic withdrawal, grant-eviction and ticket-eviction boundaries. Synthetic attempt-terminated records match the two eviction attemptIds. What remains is authoritative causal-continuity evidence connecting one submitted request to its grant and release/cancellation, together with a Must/Should decision CQ requiring that composite lifecycle separately from SeatRequest, SeatGrant and their boundary reports. The terminal-only synthetic eviction chains lack their own retained starts, and recordedAt is a reconciliation time rather than proof of actual execution cessation.
+
+**E17: admission-lifecycles (3 rows)**. `INDEX:1288`; corrected docket:497.
+
+> Run 3 adds two live lease snapshots with the same nonce, grant instant and charge but different heartbeat instants, organic release/eviction reports, and explicitly synthetic eviction-to-attempt-termination joins. It still lacks one provenance chain that binds a grant's creation, complete heartbeat-rewrite history, release/eviction, actual ledger decrement and carrier lineage. Capture-scoped ownerRef values cannot prove cross-capture owner continuity; a terminal lastHeartbeatAtMillis is not a rewrite history, and the synthetic evicted lease has no retained admission start. A Must/Should CQ must also require this lifecycle separately from SeatGrant. Keep both the provenance and separate-warrant duties open.
+
+**E18: cache-plan-resolution (1 rows)**. `INDEX:1354`; corrected docket:516.
+
+> Run 3's verdict-corpus search is now complete within its captured fields: run3-fleet/MANIFEST.yaml reports pa-cache-plan-resolution rider_evidence=absent with zero structured occurrences. Its source_facts name the resolver domain and the resolver-to-command-arguments site, but the verdict schema has no cache-plan field. Obtain an observed governed resolver result with its applicable domain/version, joined to a particular Turbo execution and the cache posture actually applied. Checkout cache topology, cacheStatus and enablement flags do not supply that execution join. This promoted Ruling-6 rider remains open; the docket authorizes no new capture or runtime change.
+
+**E19: assessment-and-selector-governance (3 rows)**. `INDEX:1447`; corrected docket:532.
+
+> Run 3 adds verdict comparison values and timestamped checkout branch/head bindings; dh:ver-git-comparison-context:001 still has no observed validity decision consuming those comparisons. Under Ruling 6, obtain a versioned branch-freshness contract binding each assessment to its branch and base operands, defining merge-base, behind-count and overlap meanings, and showing assessment provenance, recomputation and the decision that changes with the result. A recorded zero or a matching path is insufficient to establish equal trees or evidence validity.
+
+**E20: assessment-and-selector-governance (2 rows)**. `INDEX:1477`; corrected docket:545.
+
+> Run 3 now records greptileScore=5/5 in a verdict with proofTier=full, but a score spelling does not supply its governed meaning. Under Ruling 6, obtain the scale authority and version, the exact reviewed subject, score-production and revision provenance, and an observed assurance or closeout decision governed by that score. Retain the distinction between a stored readiness assertion and a current eligibility decision.
+
+**E21: assessment-and-selector-governance (1 rows)**. `INDEX:1495`; corrected docket:556.
+
+> Run 3 adds classified failure tuples and component results, which supply concrete reports but not introduced/inherited/unrelated/environment attribution rules. Under Ruling 6, obtain necessary conditions for every attribution member, overlap or precedence rules, and an assessment record binding the change, baseline, environment, assessment provenance and revision history. failureKind and failedStepId classify a report; they cannot by themselves assign responsibility or baseline causation.
+
+**E22: assessment-and-selector-governance (3 rows)**. `INDEX:1504`; corrected docket:567.
+
+> Run 3 adds proofTier=full in verdict and lease/request contexts, while result status and attained assurance remain separate. Under Ruling 6, obtain planner authority and version/revision lineage deciding a shared selector scheme versus copied domains or plan-borne classifications, together with a Must/Should CQ whose decision consumes that selector. Repeated strings and the captured priority domain cannot establish the proof-tier governance or its mapping to assurance tiers.
+
+**E23: execution-boundaries-and-elapsed-scope (1 rows)**. `INDEX:1531`; corrected docket:581.
+
+> Run 3 now has verdicts with a parent attemptId, passed component statuses and component durations, and a separate failed attempt whose planned components are explicitly not-run. Under Ruling 6, obtain a passed-step execution record preserving the authoritative parent-attempt join, each repeated execution's identity and its own actual start/end boundaries. Whole-attempt bounds and a repeated lane label do not supply the missing component occurrence boundaries; the passed-step instrumentation was excluded from the v3 scope.
+
+**E24: execution-boundaries-and-elapsed-scope (1 rows)**. `INDEX:1541`; corrected docket:592.
+
+> Run 3 now supplies an identified attempt with startedAt, endedAt and elapsedMs, so the missing-record part of the run-2 request has changed. Under Ruling 6, retain the measured-extent question: establish authoritatively whether each value covers the entire attempt/command or a particular WorkUnit occurrence, preserving target, interval and provenance. fa:ver-wall-time-evidence:001 still asks for nested occurrence bindings, clock/precision conventions and the explanation of a one-millisecond discrepancy. Parent-attempt timestamps cannot be copied to each nested execution, and an assertion-content proposal does not settle what was measured.
+
+**E25: memory-measurement (1 rows)**. `INDEX:1552`; corrected docket:607.
+
+> Run 3 now joins memoryPeakBytes=9904820224 to a particular admission release report through its root and nonce. Under Ruling 6, obtain the measurement's resource-using occurrence and process boundary, sampling method and interval, metric, unit and measurement provenance. Supply an authoritative comparison with peakRssKb that decides whether the two fields measure one family. A release-attached quantity, token charge or owner surrogate does not establish the measured process or sampling semantics.
+
+**E26: duration-and-comparison-issuance (1 rows)**. `INDEX:1562`; corrected docket:620.
+
+> Run 3 adds attempt-scoped elapsedMs, nested durationMs and otp:ver-wall-time-evidence:001, whose assertion-content, quality, token and scoped-literal models remain alternatives. Under Ruling 6, the separate RecordedWallDurationMeasurement still needs a Must/Should executable CQ that must traverse that individual instead of qualified values on an episode or execution. The carrier alternative also needs authoritative issuance, custody, copy and correction lineage and a decision CQ that distinguishes equal-content carrier tokens. Ruling 17 keeps the issuance duty open to run 4: the fleet manifests observe zero proof ledgers, so captured verdicts cannot replace the missing writer-issued provenance.
+
+**E27: duration-and-comparison-issuance (1 rows)**. `INDEX:1573`; corrected docket:633.
+
+> Run 3 adds bounded attempt durations and a recovery diagnostic with distinct standaloneDurationMs and laneRerunDurationMs inside a successful attempt. Under Ruling 6, retain both duration concessions: a Must/Should CQ requiring a RecordedWallDurationMeasurement individual rather than qualified episode/execution values, and an authoritative issuance/custody/copy/correction chain plus a CQ distinguishing carrier tokens from equal content. The comparison concession additionally needs identities for both compared executions, their measurement assertions, the comparison's issuance, and a Must/Should decision CQ consuming a distinct comparison record. Ruling 17 keeps issuance open to run 4 because zero proof ledgers were captured. Diagnostic timing alone supplies neither the paired execution identities nor a separately warranted comparison.
+
+**E28: qa-and-conformance-evidence (1 rows)**. `INDEX:1586`; corrected docket:649.
+
+> Run 3 adds an admission projection fixture, property-suite contract and S7 replay result. Those are not a record/extract/judge QA run. Under Ruling 6, obtain one provenance-bearing chain joining all three QA stages to the in-scope Yeet or CI lane, its frozen tree and cache epoch, and the assurance obligation that consumes the evidence. The captured replay's input digest and pass assertion do not supply those QA-stage or assurance joins.
+
+**E29: qa-and-conformance-evidence (3 rows)**. `INDEX:1595`; corrected docket:659.
+
+> Run 3 adds emission-v2 contract and property-suite quotations and the bounded S7 differential replay report of 41 matched admissions, but no independently issued conformance package. Under Ruling 6, obtain all three remaining chains: a package manifest with independent authority/version joining suite, implementation build, frozen inputs, replay execution, complete results, limitations, issuance and custody; a separately governed/versioned suite specification, distinct from its test-file carrier, and its Must/Should CQ; and identified replay execution/environment plus result issuance, custody, retention/correction lineage and a Must/Should CQ for a separate replay-result artifact. Ruling 17's zero-ledger census leaves issuance open to run 4; the passing replay assertion is not that missing lineage.
+
+**E30: workspace-package-identity (7 rows)**. `INDEX:1634`; corrected docket:677.
+
+> Run 3 now has 107 checkout bindings with origin, branch/head, Git-directory and cache facts, plus fleet attempt context. These identify checkout observations, not package continuity. Under Ruling 6, obtain an authoritative package-identity policy and observed lineage deciding rename, move, version change, fork and delete/recreate cases, including whether the candidate is a role or immutable-content object. No new package identity policy was admitted with the binding corpus, and a checkout token or package spelling cannot settle those cases.
+
+**E31: dependency-and-selection-contracts (6 rows)**. `INDEX:1704`; corrected docket:696.
+
+> Run 3 adds checkout bindings and an admission-order fixture whose step positions are 0 and 1; those positions do not describe a package graph. Under Ruling 6, obtain the package-report contract defining its numeric positions, ordering algorithm and dependency-edge semantics, identify the producing graph/version, and show the operational verification decision consuming that report. No new TS or package-graph observation was admitted with the journal/inventory capture.
+
+**E32: dependency-and-selection-contracts (1 rows)**. `INDEX:1758`; corrected docket:712.
+
+> Run 3 adds checkout branch/head snapshots and verdict applicability fields; it supplies no docgen selection result with a dirty-tree pin. Under Ruling 6, retain both concessions: an observed selection artifact binding base, head, dirty snapshot and selected members, a contract choosing selected extension versus selection rule and a Must/Should specialization CQ; and an independently versioned selection-rule authority, an observed pinned extension showing its application, a rule-versus-result contract and a CQ requiring the specification. Checkout paths and stored diff fingerprints do not supply those selected members or governance.
+
+**E33: dependency-and-selection-contracts (2 rows)**. `INDEX:1769`; corrected docket:724.
+
+> Run 3 adds stored diff/head/tier context and a deterministic admission-order contract, but neither is a governed affected-task selection run. Under Ruling 6, obtain the normative selection contract explaining how task inputs alter membership and whether failures open or close the selection, an observed selected set under that contract, and the operational verification decision that trusts it. The current applicability hypotheses still lack an observed accept/reject consumer.
+
+**E34: capacity-computation-and-snapshot (2 rows)**. `INDEX:1787`; corrected docket:737.
+
+> Run 3 now records requested/granted weightTokens and quotes the projection inequality activeTokenTotal + weightTokens <= capacityMaxTokens. Ruling 9 deliberately omitted capacity stamps. Under Ruling 6, obtain the authoritative capacity computation defining unit conversion, reserve subtraction and hard-floor treatment, and a provenance-preserving join from its computed value to capacityAtAdmissionTokens on an observed admission decision. A policy token charge and reconstructed ledger total cannot stand for measured remaining capacity.
+
+**E35: capacity-computation-and-snapshot (5 rows)**. `INDEX:1807`; corrected docket:749.
+
+> Run 3 now includes timestamped inventory and queue/lease reports, but Ruling 9 supplied no pre-grant capacity stamps. Under Ruling 6, obtain a Must/Should executable CQ that traverses an AdmissionSnapshot, its capture act and instant, machine and policy scope, and an authoritative correlation to the immediately pre-grant decision that materializes capacityAtAdmissionTokens. A later lease snapshot, a checkout inventory instant and the projection's capacity inequality do not establish that missing pre-grant state.
+
+**E36: origin-and-heartbeat-policy (1 rows)**. `INDEX:1857`; corrected docket:766.
+
+> Run 3 now captures a ticket's blockedOnOriginAtMillis=0 and separately records queue, withdrawal and eviction boundaries. dh:att-origin-block-marker:001 leaves the zero's meaning unresolved. Under Ruling 6, obtain the deployed threshold rule, its unit and both true/false consequences, decide grace versus staleness versus retry semantics, and observe a specifically origin-blocked case governed by that rule. A terminal eviction or zero marker does not establish a grace-window application.
+
+**E37: origin-and-heartbeat-policy (2 rows)**. `INDEX:1866`; corrected docket:777.
+
+> Run 3 adds live heartbeat observations and explicit lease eviction reports with lastHeartbeatAtMillis, plus a synthetic termination join. The Stage B heartbeat census checks four organic rows, reports one legacy row without heartbeat and finds no ordering violations; this bounds observations, not owner death. Under Ruling 6, obtain the deployed suspicion threshold and unit, the identified suspected holder, an observed stale-heartbeat case, its operational consequence, and the authority rule separating suspicion from permission to terminate. An eviction reason or last-seen heartbeat is not proof that suspicion alone authorized termination.
+
+**E38: origin-and-heartbeat-policy (2 rows)**. `INDEX:1888`; corrected docket:790.
+
+> Run 3 now supplies a persisted ticket observation containing blockedOnOriginAtMillis=0 with enqueue and heartbeat context, and the current null analysis refuses to read zero as either an epoch instant or evidence of no contention. Under Ruling 6, obtain a semantically interpreted origin-block onset/time and unit, the same ticket's observed originBusy wait, the starvation-policy decision using it, and issuance/revision provenance across the relevant ticket transitions. The observed zero and unrelated terminal chains do not establish those joins.
+
+## Reproduction method
+
+The following independent core reproduces the census, totality, cluster checks and
+framed digest without relying on the correction script or a prior report. Run from
+the checkout root with the Python invocation above, supplying the snippet on stdin.
+It writes nothing. The complete row/evidence catalog above is the durable result of
+the broader checks; temporary scripts were not added to the repository.
+
+```python
+from pathlib import Path
+from collections import Counter
+import hashlib
+import re
+import yaml
+
+p = Path("explorations/beep-ci-operational-ontology")
+b = p / "ontology/extraction/s4/beep-ci-ops"
+i = b / "runs/orun-2026-09-10T02:10:52Z.index.yaml"
+rows = yaml.safe_load(i.read_text())
+print("sha12", hashlib.sha256(i.read_bytes()).hexdigest()[:12])
+for carried in (False, True):
+    population = [r for r in rows if bool(r.get("carried_from_prior")) == carried]
+    print("carried", carried, "rows", len(population), Counter(r["outcome"] for r in population))
+d = (p / "research/auditor-run4-intake.md").read_text()
+c = d.split("### Queue C:", 1)[1].split("### Queue D:", 1)[0]
+ids = re.findall(r"(?m)^\s*- `((?:so|po):sha256:[0-9a-f]{64})`$", c)
+expected = {r["observation"] for r in rows if r["outcome"] == "unresolved"}
+print("listed", len(ids), "unique", len(set(ids)), "missing", len(expected-set(ids)), "strays", len(set(ids)-expected))
+assert len(ids) == len(set(ids)) and set(ids) == expected
+cc = yaml.safe_load((b / "work/sittings/carried-clusters.yaml").read_text())
+for cluster in cc["clusters"]:
+    name = cluster["id"]
+    actual = c.split("**" + name + "**", 1)[1].split("\n**", 1)[0]
+    found = set(re.findall(r"(?m)^\s*- `((?:so|po):sha256:[0-9a-f]{64})`$", actual))
+    wanted = {oid for oid, row in cc["rows"].items() if row["cluster"] == name and row["outcome"] == "unresolved"}
+    assert found == wanted
+    print(name, len(found), "PASS")
+s = Path(".claude/skills/ontology-foundational-auditor")
+shared = s.parent / "_shared"
+files = sorted(list((shared / "schemas").glob("*.yaml")) + list(shared.glob("*.yaml")) + list(shared.glob("*.md")) + list(shared.glob("*.json")) + list((s / "templates").glob("*.yaml")), key=lambda f: str(f.relative_to(s.parent)))
+h = hashlib.sha256()
+for f in files:
+    data = f.read_bytes()
+    h.update(f"{f.relative_to(s.parent)}\n{len(data)}\n".encode())
+    h.update(data)
+print("contracts", h.hexdigest()[:12], "files", len(files))
+```
+
+## Blockers and boundaries
+
+J01, J02 and J03 remain open. They need a record-backed routing correction or a
+steward decision; this lane did not select a new bucket, promise new C4 facts or
+decide the granularity of future flag lifting. The restored exact requirements
+prevent those summaries from concealing their underlying duties, but do not resolve
+the disputed instructions. The pin lane must address these findings and independently
+re-read C4 before proceeding. An unchecked C4 still requires it to stop without
+creating a pin, tag, manifest or seat.
+
+All record-decided changes are dirty. The final checks authenticate the corrected
+docket's accounting and source fidelity. They do not prove any new organic chain,
+execute Stage C, discharge a flag or ratify an ontology term. Historical reports,
+indexes, sitting decisions, receipts, taxonomy, dispositions, predicates, skill
+contracts and corpus pins remain unchanged.
+
+### Files
+
+- `research/auditor-run4-intake.md` — corrected evidence duties and dated census;
+  mechanically derived ID lists remain total. J01–J03 are deliberately unedited.
+- `README.md` — current Next Open Question and dated Trail with the report and blockers.
+- `ops/manifest.json` — matching merged-PR, verification, gate and namespace state.
+- `research/run4-lanes/run4-docket-verification-report.md` — this report and full evidence.
+- Repo-relative `explorations/ATLAS.md` — regenerated ignored local projection by
+  the required atlas writer; no tracked projection change.
+- Repo-relative `graft/` — ignored context graph refreshed automatically by Graft
+  before its source lookup; no authored graph or wiring change.
+
+The pre-existing untracked `research/run4-lanes/run4-docket-verification-brief.md`
+was read and preserved, not edited. No other tracked path changed. Temporary audit
+scripts and count-only receipts were kept outside the checkout; their core method
+and complete findings are reproduced here.

--- a/explorations/beep-ci-operational-ontology/research/run4-lanes/run4-docket-verification-report.md
+++ b/explorations/beep-ci-operational-ontology/research/run4-lanes/run4-docket-verification-report.md
@@ -10,8 +10,9 @@ The eight requested checks are complete. The incoming ID census, final ratificat
 bindings, Queue B quotes and engine digests pass. The prose omitted binding evidence
 duties and introduced two carried-row retirement alternatives; record-decided
 corrections are applied directly. Three judgment-dependent routing/governance findings
-(J01–J03) remain BLOCKING and unedited. A green mechanical check does not clear them.
-C4 is still unchecked, independently prohibiting run-4 launch.
+(J01–J03) were left unedited by the lane and resolved by the orchestrator the same day; see
+"Orchestrator dispositions (2026-09-12)" below for the final docket state. C4 is still
+unchecked, independently prohibiting run-4 launch.
 
 Only the docket, packet README, packet manifest and this report are authored changes.
 The incoming untracked brief remains untouched. No staging, commits, stashes,
@@ -27,7 +28,8 @@ Quotes are exact record excerpts; YAML folding and Markdown wrapping are normali
 
 ## Findings
 
-BLOCKING in an applied row describes the incoming defect. J01–J03 are unresolved.
+BLOCKING in an applied row describes the incoming defect. J01–J03 were open when the lane
+wrote this table; their orchestrator dispositions follow the table.
 
 | ID | Severity | Docket line | Record and deciding quote | Fix applied or proposed |
 | --- | --- | --- | --- | --- |
@@ -63,6 +65,28 @@ BLOCKING in an applied row describes the incoming defect. J01–J03 are unresolv
 | V06 | CONFIRMED-OK | 499 → 962 | check_manifest:1154–1168 uses relative path + newline + byte length + newline + bytes over 21 files. REVIEW-HISTORY v15: "158 families". PR #1092 review reply queues index grammar beside NDJSON and archive-path follow-ups. | All quoted digests match; four other prompts equal the run-3 manifest. Current Python 3.12 self-test passes 158 families. Denotation and seat effort are already v15; the three other follow-ups remain queued. |
 | V07 | CONFIRMED-OK | 25 → 25 | PLAN.md lines 100, 102, 104, 108, 111, 121, 124: every named checkbox is [ ]. Run-4 authoring brief: "Run 4 proper is gated" on C4. | Hard gate preserved. Verification can finish, but a pin lane must stop before creating a pin/tag/manifest/seat while C4 is unchecked. The older handoff's projection blocker is superseded by S5 amendment and current projection records. |
 | V08 | CONFIRMED-OK | 531 → 994 | Run-3 intake Not in scope and run-4 authoring brief: no scheduler/runtime work, captures, reruns, CQ/seed/contract changes, ratification/waivers or lane publication. | Section order follows run 3 after the explicit gate. All 38 generated ID lists have a preceding blank line. No prohibited Git command, seat launch, authority-record edit, capture or pin operation occurred. |
+
+## Orchestrator dispositions (2026-09-12)
+
+The three judgment findings were decided by the orchestrator after the lane's pass and applied
+to the docket in the same PR:
+
+| ID | Disposition | Docket change |
+| --- | --- | --- |
+| J01 | Accepted. `INDEX:482` describes an identity experiment with no decision prerequisite. | `so:sha256:34866c14…` moved from C(ii) to C(iii) as `assessment-model-selection` (an identity experiment over verdict records; no C4 dependence asserted). Final buckets: C(i) 14, C(ii) 2, C(iii) 68, C(iv) 54. |
+| J02 | Accepted. Ruling 17 commits C4 to issuance and custody provenance only. | The Queue A episode-closure forecast and the `recovery-durations`, `assertion-boundary` and `execution-boundaries-and-elapsed-scope` postures now state independent instrumentation requirements and say C4 is not asserted to supply them. Verbatim receipt text naming the proof-ledger writer (`ver-attempt-verdict`) is unchanged. |
+| J03 | Accepted as a governance boundary. | "The cluster lifts or re-flags together" is replaced by: the initial ratification was joint (sitting-3 Ruling 1); whether flags lift individually or only together is a run-4 sitting decision with no ruling yet. |
+
+Final docket proofs after these dispositions (2026-09-12):
+
+```text
+TOTALITY: PASS | listed: 138 | unresolved: 138 | dups: 0 | strays: 0 | missing: 0
+FIDELITY blocks=38 verbatim=138 mismatches=0
+PLACEMENT C(i): rows=14  C(ii): rows=2  C(iii): rows=68  C(iv): rows=54
+```
+
+The "Corrected docket" reproduction below records the lane's state before these dispositions
+(C(ii)=3, C(iii)=67) and is kept as the lane's evidence.
 
 ## Checks by brief item
 
@@ -328,7 +352,7 @@ than row membership.
 | `so:sha256:f025dca6b8335e444986f450f43d7970deb3f4209456efce8a23a5e1c065d446` | C(i) / wall-time-evidence-class | L1174 | E07 | PASS |
 | `po:sha256:2cc77ae5391bd35d736242a9fff5ee6d2e64ee35cc18a420060b5a541f947ca6` | C(ii) / governing-specification-comparison | L47 | E08 | PASS |
 | `po:sha256:f60ddfb04ede510a8ffe6a04a36eac20caeb92175e59245f6b436897c83907b8` | C(ii) / deferred-tail | L212 | E09 | PASS |
-| `so:sha256:34866c142b067589cef10ea45947b1e31d1f7ae8e7518b45d705f5df5a3d31ee` | C(ii) / assessment-model-selection | L482 | E10 | J01: bucket disputed |
+| `so:sha256:34866c142b067589cef10ea45947b1e31d1f7ae8e7518b45d705f5df5a3d31ee` | C(iii) / assessment-model-selection | L482 | E10 | J01: rebucketed by the orchestrator (was C(ii) at the lane's pass) |
 | `so:sha256:01fe79ebf1f0cc28550c21c941e0c4ff963cbbbcff28cffe712d9b026288d99a` | C(iii) / journal-entry-duplicate-payload | L227 | E11 | PASS |
 | `so:sha256:0385cf6e12920c8a96c520a7238b522f923a7c0116cd603fbeff793a7d0e6058` | C(iii) / journal-entry-duplicate-payload | L236 | E11 | PASS |
 | `so:sha256:05fa73f187683c8b5cfb25a3958ed5b6f3d344d1b984cb1ce1cdffe5a9b2674a` | C(iii) / journal-entry-duplicate-payload | L272 | E11 | PASS |
@@ -657,12 +681,11 @@ print("contracts", h.hexdigest()[:12], "files", len(files))
 
 ## Blockers and boundaries
 
-J01, J02 and J03 remain open. They need a record-backed routing correction or a
-steward decision; this lane did not select a new bucket, promise new C4 facts or
-decide the granularity of future flag lifting. The restored exact requirements
-prevent those summaries from concealing their underlying duties, but do not resolve
-the disputed instructions. The pin lane must address these findings and independently
-re-read C4 before proceeding. An unchecked C4 still requires it to stop without
+J01, J02 and J03 were open at the lane's pass and are resolved by the orchestrator
+dispositions above; the lane itself did not select a new bucket, promise new C4 facts or
+decide the granularity of future flag lifting. The restored exact requirements prevent
+the summaries from concealing their underlying duties. The pin lane re-reads C4
+independently before proceeding; an unchecked C4 still requires it to stop without
 creating a pin, tag, manifest or seat.
 
 All record-decided changes are dirty. The final checks authenticate the corrected
@@ -674,7 +697,8 @@ contracts and corpus pins remain unchanged.
 ### Files
 
 - `research/auditor-run4-intake.md` — corrected evidence duties and dated census;
-  mechanically derived ID lists remain total. J01–J03 are deliberately unedited.
+  mechanically derived ID lists remain total. J01–J03 were left unedited by the lane and
+  applied by the orchestrator (dispositions above).
 - `README.md` — current Next Open Question and dated Trail with the report and blockers.
 - `ops/manifest.json` — matching merged-PR, verification, gate and namespace state.
 - `research/run4-lanes/run4-docket-verification-report.md` — this report and full evidence.


### PR DESCRIPTION
## chore(explorations): verify the run-4 intake docket and restore its compressed duties

An adversarial Codex verification of research/auditor-run4-intake.md (brief and report under
research/run4-lanes/) checked every claim against the run-3 index, the sitting-2 cluster mapping,
the run-2 and run-3 ratification records, TAXONOMY flags, DISPOSITIONS, the withdrawal receipts,
DECISIONS rulings, the v15 digests and the C4 checkboxes. It confirmed the prior chain, totality,
the 15 flag clauses, the 18 bindings and the six Queue B quote pairs, and found 21 blocking and 3
minor defects, all record-decided and applied: every Queue C bucket now carries the verbatim
needed_evidence of its rows (the bucket postures had compressed or invented duties), the
later_ratifications decisions for rat-067/068/069 are quoted, the withdrawal duties are complete,
the organic eviction census is a dated counts-only read, and the namespace carry-forward is
restored. Its three routing findings are resolved here: the assessment-model row moves to C(iii),
the C4 "proof facts" forecasts become independent instrumentation requirements, and the ordering
cluster's future flag-lifting granularity is left to the run-4 sitting. Totality and blockquote
fidelity are re-proved (138/138 verbatim); the packet session surface is current.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/chore_ciops-run4-docket-verify-4d89c94e46ca/verdict.json

---

<!-- yeet-provenance:start -->
## Provenance

- Workspace: <code>beep-effect8</code>
- Branch: <code>chore/ciops-run4-docket-verify</code>
- Agents (newest first):
  - `claude-code` (desktop) · `claude-fable-5-1` · <code>beep-effect5-9e</code> · workspace <code>beep-effect5</code> · monitored

Resume the publishing agent from any beep-effect checkout on the publishing workstation:

```sh
bun run beep yeet resume 1117
```

<!-- yeet-provenance
{
  "schemaVersion": 2,
  "pr": 1117,
  "branch": "chore/ciops-run4-docket-verify",
  "workspace": "beep-effect8",
  "agents": [
    {
      "harness": "claude-code",
      "entrypoint": "claude-desktop",
      "hostHarness": null,
      "model": "claude-fable-5-1",
      "label": "beep-effect5-9e",
      "workspace": "beep-effect5",
      "role": "monitored"
    }
  ]
}
-->
<!-- yeet-provenance:end -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1117"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791801640&installation_model_id=424656&pr_number=1117&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1117&signature=44ab3f7c401fbf7e6f721adaa14b2a54783912db12a71fb47b2f3e74cf278a0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->