### PR TITLE
docs(closeout): run yeet sweep --retire from inside the lane, not the clone

### DIFF
--- a/.claude/skills/yeet/SKILL.md
+++ b/.claude/skills/yeet/SKILL.md
@@ -212,13 +212,17 @@ bun run beep yeet sweep
 
 ```bash
 bun run beep yeet sweep --retire --plan
-cd "$(git rev-parse --path-format=absolute --git-common-dir)/.." && bun run beep yeet sweep --retire --lane "$OLDPWD"
+CLONE="$(git rev-parse --path-format=absolute --git-common-dir)/.." && bun run beep yeet sweep --retire && cd "$CLONE"
 ```
 
-  The `cd` keeps your shell out of the directory being removed; `--lane` names
-  the lane from the clone. The fence exempts the invoking session's own
-  ancestry and refuses any other process still standing in the lane. `--json`
-  prints one document; `--branch` is refused with `--retire`.
+  Run it from inside the lane: `bun run beep` resolves the CLI from the
+  checkout it runs in, and the owning clone's `main` may still be behind the
+  merge and reject `--retire` as an unknown flag. The command steps its own
+  process out of the lane before removal; the trailing `cd` moves your shell
+  to the swept clone. `--lane <path>` is for a clone that already carries the
+  merged CLI. The fence exempts the invoking session's own ancestry and
+  refuses any other process still standing in the lane. `--json` prints one
+  document; `--branch` is refused with `--retire`.
 
 - Post and resolve the drafted review-thread replies for this branch's PR:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,13 +118,17 @@ models and effort levels they actually recorded.
   them.
 - Post-merge closeout is the agent's job, not the operator's. Once the PR is
   MERGED, retire the lane and sweep its owning clone in one command, run from
-  the lane worktree as the last command of the session:
-  `cd "$(git rev-parse --path-format=absolute --git-common-dir)/.." && bun run beep yeet sweep --retire --lane "$OLDPWD"`
+  inside the lane worktree as the last command of the session:
+  `CLONE="$(git rev-parse --path-format=absolute --git-common-dir)/.." && bun run beep yeet sweep --retire && cd "$CLONE"`
   (archives residue, deletes the branch, sweeps the clone; it refuses until the
-  PR is MERGED and heads that branch, so running it early is safe). The `cd`
-  keeps the shell out of the directory being removed; the fence exempts the
-  invoking session itself and still refuses any other holder. When the merged
-  change touched a systemd unit renderer, follow with
+  PR is MERGED and heads that branch, so running it early is safe). Run it from
+  the lane, never from the clone: `bun run beep` resolves the CLI from the
+  checkout it runs in, and the clone's `main` may still be behind the merge and
+  reject `--retire` as an unknown flag. The command steps its own process out
+  of the lane before removal and the fence exempts the invoking session's
+  ancestry while still refusing any other holder; the trailing `cd` moves the
+  shell to the swept clone. When the merged change touched a systemd unit
+  renderer, follow with
   `bun run beep research install-timers --refresh` and/or
   `bun run beep graft deep install-timer --refresh` (the latter is the only
   agent-allowed form of that command) from the swept clone — the installed

--- a/docs/runbooks/systemd-timers.md
+++ b/docs/runbooks/systemd-timers.md
@@ -74,14 +74,20 @@ run in. The archive fence refuses a lane that any process still stands in, and
 it exempts exactly the invoker's ancestry (the CLI, its shell, the agent
 session above them); anything else holding the lane still refuses it and the
 error prints the working form. Run it as the last command of the session, from
-the lane, with the shell stepping out first:
+inside the lane, and step the shell into the swept clone afterwards:
 
 ```bash
-cd "$(git rev-parse --path-format=absolute --git-common-dir)/.." && bun run beep yeet sweep --retire --lane "$OLDPWD"
+CLONE="$(git rev-parse --path-format=absolute --git-common-dir)/.." && bun run beep yeet sweep --retire && cd "$CLONE"
 ```
 
-`--lane <path>` names the lane when the command runs from the owning clone;
-without it the command retires the checkout it runs in. `--json` prints one
+Run it from the lane, not from the clone: `bun run beep` resolves the CLI from
+the checkout it runs in, so the lane always carries the merged flags while the
+clone's `main` may still be behind the merge and reject `--retire` as an
+unknown flag (observed 2026-09-12 on the first closeout). The command moves
+its own process out of the lane before removal, so the shell may stay in the
+lane during the run. `--lane <path>` names the lane when the command runs from
+a clone that already carries the merged CLI; without it the command retires
+the checkout it runs in. `--json` prints one
 schema-owned document (`yeet-retire-sweep-plan/v1` with `--plan`,
 `yeet-retire-sweep-report/v1` otherwise). `--branch` is refused alongside
 `--retire`: the lane's own HEAD is the branch that is retired.

--- a/standards/git-worktrees.md
+++ b/standards/git-worktrees.md
@@ -175,9 +175,12 @@ clone's `.claude/worktrees/<name>`, so a Claude Code desktop lane retires with t
 same command. After its pull request merged, the one-shot form is
 `bun run beep yeet sweep --retire [--lane <path>]`: it archive-retires the
 lane (the invoking worktree, or the one `--lane` names when run from the
-clone), deletes the branch, and sweeps the owning clone. The archive fence
-exempts only the invoking session's ancestry, so step the shell out first:
-`cd "$(git rev-parse --path-format=absolute --git-common-dir)/.." && bun run beep yeet sweep --retire --lane "$OLDPWD"`.
+clone), deletes the branch, and sweeps the owning clone. Run it from inside
+the lane, because `bun run beep` resolves the CLI from the checkout it runs in
+and the clone's `main` may still be behind the merge; the command steps its
+own process out of the lane before removal and the archive fence exempts the
+invoking session's ancestry. Step the shell into the swept clone afterwards:
+`CLONE="$(git rev-parse --path-format=absolute --git-common-dir)/.." && bun run beep yeet sweep --retire && cd "$CLONE"`.
 
 Forced removal is unsupported and remains denied by agent policy. Archive mode
 is the only removal path for local residue: the CLI inspects tracked and


### PR DESCRIPTION
## docs(closeout): run yeet sweep --retire from inside the lane, not the clone

The first live closeout of #1116 ran the baked recipe from the owning clone,
whose main was still two commits behind the merge, and the clone's CLI rejected
`--retire` as an unknown flag. `bun run beep` resolves the CLI from the checkout
it runs in, so the lane is the only checkout guaranteed to carry the merged
flags. The law, the runbook, the yeet skill, and the worktree standard now run
the command from inside the lane, capture the clone path first, and step the
shell into the swept clone afterwards; `--lane` stays documented for a clone
that already carries the merged CLI.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

## Local proof

- fallow-advisory-feedback: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/fix_closeout-recipe-lane-cli-78922dccbdb2/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791856021&installation_model_id=424656&pr_number=1124&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1124&signature=b681a77c6d649260e812089da0bdef9ee74d377b6e148fd6051e228147fb9205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

---

<!-- yeet-provenance:start -->
## Provenance

- Workspace: <code>beep-effect6</code>
- Branch: <code>fix/closeout-recipe-lane-cli</code>
- Agents (newest first):
  - `claude-code` (desktop) · `claude-fable-5-1` · <code>unruffled-gates-b2c071-b0</code> · created

Resume the publishing agent from any beep-effect checkout on the publishing workstation:

```sh
bun run beep yeet resume 1124
```

<!-- yeet-provenance
{
  "schemaVersion": 2,
  "pr": 1124,
  "branch": "fix/closeout-recipe-lane-cli",
  "workspace": "beep-effect6",
  "agents": [
    {
      "harness": "claude-code",
      "entrypoint": "claude-desktop",
      "hostHarness": null,
      "model": "claude-fable-5-1",
      "label": "unruffled-gates-b2c071-b0",
      "workspace": null,
      "role": "created"
    }
  ]
}
-->
<!-- yeet-provenance:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated worktree retirement guidance to run the sweep command from within the lane.
  - Clarified that the process moves itself out of the lane before removal.
  - Updated examples to enter the resulting clone after the sweep.
  - Clarified when to use the optional lane path and how the command resolves the CLI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->