### PR TITLE
fix(repo-cli): derive yeet repair hints from the lane-run record

### DIFF
--- a/.claude/skills/yeet/SKILL.md
+++ b/.claude/skills/yeet/SKILL.md
@@ -543,10 +543,16 @@ turbo work, so they are cheap to run mid-loop.
   stale-base refusals. Intent refusals print a summarized path list on stderr;
   the full list lives in the packet. Known sub-lane hints cover typos,
   terse-effect, every cheap gate, docgen, changeset status, secrets, SAST,
-  security, and Nix. Hint selection prefers output near the
-  actual failure marker before falling back to broad log scanning. Prefer the
-  suggested repair command in `yeet status`, the packet, or `verdict.json` over
-  rerunning the whole loop blindly.
+  security, and Nix. Hint selection follows the lane-run record: a tier lane's
+  `repairCommand` in `verdict.json` is its first red inner lane's repair
+  command, and each red inner lane carries its own (the catalog hint for its
+  exact lane id, else a known marker inside that lane's own output segment,
+  else the lane's recorded launch command). Broad log scanning of the whole
+  wrapper output is only the fallback for wrappers that emitted no lane-run
+  record. The failure packet's issue index and inbox capsule classify a raw
+  wrapper failure through the same resolver, so `verdict.json` and the packet
+  never disagree. Prefer the suggested repair command in `yeet status`, the
+  packet, or `verdict.json` over rerunning the whole loop blindly.
 - Root composite lanes prefer streaming accumulation where child commands are
   independent. For example, root `lint` streams the Turbo/Biome aggregate and
   then still runs repo-law policy lints, so one lint-family failure does not

--- a/packages/tooling/tool/cli/src/commands/Quality/Quality.schemas.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/Quality.schemas.ts
@@ -1263,6 +1263,10 @@ const NullableLaneInputDigest = S.OptionFromNullOr(S.String).pipe(
  * `inputDigest` encodes absence as `null`; callers supply a digest only when it
  * comes from the executor, such as a Turbo task hash.
  *
+ * `commandText` is the lane's own launch command. Yeet reads it back as the
+ * lane's repair command when no known sub-lane hint applies, so a red lane
+ * never needs a broad output scan to name what to rerun.
+ *
  * **Example** (Record a completed lane)
  *
  * ```ts
@@ -1277,7 +1281,8 @@ const NullableLaneInputDigest = S.OptionFromNullOr(S.String).pipe(
  *   endedAt: O.some("2026-09-03T00:00:01.000Z"),
  *   durationMs: O.some(1000),
  *   exitCode: O.some(0),
- *   inputDigest: O.none()
+ *   inputDigest: O.none(),
+ *   commandText: O.some("bun run check")
  * })
  * console.log(lane.status) // "passed"
  * ```
@@ -1296,6 +1301,7 @@ export class QualityTaskLaneRun extends S.Class<QualityTaskLaneRun>($I`QualityTa
     exitCode: OptionalLaneRunFinite,
     inputDigest: NullableLaneInputDigest,
     redSchedulingDecision: OptionalGateRedSchedulingDecision,
+    commandText: OptionalLaneRunString,
   },
   $I.annote("QualityTaskLaneRun", {
     description: "Timing and outcome facts for one lane executed inside a wrapper command.",

--- a/packages/tooling/tool/cli/src/commands/Quality/Tasks.ts
+++ b/packages/tooling/tool/cli/src/commands/Quality/Tasks.ts
@@ -1654,6 +1654,7 @@ const qualityTaskLaneRunFromOutcome = (
     ),
     inputDigest,
     redSchedulingDecision: O.isSome(outcome.failure) ? redSchedulingDecision : O.none(),
+    commandText: O.some(commandText(outcome.step.command, outcome.step.args)),
   });
 
 const skippedQualityTaskLaneRun = (lane: GithubCheckLaneWaveSpec["lanes"][number]): QualityTaskLaneRun =>
@@ -1662,6 +1663,7 @@ const skippedQualityTaskLaneRun = (lane: GithubCheckLaneWaveSpec["lanes"][number
     label: lane.step.label,
     status: "not-run-early-stop",
     inputDigest: O.none(),
+    commandText: O.some(commandText(lane.step.command, lane.step.args)),
   });
 
 const appendSkippedQualityTaskLaneRun = Effect.fn("QualityTasks.appendSkippedLaneRun")(function* (
@@ -1764,6 +1766,7 @@ const runGithubCheckLane = Effect.fn("QualityTasks.runGithubCheckLane")(function
           label: lane.step.label,
           status: "reused",
           inputDigest: O.none(),
+          commandText: O.some(commandText(lane.step.command, lane.step.args)),
         })
       ),
       failures: A.empty<QualityTaskFailed>(),

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Handler.ts
@@ -52,7 +52,6 @@ import {
   GithubCheckLaneRunStatus,
   QUALITY_TASK_LANE_RUN_ARTIFACT_PATH_ENV,
   QUALITY_TASK_LANE_RUN_PARENT_ID_ENV,
-  QualityTaskLaneRunReport,
 } from "../../Quality/Quality.schemas.ts";
 import { YeetCommandError } from "../Yeet.errors.ts";
 import {
@@ -84,6 +83,7 @@ import {
   validateStartPrEarlyPrGuard,
 } from "./Guards.ts";
 import { HEAD_INSTALL_PREFLIGHT_STEP_ID } from "./HeadInstallPreflight.ts";
+import { INNER_LANE_REPORT_FILE_NAME, readInnerLaneReports } from "./InnerLaneReports.ts";
 import {
   emptyPlanResult,
   executeStepWithArtifacts,
@@ -144,6 +144,7 @@ import { buildYeetVerdict, YeetExecutedStep, YeetVerdictJson } from "./Verdict.t
 import type { ChildProcessSpawner } from "effect/unstable/process";
 import type { AdmissionOriginGate, MemoryStats, RepoRunPlan } from "../../../internal/repo-run/index.ts";
 import type { FlakeQuarantineIncident } from "../../Quality/internal/FlakeQuarantine.ts";
+import type { QualityTaskLaneRunReport } from "../../Quality/Quality.schemas.ts";
 import type { YeetPublishIntent, YeetRunOptions, YeetRunResult } from "../Yeet.schemas.ts";
 import type { PrCloseoutReport } from "./Closeout.ts";
 import type { ProofEnvProfile, ProofStage } from "./ProofFact.ts";
@@ -1343,8 +1344,6 @@ type YeetVerdictExtras = {
 // verdict may read it only after a successful pre-push proof step in the same
 // run — anything else could attach a previous run's incidents.
 const PRE_PUSH_PROOF_STEP_ID = repoProofStepDefinition("pre-push").id;
-const INNER_LANE_REPORT_FILE_NAME = "inner-lanes.ndjson";
-const decodeInnerLaneReportOption = S.decodeUnknownOption(S.fromJsonString(QualityTaskLaneRunReport));
 
 type PrePushInnerLaneSummary = {
   readonly firstRed: string;
@@ -1387,21 +1386,6 @@ export const summarizePrePushInnerLanesForTesting = (
     }))
   );
 };
-
-const readInnerLaneReports = Effect.fn("Yeet.readInnerLaneReports")(function* (
-  context: RepoRunContext
-): Effect.fn.Return<ReadonlyArray<QualityTaskLaneRunReport>, YeetCommandError, FileSystem.FileSystem | Path.Path> {
-  const fs = yield* FileSystem.FileSystem;
-  const reportPath = yield* runOutputPathForContext(context, INNER_LANE_REPORT_FILE_NAME);
-  if (!(yield* fs.exists(reportPath).pipe(Effect.orElseSucceed(() => false)))) {
-    return A.empty();
-  }
-  const text = yield* fs
-    .readFileString(reportPath)
-    .pipe(Effect.mapError(YeetCommandError.new(`Failed to read durable inner-lane report "${reportPath}".`)));
-  const lines = pipe(text, Str.split("\n"), A.filter(Str.isNonEmpty));
-  return A.getSomes(A.map(lines, (line) => decodeInnerLaneReportOption(line)));
-});
 
 const readFlakeQuarantineIncidents = Effect.fn("Yeet.readFlakeQuarantineIncidents")(function* (
   repoRoot: string

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/InnerLaneReports.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/InnerLaneReports.ts
@@ -1,0 +1,120 @@
+/**
+ * Durable inner-lane report reader shared by the verdict and packet writers.
+ *
+ * **Details**
+ *
+ * Wrapper lanes append one `quality-task-lane-run/v1` line per inner lane to
+ * `inner-lanes.ndjson` under the run artifact directory. The verdict builder
+ * and the failure-packet writer both read it back, so repair hints follow the
+ * lane that actually went red instead of a marker scan of the whole log.
+ *
+ * @packageDocumentation
+ * @since 0.0.0
+ */
+
+import { Effect, FileSystem } from "effect";
+import * as A from "effect/Array";
+import { dual, pipe } from "effect/Function";
+import * as O from "effect/Option";
+import * as S from "effect/Schema";
+import * as Str from "effect/String";
+import { QualityTaskLaneRunReport } from "../../Quality/Quality.schemas.ts";
+import { YeetCommandError } from "../Yeet.errors.ts";
+import { runArtifactPathForContext } from "./ArtifactPaths.ts";
+import type { Path } from "effect";
+import type { RepoRunContext } from "../../../internal/repo-run/RepoRun.models.ts";
+import type { QualityTaskLaneRun } from "../../Quality/Quality.schemas.ts";
+
+/**
+ * File name of the durable inner-lane report inside the run artifact directory.
+ *
+ * **Example** (Resolve the report path for a run)
+ *
+ * ```ts
+ * import { INNER_LANE_REPORT_FILE_NAME } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(INNER_LANE_REPORT_FILE_NAME) // "inner-lanes.ndjson"
+ * ```
+ *
+ * @category constants
+ * @since 0.0.0
+ */
+export const INNER_LANE_REPORT_FILE_NAME = "inner-lanes.ndjson";
+
+const decodeInnerLaneReportOption = S.decodeUnknownOption(S.fromJsonString(QualityTaskLaneRunReport));
+
+/**
+ * Read every decodable inner-lane report line recorded for the run.
+ *
+ * **Details**
+ *
+ * A missing file yields an empty list; undecodable lines are skipped so one
+ * truncated append never hides the lanes that were recorded cleanly.
+ *
+ * **Example** (Inspect the reader)
+ *
+ * ```ts
+ * import { readInnerLaneReports } from "@beep/repo-cli/test/Yeet"
+ * import { Effect } from "effect"
+ *
+ * const program = Effect.succeed(readInnerLaneReports)
+ * console.log(Effect.isEffect(program)) // true
+ * ```
+ *
+ * @param context - Repo run context that locates the run artifact directory.
+ * @returns Every decodable report, in append order.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const readInnerLaneReports = Effect.fn("Yeet.readInnerLaneReports")(function* (
+  context: RepoRunContext
+): Effect.fn.Return<ReadonlyArray<QualityTaskLaneRunReport>, YeetCommandError, FileSystem.FileSystem | Path.Path> {
+  const fs = yield* FileSystem.FileSystem;
+  const reportPath = yield* runArtifactPathForContext(context, INNER_LANE_REPORT_FILE_NAME);
+  if (!(yield* fs.exists(reportPath).pipe(Effect.orElseSucceed(() => false)))) {
+    return A.empty();
+  }
+  const text = yield* fs
+    .readFileString(reportPath)
+    .pipe(Effect.mapError(YeetCommandError.new(`Failed to read durable inner-lane report "${reportPath}".`)));
+  const lines = pipe(text, Str.split("\n"), A.filter(Str.isNonEmpty));
+  return A.getSomes(A.map(lines, (line) => decodeInnerLaneReportOption(line)));
+});
+
+/**
+ * Collect the inner lane runs recorded under one wrapper lane, in append order.
+ *
+ * **Example** (Select one wrapper's lanes)
+ *
+ * ```ts
+ * import { QualityTaskLaneRun, QualityTaskLaneRunReport } from "@beep/repo-cli/test/Quality"
+ * import { laneRunsForWrapper } from "@beep/repo-cli/test/Yeet"
+ * import * as O from "effect/Option"
+ *
+ * const report = QualityTaskLaneRunReport.make({
+ *   schemaVersion: "quality-task-lane-run/v1",
+ *   parentLaneId: O.some("full:01-pre-push"),
+ *   lanes: [QualityTaskLaneRun.make({ id: "quality:check", label: "quality:check", status: "passed", inputDigest: O.none() })],
+ * })
+ *
+ * console.log(laneRunsForWrapper([report], "full:01-pre-push").length) // 1
+ * ```
+ *
+ * @param reports - Every report read for the run.
+ * @param wrapperLaneId - Plan step id of the wrapper lane.
+ * @returns The lane runs whose report names that wrapper as parent.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const laneRunsForWrapper: {
+  (wrapperLaneId: string): (reports: ReadonlyArray<QualityTaskLaneRunReport>) => ReadonlyArray<QualityTaskLaneRun>;
+  (reports: ReadonlyArray<QualityTaskLaneRunReport>, wrapperLaneId: string): ReadonlyArray<QualityTaskLaneRun>;
+} = dual(
+  2,
+  (reports: ReadonlyArray<QualityTaskLaneRunReport>, wrapperLaneId: string): ReadonlyArray<QualityTaskLaneRun> =>
+    pipe(
+      reports,
+      A.filter((report) => O.contains(report.parentLaneId, wrapperLaneId)),
+      A.flatMap((report) => report.lanes)
+    )
+);

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/IssueArtifacts.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/IssueArtifacts.ts
@@ -15,9 +15,11 @@ import { renderPackageQualityPacketMarkdown } from "../Yeet.render.ts";
 import { YeetRunResult } from "../Yeet.schemas.ts";
 import { artifactDirForContext, safeArtifactName } from "./ArtifactPaths.ts";
 import { executeHeadInstallPreflight, HEAD_INSTALL_PREFLIGHT_STEP_ID } from "./HeadInstallPreflight.ts";
+import { laneRunsForWrapper, readInnerLaneReports } from "./InnerLaneReports.ts";
 import { buildQualityIssueIndex, qualityIssuesFromStepResult } from "./QualityIssueIndex.ts";
 import type { ChildProcessSpawner } from "effect/unstable/process";
 import type { RepoPlanStep, RepoRunContext, RepoStepRunResult } from "../../../internal/repo-run/index.ts";
+import type { QualityTaskLaneRunReport } from "../../Quality/Quality.schemas.ts";
 import type { PackageQualityReport, QualityIssue, QualityIssueIndex } from "../Yeet.schemas.ts";
 
 const commandFailure = (result: RepoStepRunResult, message: string): YeetCommandError =>
@@ -271,14 +273,17 @@ export const writeIssueArtifacts = Effect.fn("Yeet.writeIssueArtifacts")(functio
 const issuesFromResults = (
   context: RepoRunContext,
   steps: ReadonlyArray<RepoPlanStep>,
-  results: ReadonlyArray<RepoStepRunResult>
+  results: ReadonlyArray<RepoStepRunResult>,
+  innerLaneReports: ReadonlyArray<QualityTaskLaneRunReport>
 ): ReadonlyArray<QualityIssue> =>
   pipe(
     results,
     A.flatMap((result) =>
       pipe(
         A.findFirst(steps, (step) => step.id === result.stepId),
-        O.map((step) => qualityIssuesFromStepResult(context, step, result)),
+        O.map((step) =>
+          qualityIssuesFromStepResult(context, step, result, laneRunsForWrapper(innerLaneReports, step.id))
+        ),
         O.getOrElse(A.empty<QualityIssue>)
       )
     )
@@ -456,7 +461,12 @@ export const failWithIssueArtifacts = Effect.fn("Yeet.failWithIssueArtifacts")(f
   results: ReadonlyArray<RepoStepRunResult>,
   message: string
 ): Effect.fn.Return<never, YeetCommandError, FileSystem.FileSystem | Path.Path> {
-  const index = buildQualityIssueIndex(issuesFromResults(context, steps, results));
+  // The side channel is advisory for packets: a read failure must not replace
+  // the real command failure this Effect exists to report.
+  const innerLaneReports = yield* readInnerLaneReports(context).pipe(
+    Effect.orElseSucceed(A.empty<QualityTaskLaneRunReport>)
+  );
+  const index = buildQualityIssueIndex(issuesFromResults(context, steps, results, innerLaneReports));
   const artifacts = yield* writeIssueArtifacts(context, index);
   yield* Console.error(`${message}\nYeet quality packets written to ${artifacts.artifactDir}`);
   for (const packetPath of artifacts.packetPaths) {

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/IssueClassification.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/IssueClassification.ts
@@ -6,11 +6,14 @@
  */
 
 import * as A from "effect/Array";
-import { pipe } from "effect/Function";
+import { dual, pipe } from "effect/Function";
+import * as HashSet from "effect/HashSet";
 import * as O from "effect/Option";
 import * as Str from "effect/String";
+import { GithubCheckLaneRunStatus } from "../../Quality/Quality.schemas.ts";
 import { QualityIssueCategory, QualityIssueRouting } from "../Yeet.schemas.ts";
 import type { RepoPlanStep } from "../../../internal/repo-run/index.ts";
+import type { QualityTaskLaneRun } from "../../Quality/Quality.schemas.ts";
 
 const KNOWN_SUB_LANE_TAIL_CHARS = 16 * 1024;
 
@@ -112,8 +115,26 @@ export const routeForCategory = (category: QualityIssueCategory): ReadonlyArray<
  * @category classification
  * @since 0.0.0
  */
-export const categoryForStep = (step: RepoPlanStep): QualityIssueCategory => {
-  const label = step.label;
+export const categoryForStep = (step: RepoPlanStep): QualityIssueCategory => categoryForLabel(step.label);
+
+/**
+ * Infer the default issue category from a lane or step label.
+ *
+ * **Example** (Classify a lane-run label)
+ *
+ * ```ts
+ * import { strictEqual } from "node:assert"
+ * import { categoryForLabel } from "@beep/repo-cli/test/Yeet"
+ *
+ * strictEqual(categoryForLabel("quality:coverage"), "test")
+ * ```
+ *
+ * @param label - Lane or step label scanned for known lane names.
+ * @returns The broad quality issue category for that label.
+ * @category classification
+ * @since 0.0.0
+ */
+export const categoryForLabel = (label: string): QualityIssueCategory => {
   if (Str.includes("docgen")(label)) {
     return "docgen-jsdoc-quality";
   }
@@ -135,7 +156,7 @@ export const categoryForStep = (step: RepoPlanStep): QualityIssueCategory => {
   if (Str.includes("lint")(label)) {
     return "lint-tool";
   }
-  if (Str.includes("test")(label)) {
+  if (Str.includes("test")(label) || Str.includes("coverage")(label)) {
     return "test";
   }
   if (Str.includes("build")(label)) {
@@ -449,3 +470,306 @@ export const knownSubLaneRemediationFromOutput = (output: string | undefined): O
     knownSubLaneHintFromOutput(output),
     O.map((hint) => hint.remediation)
   );
+
+/**
+ * Return the remediation for a known sub-lane named exactly by its lane id.
+ *
+ * **Details**
+ *
+ * The `quality-task-lane-run/v1` record names the red lane precisely, so this
+ * lookup never scans output. It matches only catalog needles that are
+ * themselves lane ids (`goals:index-check`, `lint:effect-imports`, ...).
+ * Lanes whose catalog needle is a marker inside their output (`osv`,
+ * `changeset`, `typos`) are served by
+ * {@link knownSubLaneRemediationFromLaneOutput} instead.
+ *
+ * **Example** (Look up the goals index gate by lane id)
+ *
+ * ```ts
+ * import * as O from "effect/Option"
+ * import { knownSubLaneRemediationForLaneId } from "@beep/repo-cli/test/Yeet"
+ *
+ * console.log(O.isSome(knownSubLaneRemediationForLaneId("goals:index-check")))
+ * ```
+ *
+ * @param laneId - Stable lane id from the lane-run record.
+ * @returns Remediation text when a catalog needle equals the lane id.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const knownSubLaneRemediationForLaneId = (laneId: string): O.Option<string> =>
+  pipe(
+    knownSubLaneHintForLaneId(laneId),
+    O.map((hint) => hint.remediation)
+  );
+
+const knownSubLaneHintForLaneId = (laneId: string): O.Option<KnownSubLaneHint> => {
+  const normalized = Str.toLowerCase(laneId);
+  return A.findFirst(knownSubLaneHints, (hint) => hint.needle === normalized);
+};
+
+const LANE_LOG_PREFIX = "[beep-cli] ";
+const LANE_OUTCOME_PATTERN = /^(?:ok|failed|done) in \d+ms$/u;
+const LANE_REPORT_PREFIXES: ReadonlyArray<string> = ["[beep-quality-task-lane-run] ", "[beep-github-check-run] "];
+const TAGGED_LINE_PATTERN = /^\[[a-z-]+\] /u;
+
+const laneLogLabel = (line: string): O.Option<string> => {
+  if (!Str.startsWith(LANE_LOG_PREFIX)(line)) {
+    return O.none();
+  }
+  const rest = Str.slice(LANE_LOG_PREFIX.length)(line);
+  return pipe(
+    Str.indexOf(": ")(rest),
+    O.map((index) => Str.slice(0, index)(rest))
+  );
+};
+
+const isLaneOutcomeLine = (line: string, laneLabel: string): boolean =>
+  O.contains(laneLogLabel(line), laneLabel) &&
+  LANE_OUTCOME_PATTERN.test(Str.slice(LANE_LOG_PREFIX.length + laneLabel.length + 2)(line));
+
+const isLaneBoundaryLine = (line: string, siblingLabels: HashSet.HashSet<string>): boolean =>
+  A.some(LANE_REPORT_PREFIXES, (prefix) => Str.startsWith(prefix)(line)) ||
+  (Str.startsWith(LANE_LOG_PREFIX)(line) &&
+    (Str.includes(": running lane ")(line) || Str.includes(": first red ")(line))) ||
+  O.exists(laneLogLabel(line), (label) => HashSet.has(siblingLabels, label));
+
+/**
+ * Slice one lane's own output out of a wrapper's captured output.
+ *
+ * **Details**
+ *
+ * Wrapper lanes stream every inner lane inline. A lane's segment starts at its
+ * last launch line (`[beep-cli] <label>: <command>`), ends at its outcome line
+ * (`[beep-cli] <label>: failed in 12ms`, kept), and is cut short by the next
+ * sibling launch line, tier `running lane` / `first red` line, or embedded
+ * lane-run report. Nested child steps keep their own labels, so they never end
+ * the segment early.
+ *
+ * **Example** (Slice a red lane's output away from a passing sibling)
+ *
+ * ```ts
+ * import * as HashSet from "effect/HashSet"
+ * import * as O from "effect/Option"
+ * import { laneOutputSegment } from "@beep/repo-cli/test/Yeet"
+ *
+ * const output = [
+ *   "[beep-cli] quality:security: bun run beep quality github-checks security",
+ *   "No vulnerabilities found",
+ *   "[beep-cli] quality:security: ok in 10ms",
+ *   "[beep-cli] quality:coverage: bun run beep ci lane coverage",
+ *   "FAIL test/protocol.test.ts",
+ *   "[beep-cli] quality:coverage: failed in 20ms",
+ * ].join("\n")
+ * const siblings = HashSet.make("quality:security", "quality:coverage")
+ *
+ * console.log(O.getOrElse(laneOutputSegment(output, "quality:coverage", siblings), () => ""))
+ * ```
+ *
+ * @param output - Captured wrapper output.
+ * @param laneLabel - Label of the lane whose segment is wanted.
+ * @param siblingLabels - Labels of every lane the wrapper ran; their launch
+ * lines end the segment.
+ * @returns The lane's launch line, body, and outcome line when the launch
+ * line is present.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const laneOutputSegment: {
+  (laneLabel: string, siblingLabels: HashSet.HashSet<string>): (output: string | undefined) => O.Option<string>;
+  (output: string | undefined, laneLabel: string, siblingLabels: HashSet.HashSet<string>): O.Option<string>;
+} = dual(
+  3,
+  (output: string | undefined, laneLabel: string, siblingLabels: HashSet.HashSet<string>): O.Option<string> => {
+    const lines = pipe(output ?? "", Str.replace(/\r\n/gu, "\n"), Str.split("\n"));
+    const isLaunchLine = (line: string): boolean =>
+      O.contains(laneLogLabel(line), laneLabel) && !isLaneOutcomeLine(line, laneLabel);
+    return pipe(
+      A.findLastIndex(lines, isLaunchLine),
+      O.map((start) => {
+        const own = A.drop(lines, start);
+        const body = A.takeWhile(
+          A.drop(own, 1),
+          (line) => !isLaneOutcomeLine(line, laneLabel) && !isLaneBoundaryLine(line, siblingLabels)
+        );
+        const outcomeLength = O.exists(A.get(own, A.length(body) + 1), (line) => isLaneOutcomeLine(line, laneLabel))
+          ? 1
+          : 0;
+        return pipe(own, A.take(A.length(body) + 1 + outcomeLength), A.join("\n"));
+      })
+    );
+  }
+);
+
+const taggedLines = (segment: string): string =>
+  pipe(
+    segment,
+    Str.split("\n"),
+    A.filter((line) => TAGGED_LINE_PATTERN.test(line)),
+    A.join("\n")
+  );
+
+/**
+ * Return the remediation for a known sub-lane marker found inside one lane's
+ * own output segment.
+ *
+ * **Details**
+ *
+ * Only tagged log lines (`[beep-cli] ...`, `[github-checks] ...`) inside the
+ * lane's segment are scanned, so a passing sibling's `security:osv-scan`
+ * launch line or a stray `unix` in test output can no longer name the hint.
+ * When the lane has no launch line in the output, or its tagged lines carry no
+ * known marker, the caller falls back to the lane's own command text.
+ *
+ * **Example** (Find the typos marker inside a broad lint lane)
+ *
+ * ```ts
+ * import * as HashSet from "effect/HashSet"
+ * import * as O from "effect/Option"
+ * import { knownSubLaneRemediationFromLaneOutput } from "@beep/repo-cli/test/Yeet"
+ *
+ * const output = [
+ *   "[beep-cli] quality:lint-policy: bun run beep ci lane lint-policy",
+ *   "[beep-cli] lint:typos: typos",
+ *   "[beep-cli] lint:typos: failed in 12ms",
+ *   "[beep-cli] quality:lint-policy: failed in 40ms",
+ * ].join("\n")
+ *
+ * console.log(
+ *   O.isSome(knownSubLaneRemediationFromLaneOutput(output, "quality:lint-policy", HashSet.make("quality:lint-policy")))
+ * )
+ * ```
+ *
+ * @param output - Captured wrapper output.
+ * @param laneLabel - Label of the red lane.
+ * @param siblingLabels - Labels of every lane the wrapper ran.
+ * @returns Remediation text when a known marker sits inside the lane's segment.
+ * @category utilities
+ * @since 0.0.0
+ */
+export const knownSubLaneRemediationFromLaneOutput: {
+  (laneLabel: string, siblingLabels: HashSet.HashSet<string>): (output: string | undefined) => O.Option<string>;
+  (output: string | undefined, laneLabel: string, siblingLabels: HashSet.HashSet<string>): O.Option<string>;
+} = dual(
+  3,
+  (output: string | undefined, laneLabel: string, siblingLabels: HashSet.HashSet<string>): O.Option<string> =>
+    pipe(
+      knownSubLaneHintFromLaneOutput(output, laneLabel, siblingLabels),
+      O.map((hint) => hint.remediation)
+    )
+);
+
+const knownSubLaneHintFromLaneOutput = (
+  output: string | undefined,
+  laneLabel: string,
+  siblingLabels: HashSet.HashSet<string>
+): O.Option<KnownSubLaneHint> =>
+  pipe(laneOutputSegment(output, laneLabel, siblingLabels), O.map(taggedLines), O.flatMap(knownSubLaneHintFromOutput));
+
+// The recorded launch command is the last resort: no prose, but always the
+// exact command that went red, keyed by the lane id so packets stay precise.
+const launchCommandHint = (lane: QualityTaskLaneRun): O.Option<KnownSubLaneHint> =>
+  pipe(
+    lane.commandText,
+    O.map((commandText) => ({
+      needle: lane.id,
+      subCategory: lane.id,
+      category: categoryForLabel(lane.label),
+      remediation: commandText,
+    }))
+  );
+
+/**
+ * Resolve the hint for one recorded lane run.
+ *
+ * **Details**
+ *
+ * A red lane resolves, in order, to the catalog hint keyed by its exact lane
+ * id, then a known marker inside its own output segment, then its recorded
+ * launch command. Lanes that did not fail never carry a hint. The verdict's
+ * per-lane `repairCommand` and the failure packet's issue classification both
+ * come from this one resolver.
+ *
+ * **Example** (Resolve a red cheap gate by lane id)
+ *
+ * ```ts
+ * import { QualityTaskLaneRun } from "@beep/repo-cli/test/Quality"
+ * import { knownSubLaneHintForLaneRun } from "@beep/repo-cli/test/Yeet"
+ * import * as HashSet from "effect/HashSet"
+ * import * as O from "effect/Option"
+ *
+ * const lane = QualityTaskLaneRun.make({
+ *   id: "goals:index-check",
+ *   label: "goals:index-check",
+ *   status: "failed",
+ *   inputDigest: O.none(),
+ * })
+ *
+ * console.log(O.map(knownSubLaneHintForLaneRun(lane, HashSet.make("goals:index-check"), ""), (hint) => hint.subCategory))
+ * ```
+ *
+ * @param lane - One recorded lane run.
+ * @param siblingLabels - Labels of every lane the wrapper ran.
+ * @param wrapperOutput - Captured wrapper output.
+ * @returns The lane's hint when it failed and one could be resolved.
+ * @category classification
+ * @since 0.0.0
+ */
+export const knownSubLaneHintForLaneRun: {
+  (
+    siblingLabels: HashSet.HashSet<string>,
+    wrapperOutput: string | undefined
+  ): (lane: QualityTaskLaneRun) => O.Option<KnownSubLaneHint>;
+  (
+    lane: QualityTaskLaneRun,
+    siblingLabels: HashSet.HashSet<string>,
+    wrapperOutput: string | undefined
+  ): O.Option<KnownSubLaneHint>;
+} = dual(
+  3,
+  (
+    lane: QualityTaskLaneRun,
+    siblingLabels: HashSet.HashSet<string>,
+    wrapperOutput: string | undefined
+  ): O.Option<KnownSubLaneHint> =>
+    GithubCheckLaneRunStatus.is.failed(lane.status)
+      ? pipe(
+          knownSubLaneHintForLaneId(lane.id),
+          O.orElse(() => knownSubLaneHintFromLaneOutput(wrapperOutput, lane.label, siblingLabels)),
+          O.orElse(() => launchCommandHint(lane))
+        )
+      : O.none()
+);
+
+/**
+ * Resolve the hint for the first red lane in a wrapper's lane-run record.
+ *
+ * **Example** (No red lane, no hint)
+ *
+ * ```ts
+ * import { knownSubLaneHintForFirstRedLane } from "@beep/repo-cli/test/Yeet"
+ * import * as O from "effect/Option"
+ *
+ * console.log(O.isNone(knownSubLaneHintForFirstRedLane([], "")))
+ * ```
+ *
+ * @param runs - Lane runs recorded under one wrapper, in append order.
+ * @param wrapperOutput - Captured wrapper output.
+ * @returns The first red lane's hint when one could be resolved.
+ * @category classification
+ * @since 0.0.0
+ */
+export const knownSubLaneHintForFirstRedLane: {
+  (wrapperOutput: string | undefined): (runs: ReadonlyArray<QualityTaskLaneRun>) => O.Option<KnownSubLaneHint>;
+  (runs: ReadonlyArray<QualityTaskLaneRun>, wrapperOutput: string | undefined): O.Option<KnownSubLaneHint>;
+} = dual(
+  2,
+  (runs: ReadonlyArray<QualityTaskLaneRun>, wrapperOutput: string | undefined): O.Option<KnownSubLaneHint> => {
+    const siblingLabels = HashSet.fromIterable(A.map(runs, (lane) => lane.label));
+    return pipe(
+      runs,
+      A.findFirst((lane) => GithubCheckLaneRunStatus.is.failed(lane.status)),
+      O.flatMap((lane) => knownSubLaneHintForLaneRun(lane, siblingLabels, wrapperOutput))
+    );
+  }
+);

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/IssueParser.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/IssueParser.ts
@@ -9,18 +9,25 @@ import { Order } from "effect";
 import * as A from "effect/Array";
 import { dual, flow, pipe } from "effect/Function";
 import * as O from "effect/Option";
+import * as S from "effect/Schema";
 import * as Str from "effect/String";
 import { optionalProp } from "../../../internal/cli/OptionRecord.ts";
 import { decodeSchemaFirstPolicyFindingLine } from "../../../internal/quality/SchemaFirstPolicyFinding.ts";
-import { commandTextForStep, TurboWorkspacePackage, turboTaskForStep } from "../../../internal/repo-run/index.ts";
-import { QualityIssue } from "../Yeet.schemas.ts";
-import { categoryForStep, knownSubLaneHintFromOutput, routeForCategory } from "./IssueClassification.ts";
-import type {
-  RepoPlanStep,
+import {
+  commandTextForStep,
   RepoRunContext,
-  RepoStepRunResult,
-  TurboPlanTask,
+  TurboWorkspacePackage,
+  turboTaskForStep,
 } from "../../../internal/repo-run/index.ts";
+import { QualityIssue } from "../Yeet.schemas.ts";
+import {
+  categoryForStep,
+  knownSubLaneHintForFirstRedLane,
+  knownSubLaneHintFromOutput,
+  routeForCategory,
+} from "./IssueClassification.ts";
+import type { RepoPlanStep, RepoStepRunResult, TurboPlanTask } from "../../../internal/repo-run/index.ts";
+import type { QualityTaskLaneRun } from "../../Quality/Quality.schemas.ts";
 import type { QualityIssueCategory, QualityIssueSeverity } from "../Yeet.schemas.ts";
 
 const MAX_RAW_EXCERPT_CHARS = 4 * 1024;
@@ -313,13 +320,20 @@ const schemaFirstPolicyIssueFromLine = (
     })
   );
 
+// The lane-run record names the red lane; the whole-output marker scan is only
+// the fallback for wrappers that emitted no record (or a red lane no rule
+// could resolve), because a passing sibling's marker used to win the hint.
 const fallbackIssueFromResult = (
   context: RepoRunContext,
   step: RepoPlanStep,
   result: RepoStepRunResult,
+  innerLanes: ReadonlyArray<QualityTaskLaneRun>,
   inferredPackageName: O.Option<string> = O.none()
 ): QualityIssue => {
-  const subLaneHint = knownSubLaneHintFromOutput(result.output);
+  const subLaneHint = pipe(
+    knownSubLaneHintForFirstRedLane(innerLanes, result.output),
+    O.orElse(() => knownSubLaneHintFromOutput(result.output))
+  );
   const category = pipe(
     subLaneHint,
     O.map((hint) => hint.category),
@@ -355,16 +369,19 @@ const fallbackIssueFromResult = (
 const fallbackIssuesFromResult = (
   context: RepoRunContext,
   step: RepoPlanStep,
-  result: RepoStepRunResult
+  result: RepoStepRunResult,
+  innerLanes: ReadonlyArray<QualityTaskLaneRun>
 ): ReadonlyArray<QualityIssue> => {
   const packageNames = filteredPackageNamesForStep(step);
   return A.isReadonlyArrayNonEmpty(packageNames)
     ? pipe(
         packageNames,
-        A.map((packageName) => fallbackIssueFromResult(context, step, result, O.some(packageName)))
+        A.map((packageName) => fallbackIssueFromResult(context, step, result, innerLanes, O.some(packageName)))
       )
-    : [fallbackIssueFromResult(context, step, result)];
+    : [fallbackIssueFromResult(context, step, result, innerLanes)];
 };
+
+const isRepoRunContext = S.is(RepoRunContext);
 
 /**
  * Convert a failed step result into quality issues.
@@ -402,29 +419,50 @@ const fallbackIssuesFromResult = (
  * @param context - Shared run context.
  * @param step - Planned step that produced the result.
  * @param result - Captured step result.
+ * @param innerLanes - Lane runs the wrapper recorded for this step; the first
+ * red one classifies a raw failure before any output scan.
  * @returns Structured or raw issues; successful results produce no issues.
  * @category parsing
  * @since 0.0.0
  */
 export const qualityIssuesFromStepResult: {
-  (context: RepoRunContext, step: RepoPlanStep, result: RepoStepRunResult): ReadonlyArray<QualityIssue>;
-  (step: RepoPlanStep, result: RepoStepRunResult): (context: RepoRunContext) => ReadonlyArray<QualityIssue>;
-} = dual(3, (context: RepoRunContext, step: RepoPlanStep, result: RepoStepRunResult): ReadonlyArray<QualityIssue> => {
-  if (result.exitCode === 0) {
-    return A.empty();
+  (
+    context: RepoRunContext,
+    step: RepoPlanStep,
+    result: RepoStepRunResult,
+    innerLanes?: ReadonlyArray<QualityTaskLaneRun>
+  ): ReadonlyArray<QualityIssue>;
+  (
+    step: RepoPlanStep,
+    result: RepoStepRunResult,
+    innerLanes?: ReadonlyArray<QualityTaskLaneRun>
+  ): (context: RepoRunContext) => ReadonlyArray<QualityIssue>;
+} = dual(
+  (args) => isRepoRunContext(args[0]),
+  (
+    context: RepoRunContext,
+    step: RepoPlanStep,
+    result: RepoStepRunResult,
+    innerLanes: ReadonlyArray<QualityTaskLaneRun> = A.empty()
+  ): ReadonlyArray<QualityIssue> => {
+    if (result.exitCode === 0) {
+      return A.empty();
+    }
+
+    const parsedIssues = pipe(
+      result.output ?? "",
+      nonEmptyLines,
+      A.map((line) =>
+        pipe(
+          schemaFirstPolicyIssueFromLine(context, step, result, line),
+          O.orElse(() => diagnosticIssueFromLine(context, step, result, line))
+        )
+      ),
+      A.getSomes
+    );
+
+    return A.isReadonlyArrayNonEmpty(parsedIssues)
+      ? parsedIssues
+      : fallbackIssuesFromResult(context, step, result, innerLanes);
   }
-
-  const parsedIssues = pipe(
-    result.output ?? "",
-    nonEmptyLines,
-    A.map((line) =>
-      pipe(
-        schemaFirstPolicyIssueFromLine(context, step, result, line),
-        O.orElse(() => diagnosticIssueFromLine(context, step, result, line))
-      )
-    ),
-    A.getSomes
-  );
-
-  return A.isReadonlyArrayNonEmpty(parsedIssues) ? parsedIssues : fallbackIssuesFromResult(context, step, result);
-});
+);

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/QualityIssueIndex.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/QualityIssueIndex.ts
@@ -24,7 +24,14 @@ export {
   QualityIssueRouting,
   QualityIssueSeverity,
 } from "../Yeet.schemas.ts";
-export { knownSubLaneRemediationFromOutput } from "./IssueClassification.ts";
+export {
+  knownSubLaneHintForFirstRedLane,
+  knownSubLaneHintForLaneRun,
+  knownSubLaneRemediationForLaneId,
+  knownSubLaneRemediationFromLaneOutput,
+  knownSubLaneRemediationFromOutput,
+  laneOutputSegment,
+} from "./IssueClassification.ts";
 export { qualityIssuesFromStepResult } from "./IssueParser.ts";
 
 const issueOrder: Order.Order<QualityIssue> = Order.combine(

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Verdict.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Verdict.ts
@@ -15,13 +15,15 @@ import { O } from "@beep/utils";
 import { Effect, SchemaTransformation } from "effect";
 import * as A from "effect/Array";
 import { dual, identity, pipe } from "effect/Function";
+import * as HashSet from "effect/HashSet";
 import * as S from "effect/Schema";
 import { commandTextForStep, RepoPlanStep, RepoStepRunResult } from "../../../internal/repo-run/RepoRun.models.ts";
 import { JsonStringCodec } from "../../../internal/schema/JsonCodec.ts";
 import { FlakeQuarantineIncident } from "../../Quality/internal/FlakeQuarantine.ts";
 import { GithubCheckFailurePolicy, QualityTaskLaneRunReport } from "../../Quality/Quality.schemas.ts";
+import { laneRunsForWrapper } from "./InnerLaneReports.ts";
 import { GIT_PUSH_STEP_ID, YeetProofTier } from "./Planner.ts";
-import { knownSubLaneRemediationFromOutput } from "./QualityIssueIndex.ts";
+import { knownSubLaneHintForLaneRun, knownSubLaneRemediationFromOutput } from "./QualityIssueIndex.ts";
 import type { QualityTaskLaneRun } from "../../Quality/Quality.schemas.ts";
 
 const $I = $RepoCliId.create("commands/Yeet/internal/Verdict");
@@ -667,18 +669,27 @@ export class YeetExecutedStep extends S.Class<YeetExecutedStep>($I`YeetExecutedS
   })
 ) {}
 
-const laneFromExecuted = (executed: YeetExecutedStep, tier: O.Option<YeetProofTier>): YeetVerdictLane => {
+// A wrapper (tier) lane repairs whatever its first red inner lane repairs. The
+// lane-run record names that lane; scanning the whole wrapper output for
+// markers is only the fallback for wrappers that emitted no record, because a
+// passing sibling's marker (`security:osv-scan`, `changeset-status`) sits in
+// the same log as the real failure and used to win the hint.
+const laneFromExecuted = (
+  executed: YeetExecutedStep,
+  tier: O.Option<YeetProofTier>,
+  innerLanes: ReadonlyArray<YeetVerdictLane>
+): YeetVerdictLane => {
   const failed = executed.result.exitCode !== 0;
   const status = executed.status ?? (failed ? "failed" : "passed");
-  const repairCommand =
-    status === "failed"
-      ? O.some(
-          pipe(
-            knownSubLaneRemediationFromOutput(executed.result.output),
-            O.getOrElse(() => commandTextForStep(executed.step))
-          )
-        )
-      : O.none<string>();
+  const repairCommand = YeetLaneStatus.is.failed(status)
+    ? pipe(
+        innerLanes,
+        A.findFirst((lane) => YeetLaneStatus.is.failed(lane.status)),
+        O.flatMap((lane) => O.fromUndefinedOr(lane.repairCommand)),
+        O.orElse(() => knownSubLaneRemediationFromOutput(executed.result.output)),
+        O.orElseSome(() => commandTextForStep(executed.step))
+      )
+    : O.none<string>();
   return YeetVerdictLane.make({
     id: executed.step.id,
     label: executed.step.label,
@@ -708,7 +719,25 @@ const laneFromPlanned = (step: RepoPlanStep, tier: O.Option<YeetProofTier>): Yee
     inputDigest: O.none(),
   });
 
-const laneFromQualityTaskRun = (lane: QualityTaskLaneRun, tier: O.Option<YeetProofTier>): YeetVerdictLane =>
+// A red inner lane's repair command comes from the lane itself (catalog hint
+// by exact lane id, then a known marker inside its own output segment, then
+// its recorded launch command); the failure packet classifies through the
+// same resolver so verdict and packet never disagree.
+const laneRunRepairCommand = (
+  lane: QualityTaskLaneRun,
+  siblingLabels: HashSet.HashSet<string>,
+  wrapperOutput: string | undefined
+): O.Option<string> =>
+  pipe(
+    knownSubLaneHintForLaneRun(lane, siblingLabels, wrapperOutput),
+    O.map((hint) => hint.remediation)
+  );
+
+const laneFromQualityTaskRun = (
+  lane: QualityTaskLaneRun,
+  tier: O.Option<YeetProofTier>,
+  repairCommand: O.Option<string>
+): YeetVerdictLane =>
   YeetVerdictLane.make({
     id: lane.id,
     label: lane.label,
@@ -721,19 +750,22 @@ const laneFromQualityTaskRun = (lane: QualityTaskLaneRun, tier: O.Option<YeetPro
     ...O.getSomesStruct({
       durationMs: lane.durationMs,
       exitCode: lane.exitCode,
+      repairCommand,
     }),
   });
 
 const innerLanesForWrapper = (
   reports: ReadonlyArray<QualityTaskLaneRunReport>,
   wrapperLaneId: string,
-  tier: O.Option<YeetProofTier>
-): ReadonlyArray<YeetVerdictLane> =>
-  pipe(
-    reports,
-    A.filter((report) => O.exists(report.parentLaneId, (parentLaneId) => parentLaneId === wrapperLaneId)),
-    A.flatMap((report) => A.map(report.lanes, (lane) => laneFromQualityTaskRun(lane, tier)))
+  tier: O.Option<YeetProofTier>,
+  wrapperOutput: string | undefined
+): ReadonlyArray<YeetVerdictLane> => {
+  const runs = laneRunsForWrapper(reports, wrapperLaneId);
+  const siblingLabels = HashSet.fromIterable(A.map(runs, (lane) => lane.label));
+  return A.map(runs, (lane) =>
+    laneFromQualityTaskRun(lane, tier, laneRunRepairCommand(lane, siblingLabels, wrapperOutput))
   );
+};
 
 /**
  * Run identity, outcome, planned steps, and executed results used to build the run verdict.
@@ -819,15 +851,14 @@ export const buildYeetVerdict = (input: BuildYeetVerdictInput): YeetVerdict => {
     input.executed,
     A.map((entry) => entry.step.id)
   );
+  const wrappers = A.map(input.executed, (entry) => ({
+    entry,
+    inner: innerLanesForWrapper(input.innerLaneReports, entry.step.id, input.proofTier, entry.result.output),
+  }));
   const lanes = pipe(
-    input.executed,
-    A.map((entry) => laneFromExecuted(entry, input.proofTier)),
-    A.appendAll(
-      pipe(
-        input.executed,
-        A.flatMap((entry) => innerLanesForWrapper(input.innerLaneReports, entry.step.id, input.proofTier))
-      )
-    ),
+    wrappers,
+    A.map(({ entry, inner }) => laneFromExecuted(entry, input.proofTier, inner)),
+    A.appendAll(A.flatMap(wrappers, ({ inner }) => inner)),
     A.appendAll(
       pipe(
         input.planned,

--- a/packages/tooling/tool/cli/src/test/Yeet.test-kit.ts
+++ b/packages/tooling/tool/cli/src/test/Yeet.test-kit.ts
@@ -35,6 +35,7 @@ export * from "../commands/Yeet/internal/Handler.ts";
 export * from "../commands/Yeet/internal/Inbox.ts";
 export * from "../commands/Yeet/internal/InboxPorcelain.ts";
 export * from "../commands/Yeet/internal/InboxView.ts";
+export * from "../commands/Yeet/internal/InnerLaneReports.ts";
 export * from "../commands/Yeet/internal/IssueArtifacts.ts";
 export * from "../commands/Yeet/internal/IssueClassification.ts";
 export * from "../commands/Yeet/internal/IssueParser.ts";

--- a/packages/tooling/tool/cli/test/yeet-verdict-lane-repair.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-verdict-lane-repair.test.ts
@@ -1,0 +1,470 @@
+import { QualityTaskLaneRun, QualityTaskLaneRunReport } from "@beep/repo-cli/test/Quality";
+import {
+  artifactDirForContext,
+  BuildYeetVerdictInput,
+  buildYeetVerdictForTesting,
+  failWithIssueArtifacts,
+  INNER_LANE_REPORT_FILE_NAME,
+  knownSubLaneHintForFirstRedLane,
+  knownSubLaneRemediationForLaneId,
+  knownSubLaneRemediationFromLaneOutput,
+  knownSubLaneRemediationFromOutput,
+  laneOutputSegment,
+  laneRunsForWrapper,
+  QualityIssueIndex,
+  qualityIssuesFromStepResult,
+  RepoPlanStep,
+  RepoRunContext,
+  RepoStepRunResult,
+  runArtifactPathForContext,
+  TurboPlanSnapshot,
+  YeetCommandError,
+  YeetExecutedStep,
+} from "@beep/repo-cli/test/Yeet";
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import * as NodePath from "@effect/platform-node/NodePath";
+import { describe, expect, it } from "@effect/vitest";
+import { assertInstanceOf, assertNone, assertSome } from "@effect/vitest/utils";
+import { Effect, FileSystem, Layer, Path } from "effect";
+import * as A from "effect/Array";
+import * as HashSet from "effect/HashSet";
+import * as O from "effect/Option";
+import * as S from "effect/Schema";
+import type { YeetVerdict, YeetVerdictLane } from "@beep/repo-cli/test/Yeet";
+
+const OSV_HINT = "Inspect the OSV finding and rerun `bun run beep quality github-checks security`.";
+const CHANGESET_HINT_PREFIX = "Run `bun run beep quality changeset-status --since origin/main`.";
+const GOALS_INDEX_HINT = "Run `bun run beep goals index`, inspect the update, then rerun the cheap-gates tier.";
+const TYPOS_HINT =
+  "Run the typos checker on the flagged files and fix the spelling, or whitelist intentional terms in `_typos.toml`.";
+
+const wrapperStep = (id: string, label: string, tier: string): RepoPlanStep =>
+  RepoPlanStep.make({
+    id,
+    label,
+    phase: "full",
+    command: "bun",
+    args: ["run", "beep", "quality", "github-checks", tier],
+    cwd: "/repo",
+    scope: "repo",
+    mutability: "readonly",
+    resume: "never",
+  });
+
+const laneRun = (
+  id: string,
+  status: QualityTaskLaneRun["status"],
+  commandText: O.Option<string> = O.none()
+): QualityTaskLaneRun =>
+  QualityTaskLaneRun.make({
+    id,
+    label: id,
+    status,
+    inputDigest: O.none(),
+    commandText,
+  });
+
+const buildVerdict = (
+  step: RepoPlanStep,
+  output: string,
+  lanes: ReadonlyArray<QualityTaskLaneRun>,
+  exitCode = 1
+): YeetVerdict =>
+  buildYeetVerdictForTesting(
+    BuildYeetVerdictInput.make({
+      base: "origin/main",
+      branch: "feat/effect-vitest-grouped-report",
+      createdAt: "2026-09-12T00:00:00.000Z",
+      executed: [
+        YeetExecutedStep.make({
+          result: RepoStepRunResult.make({
+            stepId: step.id,
+            commandText: "bun run beep quality github-checks pre-push",
+            exitCode,
+            output,
+          }),
+          step,
+        }),
+      ],
+      innerLaneReports: A.isReadonlyArrayEmpty(lanes)
+        ? []
+        : [
+            QualityTaskLaneRunReport.make({
+              schemaVersion: "quality-task-lane-run/v1",
+              parentLaneId: O.some(step.id),
+              lanes,
+            }),
+          ],
+      head: "HEAD",
+      message: exitCode === 0 ? "yeet verification proof passed." : "yeet verification proof failed.",
+      mode: "verify",
+      outcome: exitCode === 0 ? "success" : "failure",
+      packetPaths: [],
+      planned: [step],
+      proofTier: O.some("full"),
+      runId: "feat/effect-vitest-grouped-report",
+    })
+  );
+
+const laneById = (verdict: YeetVerdict, id: string): YeetVerdictLane =>
+  O.getOrThrowWith(
+    A.findFirst(verdict.lanes, (lane) => lane.id === id),
+    () => new Error(`verdict has no lane ${id}`)
+  );
+
+const fullProofStep = wrapperStep("full:01-pre-push", "full:pre-push", "pre-push");
+const cheapGatesStep = wrapperStep("full:00-cheap-gates", "full:cheap-gates", "cheap-gates");
+
+// Sequential pre-push tier: the OSV lane passes and prints its marker, then
+// coverage fails on a property flake. The whole-output scan used to pick OSV.
+const fullProofOutput = [
+  "[beep-cli] pre-push: running lane quality:security",
+  "[beep-cli] quality:security: bun run beep quality github-checks security",
+  "[github-checks] security: osv scan",
+  "[beep-cli] security:osv-scan: docker run --rm ghcr.io/google/osv-scanner:latest --lockfile bun.lock",
+  "No vulnerabilities found (checked 2309 packages, 2 ignored)",
+  "[beep-cli] quality:security: ok in 4200ms",
+  "[beep-cli] pre-push: running lane quality:coverage",
+  "[beep-cli] quality:coverage: bun run beep ci lane coverage",
+  "FAIL packages/acp/test/protocol.test.ts > round-trips every request",
+  "Error: Property failed after 12 tests",
+  "[beep-cli] quality:coverage: failed in 91000ms",
+  "[beep-cli] pre-push: first red quality:coverage; skipped 1 lane(s) after red",
+  '[beep-quality-task-lane-run] {"schemaVersion":"quality-task-lane-run/v1","lanes":[]}',
+].join("\n");
+
+// Concurrent cheap tier: changeset-status launches last, so its marker is the
+// latest needle inside the first failure-looking window (a benign "0 errors"
+// line), while goals:index-check is the lane that actually went red.
+const cheapGatesOutput = [
+  "[beep-cli] cheap-gates: running lane goals:index-check",
+  "[beep-cli] cheap-gates: running lane lint:effect-imports",
+  "[beep-cli] cheap-gates: running lane quality:changeset-status",
+  "[beep-cli] goals:index-check: bun run beep goals index --check",
+  "[beep-cli] lint:effect-imports: bun run beep laws effect-imports --check",
+  "[beep-cli] quality:changeset-status: bun run changeset:status:since-main",
+  "effect-imports: 0 errors in 412 files",
+  "[beep-cli] lint:effect-imports: ok in 300ms",
+  "🦋  info Changesets cover every changed package.",
+  "[beep-cli] quality:changeset-status: ok in 900ms",
+  "local goals/INDEX.md drifts from goals/*/ops/manifest.json; run bun run beep goals index --write",
+  "[beep-cli] goals:index-check: failed in 1200ms",
+  "[beep-cli] cheap-gates: first red goals:index-check; skipped 0 lane(s) after red",
+  "[beep-cli] cheap-gates: failed 1 step(s)",
+  "[beep-cli]   goals:index-check: exit 1",
+  "[beep-cli]     command: bun run beep goals index --check",
+].join("\n");
+
+describe("yeet verdict lane repair commands", () => {
+  it("documents the whole-output scan trap the lane-run record replaces", () => {
+    expect(O.getOrUndefined(knownSubLaneRemediationFromOutput(fullProofOutput))).toBe(OSV_HINT);
+    expect(O.getOrUndefined(knownSubLaneRemediationFromOutput(cheapGatesOutput))).toContain(CHANGESET_HINT_PREFIX);
+  });
+
+  it("gives the tier lane and the red coverage lane coverage's own command instead of the passing OSV marker", () => {
+    const verdict = buildVerdict(fullProofStep, fullProofOutput, [
+      laneRun("quality:security", "passed", O.some("bun run beep quality github-checks security")),
+      laneRun("quality:coverage", "failed", O.some("bun run beep ci lane coverage")),
+      laneRun("quality:docgen", "not-run-early-stop", O.some("bun run beep ci lane docgen")),
+    ]);
+
+    expect(laneById(verdict, fullProofStep.id)).toMatchObject({
+      status: "failed",
+      repairCommand: "bun run beep ci lane coverage",
+    });
+    expect(laneById(verdict, "quality:coverage")).toMatchObject({
+      status: "failed",
+      repairCommand: "bun run beep ci lane coverage",
+    });
+    expect(laneById(verdict, "quality:security").repairCommand).toBeUndefined();
+    expect(laneById(verdict, "quality:docgen").repairCommand).toBeUndefined();
+  });
+
+  it("gives the cheap-gates tier lane the red goals index hint while changeset-status passed", () => {
+    const verdict = buildVerdict(cheapGatesStep, cheapGatesOutput, [
+      laneRun("lint:effect-imports", "passed", O.some("bun run beep laws effect-imports --check")),
+      laneRun("quality:changeset-status", "passed", O.some("bun run changeset:status:since-main")),
+      laneRun("goals:index-check", "failed", O.some("bun run beep goals index --check")),
+    ]);
+
+    expect(laneById(verdict, cheapGatesStep.id).repairCommand).toBe(GOALS_INDEX_HINT);
+    expect(laneById(verdict, "goals:index-check").repairCommand).toBe(GOALS_INDEX_HINT);
+    expect(laneById(verdict, "quality:changeset-status").repairCommand).toBeUndefined();
+    expect(laneById(verdict, "lint:effect-imports").repairCommand).toBeUndefined();
+  });
+
+  it("keeps a sub-lane marker found inside the red lane's own segment over its launch command", () => {
+    const output = [
+      "[beep-cli] pre-push: running lane quality:security",
+      "[beep-cli] quality:security: bun run beep quality github-checks security",
+      "[beep-cli] security:osv-scan: docker run --rm ghcr.io/google/osv-scanner:latest",
+      "No vulnerabilities found (checked 2309 packages, 2 ignored)",
+      "[beep-cli] quality:security: ok in 4200ms",
+      "[beep-cli] pre-push: running lane quality:lint-policy",
+      "[beep-cli] quality:lint-policy: bun run beep ci lane lint-policy",
+      "[beep-cli] lint:typos: typos",
+      "error: misspelling found in packages/acp/README.md",
+      "[beep-cli] lint:typos: failed in 12ms",
+      "[beep-cli] quality:lint-policy: failed in 40ms",
+      "[beep-cli] pre-push: first red quality:lint-policy; skipped 2 lane(s) after red",
+    ].join("\n");
+    const verdict = buildVerdict(fullProofStep, output, [
+      laneRun("quality:security", "passed", O.some("bun run beep quality github-checks security")),
+      laneRun("quality:lint-policy", "failed", O.some("bun run beep ci lane lint-policy")),
+    ]);
+
+    expect(laneById(verdict, fullProofStep.id).repairCommand).toBe(TYPOS_HINT);
+    expect(laneById(verdict, "quality:lint-policy").repairCommand).toBe(TYPOS_HINT);
+  });
+
+  it("follows the first red lane in record order when several lanes failed", () => {
+    const verdict = buildVerdict(fullProofStep, "", [
+      laneRun("quality:check", "failed", O.some("bun run beep ci lane check")),
+      laneRun("quality:coverage", "failed", O.some("bun run beep ci lane coverage")),
+    ]);
+
+    expect(laneById(verdict, fullProofStep.id).repairCommand).toBe("bun run beep ci lane check");
+    expect(laneById(verdict, "quality:check").repairCommand).toBe("bun run beep ci lane check");
+    expect(laneById(verdict, "quality:coverage").repairCommand).toBe("bun run beep ci lane coverage");
+  });
+
+  it("keeps the whole-output scan and wrapper command fallbacks for wrappers without a lane-run record", () => {
+    const withMarker = buildVerdict(fullProofStep, "[beep-cli] lint:typos: typos\nerror: misspelling found", []);
+    const withoutMarker = buildVerdict(fullProofStep, "segmentation fault", []);
+
+    expect(laneById(withMarker, fullProofStep.id).repairCommand).toBe(TYPOS_HINT);
+    expect(laneById(withoutMarker, fullProofStep.id).repairCommand).toBe("bun run beep quality github-checks pre-push");
+    expect(withMarker.lanes).toHaveLength(1);
+  });
+
+  it("leaves passing wrappers and lanes without repair commands", () => {
+    const verdict = buildVerdict(
+      fullProofStep,
+      fullProofOutput,
+      [laneRun("quality:security", "passed", O.some("bun run beep quality github-checks security"))],
+      0
+    );
+
+    expect(laneById(verdict, fullProofStep.id).repairCommand).toBeUndefined();
+    expect(laneById(verdict, "quality:security").repairCommand).toBeUndefined();
+  });
+});
+
+describe("lane-run hint helpers", () => {
+  it("matches catalog hints by exact lane id only", () => {
+    expect(O.getOrUndefined(knownSubLaneRemediationForLaneId("goals:index-check"))).toBe(GOALS_INDEX_HINT);
+    assertNone(knownSubLaneRemediationForLaneId("quality:coverage"));
+    assertNone(knownSubLaneRemediationForLaneId("repo-sanity:changeset-graph"));
+  });
+
+  it("slices one lane's segment between its launch line and its outcome line", () => {
+    const siblings = HashSet.make("quality:security", "quality:coverage");
+    const segment = O.getOrUndefined(laneOutputSegment(fullProofOutput, "quality:coverage", siblings));
+
+    expect(segment).toBe(
+      [
+        "[beep-cli] quality:coverage: bun run beep ci lane coverage",
+        "FAIL packages/acp/test/protocol.test.ts > round-trips every request",
+        "Error: Property failed after 12 tests",
+        "[beep-cli] quality:coverage: failed in 91000ms",
+      ].join("\n")
+    );
+    expect(O.getOrUndefined(laneOutputSegment(fullProofOutput, "quality:security", siblings))).toBe(
+      [
+        "[beep-cli] quality:security: bun run beep quality github-checks security",
+        "[github-checks] security: osv scan",
+        "[beep-cli] security:osv-scan: docker run --rm ghcr.io/google/osv-scanner:latest --lockfile bun.lock",
+        "No vulnerabilities found (checked 2309 packages, 2 ignored)",
+        "[beep-cli] quality:security: ok in 4200ms",
+      ].join("\n")
+    );
+    assertNone(laneOutputSegment(fullProofOutput, "quality:docgen", siblings));
+  });
+
+  it("cuts a segment at a sibling launch line when the lane never printed an outcome", () => {
+    const output = [
+      "[beep-cli] goals:index-check: bun run beep goals index --check",
+      "local goals/INDEX.md drifts from goals/*/ops/manifest.json",
+      "[beep-cli] quality:changeset-status: bun run changeset:status:since-main",
+      "🦋  info Changesets cover every changed package.",
+    ].join("\n");
+    const siblings = HashSet.make("goals:index-check", "quality:changeset-status");
+
+    expect(O.getOrUndefined(laneOutputSegment(output, "goals:index-check", siblings))).toBe(
+      [
+        "[beep-cli] goals:index-check: bun run beep goals index --check",
+        "local goals/INDEX.md drifts from goals/*/ops/manifest.json",
+      ].join("\n")
+    );
+  });
+
+  it("scans only tagged lines inside the lane segment for markers", () => {
+    const siblings = HashSet.make("quality:security", "quality:coverage");
+    const unixNoise = [
+      "[beep-cli] quality:coverage: bun run beep ci lane coverage",
+      "Error: spawn failed on unix socket /tmp/docgen.sock",
+      "[beep-cli] quality:coverage: failed in 91000ms",
+    ].join("\n");
+
+    assertNone(knownSubLaneRemediationFromLaneOutput(fullProofOutput, "quality:coverage", siblings));
+    assertNone(knownSubLaneRemediationFromLaneOutput(unixNoise, "quality:coverage", siblings));
+    expect(O.getOrUndefined(knownSubLaneRemediationFromLaneOutput(fullProofOutput, "quality:security", siblings))).toBe(
+      OSV_HINT
+    );
+  });
+});
+
+const runContext = RepoRunContext.make({
+  repoRoot: "/repo",
+  cwd: "/repo",
+  base: "origin/main",
+  head: "HEAD",
+  branch: "feat/effect-vitest-grouped-report",
+  packetDir: ".beep/yeet",
+  originalArgv: [],
+  turbo: TurboPlanSnapshot.make({ graphHealthStatus: "ok", graphHealthWarnings: [], packages: [], tasks: [] }),
+});
+
+const stepResult = (step: RepoPlanStep, output: string): RepoStepRunResult =>
+  RepoStepRunResult.make({
+    stepId: step.id,
+    commandText: "bun run beep quality github-checks pre-push",
+    exitCode: 1,
+    output,
+  });
+
+const reportFor = (wrapperLaneId: string, lanes: ReadonlyArray<QualityTaskLaneRun>): QualityTaskLaneRunReport =>
+  QualityTaskLaneRunReport.make({
+    schemaVersion: "quality-task-lane-run/v1",
+    parentLaneId: O.some(wrapperLaneId),
+    lanes,
+  });
+
+const fullProofLanes: ReadonlyArray<QualityTaskLaneRun> = [
+  laneRun("quality:security", "passed", O.some("bun run beep quality github-checks security")),
+  laneRun("quality:coverage", "failed", O.some("bun run beep ci lane coverage")),
+  laneRun("quality:docgen", "not-run-early-stop", O.some("bun run beep ci lane docgen")),
+];
+
+const cheapGatesLanes: ReadonlyArray<QualityTaskLaneRun> = [
+  laneRun("lint:effect-imports", "passed", O.some("bun run beep laws effect-imports --check")),
+  laneRun("quality:changeset-status", "passed", O.some("bun run changeset:status:since-main")),
+  laneRun("goals:index-check", "failed", O.some("bun run beep goals index --check")),
+];
+
+describe("failure packet issues", () => {
+  it("classifies the raw pre-push failure by the red coverage lane, not the passing OSV marker", () => {
+    const issues = qualityIssuesFromStepResult(
+      runContext,
+      fullProofStep,
+      stepResult(fullProofStep, fullProofOutput),
+      fullProofLanes
+    );
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({
+      category: "test",
+      subCategory: "quality:coverage",
+      remediation: "bun run beep ci lane coverage",
+      message: "full:pre-push failed in quality:coverage with exit code 1.",
+    });
+  });
+
+  it("classifies the raw cheap-gates failure by the red goals index gate", () => {
+    const issues = qualityIssuesFromStepResult(
+      runContext,
+      cheapGatesStep,
+      stepResult(cheapGatesStep, cheapGatesOutput),
+      cheapGatesLanes
+    );
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({
+      category: "repo-law",
+      subCategory: "goals-index",
+      remediation: GOALS_INDEX_HINT,
+      message: "full:cheap-gates failed in goals-index with exit code 1.",
+    });
+  });
+
+  it("keeps the whole-output scan when the wrapper recorded no lanes", () => {
+    const issues = qualityIssuesFromStepResult(runContext, fullProofStep, stepResult(fullProofStep, fullProofOutput));
+
+    expect(issues[0]).toMatchObject({ category: "security-audit", subCategory: "security", remediation: OSV_HINT });
+  });
+
+  it("accepts the data-last form with recorded lanes", () => {
+    const dataLast = qualityIssuesFromStepResult(
+      cheapGatesStep,
+      stepResult(cheapGatesStep, cheapGatesOutput),
+      cheapGatesLanes
+    )(runContext);
+    const dataFirst = qualityIssuesFromStepResult(
+      runContext,
+      cheapGatesStep,
+      stepResult(cheapGatesStep, cheapGatesOutput),
+      cheapGatesLanes
+    );
+
+    expect(dataLast).toStrictEqual(dataFirst);
+  });
+});
+
+describe("inner-lane reports", () => {
+  it("selects the lane runs recorded under one wrapper", () => {
+    const reports = [reportFor(fullProofStep.id, fullProofLanes), reportFor(cheapGatesStep.id, cheapGatesLanes)];
+
+    expect(A.map(laneRunsForWrapper(reports, cheapGatesStep.id), (lane) => lane.id)).toStrictEqual([
+      "lint:effect-imports",
+      "quality:changeset-status",
+      "goals:index-check",
+    ]);
+    expect(A.isReadonlyArrayEmpty(laneRunsForWrapper(reports, "full:99-unknown"))).toBe(true);
+  });
+
+  it("resolves the first red lane's hint from the record", () => {
+    const hint = knownSubLaneHintForFirstRedLane(fullProofLanes, fullProofOutput);
+
+    assertSome(
+      O.map(hint, (value) => value.subCategory),
+      "quality:coverage"
+    );
+    assertNone(knownSubLaneHintForFirstRedLane([], fullProofOutput));
+  });
+});
+
+const PlatformLayer = Layer.mergeAll(NodeFileSystem.layer, NodePath.layer);
+const encodeLaneRunReport = S.encodeSync(S.fromJsonString(QualityTaskLaneRunReport));
+const decodeIssueIndex = S.decodeSync(S.fromJsonString(QualityIssueIndex));
+
+it.layer(PlatformLayer, { timeout: "30 seconds" })("failure packets on disk", (it) => {
+  it.effect("writes the red lane's remediation into the issue index from the recorded side channel", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tmpDir = yield* fs.makeTempDirectoryScoped();
+      const context = RepoRunContext.make({ ...runContext, repoRoot: tmpDir, cwd: tmpDir });
+      const reportPath = yield* runArtifactPathForContext(context, INNER_LANE_REPORT_FILE_NAME);
+      yield* fs.makeDirectory(path.dirname(reportPath), { recursive: true });
+      yield* fs.writeFileString(reportPath, `${encodeLaneRunReport(reportFor(fullProofStep.id, fullProofLanes))}\n`);
+
+      const error = yield* Effect.flip(
+        failWithIssueArtifacts(
+          context,
+          [fullProofStep],
+          [stepResult(fullProofStep, fullProofOutput)],
+          "yeet verification proof failed."
+        )
+      );
+      assertInstanceOf(error, YeetCommandError);
+
+      const indexPath = path.join(yield* artifactDirForContext(context), "quality-issue-index.json");
+      const index = decodeIssueIndex(yield* fs.readFileString(indexPath));
+      expect(index.issues).toHaveLength(1);
+      expect(index.issues[0]).toMatchObject({
+        subCategory: "quality:coverage",
+        remediation: "bun run beep ci lane coverage",
+      });
+    })
+  );
+});

--- a/standards/effect-vitest.inventory.jsonc
+++ b/standards/effect-vitest.inventory.jsonc
@@ -162780,6 +162780,27 @@
       "status": "open"
     },
     {
+      "id": "EV010:packages/tooling/tool/cli/test/yeet-verdict-lane-repair.test.ts:24:@effect/platform-node/NodeFileSystem@0#1",
+      "lens": "resource",
+      "ruleId": "EV010",
+      "package": "@beep/repo-cli",
+      "file": "packages/tooling/tool/cli/test/yeet-verdict-lane-repair.test.ts",
+      "line": 24,
+      "endLine": 24,
+      "symbol": "@effect/platform-node/NodeFileSystem",
+      "occurrence": "v2:1e14fe3983e1b10ec8ca10f275771b44fe07b6efae5f900877c3f472b89c0872",
+      "class": "platform-filesystem-candidate",
+      "evidence": "import * as NodeFileSystem from \"@effect/platform-node/NodeFileSystem\";",
+      "replacement": {
+        "primitive": "it.layer",
+        "sketch": "it.layer: Use for per-test-layer-provide candidates (EV002, candidate class per-test-layer-provide), resource-wrapper candidates (EV003, candidate class resource-wrapper), and platform-filesystem-candidate judgments (EV010, candidate class platform-filesystem-candidate)."
+      },
+      "severity": "info",
+      "confidence": 0.55,
+      "mechanization": "judgment",
+      "status": "open"
+    },
+    {
       "id": "EV010:packages/tooling/tool/cli/test/yeet-watch-mode.test.ts:20:@effect/platform-node/NodeFileSystem@0#1",
       "lens": "resource",
       "ruleId": "EV010",


### PR DESCRIPTION
## fix(repo-cli): derive yeet repair hints from the lane-run record

The verdict's tier lane hint came from a marker scan of the whole wrapper
output, so a passing sibling's marker (security:osv-scan, changeset-status)
beat the lane that actually went red, and red inner lanes carried no repair
command at all.

- QualityTaskLaneRun records its launch command (commandText).
- A red inner lane resolves its own hint: catalog hint by exact lane id, else
  a known marker inside that lane's own output segment (tagged lines only),
  else its recorded launch command. The tier lane follows its first red inner
  lane; the whole-output scan remains only for wrappers without a record.
- The failure packet and inbox capsule classify raw wrapper failures through
  the same resolver, reading inner-lanes.ndjson via the shared
  InnerLaneReports module (moved out of Handler).
- Focused tests reproduce both 2026-09-12 misfires from #1098 synthetically
  and prove the record-first derivation end to end, including on disk.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

## Local proof

- fallow-advisory-feedback: passed
- commit:git:commit: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/fix_yeet-lane-repair-hints-68c8405392a8/verdict.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- yeet-provenance:start -->
## Provenance

- Workspace: <code>beep-effect3</code>
- Branch: <code>fix/yeet-lane-repair-hints</code>
- Agents (newest first):
  - `claude-code` (desktop) · `claude-fable-5-1` · <code>inspiring-keller-0487c2-33</code> · monitored

Resume the publishing agent from any beep-effect checkout on the publishing workstation:

```sh
bun run beep yeet resume 1119
```

<!-- yeet-provenance
{
  "schemaVersion": 2,
  "pr": 1119,
  "branch": "fix/yeet-lane-repair-hints",
  "workspace": "beep-effect3",
  "agents": [
    {
      "harness": "claude-code",
      "entrypoint": "claude-desktop",
      "hostHarness": null,
      "model": "claude-fable-5-1",
      "label": "inspiring-keller-0487c2-33",
      "workspace": null,
      "role": "monitored"
    }
  ]
}
-->
<!-- yeet-provenance:end -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791802961&installation_model_id=424656&pr_number=1119&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1119&signature=8c15cd9cf897c9f19d0d06f7089cca9c84797b175da126725eb70b281418a726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
