### PR TITLE
fix(repo-cli): point the retire fence hint at the lane and warn about piped output

### DIFF
--- a/.changeset/closeout-hint-lane-form.md
+++ b/.changeset/closeout-hint-lane-form.md
@@ -1,0 +1,11 @@
+---
+"@beep/repo-cli": patch
+---
+
+`beep yeet sweep --retire` now explains a fence refusal correctly: the holders
+it names are outside the command's own ancestry (an editor, another shell, or
+the other stages of a pipeline the output was piped into), so the hint says to
+leave or close them, redirect output to a file, and rerun from the lane, and
+keeps the `--lane` form for a clone that already carries the merged CLI. The
+old hint sent the operator to the owning clone, which neither removes the
+holder nor works while that clone's `main` is still behind the merge.

--- a/.claude/skills/yeet/SKILL.md
+++ b/.claude/skills/yeet/SKILL.md
@@ -219,7 +219,9 @@ CLONE="$(git rev-parse --path-format=absolute --git-common-dir)/.." && bun run b
   checkout it runs in, and the owning clone's `main` may still be behind the
   merge and reject `--retire` as an unknown flag. The command steps its own
   process out of the lane before removal; the trailing `cd` moves your shell
-  to the swept clone. `--lane <path>` is for a clone that already carries the
+  to the swept clone. Redirect the output to a file rather than piping it:
+  the other stages of a shell pipeline stand in the lane and the fence counts
+  them as holders. `--lane <path>` is for a clone that already carries the
   merged CLI. The fence exempts the invoking session's own ancestry and
   refuses any other process still standing in the lane. `--json` prints one
   document; `--branch` is refused with `--retire`.

--- a/docs/runbooks/systemd-timers.md
+++ b/docs/runbooks/systemd-timers.md
@@ -85,7 +85,9 @@ the checkout it runs in, so the lane always carries the merged flags while the
 clone's `main` may still be behind the merge and reject `--retire` as an
 unknown flag (observed 2026-09-12 on the first closeout). The command moves
 its own process out of the lane before removal, so the shell may stay in the
-lane during the run. `--lane <path>` names the lane when the command runs from
+lane during the run, but redirect its output to a file rather than piping it:
+the other stages of a shell pipeline stand in the lane and the fence counts
+them as holders. `--lane <path>` names the lane when the command runs from
 a clone that already carries the merged CLI; without it the command retires
 the checkout it runs in. `--json` prints one
 schema-owned document (`yeet-retire-sweep-plan/v1` with `--plan`,

--- a/packages/tooling/tool/cli/src/commands/Yeet/internal/Retire.ts
+++ b/packages/tooling/tool/cli/src/commands/Yeet/internal/Retire.ts
@@ -251,9 +251,14 @@ const isWithin = (path: Path.Path, root: string, candidate: string): boolean =>
  *
  * **Details**
  *
- * A holder the fence could not exempt is usually a shell or editor left in the
- * lane; the form that works runs from the owning clone and names the lane.
- * Any other removal failure is reported as the service phrased it.
+ * A holder the fence could not exempt is a process outside the invoker's own
+ * ancestry: an editor or another shell left in the lane, or the other stages
+ * of a shell pipeline this command's output was piped into. The hint says to
+ * leave or close them, redirect the output to a file, and rerun from the lane,
+ * because `bun run beep` resolves the CLI from the checkout it runs in and the
+ * owning clone's `main` may still be behind the merge; the `--lane` form is
+ * kept for a clone that already carries the merged CLI. Any other removal
+ * failure is reported as the service phrased it.
  *
  * **Example** (Append the hint only for a holder)
  *
@@ -276,7 +281,7 @@ export const retirementFailureMessage: {
   (message: string): (plan: YeetRetirePlan) => string;
 } = dual(2, (plan: YeetRetirePlan, message: string): string =>
   Str.includes("still hold it")(message)
-    ? `yeet sweep --retire could not retire ${plan.worktreePath}: ${message} Leave the lane first: cd "${plan.owningClone}" && bun run beep yeet sweep --retire --lane "${plan.worktreePath}"`
+    ? `yeet sweep --retire could not retire ${plan.worktreePath}: ${message} Those holders are outside this command's own ancestry (an editor, another shell, or the other stages of a pipeline its output was piped into): leave or close them, redirect output to a file instead of piping it, and rerun from the lane: bun run beep yeet sweep --retire. From a clone that already carries the merged CLI: cd "${plan.owningClone}" && bun run beep yeet sweep --retire --lane "${plan.worktreePath}"`
     : `yeet sweep --retire could not retire ${plan.worktreePath}: ${message}`
 );
 

--- a/packages/tooling/tool/cli/test/yeet-sweep-retire.test.ts
+++ b/packages/tooling/tool/cli/test/yeet-sweep-retire.test.ts
@@ -342,6 +342,9 @@ describe("yeet sweep --retire", { concurrent: false }, () => {
     expect(retirementFailureMessage(plan, "pid 7 via cwd still hold it, and any write would be lost.")).toContain(
       'cd "/clones/x" && bun run beep yeet sweep --retire --lane "/clones/x/.claude/worktrees/lane"'
     );
+    expect(retirementFailureMessage(plan, "pid 7 via cwd still hold it, and any write would be lost.")).toContain(
+      "redirect output to a file instead of piping it, and rerun from the lane: bun run beep yeet sweep --retire."
+    );
     expect(retirementFailureMessage(plan, "Could not write the residue manifest.")).not.toContain("--lane");
     expect(pipe(plan, retirementFailureMessage("disk full"))).toBe(retirementFailureMessage(plan, "disk full"));
   });


### PR DESCRIPTION
## fix(repo-cli): point the retire fence hint at the lane and warn about piped output

When the archive fence refuses `yeet sweep --retire`, the hint told the operator
to step into the owning clone and pass `--lane`. That neither removes the holder
it named nor works while the clone's main is still behind the merge, because
`bun run beep` resolves the CLI from the checkout it runs in. The hint now says
the holders are outside the command's own ancestry (an editor, another shell, or
the other stages of a pipeline the output was piped into), to leave or close
them, redirect output to a file, and rerun from the lane, and keeps the `--lane`
form for a clone that already carries the merged CLI. The runbook and the yeet
skill carry the pipeline rule, which the first closeout of #1124 tripped over.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

## Local proof

- fallow-advisory-feedback: passed
- publish:head-install-preflight: passed
- early-publish:git:push: passed

Verdict: .beep/yeet/runs/fix_closeout-hint-lane-form-a66e7717e2d4/verdict.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/beep-effect/codesmith/beep-effect/pr/1127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791858241&installation_model_id=424656&pr_number=1127&repository=beep-effect%2Fbeep-effect&return_to=https%3A%2F%2Fgithub.com%2Fbeep-effect%2Fbeep-effect%2Fpull%2F1127&signature=8e6b60d690b1853b9c73348d1e7a89c978c4fa75bf50b619391988bf5de2d86f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

---

<!-- yeet-provenance:start -->
## Provenance

- Workspace: <code>beep-effect6</code>
- Branch: <code>fix/closeout-hint-lane-form</code>
- Agents (newest first):
  - `claude-code` (desktop) · `claude-fable-5-1` · <code>nice-ellis-1db28f-8a</code> · monitored

Resume the publishing agent from any beep-effect checkout on the publishing workstation:

```sh
bun run beep yeet resume 1127
```

<!-- yeet-provenance
{
  "schemaVersion": 2,
  "pr": 1127,
  "branch": "fix/closeout-hint-lane-form",
  "workspace": "beep-effect6",
  "agents": [
    {
      "harness": "claude-code",
      "entrypoint": "claude-desktop",
      "hostHarness": null,
      "model": "claude-fable-5-1",
      "label": "nice-ellis-1db28f-8a",
      "workspace": null,
      "role": "monitored"
    }
  ]
}
-->
<!-- yeet-provenance:end -->
