### PR TITLE
chore(coverage): record the measured HostProcess row after the browser fallbacks

### DIFF
--- a/standards/coverage.regression-baseline.jsonc
+++ b/standards/coverage.regression-baseline.jsonc
@@ -37387,15 +37387,15 @@
           }
         },
         "packages/foundation/modeling/utils/src/HostProcess.ts": {
-          "lines": 71.42,
-          "statements": 71.42,
-          "branches": 100,
-          "functions": 0,
+          "lines": 100,
+          "statements": 100,
+          "branches": 50,
+          "functions": 100,
           "uncovered": {
-            "lines": 2,
-            "statements": 2,
-            "branches": 0,
-            "functions": 2
+            "lines": 0,
+            "statements": 0,
+            "branches": 2,
+            "functions": 0
           }
         },
         "packages/foundation/modeling/utils/src/Html.ts": {


### PR DESCRIPTION
## chore(coverage): record the measured HostProcess row after the browser fallbacks

#1109 read the host process through `globalThis` with `"browser"` and
`"unknown"` fallbacks, which added two branches that never run under Node.
The baseline row still carried the pre-#1109 shape (branches 100, lines
71.42, functions 0), so `Heavy / Coverage Regression` went red on main at
575a228d3b and on every pull request merged since. Record the row both local
and hosted runs measure (run 34689062768): lines, statements and functions
100, branches 50 with two uncovered.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MaJ9cz5wMHVZsPr3VGhKfh

## Local proof

- fallow-advisory-feedback: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/chore_hostprocess-coverage-row-a12f37fb4db2/verdict.json

---

<!-- yeet-provenance:start -->
## Provenance

- Workspace: <code>beep-effect</code>
- Branch: <code>chore/hostprocess-coverage-row</code>
- Agents (newest first):
  - `claude-code` (cli) · `claude-fable-5-1` · <code>beep-effect-79</code> · created

Resume the publishing agent from any beep-effect checkout on the publishing workstation:

```sh
bun run beep yeet resume 1120
```

<!-- yeet-provenance
{
  "schemaVersion": 2,
  "pr": 1120,
  "branch": "chore/hostprocess-coverage-row",
  "workspace": "beep-effect",
  "agents": [
    {
      "harness": "claude-code",
      "entrypoint": "cli",
      "hostHarness": null,
      "model": "claude-fable-5-1",
      "label": "beep-effect-79",
      "workspace": null,
      "role": "created"
    }
  ]
}
-->
<!-- yeet-provenance:end -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791805512&installation_model_id=424656&pr_number=1120&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1120&signature=0da80718c433ac976bdf0f7ab47699bd8945d185e87b5309af2111a38ca57079"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->